### PR TITLE
Use explicit git tag for test data repo

### DIFF
--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
+        GIT_TAG b29759ac3b635746cfb023c27f81f0a46e66fc95
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Always updating to head looks like a bad idea, we better spell out the revision explicitly.