### PR TITLE
Revise cmake build instructions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -34,9 +34,8 @@ Use the following commands to clone repository and build (it is recommended to b
 ```
 $ git clone https://github.com/OpenEnroth/OpenEnroth.git
 $ cd OpenEnroth
-$ mkdir build && cd build
-$ cmake ..
-$ make
+$ cmake -B build -S .
+$ cmake --build build
 ```
 
 To compile x86 build on x86_64 platform you can pass `-m32` via compiler flags to cmake.


### PR DESCRIPTION
As of cmake 3.13, it isn't necessary to create a directory, cd into it etc...

`cmake -B build` creates the build directory for us, and `-S .` specifies the current directory (`OpenEnroth`) as the source directory.

`cmake --build build` runs `make` (or another generator) for us in the build directory.

This makes the build instructions agnostic, and we don't have to worry about what generator the user is running.