### PR TITLE
Lower the language standard requirement to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 include(AppleLibcxxAssertions)
 include(ExternalProject)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(ENABLE_TESTS)


### PR DESCRIPTION
It was bumped to C++23 originally because of the `std::to_underlying`, but since then it was discovered that it's not available with the latest Android toolchain.  Many popular GNU/Linux and *BSD systems are also not ready for it, so reduce to C++20 while we're not actually using any C++23 features yet.

Tested on FreeBSD 12.4 and 13.1 against Clang 13.0.0.