### PR TITLE
Refactor of spells casting function

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1380,7 +1380,7 @@ void Game::EventLoop() {
 
                     _506360_installing_beacon = true;
 
-                    pPlayer9->CastSpellModifyMana(uRequiredMana);
+                    pPlayer9->SpendMana(uRequiredMana);
                     if (pParty->bTurnBasedModeOn) {
                         v60 = sRecoveryTime;
                         pParty->pTurnBasedPlayerRecoveryTimes[_506348_current_lloyd_playerid] = sRecoveryTime;
@@ -1477,7 +1477,7 @@ void Game::EventLoop() {
                         Actor::InitializeActors();
                     }
 
-                    pParty->pPlayers[(uint8_t)TownPortalCasterId].CastSpellModifyMana(0x14u);
+                    pParty->pPlayers[(uint8_t)TownPortalCasterId].SpendMana(0x14u);
                     pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
                     continue;
                 case UIMSG_HintTownPortal: {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1380,7 +1380,7 @@ void Game::EventLoop() {
 
                     _506360_installing_beacon = true;
 
-                    pPlayer9->CanCastSpell(uRequiredMana);
+                    pPlayer9->CastSpellModifyMana(uRequiredMana);
                     if (pParty->bTurnBasedModeOn) {
                         v60 = sRecoveryTime;
                         pParty->pTurnBasedPlayerRecoveryTimes[_506348_current_lloyd_playerid] = sRecoveryTime;
@@ -1392,7 +1392,7 @@ void Game::EventLoop() {
                                              (double)sRecoveryTime *
                                              flt_debugrecmod3));
                     }
-                    pAudioPlayer->PlaySpellSound(lloyds_beacon_spell_id, 0);
+                    pAudioPlayer->PlaySpellSound(LloydsBeaconSpellId, 0);
                     if (bRecallingBeacon) {
                         if (pCurrentMapName != pGames_LOD->GetSubNodeName(pPlayer9->vBeacons[uMessageParam].SaveFileID)) {
                             SaveGame(1, 0);
@@ -1418,7 +1418,7 @@ void Game::EventLoop() {
                         pGUIWindow_CurrentMenu->Release();
                         pGUIWindow_CurrentMenu = 0;
                     } else {
-                        pPlayer9->SetBeacon(uMessageParam, lloyds_beacon_spell_level);
+                        pPlayer9->SetBeacon(uMessageParam, LloydsBeaconSpellLevel);
                     }
                     continue;
                 case UIMSG_ClickTownInTP:
@@ -1477,7 +1477,7 @@ void Game::EventLoop() {
                         Actor::InitializeActors();
                     }
 
-                    pParty->pPlayers[(uint8_t)town_portal_caster_id].CanCastSpell(0x14u);
+                    pParty->pPlayers[(uint8_t)TownPortalCasterId].CastSpellModifyMana(0x14u);
                     pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
                     continue;
                 case UIMSG_HintTownPortal: {

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -246,7 +246,6 @@ bool Player::CanCastSpell(unsigned int uRequiredMana) {
     }
 
     // not enough mana
-    pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
     return false;
 }
 

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -238,7 +238,9 @@ int PlayerCreation_GetUnspentAttributePointCount() {
 
 //----- (00427730) --------------------------------------------------------
 bool Player::CanCastSpell(unsigned int uRequiredMana) {
-    if (engine->config->debug.AllMagic.Get()) return true;
+    if (engine->config->debug.AllMagic.Get()) {
+        return true;
+    }
     if (sMana >= uRequiredMana) {  // enough mana
         return true;
     }
@@ -248,7 +250,11 @@ bool Player::CanCastSpell(unsigned int uRequiredMana) {
     return false;
 }
 
-void Player::CastSpellModifyMana(unsigned int uRequiredMana) {
+void Player::SpendMana(unsigned int uRequiredMana) {
+    if (engine->config->debug.AllMagic.Get()) {
+        return;
+    }
+    assert(sMana >= uRequiredMana);
     sMana -= uRequiredMana; // remove mana required for spell
 }
 

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -240,13 +240,16 @@ int PlayerCreation_GetUnspentAttributePointCount() {
 bool Player::CanCastSpell(unsigned int uRequiredMana) {
     if (engine->config->debug.AllMagic.Get()) return true;
     if (sMana >= uRequiredMana) {  // enough mana
-        sMana -= uRequiredMana;    // removes mana
         return true;
     }
 
     // not enough mana
     pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
     return false;
+}
+
+void Player::CastSpellModifyMana(unsigned int uRequiredMana) {
+    sMana -= uRequiredMana; // remove mana required for spell
 }
 
 //----- (004BE2DD) --------------------------------------------------------

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -298,7 +298,7 @@ struct Player {
                       int _2devent_idx);  // 0x4BE2DD
     bool Recover(GameTime dt);
     bool CanCastSpell(unsigned int uRequiredMana);
-    void CastSpellModifyMana(unsigned int uRequiredMana);
+    void SpendMana(unsigned int uRequiredMana);
     void PlayAwardSound();
     void EquipBody(ITEM_EQUIP_TYPE uEquipType);
     bool HasUnderwaterSuitEquipped();

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -298,6 +298,7 @@ struct Player {
                       int _2devent_idx);  // 0x4BE2DD
     bool Recover(GameTime dt);
     bool CanCastSpell(unsigned int uRequiredMana);
+    void CastSpellModifyMana(unsigned int uRequiredMana);
     void PlayAwardSound();
     void EquipBody(ITEM_EQUIP_TYPE uEquipType);
     bool HasUnderwaterSuitEquipped();

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -700,11 +700,6 @@ void CastSpellInfoHelpers::CastSpell() {
 
                     if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
                         spellduration = 3600 * spell_level;
-                    } else {
-                        spellduration = 0;
-                    }
-
-                    if (spellduration > 0) {
                         item->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
                         item->uAttributes |= ITEM_TEMP_BONUS;
                     }
@@ -2372,13 +2367,13 @@ void CastSpellInfoHelpers::CastSpell() {
                 {
                     switch (spell_mastery) {
                         case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 180 * spell_level;
-                            break;  // 3 минуты * количество очков навыка
+                            amount = 60 * 3 * spell_level; // skill points * (3 minutes)
+                            break;
                         case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;  // 1 час * количество очков навыка
+                            amount = 60 * 60 * spell_level; // skill points * (1 hour)
+                            break;
                         case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
+                            amount = 60 * 60 * 24 * spell_level; // skill points * (1 day)
                             break;
                         case PLAYER_SKILL_MASTERY_GRANDMASTER:
                             amount = 0;
@@ -3183,7 +3178,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     break;
                 }
                 default:
-                    break;
+                    continue;
             }
 
             spell_sound_flag = true;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -315,6 +315,10 @@ void CastSpellInfoHelpers::CastSpell() {
                 TownPortalCasterId = pCastSpell->uPlayerID;
                 pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastTownPortal, 0, 0);
                 spell_sound_flag = true;
+            } else {
+                pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
+                pCastSpell->uSpellID = 0;
+                continue;
             }
         } else if (pCastSpell->uSpellID == SPELL_WATER_LLOYDS_BEACON) {
             if (pCurrentMapName == "d05.blv") {  // Arena
@@ -331,17 +335,18 @@ void CastSpellInfoHelpers::CastSpell() {
                 LloydsBeaconSpellId = pCastSpell->uSpellID;
                 pCastSpell->uFlags |= ON_CAST_NoRecoverySpell;
                 pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
+            } else {
+                pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
+                pCastSpell->uSpellID = 0;
+                continue;
             }
         } else {
         int amount;
-        Vec3i spell_velocity;
-
-        spell_velocity.x = 0;
-        spell_velocity.y = 0;
-        spell_velocity.z = 0;
+        Vec3i spell_velocity = Vec3i(0, 0, 0);
 
         if (!pPlayer->CanCastSpell(uRequiredMana)) {
             // Not enough mana for current spell, check the next one
+            pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
             pCastSpell->uSpellID = 0;
             continue;
         }
@@ -425,7 +430,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     continue;
                 }
                 if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.uSectorID = 0;
                     pSpellSprite.field_60_distance_related_prolly_lod = 0;
                     pSpellSprite.uFacing = 0;
@@ -443,7 +448,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 monster_id = PID_ID(spell_targeted_at);
                 if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.uSectorID = 0;
                     pSpellSprite.field_60_distance_related_prolly_lod = 0;
                     pSpellSprite.uFacing = 0;
@@ -465,7 +470,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 // v730 = spell_targeted_at >> 3;
                 // HIDWORD(spellduration) =
                 // (int)&pActors[PID_ID(spell_targeted_at)];
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition.x = pActors[PID_ID(spell_targeted_at)].vPosition.x;
                 pSpellSprite.vPosition.y = pActors[PID_ID(spell_targeted_at)].vPosition.y;
                 pSpellSprite.vPosition.z = pActors[PID_ID(spell_targeted_at)].vPosition.z;
@@ -498,7 +503,7 @@ void CastSpellInfoHelpers::CastSpell() {
             case SPELL_LIGHT_LIGHT_BOLT:
             case SPELL_DARK_DRAGON_BREATH:
             {
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -526,7 +531,7 @@ void CastSpellInfoHelpers::CastSpell() {
             case SPELL_BODY_FLYING_FIST:
             case SPELL_DARK_TOXIC_CLOUD:
             {
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 // TODO(pskelton): was pParty->uPartyHeight / 2
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -551,7 +556,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                     continue;
                 }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -628,7 +633,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), spell_mastery, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
@@ -645,7 +650,7 @@ void CastSpellInfoHelpers::CastSpell() {
             case SPELL_DARK_SHRINKING_RAY:
             {
                 // spell_id different?
-                InitSpellSprite( &pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -806,6 +811,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     default:
                         assert(false);
                 }
+
                 bool has_weak = false;
                 for (uint pl_id = 0; pl_id < 4; pl_id++) {
                     if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
@@ -813,12 +819,17 @@ void CastSpellInfoHelpers::CastSpell() {
                     }
                 }
                 if (has_weak) {
-                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                    // If any chanracter is in weak state, spell has no effect but mana is
+                    // spent
+                    // TODO: Vanilla bug here? See: https://www.celestialheavens.com/forum/10/7196
+                    pPlayer->SpendMana(uRequiredMana);
+                    continue;
                 }
+                pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
                 break;
             }
 
@@ -870,7 +881,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     dist_Z = abs(pActors[monster_id].vPosition.z - pParty->vPosition.z);
                     int count = int_get_vector_length(dist_X, dist_Y, dist_Z);
                     if ((double)count <= 307.2) {
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.uSectorID = 0;
                         pSpellSprite.field_60_distance_related_prolly_lod = 0;
                         pSpellSprite.uFacing = 0;
@@ -887,6 +898,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 } else {
                     // Previous behavoiur - decrease mana but do not play sound if
                     // spell is targeted wrong
+                    // TODO: revisit, maybe we want to properly play sound and display a message here?
                     pPlayer->SpendMana(uRequiredMana);
                     pCastSpell->uSpellID = 0;
                     continue;
@@ -1012,7 +1024,7 @@ void CastSpellInfoHelpers::CastSpell() {
                                     (double)spell_targeted_at - 2500);
                             yaw = TrigLUT.Atan2(j, k);
                         }
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.vPosition.x = dist_X;
                         pSpellSprite.vPosition.y = dist_Y;
                         pSpellSprite.vPosition.z = spell_targeted_at + dist_Z;
@@ -1041,7 +1053,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     continue;
                 }
                 int mon_num = render->GetActorsInViewport(4096);
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -1125,7 +1137,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     default:
                         assert(false);
                 }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -1262,7 +1274,7 @@ void CastSpellInfoHelpers::CastSpell() {
                                  (double)(dist_Z + 2500)));
                         yaw = TrigLUT.Atan2(j, k);
                     }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = dist_X;
                     pSpellSprite.vPosition.y = dist_Y;
                     pSpellSprite.vPosition.z = (int)(spell_targeted_at + (dist_Z + 2500));
@@ -1339,7 +1351,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         assert(false);
                 }
                 if (amount == 1) {
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -1353,7 +1365,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         ++pTurnEngine->pending_actions;
                     }
                 } else {
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -1642,7 +1654,7 @@ void CastSpellInfoHelpers::CastSpell() {
 
             case SPELL_EARTH_ROCK_BLAST:
             {
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -1665,7 +1677,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     continue;
                 }
                 pSpellSprite.uType = SPRITE_SPELL_EARTH_DEATH_BLOSSOM;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.vPosition.x = pParty->vPosition.x;
                 pSpellSprite.vPosition.y = pParty->vPosition.y;
                 pSpellSprite.uSectorID = 0;
@@ -1831,7 +1843,7 @@ void CastSpellInfoHelpers::CastSpell() {
                             192);
                 // ++pSpellSprite.uType;
                 pSpellSprite.uType = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -2102,7 +2114,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         }
                     }
 
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].uActorHeight;
@@ -2154,7 +2166,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         pActors[monster_id].pMonsterInfo.uHostilityType =
                             MonsterInfo::Hostility_Long;
                     }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z +
@@ -2195,7 +2207,7 @@ void CastSpellInfoHelpers::CastSpell() {
                                         GameTime::FromSeconds(amount)),
                                     spell_mastery, 0, 0, 0);
                     }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
@@ -2223,7 +2235,7 @@ void CastSpellInfoHelpers::CastSpell() {
                             192);
                 // ++pSpellSprite.uType;
                 pSpellSprite.uType = SPRITE_SPELL_MIND_MASS_FEAR_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -2550,7 +2562,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 int mon_num = render->GetActorsInViewport(4096);
                 // ++pSpellSprite.uType;
                 pSpellSprite.uType = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -2693,7 +2705,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 int mon_num = render->GetActorsInViewport(4096);
                 // ++pSpellSprite.uType;
                 pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -2892,7 +2904,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 }
                 // ++pSpellSprite.uType;
                 pSpellSprite.uType = SPRITE_SPELL_DARK_REANIMATE_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;
@@ -2942,7 +2954,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     default:
                         assert(false);
                 }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 // TODO(pskelton): was pParty->uPartyHeight / 2
                 pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -3001,7 +3013,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
@@ -3094,7 +3106,7 @@ void CastSpellInfoHelpers::CastSpell() {
             case SPELL_DARK_SOULDRINKER:
             {
                 int mon_num = render->GetActorsInViewport((int64_t)pCamera3D->GetMouseInfoDepth());
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                 pSpellSprite.uSectorID = 0;
                 pSpellSprite.field_60_distance_related_prolly_lod = 0;
                 pSpellSprite.uFacing = 0;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -359,7 +359,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
                             GameTime(pParty->GetPlayingTime() + (GameTime::FromSeconds(3600 * spell_level))),
                             spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -407,7 +406,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY + 10, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -416,6 +414,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     monster_id = PID_ID(spell_targeted_at);
                     if (!spell_targeted_at) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
@@ -429,7 +428,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
                         Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -448,7 +446,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
                         Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -473,10 +470,10 @@ void CastSpellInfoHelpers::CastSpell() {
                     int obj_id = pSpellSprite.Create(0, 0, 0, 0);
                     if (!MonsterStats::BelongsToSupertype(pActors[PID_ID(spell_targeted_at)].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD)) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     Actor::DamageMonsterFromParty(PID(OBJECT_Item, obj_id), PID_ID(spell_targeted_at), &spell_velocity);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -514,7 +511,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -537,7 +533,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -562,7 +557,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -578,7 +572,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pActors[monster_id].vVelocity.y = 0;
                         spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -611,7 +604,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
                         spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -640,7 +632,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
                         pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -661,7 +652,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -677,6 +667,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         _50C9D4_AfterEnchClickEventSecondParam = 0;
                         _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
 
@@ -719,7 +710,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     }
 
                     _50C9A8_item_enchantment_timer = 256;
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -744,7 +734,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
                     pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
                         .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -794,7 +783,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
 
                     pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -816,18 +804,19 @@ void CastSpellInfoHelpers::CastSpell() {
                         default:
                             assert(false);
                     }
+                    bool has_weak = false;
                     for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak))
-                            spell_sound_flag = false;
+                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
+                            has_weak = true;
+                        }
                     }
-                    if (spell_sound_flag) {
+                    if (has_weak) {
                         pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -855,19 +844,17 @@ void CastSpellInfoHelpers::CastSpell() {
                         spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
                         pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
                             .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, spell_overlay_id, 0);
-                        spell_sound_flag = true;
-                        break;
+                    } else {
+                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                            spell_fx_renderer->SetPlayerBuffAnim(
+                                    pCastSpell->uSpellID, pl_id);
+                            spell_overlay_id = pOtherOverlayList->_4418B1(
+                                    10000, pl_id + 310, 0, 65536);
+                            pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                                .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                                        spell_mastery, amount, spell_overlay_id, 0);
+                        }
                     }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pl_id);
-                        spell_overlay_id = pOtherOverlayList->_4418B1(
-                                10000, pl_id + 310, 0, 65536);
-                        pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
-                            .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                                    spell_mastery, amount, spell_overlay_id, 0);
-                    }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -893,11 +880,17 @@ void CastSpellInfoHelpers::CastSpell() {
                             pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
                             pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
                             Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                            spell_sound_flag = true;
                         } else {
                             SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                            pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                             continue;
                         }
+                    } else
+                    {
+                        // Previous behavoiur - decrease mana but do not play sound even if
+                        // spell is targeted wrong
+                        pPlayer->CastSpellModifyMana(uRequiredMana);
+                        continue;
                     }
                     break;
                 }
@@ -951,7 +944,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() +
                                 GameTime::FromSeconds(spellduration)),
                             spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -974,7 +966,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() +
                                 GameTime::FromSeconds(spellduration)),
                             spell_mastery, spell_level, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1040,7 +1031,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             k = grng->Random(1024) - 512;
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1069,7 +1059,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         spell_fx_renderer->RenderAsSprite(&pSpellSprite);
                         spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.OrangeyRed.C32(), 0x40);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1083,7 +1072,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, 0, spell_overlay_id, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1116,7 +1104,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, 0, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1161,7 +1148,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         }
                         spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1176,7 +1162,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     }
                     pParty->uFlags |= PARTY_FLAGS_1_LANDING;
                     pParty->uFallSpeed = 1000;
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1213,7 +1198,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1239,7 +1223,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)),
                             spell_mastery, amount, spell_overlay_id,
                             pCastSpell->uPlayerID + 1);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1299,7 +1282,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         j = grng->Random(1024) - 512;
                         k = grng->Random(1024) - 512;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1335,7 +1317,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                 pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1401,7 +1382,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                     spell_spray_angle_end);
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1435,7 +1415,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
                         pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1447,6 +1426,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         _50C9D4_AfterEnchClickEventSecondParam = 0;
                         _50C9D8_AfterEnchClickEventTimeout = 1;
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
 
@@ -1473,12 +1453,12 @@ void CastSpellInfoHelpers::CastSpell() {
                         _50C9D4_AfterEnchClickEventSecondParam = 0;
                         _50C9D8_AfterEnchClickEventTimeout = 1;
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
 
                     item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
                     _50C9A8_item_enchantment_timer = 256;
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1487,6 +1467,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     uRequiredMana = 0;
                     amount = 10 * spell_level;
                     bool item_not_broken = true;
+                    bool spell_failed = true;
                     int rnd = grng->Random(100);
                     pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
                     ItemGen *spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
@@ -1568,8 +1549,7 @@ void CastSpellInfoHelpers::CastSpell() {
                                     spell_item_to_enchant->m_enchantmentStrength = ench_power;
                                     spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
                                     _50C9A8_item_enchantment_timer = 256;
-                                    spell_sound_flag = true;
-                                    break;
+                                    spell_failed = false;
                                 } else { // weapons or we won the lottery for special enchantment
                                     int ench_found = 0;
                                     int to_item_apply_sum = 0;
@@ -1611,16 +1591,16 @@ void CastSpellInfoHelpers::CastSpell() {
                                     spell_item_to_enchant->special_enchantment = (ITEM_ENCHANTMENT)ench_array[step];
                                     spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
                                     _50C9A8_item_enchantment_timer = 256;
-                                    spell_sound_flag = true;
-                                    break;
+                                    spell_failed = false;
                                 }
                             }
                         }
                     }
 
-                    if (spell_sound_flag == 0) {
+                    if (spell_failed) {
                         SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
                         pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     break;
@@ -1646,17 +1626,14 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Petrified)) {
                         if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
                             pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Petrified);
-                            spell_sound_flag = true;
-                            break;
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Petrified,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
                         }
-
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Petrified,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1675,7 +1652,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1701,7 +1677,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pSpellSprite.Create(pParty->sRotationZ, TrigLUT.uIntegerHalfPi / 2, spell_speed, 0) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1732,7 +1707,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(amount)),
                             spell_mastery, 0, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1763,8 +1737,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             .Apply(
                                     GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
                                     spell_mastery, amount, 0, 0);
-                        spell_sound_flag = true;
-                        break;
                     } else if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
                         monster_id = PID_ID(pCastSpell->spell_target_pid);
                         pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE].Apply(
@@ -1775,7 +1747,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             ->_4A7E89_sparkles_on_actor_after_it_casts_buff(
                                     &pActors[monster_id], 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1797,26 +1768,21 @@ void CastSpellInfoHelpers::CastSpell() {
                         default:
                             assert(false);
                     }
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                        spell_sound_flag = true;
-                        break;
-                    }
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
-                    } else {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Cursed,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
-                        if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                            spell_sound_flag = true;
-                            break;
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Cursed,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        }
+                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                            spell_fx_renderer->SetPlayerBuffAnim(
+                                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
                         }
                     }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1835,19 +1801,17 @@ void CastSpellInfoHelpers::CastSpell() {
                             .Apply(GameTime(pParty->GetPlayingTime() +
                                         GameTime::FromSeconds(spellduration)),
                                     spell_mastery, 0, 0, 0);
-                        spell_sound_flag = true;
-                        break;
+                    } else {
+                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                            spell_fx_renderer->SetPlayerBuffAnim(
+                                    pCastSpell->uSpellID, pl_id);
+                            pParty->pPlayers[pl_id]
+                                .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(spellduration)),
+                                        spell_mastery, 0, 0, 0);
+                        }
                     }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pl_id);
-                        pParty->pPlayers[pl_id]
-                            .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                        GameTime::FromSeconds(spellduration)),
-                                    spell_mastery, 0, 0, 0);
-                    }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1903,7 +1867,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                             spell_mastery, 0, 0, 0);
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1915,28 +1878,25 @@ void CastSpellInfoHelpers::CastSpell() {
                         amount = 86400 * spell_level;
                     }
                     pOtherOverlayList->_4418B1(5080, pCastSpell->uPlayerID_2 + 100, 0, 65536);
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                        spell_sound_flag = true;
-                        break;
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Dead, GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Unconscious,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        }
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                                Condition_Weak, 0);
                     }
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
-                    } else {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Dead, GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Unconscious,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
-                    }
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                            Condition_Weak, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -1972,7 +1932,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         spell_fx_renderer->SetPlayerBuffAnim(
                                 pCastSpell->uSpellID, pl_array[i] - 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2025,7 +1984,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         spell_fx_renderer->SetPlayerBuffAnim(
                                 pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2047,24 +2005,17 @@ void CastSpellInfoHelpers::CastSpell() {
                         default:
                             assert(false);
                     }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
-                        spell_sound_flag = true;
-                        break;
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        }
                     }
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
-                        spell_sound_flag = true;
-                        break;
-                    }
-
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                                Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2086,24 +2037,18 @@ void CastSpellInfoHelpers::CastSpell() {
                         default:
                             assert(false);
                     }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
-                        spell_sound_flag = true;
-                        break;
-                    }
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
-                        spell_sound_flag = true;
-                        break;
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Fear, GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        }
                     }
 
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                                Condition_Fear, GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2166,7 +2111,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
                         pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2220,7 +2164,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
                         pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2261,7 +2204,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
                         pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2323,7 +2265,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                             spell_mastery, 0, 0, 0);
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2350,7 +2291,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
                                 Condition_Weak, 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2425,7 +2365,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         }
                         EventProcessor(event, spell_targeted_at, 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2452,15 +2391,13 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak)) {
                         if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
                             pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Weak);
-                            spell_sound_flag = true;
-                            break;
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Weak, GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
                         }
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Weak, GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2500,7 +2437,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                     pActors[monster_id].pMonsterInfo.uHP;
                         }
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2532,27 +2468,24 @@ void CastSpellInfoHelpers::CastSpell() {
                             pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Weak);
                             pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Medium);
                             pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Severe);
-                            spell_sound_flag = true;
-                            break;
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Poison_Weak,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Poison_Medium,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Poison_Severe,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
                         }
-
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Poison_Weak,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Poison_Medium,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Poison_Severe,
-                                    GameTime(pParty->GetPlayingTime() -
-                                        GameTime::FromSeconds(amount)));
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2566,7 +2499,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() +
                                 GameTime::FromSeconds(3600 * spell_level)),
                             spell_mastery, spell_level, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2593,7 +2525,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                     GameTime::FromSeconds(3600 * spell_level)),
                                 spell_mastery, spell_level, spell_level, 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2604,7 +2535,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                 pCastSpell->uSpellID, pl_id);
                         pParty->pPlayers[pl_id].Heal(5 * spell_level + 10);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2673,7 +2603,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         for (SpellBuff &buff : pActors[_50BF30_actors_in_viewport_ids[spell_targeted_at]].pActorBuffs)
                             buff.Reset();
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2712,7 +2641,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         continue;
                     }
                     Spawn_Light_Elemental(pCastSpell->uPlayerID, spell_mastery, spellduration);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2750,7 +2678,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() +
                                 GameTime::FromSeconds(spellduration)),
                             spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2782,7 +2709,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                 _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
                     }
                     spell_fx_renderer->_4A8BFC_prismatic_light();
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2836,7 +2762,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, spell_level + 5, 0, 0);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2897,7 +2822,6 @@ void CastSpellInfoHelpers::CastSpell() {
                                         60 * (spell_level * spellduration + 60))),
                                 spell_mastery, spell_level + 5, 0, 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2920,7 +2844,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     }
                     sRecoveryTime += -5 * spell_level;
                     ++pPlayer->uNumDivineInterventionCastsThisDay;
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -2956,10 +2879,12 @@ void CastSpellInfoHelpers::CastSpell() {
                     monster_id = PID_ID(pCastSpell->spell_target_pid);
                     if (monster_id == -1) {
                         SpellFailed(pCastSpell, LSTR_NO_VALID_SPELL_TARGET);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     if (pActors[monster_id].sCurrentHP > 0 || pActors[monster_id].uAIState != Dead && pActors[monster_id].uAIState != Dying) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     // ++pSpellSprite.uType;
@@ -2993,7 +2918,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (pActors[monster_id].sCurrentHP > 10 * amount) {
                         pActors[monster_id].sCurrentHP = 10 * amount;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3037,7 +2961,6 @@ void CastSpellInfoHelpers::CastSpell() {
                             spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
                         } while (spell_spray_angle_start <= spell_spray_angle_end);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3068,6 +2991,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         }
                         if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
                             SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                            pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                             continue;
                         }
                         pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
@@ -3087,7 +3011,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
                         pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3104,6 +3027,7 @@ void CastSpellInfoHelpers::CastSpell() {
                             achieved_awards[pCastSpell->uPlayerID_2 - 4] <= 0 ||
                             achieved_awards[pCastSpell->uPlayerID_2 - 4] >= 3) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
                     int hireling_idx = achieved_awards[pCastSpell->uPlayerID_2 - 4] - 1;
@@ -3122,7 +3046,6 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (ddm_dlv->uReputation > 10000) {
                         ddm_dlv->uReputation = 10000;
                     }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3152,18 +3075,16 @@ void CastSpellInfoHelpers::CastSpell() {
                             .Apply(GameTime(pParty->GetPlayingTime() +
                                         GameTime::FromSeconds(spellduration)),
                                     spell_mastery, amount, 0, 0);
-                        spell_sound_flag = true;
-                        break;
+                    } else {
+                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
+                            pParty->pPlayers[pl_id]
+                                .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(spellduration)),
+                                        spell_mastery, amount, 0, 0);
+                        }
                     }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
-                        pParty->pPlayers[pl_id]
-                            .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                        GameTime::FromSeconds(spellduration)),
-                                    spell_mastery, amount, 0, 0);
-                    }
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3221,7 +3142,6 @@ void CastSpellInfoHelpers::CastSpell() {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_array[j]);
                     }
                     spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Black.C32(), 64);
-                    spell_sound_flag = true;
                     break;
                 }
 
@@ -3260,13 +3180,13 @@ void CastSpellInfoHelpers::CastSpell() {
                                 rand_y + pParty->vPosition.y, terr_height + 16,
                                 grng->Random(500) + 500, 1, 0, 0, 0);
                     }
-                    spell_sound_flag = true;
                     break;
                 }
                 default:
                     break;
             }
 
+            spell_sound_flag = true;
             pPlayer->CastSpellModifyMana(uRequiredMana);
         }
 

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -327,940 +327,690 @@ void CastSpellInfoHelpers::CastSpell() {
             }
         } else
         {
-            int amount;
-            Vec3i spell_velocity;
+        int amount;
+        Vec3i spell_velocity;
 
-            spell_velocity.x = 0;
-            spell_velocity.y = 0;
-            spell_velocity.z = 0;
+        spell_velocity.x = 0;
+        spell_velocity.y = 0;
+        spell_velocity.z = 0;
 
-            if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                // Not enough mana for current spell, check the next one
-                continue;
+        if (!pPlayer->CanCastSpell(uRequiredMana)) {
+            // Not enough mana for current spell, check the next one
+            continue;
+        }
+
+        switch (pCastSpell->uSpellID) {
+            case SPELL_FIRE_TORCH_LIGHT:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 2;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 4;
+                        break;
+                    default:
+                        assert(false);
+                }
+                pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
+                        GameTime(pParty->GetPlayingTime() + (GameTime::FromSeconds(3600 * spell_level))),
+                        spell_mastery, amount, 0, 0);
+                break;
             }
 
-            switch (pCastSpell->uSpellID) {
-                case SPELL_FIRE_TORCH_LIGHT:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 2;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 4;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
-                            GameTime(pParty->GetPlayingTime() + (GameTime::FromSeconds(3600 * spell_level))),
-                            spell_mastery, amount, 0, 0);
-                    break;
-                }
-
-                case SPELL_FIRE_FIRE_SPIKE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 7;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 9;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    int spikes_active = 0;
-                    for (uint i = 0; i < pSpriteObjects.size(); ++i) {
-                        SpriteObject *object = &pSpriteObjects[i];
-                        if (object->uType &&
-                                object->spell_id == SPELL_FIRE_FIRE_SPIKE &&
-                                object->spell_caster_pid == PID(OBJECT_Player, pCastSpell->uPlayerID)) {
-                            ++spikes_active;
-                        }
-                    }
-                    if (spikes_active > amount) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = (short)target_direction.uYawAngle;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY + 10, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_AIR_IMPLOSION:
-                {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (!spell_targeted_at) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.uSectorID = 0;
-                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                        pSpellSprite.uFacing = 0;
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight / 2;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                    }
-                    break;
-                }
-
-                case SPELL_EARTH_MASS_DISTORTION:
-                {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.uSectorID = 0;
-                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                        pSpellSprite.uFacing = 0;
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
-                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_DESTROY_UNDEAD:
-                {
-                    if (!spell_targeted_at ||
-                            PID_TYPE(spell_targeted_at) != OBJECT_Actor) {
+            case SPELL_FIRE_FIRE_SPIKE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3;
                         break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 7;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 9;
+                        break;
+                    default:
+                        assert(false);
+                }
+                int spikes_active = 0;
+                for (uint i = 0; i < pSpriteObjects.size(); ++i) {
+                    SpriteObject *object = &pSpriteObjects[i];
+                    if (object->uType &&
+                            object->spell_id == SPELL_FIRE_FIRE_SPIKE &&
+                            object->spell_caster_pid == PID(OBJECT_Player, pCastSpell->uPlayerID)) {
+                        ++spikes_active;
                     }
-                    // v730 = spell_targeted_at >> 3;
-                    // HIDWORD(spellduration) =
-                    // (int)&pActors[PID_ID(spell_targeted_at)];
+                }
+                if (spikes_active > amount) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = (short)target_direction.uYawAngle;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY + 10, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_AIR_IMPLOSION:
+            {
+                monster_id = PID_ID(spell_targeted_at);
+                if (!spell_targeted_at) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[PID_ID(spell_targeted_at)].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[PID_ID(spell_targeted_at)].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[PID_ID(spell_targeted_at)].vPosition.z;
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight / 2;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                }
+                break;
+            }
+
+            case SPELL_EARTH_MASS_DISTORTION:
+            {
+                monster_id = PID_ID(spell_targeted_at);
+                if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
+                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_DESTROY_UNDEAD:
+            {
+                if (!spell_targeted_at ||
+                        PID_TYPE(spell_targeted_at) != OBJECT_Actor) {
+                    break;
+                }
+                // v730 = spell_targeted_at >> 3;
+                // HIDWORD(spellduration) =
+                // (int)&pActors[PID_ID(spell_targeted_at)];
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition.x = pActors[PID_ID(spell_targeted_at)].vPosition.x;
+                pSpellSprite.vPosition.y = pActors[PID_ID(spell_targeted_at)].vPosition.y;
+                pSpellSprite.vPosition.z = pActors[PID_ID(spell_targeted_at)].vPosition.z;
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = target_direction.uYawAngle;
+                pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                int obj_id = pSpellSprite.Create(0, 0, 0, 0);
+                if (!MonsterStats::BelongsToSupertype(pActors[PID_ID(spell_targeted_at)].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD)) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                Actor::DamageMonsterFromParty(PID(OBJECT_Item, obj_id), PID_ID(spell_targeted_at), &spell_velocity);
+                break;
+            }
+
+            case SPELL_FIRE_FIRE_BOLT:
+            case SPELL_FIRE_FIREBALL:
+            case SPELL_FIRE_INCINERATE:
+            case SPELL_AIR_LIGHNING_BOLT:
+            case SPELL_WATER_ICE_BOLT:
+            case SPELL_WATER_ICE_BLAST:
+            case SPELL_EARTH_STUN:
+            case SPELL_EARTH_DEADLY_SWARM:
+            case SPELL_MIND_MIND_BLAST:
+            case SPELL_MIND_PSYCHIC_SHOCK:
+            case SPELL_BODY_HARM:
+            case SPELL_LIGHT_LIGHT_BOLT:
+            case SPELL_DARK_DRAGON_BREATH:
+            {
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                } else {
+                    pSpellSprite.uSectorID = 0;
+                }
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = target_direction.uYawAngle;
+                if (pCastSpell->uSpellID == SPELL_AIR_LIGHNING_BOLT) {
+                    pSpellSprite.uAttributes |= SPRITE_SKIP_A_FRAME;
+                }
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_WATER_ACID_BURST:
+            case SPELL_EARTH_BLADES:
+            case SPELL_BODY_FLYING_FIST:
+            case SPELL_DARK_TOXIC_CLOUD:
+            {
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                // TODO(pskelton): was pParty->uPartyHeight / 2
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = target_direction.uYawAngle;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_SUNRAY:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor ||
+                        uCurrentlyLoadedLevelType == LEVEL_Outdoor &&
+                        (pParty->uCurrentHour < 5 || pParty->uCurrentHour >= 21)) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = target_direction.uYawAngle;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_PARALYZE:
+            {
+                monster_id = PID_ID(spell_targeted_at);
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
+                        pActors[monster_id].DoesDmgTypeDoDamage(DMGT_LIGHT)) {
+                    Actor::AI_Stand(PID_ID(spell_targeted_at), 4, 0x80, 0);
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3 * 60 * spell_level)), spell_mastery, 0, 0, 0);
+                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                    pActors[monster_id].vVelocity.x = 0;
+                    pActors[monster_id].vVelocity.y = 0;
+                    spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                }
+                break;
+            }
+
+            case SPELL_EARTH_SLOW:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 180 * spell_level;
+                        amount = 2;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 300 * spell_level;
+                        amount = 2;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 300 * spell_level;
+                        amount = 4;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 300 * spell_level;
+                        amount = 8;
+                        break;
+                    default:
+                        assert(false);
+                }
+                // v721 = 836 * PID_ID(spell_targeted_at);
+                monster_id = PID_ID(spell_targeted_at);
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, 0, 0);
+                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                    spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                }
+                break;
+            }
+
+            case SPELL_MIND_CHARM:
+            {
+                monster_id = PID_ID(spell_targeted_at);
+                if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_MIND)) {
+                    uint power = 300 * spell_level;
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                        power = 600 * spell_level;
+                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
+                        power = 29030400;
+                    }
+
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), spell_mastery, 0, 0, 0);
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
                     pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                     pSpellSprite.uFacing = target_direction.uYawAngle;
                     pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    int obj_id = pSpellSprite.Create(0, 0, 0, 0);
-                    if (!MonsterStats::BelongsToSupertype(pActors[PID_ID(spell_targeted_at)].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD)) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, obj_id), PID_ID(spell_targeted_at), &spell_velocity);
-                    break;
+                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                }
+                break;
+            }
+
+            case SPELL_DARK_SHRINKING_RAY:
+            {
+                // spell_id different?
+                InitSpellSprite( &pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = target_direction.uYawAngle;
+                pSpellSprite.spell_id = SPELL_FIRE_PROTECTION_FROM_FIRE;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_DARK_VAMPIRIC_WEAPON:
+            case SPELL_FIRE_FIRE_AURA:
+            {
+                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                item->UpdateTempBonus(pParty->GetPlayingTime());
+                if (item->uItemID == ITEM_BLASTER || item->uItemID == ITEM_BLASTER_RIFLE ||
+                        item->IsBroken() || pItemTable->IsMaterialNonCommon(item) || item->special_enchantment != ITEM_ENCHANTMENT_NULL || item->uEnchantmentType != 0 ||
+                        !IsWeapon(item->GetItemEquipType())) {
+                    _50C9D0_AfterEnchClickEventId = 113;
+                    _50C9D4_AfterEnchClickEventSecondParam = 0;
+                    _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
                 }
 
-                case SPELL_FIRE_FIRE_BOLT:
-                case SPELL_FIRE_FIREBALL:
-                case SPELL_FIRE_INCINERATE:
-                case SPELL_AIR_LIGHNING_BOLT:
-                case SPELL_WATER_ICE_BOLT:
-                case SPELL_WATER_ICE_BLAST:
-                case SPELL_EARTH_STUN:
-                case SPELL_EARTH_DEADLY_SWARM:
-                case SPELL_MIND_MIND_BLAST:
-                case SPELL_MIND_PSYCHIC_SHOCK:
-                case SPELL_BODY_HARM:
-                case SPELL_LIGHT_LIGHT_BOLT:
-                case SPELL_DARK_DRAGON_BREATH:
-                {
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    } else {
-                        pSpellSprite.uSectorID = 0;
-                    }
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    if (pCastSpell->uSpellID == SPELL_AIR_LIGHNING_BOLT) {
-                        pSpellSprite.uAttributes |= SPRITE_SKIP_A_FRAME;
-                    }
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_WATER_ACID_BURST:
-                case SPELL_EARTH_BLADES:
-                case SPELL_BODY_FLYING_FIST:
-                case SPELL_DARK_TOXIC_CLOUD:
-                {
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    // TODO(pskelton): was pParty->uPartyHeight / 2
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_SUNRAY:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor ||
-                            uCurrentlyLoadedLevelType == LEVEL_Outdoor &&
-                            (pParty->uCurrentHour < 5 || pParty->uCurrentHour >= 21)) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_PARALYZE:
-                {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
-                            pActors[monster_id].DoesDmgTypeDoDamage(DMGT_LIGHT)) {
-                        Actor::AI_Stand(PID_ID(spell_targeted_at), 4, 0x80, 0);
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3 * 60 * spell_level)), spell_mastery, 0, 0, 0);
-                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                        pActors[monster_id].vVelocity.x = 0;
-                        pActors[monster_id].vVelocity.y = 0;
-                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
-                    }
-                    break;
-                }
-
-                case SPELL_EARTH_SLOW:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 180 * spell_level;
-                            amount = 2;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 300 * spell_level;
-                            amount = 2;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 300 * spell_level;
-                            amount = 4;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 300 * spell_level;
-                            amount = 8;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    // v721 = 836 * PID_ID(spell_targeted_at);
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, 0, 0);
-                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_CHARM:
-                {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_MIND)) {
-                        uint power = 300 * spell_level;
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                            power = 600 * spell_level;
-                        } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
-                            power = 29030400;
+                switch (pCastSpell->uSpellID) {
+                    case SPELL_FIRE_FIRE_AURA:
+                        switch (spell_mastery) {
+                            case PLAYER_SKILL_MASTERY_NOVICE:
+                                item->special_enchantment = ITEM_ENCHANTMENT_OF_FIRE;
+                                break;
+                            case PLAYER_SKILL_MASTERY_EXPERT:
+                                item->special_enchantment = ITEM_ENCHANTMENT_OF_FLAME;
+                                break;
+                            case PLAYER_SKILL_MASTERY_MASTER:
+                            case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                                item->special_enchantment = ITEM_ENCHANTMENT_OF_INFERNOS;
+                                break;
+                            default:
+                                __debugbreak();
                         }
 
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), spell_mastery, 0, 0, 0);
+                        item->uAttributes |= ITEM_AURA_EFFECT_RED;
+                        break;
+                    case SPELL_DARK_VAMPIRIC_WEAPON:
+                        item->special_enchantment = ITEM_ENCHANTMENT_VAMPIRIC;
+                        item->uAttributes |= ITEM_AURA_EFFECT_PURPLE;
+                        break;
+                    default:
+                        __debugbreak();
+                }
+
+                if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spellduration = 3600 * spell_level;
+                    item->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
+                    item->uAttributes |= ITEM_TEMP_BONUS;
+                }
+
+                _50C9A8_item_enchantment_timer = 256;
+                break;
+            }
+
+            case SPELL_BODY_REGENERATION:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 1;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 1;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 3;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 10;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
+                    .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
+                break;
+            }
+
+            case SPELL_FIRE_PROTECTION_FROM_FIRE:
+            case SPELL_AIR_PROTECTION_FROM_AIR:
+            case SPELL_WATER_PROTECTION_FROM_WATER:
+            case SPELL_EARTH_PROTECTION_FROM_EARTH:
+            case SPELL_MIND_PROTECTION_FROM_MIND:
+            case SPELL_BODY_PROTECTION_FROM_BODY:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = std::to_underlying(spell_mastery) * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                switch (pCastSpell->uSpellID) {
+                    case SPELL_FIRE_PROTECTION_FROM_FIRE:
+                        buff_resist = PARTY_BUFF_RESIST_FIRE;
+                        break;
+                    case SPELL_AIR_PROTECTION_FROM_AIR:
+                        buff_resist = PARTY_BUFF_RESIST_AIR;
+                        break;
+                    case SPELL_WATER_PROTECTION_FROM_WATER:
+                        buff_resist = PARTY_BUFF_RESIST_WATER;
+                        break;
+                    case SPELL_EARTH_PROTECTION_FROM_EARTH:
+                        buff_resist = PARTY_BUFF_RESIST_EARTH;
+                        break;
+                    case SPELL_MIND_PROTECTION_FROM_MIND:
+                        buff_resist = PARTY_BUFF_RESIST_MIND;
+                        break;
+                    case SPELL_BODY_PROTECTION_FROM_BODY:
+                        buff_resist = PARTY_BUFF_RESIST_BODY;
+                        break;
+                    default:
+                        assert(false);
+                        continue;
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+
+                pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
+                break;
+            }
+
+            case SPELL_FIRE_HASTE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 60 * (spell_level + 60);
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 60 * (spell_level + 60);
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 180 * (spell_level + 20);
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 240 * (spell_level + 15);
+                        break;
+                    default:
+                        assert(false);
+                }
+                bool has_weak = false;
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
+                        has_weak = true;
+                    }
+                }
+                if (has_weak) {
+                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_BLESS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 900 * (spell_level + 4);
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 3600 * (spell_level + 1);
+                        break;
+                    default:
+                        assert(false);
+                }
+                amount = spell_level + 5;
+                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, spell_overlay_id, 0);
+                } else {
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_id);
+                        spell_overlay_id = pOtherOverlayList->_4418B1(
+                                10000, pl_id + 310, 0, 65536);
+                        pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                            .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, amount, spell_overlay_id, 0);
+                    }
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_SPIRIT_LASH:
+            {
+                if (spell_targeted_at &&
+                        PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                    int monster_id = PID_ID(spell_targeted_at);
+                    dist_X = abs(pActors[monster_id].vPosition.x -
+                            pParty->vPosition.x);
+                    dist_Y = abs(pActors[monster_id].vPosition.y -
+                            pParty->vPosition.y);
+                    dist_Z = abs(pActors[monster_id].vPosition.z -
+                            pParty->vPosition.z);
+                    int count = int_get_vector_length(dist_X, dist_Y, dist_Z);
+                    if ((double)count <= 307.2) {
                         InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.uSectorID = 0;
+                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                        pSpellSprite.uFacing = 0;
                         pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                         pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                    }
-                    break;
-                }
-
-                case SPELL_DARK_SHRINKING_RAY:
-                {
-                    // spell_id different?
-                    InitSpellSprite( &pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.spell_id = SPELL_FIRE_PROTECTION_FROM_FIRE;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_DARK_VAMPIRIC_WEAPON:
-                case SPELL_FIRE_FIRE_AURA:
-                {
-                    ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
-                    item->UpdateTempBonus(pParty->GetPlayingTime());
-                    if (item->uItemID == ITEM_BLASTER || item->uItemID == ITEM_BLASTER_RIFLE ||
-                            item->IsBroken() || pItemTable->IsMaterialNonCommon(item) || item->special_enchantment != ITEM_ENCHANTMENT_NULL || item->uEnchantmentType != 0 ||
-                            !IsWeapon(item->GetItemEquipType())) {
-                        _50C9D0_AfterEnchClickEventId = 113;
-                        _50C9D4_AfterEnchClickEventSecondParam = 0;
-                        _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
+                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
+                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                    } else {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
-
-                    switch (pCastSpell->uSpellID) {
-                        case SPELL_FIRE_FIRE_AURA:
-                            switch (spell_mastery) {
-                                case PLAYER_SKILL_MASTERY_NOVICE:
-                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_FIRE;
-                                    break;
-                                case PLAYER_SKILL_MASTERY_EXPERT:
-                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_FLAME;
-                                    break;
-                                case PLAYER_SKILL_MASTERY_MASTER:
-                                case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_INFERNOS;
-                                    break;
-                                default:
-                                    __debugbreak();
-                            }
-
-                            item->uAttributes |= ITEM_AURA_EFFECT_RED;
-                            break;
-                        case SPELL_DARK_VAMPIRIC_WEAPON:
-                            item->special_enchantment = ITEM_ENCHANTMENT_VAMPIRIC;
-                            item->uAttributes |= ITEM_AURA_EFFECT_PURPLE;
-                            break;
-                        default:
-                            __debugbreak();
-                    }
-
-                    if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spellduration = 3600 * spell_level;
-                        item->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
-                        item->uAttributes |= ITEM_TEMP_BONUS;
-                    }
-
-                    _50C9A8_item_enchantment_timer = 256;
-                    break;
-                }
-
-                case SPELL_BODY_REGENERATION:
+                } else
                 {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 1;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 1;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 10;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
-                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                    break;
+                    // Previous behavoiur - decrease mana but do not play sound even if
+                    // spell is targeted wrong
+                    pPlayer->CastSpellModifyMana(uRequiredMana);
+                    continue;
                 }
+                break;
+            }
 
-                case SPELL_FIRE_PROTECTION_FROM_FIRE:
-                case SPELL_AIR_PROTECTION_FROM_AIR:
-                case SPELL_WATER_PROTECTION_FROM_WATER:
-                case SPELL_EARTH_PROTECTION_FROM_EARTH:
-                case SPELL_MIND_PROTECTION_FROM_MIND:
-                case SPELL_BODY_PROTECTION_FROM_BODY:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = std::to_underlying(spell_mastery) * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    switch (pCastSpell->uSpellID) {
-                        case SPELL_FIRE_PROTECTION_FROM_FIRE:
-                            buff_resist = PARTY_BUFF_RESIST_FIRE;
-                            break;
-                        case SPELL_AIR_PROTECTION_FROM_AIR:
-                            buff_resist = PARTY_BUFF_RESIST_AIR;
-                            break;
-                        case SPELL_WATER_PROTECTION_FROM_WATER:
-                            buff_resist = PARTY_BUFF_RESIST_WATER;
-                            break;
-                        case SPELL_EARTH_PROTECTION_FROM_EARTH:
-                            buff_resist = PARTY_BUFF_RESIST_EARTH;
-                            break;
-                        case SPELL_MIND_PROTECTION_FROM_MIND:
-                            buff_resist = PARTY_BUFF_RESIST_MIND;
-                            break;
-                        case SPELL_BODY_PROTECTION_FROM_BODY:
-                            buff_resist = PARTY_BUFF_RESIST_BODY;
-                            break;
-                        default:
-                            assert(false);
-                            continue;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-
-                    pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                    break;
+            case SPELL_AIR_SHIELD:
+            case SPELL_EARTH_STONESKIN:
+            case SPELL_SPIRIT_HEROISM:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 900 * (spell_level + 4);
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 3600 * (spell_level + 1);
+                        break;
+                    default:
+                        assert(false);
                 }
-
-                case SPELL_FIRE_HASTE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 60 * (spell_level + 60);
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 60 * (spell_level + 60);
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 180 * (spell_level + 20);
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 240 * (spell_level + 15);
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    bool has_weak = false;
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
-                            has_weak = true;
-                        }
-                    }
-                    if (has_weak) {
-                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_BLESS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 900 * (spell_level + 4);
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 3600 * (spell_level + 1);
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    amount = spell_level + 5;
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
-                            .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, spell_overlay_id, 0);
-                    } else {
-                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                            spell_fx_renderer->SetPlayerBuffAnim(
-                                    pCastSpell->uSpellID, pl_id);
-                            spell_overlay_id = pOtherOverlayList->_4418B1(
-                                    10000, pl_id + 310, 0, 65536);
-                            pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
-                                .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                                        spell_mastery, amount, spell_overlay_id, 0);
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_SPIRIT_LASH:
-                {
-                    if (spell_targeted_at &&
-                            PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        int monster_id = PID_ID(spell_targeted_at);
-                        dist_X = abs(pActors[monster_id].vPosition.x -
-                                pParty->vPosition.x);
-                        dist_Y = abs(pActors[monster_id].vPosition.y -
-                                pParty->vPosition.y);
-                        dist_Z = abs(pActors[monster_id].vPosition.z -
-                                pParty->vPosition.z);
-                        int count = int_get_vector_length(dist_X, dist_Y, dist_Z);
-                        if ((double)count <= 307.2) {
-                            InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                            pSpellSprite.uSectorID = 0;
-                            pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                            pSpellSprite.uFacing = 0;
-                            pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                            pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                            pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
-                            pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
-                            Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                        } else {
-                            SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                            pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                            continue;
-                        }
-                    } else
-                    {
-                        // Previous behavoiur - decrease mana but do not play sound even if
-                        // spell is targeted wrong
-                        pPlayer->CastSpellModifyMana(uRequiredMana);
-                        continue;
-                    }
-                    break;
-                }
-
-                case SPELL_AIR_SHIELD:
-                case SPELL_EARTH_STONESKIN:
-                case SPELL_SPIRIT_HEROISM:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 900 * (spell_level + 4);
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 3600 * (spell_level + 1);
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    switch (pCastSpell->uSpellID) {
-                        case SPELL_AIR_SHIELD:
-                            amount = 0;
-                            buff_resist = PARTY_BUFF_SHIELD;
-                            break;
-                        case SPELL_EARTH_STONESKIN:
-                            amount = spell_level + 5;
-                            buff_resist = PARTY_BUFF_STONE_SKIN;
-                            break;
-                        case SPELL_SPIRIT_HEROISM:
-                            amount = spell_level + 5;
-                            buff_resist = PARTY_BUFF_HEROISM;
-                            break;
-                        default:
-                            assert(false);
-                            continue;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[buff_resist].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    break;
-                }
-
-                case SPELL_FIRE_IMMOLATION:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spellduration = 600 * spell_level;
-                    } else {
-                        spellduration = 60 * spell_level;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(spellduration)),
-                            spell_mastery, spell_level, 0, 0);
-                    break;
-                }
-
-                case SPELL_FIRE_METEOR_SHOWER:
-                {
-                    if (spell_mastery < PLAYER_SKILL_MASTERY_MASTER) {
-                        continue;
-                    }
-
-                    int meteor_num;
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        meteor_num = 20;
-                    } else {
-                        meteor_num = 16;
-                    }
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_CANT_METEOR_SHOWER_INDOORS);
-                        continue;
-                    }
-                    obj_type = PID_TYPE(spell_targeted_at);
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (obj_type == OBJECT_Actor) {  // quick cast can specify target
-                        dist_X = pActors[monster_id].vPosition.x;
-                        dist_Y = pActors[monster_id].vPosition.y;
-                        dist_Z = pActors[monster_id].vPosition.z;
-                    } else {
-                        dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
-                        dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
-                        dist_Z = pParty->vPosition.z;
-                    }
-                    uint64_t k = 0;
-                    int j = 0;
-                    if (meteor_num > 0) {
-                        int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
-                        for (; meteor_num; meteor_num--) {
-                            uint32_t yaw, pitch;
-                            spell_targeted_at = grng->Random(1000);
-                            if (sqrt(((double)spell_targeted_at - 2500) *
-                                        ((double)spell_targeted_at - 2500) + j * j + k * k) <= 1.0) {
-                                yaw = 0;
-                                pitch = 0;
-                            } else {
-                                pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
-                                        (double)spell_targeted_at - 2500);
-                                yaw = TrigLUT.Atan2(j, k);
-                            }
-                            InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                            pSpellSprite.vPosition.x = dist_X;
-                            pSpellSprite.vPosition.y = dist_Y;
-                            pSpellSprite.vPosition.z = spell_targeted_at + dist_Z;
-                            pSpellSprite.uSectorID = 0;
-                            pSpellSprite.spell_target_pid = target_pid;
-                            pSpellSprite.field_60_distance_related_prolly_lod =
-                                stru_50C198._427546(spell_targeted_at + 2500);
-                            pSpellSprite.uFacing = yaw;
-                            if (pParty->bTurnBasedModeOn) {
-                                pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                            }
-                            if (pSpellSprite.Create(yaw, pitch, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 && pParty->bTurnBasedModeOn) {
-                                ++pTurnEngine->pending_actions;
-                            }
-                            j = grng->Random(1024) - 512;
-                            k = grng->Random(1024) - 512;
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_FIRE_INFERNO:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-                        SpellFailed(pCastSpell, LSTR_CANT_INFERNO_OUTDOORS);
-                        continue;
-                    }
-                    int mon_num = render->GetActorsInViewport(4096);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    for (uint i = 0; i < mon_num; i++) {
-                        pSpellSprite.vPosition.x = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.z -
-                            (unsigned int)(int64_t)((double)pActors
-                                    [_50BF30_actors_in_viewport_ids
-                                    [i]].uActorHeight * -0.8);
-                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[i]);
-                        Actor::DamageMonsterFromParty(
-                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                                _50BF30_actors_in_viewport_ids[i], &spell_velocity);
-                        spell_fx_renderer->RenderAsSprite(&pSpellSprite);
-                        spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.OrangeyRed.C32(), 0x40);
-                    }
-                    break;
-                }
-
-                case SPELL_AIR_WIZARD_EYE:
-                {
-                    spellduration = 3600 * spell_level;
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        spell_overlay_id =
-                            pOtherOverlayList->_4418B1(2000, pl_id + 100, 0, 65536);
-                    }
-                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, 0, spell_overlay_id, 0);
-                    break;
-                }
-
-                case SPELL_AIR_FEATHER_FALL:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 300 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 3600 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        pOtherOverlayList->_4418B1(2010, pl_id + 100, 0, 65536);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-
-                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, 0, 0, 0);
-                    break;
-                }
-
-                case SPELL_AIR_SPARKS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 7;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 9;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_spray_angle_start = ONE_THIRD_PI / -2;
-                    spell_spray_angle_end = ONE_THIRD_PI / 2;
-                    while (spell_spray_angle_start <= spell_spray_angle_end) {
-                        pSpellSprite.uSpriteFrameID = grng->Random(64); // TODO(captainurist): this doesn't look like a frame id initialization
-                        pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
-                        if (pSpellSprite.Create(
-                                    (int16_t)(spell_spray_angle_start + (short)target_direction.uYawAngle),
-                                    target_direction.uPitchAngle,
-                                    pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
-                                    pCastSpell->uPlayerID + 1) != -1 &&
-                                pParty->bTurnBasedModeOn) {
-                            ++pTurnEngine->pending_actions;
-                        }
-                        spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                    }
-                    break;
-                }
-
-                case SPELL_AIR_JUMP:
-                {
-                    if (pParty->IsAirborne()) {
-                        SpellFailed(pCastSpell, LSTR_CANT_JUMP_AIRBORNE);
-                        continue;
-                    }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
-                    }
-                    pParty->uFlags |= PARTY_FLAGS_1_LANDING;
-                    pParty->uFallSpeed = 1000;
-                    break;
-                }
-
-                case SPELL_AIR_INVISIBILITY:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 600 * spell_level;
-                            amount = spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 600 * spell_level;
-                            amount = 2 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 600 * spell_level;
-                            amount = 3 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 3600 * spell_level;
-                            amount = 4 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (pParty->GetRedOrYellowAlert()) {
-                        SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
-                        continue;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    break;
-                }
-
-                case SPELL_AIR_FLY:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
-                        continue;
-                    }
-                    if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() && !engine->config->debug.AllMagic.Get()) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 1;
-                    } else {
+                switch (pCastSpell->uSpellID) {
+                    case SPELL_AIR_SHIELD:
                         amount = 0;
-                    }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++)
-                        pOtherOverlayList->_4418B1(2090, pl_id + 100, 0, 65536);
-                    spell_overlay_id = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
-                    pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)),
-                            spell_mastery, amount, spell_overlay_id,
-                            pCastSpell->uPlayerID + 1);
-                    break;
+                        buff_resist = PARTY_BUFF_SHIELD;
+                        break;
+                    case SPELL_EARTH_STONESKIN:
+                        amount = spell_level + 5;
+                        buff_resist = PARTY_BUFF_STONE_SKIN;
+                        break;
+                    case SPELL_SPIRIT_HEROISM:
+                        amount = spell_level + 5;
+                        buff_resist = PARTY_BUFF_HEROISM;
+                        break;
+                    default:
+                        assert(false);
+                        continue;
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[buff_resist].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                break;
+            }
+
+            case SPELL_FIRE_IMMOLATION:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spellduration = 600 * spell_level;
+                } else {
+                    spellduration = 60 * spell_level;
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(spellduration)),
+                        spell_mastery, spell_level, 0, 0);
+                break;
+            }
+
+            case SPELL_FIRE_METEOR_SHOWER:
+            {
+                if (spell_mastery < PLAYER_SKILL_MASTERY_MASTER) {
+                    continue;
                 }
 
-                case SPELL_AIR_STARBURST:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_CANT_STARBURST_INDOORS);
-                        continue;
-                    }
-                    obj_type = PID_TYPE(spell_targeted_at);
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (obj_type == OBJECT_Actor) {
-                        dist_X = pActors[monster_id].vPosition.x;
-                        dist_Y = pActors[monster_id].vPosition.y;
-                        dist_Z = pActors[monster_id].vPosition.z;
-                    } else {
-                        dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
-                        dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
-                        dist_Z = pParty->vPosition.z;
-                    }
-                    uint64_t k = 0;
-                    int j = 0;
+                int meteor_num;
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    meteor_num = 20;
+                } else {
+                    meteor_num = 16;
+                }
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    SpellFailed(pCastSpell, LSTR_CANT_METEOR_SHOWER_INDOORS);
+                    continue;
+                }
+                obj_type = PID_TYPE(spell_targeted_at);
+                monster_id = PID_ID(spell_targeted_at);
+                if (obj_type == OBJECT_Actor) {  // quick cast can specify target
+                    dist_X = pActors[monster_id].vPosition.x;
+                    dist_Y = pActors[monster_id].vPosition.y;
+                    dist_Z = pActors[monster_id].vPosition.z;
+                } else {
+                    dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
+                    dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
+                    dist_Z = pParty->vPosition.z;
+                }
+                uint64_t k = 0;
+                int j = 0;
+                if (meteor_num > 0) {
                     int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
-                    uint32_t yaw, pitch;
-                    for (uint star_num = 20; star_num; star_num--) {
+                    for (; meteor_num; meteor_num--) {
+                        uint32_t yaw, pitch;
                         spell_targeted_at = grng->Random(1000);
-                        if (sqrt(((double)spell_targeted_at + (double)dist_Z -
-                                        (double)(dist_Z + 2500)) *
-                                    ((double)spell_targeted_at + (double)dist_Z -
-                                     (double)(dist_Z + 2500)) +
-                                    j * j + k * k) <= 1.0) {
+                        if (sqrt(((double)spell_targeted_at - 2500) *
+                                    ((double)spell_targeted_at - 2500) + j * j + k * k) <= 1.0) {
                             yaw = 0;
                             pitch = 0;
                         } else {
                             pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
-                                    ((double)spell_targeted_at + (double)dist_Z -
-                                     (double)(dist_Z + 2500)));
+                                    (double)spell_targeted_at - 2500);
                             yaw = TrigLUT.Atan2(j, k);
                         }
                         InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.vPosition.x = dist_X;
                         pSpellSprite.vPosition.y = dist_Y;
-                        pSpellSprite.vPosition.z = (int)(spell_targeted_at + (dist_Z + 2500));
+                        pSpellSprite.vPosition.z = spell_targeted_at + dist_Z;
                         pSpellSprite.uSectorID = 0;
                         pSpellSprite.spell_target_pid = target_pid;
                         pSpellSprite.field_60_distance_related_prolly_lod =
@@ -1269,1673 +1019,336 @@ void CastSpellInfoHelpers::CastSpell() {
                         if (pParty->bTurnBasedModeOn) {
                             pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
                         }
-                        if (pSpellSprite.Create(yaw, pitch,
-                                    pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 &&
-                                pParty->bTurnBasedModeOn) {
+                        if (pSpellSprite.Create(yaw, pitch, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 && pParty->bTurnBasedModeOn) {
                             ++pTurnEngine->pending_actions;
                         }
                         j = grng->Random(1024) - 512;
                         k = grng->Random(1024) - 512;
                     }
-                    break;
                 }
+                break;
+            }
 
-                case SPELL_WATER_AWAKEN:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 180 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    for (int i = 0; i < 4; i++) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            if (pParty->pPlayers[i].conditions.Has(Condition_Sleep)) {
-                                pParty->pPlayers[i].conditions.Reset(Condition_Sleep);
-                                pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
-                            }
-                        } else {
-                            if (pParty->pPlayers[i]
-                                    .DiscardConditionIfLastsLongerThan(
-                                        Condition_Sleep,
-                                        GameTime(pParty->GetPlayingTime() - GameTime::FromSeconds(amount))))
-                                pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
-                        }
-                    }
-                    break;
+            case SPELL_FIRE_INFERNO:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
+                    SpellFailed(pCastSpell, LSTR_CANT_INFERNO_OUTDOORS);
+                    continue;
                 }
+                int mon_num = render->GetActorsInViewport(4096);
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                for (uint i = 0; i < mon_num; i++) {
+                    pSpellSprite.vPosition.x = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.z -
+                        (unsigned int)(int64_t)((double)pActors
+                                [_50BF30_actors_in_viewport_ids
+                                [i]].uActorHeight * -0.8);
+                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[i]);
+                    Actor::DamageMonsterFromParty(
+                            PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                            _50BF30_actors_in_viewport_ids[i], &spell_velocity);
+                    spell_fx_renderer->RenderAsSprite(&pSpellSprite);
+                    spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.OrangeyRed.C32(), 0x40);
+                }
+                break;
+            }
 
-                case SPELL_WATER_POISON_SPRAY:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 1;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 7;
-                            break;
-                        default:
-                            assert(false);
+            case SPELL_AIR_WIZARD_EYE:
+            {
+                spellduration = 3600 * spell_level;
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    spell_overlay_id =
+                        pOtherOverlayList->_4418B1(2000, pl_id + 100, 0, 65536);
+                }
+                pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, 0, spell_overlay_id, 0);
+                break;
+            }
+
+            case SPELL_AIR_FEATHER_FALL:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 300 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 3600 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    pOtherOverlayList->_4418B1(2010, pl_id + 100, 0, 65536);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+
+                pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, 0, 0, 0);
+                break;
+            }
+
+            case SPELL_AIR_SPARKS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 7;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 9;
+                        break;
+                    default:
+                        assert(false);
+                }
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_spray_angle_start = ONE_THIRD_PI / -2;
+                spell_spray_angle_end = ONE_THIRD_PI / 2;
+                while (spell_spray_angle_start <= spell_spray_angle_end) {
+                    pSpellSprite.uSpriteFrameID = grng->Random(64); // TODO(captainurist): this doesn't look like a frame id initialization
+                    pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
+                    if (pSpellSprite.Create(
+                                (int16_t)(spell_spray_angle_start + (short)target_direction.uYawAngle),
+                                target_direction.uPitchAngle,
+                                pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
+                                pCastSpell->uPlayerID + 1) != -1 &&
+                            pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
                     }
-                    if (amount == 1) {
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        if (pParty->bTurnBasedModeOn) {
-                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                        }
-                        spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                        if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                            ++pTurnEngine->pending_actions;
-                        }
+                    spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
+                }
+                break;
+            }
+
+            case SPELL_AIR_JUMP:
+            {
+                if (pParty->IsAirborne()) {
+                    SpellFailed(pCastSpell, LSTR_CANT_JUMP_AIRBORNE);
+                    continue;
+                }
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
+                }
+                pParty->uFlags |= PARTY_FLAGS_1_LANDING;
+                pParty->uFallSpeed = 1000;
+                break;
+            }
+
+            case SPELL_AIR_INVISIBILITY:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 600 * spell_level;
+                        amount = spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 600 * spell_level;
+                        amount = 2 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 600 * spell_level;
+                        amount = 3 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 3600 * spell_level;
+                        amount = 4 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (pParty->GetRedOrYellowAlert()) {
+                    SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
+                    continue;
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                break;
+            }
+
+            case SPELL_AIR_FLY:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
+                    continue;
+                }
+                if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() && !engine->config->debug.AllMagic.Get()) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 1;
+                } else {
+                    amount = 0;
+                }
+                for (uint pl_id = 0; pl_id < 4; pl_id++)
+                    pOtherOverlayList->_4418B1(2090, pl_id + 100, 0, 65536);
+                spell_overlay_id = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
+                pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)),
+                        spell_mastery, amount, spell_overlay_id,
+                        pCastSpell->uPlayerID + 1);
+                break;
+            }
+
+            case SPELL_AIR_STARBURST:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    SpellFailed(pCastSpell, LSTR_CANT_STARBURST_INDOORS);
+                    continue;
+                }
+                obj_type = PID_TYPE(spell_targeted_at);
+                monster_id = PID_ID(spell_targeted_at);
+                if (obj_type == OBJECT_Actor) {
+                    dist_X = pActors[monster_id].vPosition.x;
+                    dist_Y = pActors[monster_id].vPosition.y;
+                    dist_Z = pActors[monster_id].vPosition.z;
+                } else {
+                    dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
+                    dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
+                    dist_Z = pParty->vPosition.z;
+                }
+                uint64_t k = 0;
+                int j = 0;
+                int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
+                uint32_t yaw, pitch;
+                for (uint star_num = 20; star_num; star_num--) {
+                    spell_targeted_at = grng->Random(1000);
+                    if (sqrt(((double)spell_targeted_at + (double)dist_Z -
+                                    (double)(dist_Z + 2500)) *
+                                ((double)spell_targeted_at + (double)dist_Z -
+                                 (double)(dist_Z + 2500)) +
+                                j * j + k * k) <= 1.0) {
+                        yaw = 0;
+                        pitch = 0;
                     } else {
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                        if (pParty->bTurnBasedModeOn) {
-                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                        }
-                        spell_spray_angle_start = ONE_THIRD_PI / -2;
-                        spell_spray_angle_end = ONE_THIRD_PI / 2;
-                        if (spell_spray_angle_start <= spell_spray_angle_end) {
-                            do {
-                                pSpellSprite.uFacing = spell_spray_angle_start +
-                                    target_direction.uYawAngle;
-                                if (pSpellSprite.Create(
-                                            pSpellSprite.uFacing,
-                                            target_direction.uPitchAngle,
-                                            pObjectList
-                                            ->pObjects[pSpellSprite.uObjectDescID]
-                                            .uSpeed,
-                                            pCastSpell->uPlayerID + 1) != -1 &&
-                                        pParty->bTurnBasedModeOn) {
-                                    ++pTurnEngine->pending_actions;
-                                }
-                                spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                            } while (spell_spray_angle_start <=
-                                    spell_spray_angle_end);
-                        }
+                        pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
+                                ((double)spell_targeted_at + (double)dist_Z -
+                                 (double)(dist_Z + 2500)));
+                        yaw = TrigLUT.Atan2(j, k);
                     }
-                    break;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = dist_X;
+                    pSpellSprite.vPosition.y = dist_Y;
+                    pSpellSprite.vPosition.z = (int)(spell_targeted_at + (dist_Z + 2500));
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.spell_target_pid = target_pid;
+                    pSpellSprite.field_60_distance_related_prolly_lod =
+                        stru_50C198._427546(spell_targeted_at + 2500);
+                    pSpellSprite.uFacing = yaw;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
+                    if (pSpellSprite.Create(yaw, pitch,
+                                pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 &&
+                            pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    j = grng->Random(1024) - 512;
+                    k = grng->Random(1024) - 512;
                 }
+                break;
+            }
 
-                case SPELL_WATER_WATER_WALK:
-                {
-                    if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana()) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:  // break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 3600 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, spell_overlay_id,
-                            pCastSpell->uPlayerID + 1);
+            case SPELL_WATER_AWAKEN:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 180 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                for (int i = 0; i < 4; i++) {
                     if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
-                    }
-                    break;
-                }
-
-                case SPELL_WATER_RECHARGE_ITEM:
-                {
-                    ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
-                    if (item->GetItemEquipType() != EQUIP_WAND || item->IsBroken()) {
-                        _50C9D0_AfterEnchClickEventId = 113;
-                        _50C9D4_AfterEnchClickEventSecondParam = 0;
-                        _50C9D8_AfterEnchClickEventTimeout = 1;
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-
-                    double spell_recharge_factor;
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.5;  // 50 %
-                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
-                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.69999999;  // 30 %
-                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.80000001;  // 20 %
+                        if (pParty->pPlayers[i].conditions.Has(Condition_Sleep)) {
+                            pParty->pPlayers[i].conditions.Reset(Condition_Sleep);
+                            pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
+                        }
                     } else {
-                        spell_recharge_factor = 0.0;
-                    }
-
-                    if (spell_recharge_factor > 1.0) {
-                        spell_recharge_factor = 1.0;
-                    }
-
-                    int uNewCharges = item->uMaxCharges * spell_recharge_factor;
-                    item->uMaxCharges = uNewCharges;
-                    item->uNumCharges = uNewCharges;
-                    if (uNewCharges <= 0) {
-                        _50C9D0_AfterEnchClickEventId = 113;
-                        _50C9D4_AfterEnchClickEventSecondParam = 0;
-                        _50C9D8_AfterEnchClickEventTimeout = 1;
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-
-                    item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
-                    _50C9A8_item_enchantment_timer = 256;
-                    break;
-                }
-
-                case SPELL_WATER_ENCHANT_ITEM:
-                {
-                    uRequiredMana = 0;
-                    amount = 10 * spell_level;
-                    bool item_not_broken = true;
-                    bool spell_failed = true;
-                    int rnd = grng->Random(100);
-                    pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
-                    ItemGen *spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
-                    ITEM_EQUIP_TYPE this_equip_type = pItemTable->pItems[spell_item_to_enchant->uItemID].uEquipType;
-
-                    // refs
-                    // https://www.gog.com/forum/might_and_magic_series/a_little_enchant_item_testing_in_mm7
-                    // http://www.pottsland.com/mm6/enchant.shtml
-                    // also see STDITEMS.tx and SPCITEMS.txt in Events.lod
-
-                    if ((spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT)) {
-                        __debugbreak(); // SPELL_WATER_ENCHANT_ITEM is a master level spell
-                    }
-
-                    if ((spell_mastery == PLAYER_SKILL_MASTERY_MASTER || spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) &&
-                            IsRegular(spell_item_to_enchant->uItemID) &&
-                            spell_item_to_enchant->special_enchantment == ITEM_ENCHANTMENT_NULL &&
-                            spell_item_to_enchant->uEnchantmentType == 0 &&
-                            spell_item_to_enchant->m_enchantmentStrength == 0 &&
-                            !spell_item_to_enchant->IsBroken()) {
-                        // break items with low value
-                        if ((spell_item_to_enchant->GetValue() < 450 && !IsWeapon(this_equip_type)) ||  // not weapons
-                                (spell_item_to_enchant->GetValue() < 250 && IsWeapon(this_equip_type))) {  // weapons
-                            if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
-                                spell_item_to_enchant->SetBroken();
-                            }
-                            item_not_broken = false;
-                        } else {
-                            // random item break
-                            if (rnd >= 10 * spell_level) {  // 10% chance of success per spell level
-                                if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
-                                    spell_item_to_enchant->SetBroken();
-                                }
-                            } else {
-                                // Weapons are limited to special enchantments, but all other types can have either
-                                if (rnd < 80 && IsPassiveEquipment(this_equip_type)) { // chance to roll standard enchantment on non-weapons
-                                    int ench_found = 0;
-                                    int to_item_apply_sum = 0;
-                                    int ench_array[100] = { 0 };
-
-                                    // finds how many possible enchaments and adds up to item apply values
-                                    // if (pItemTable->pEnchantments_count > 0) {
-                                    for (int norm_ench_loop = 0; norm_ench_loop < 24; ++norm_ench_loop) {
-                                        char* this_bon_state = pItemTable->pEnchantments[norm_ench_loop].pBonusStat;
-                                        if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
-                                            int this_to_apply = pItemTable->pEnchantments[norm_ench_loop].to_item[this_equip_type];
-                                            to_item_apply_sum += this_to_apply;
-                                            if (this_to_apply) {
-                                                ench_array[ench_found] = norm_ench_loop;
-                                                ench_found++;
-                                            }
-                                        }
-                                    }
-                                    // }
-
-                                    // pick a random ench
-                                    int item_apply_rand = grng->Random(to_item_apply_sum);
-                                    int target_item_apply_rand = item_apply_rand + 1;
-                                    int current_item_apply_sum = 0;
-                                    int step = 0;
-
-                                    // step through until we hit that ench
-                                    for (step = 0; step < ench_found; step++) {
-                                        current_item_apply_sum += pItemTable->pEnchantments[ench_array[step]].to_item[this_equip_type];
-                                        if (current_item_apply_sum >= target_item_apply_rand) {
-                                            break;
-                                        }
-                                    }
-
-                                    // assign ench and power
-                                    spell_item_to_enchant->uEnchantmentType = (ITEM_ENCHANTMENT)ench_array[step];
-
-                                    int ench_power = 0;
-                                    // master 3-8  - guess work needs checking
-                                    if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) ench_power = grng->Random(6) + 3;
-                                    // gm 6-12   - guess work needs checking
-                                    if (spell_mastery== PLAYER_SKILL_MASTERY_GRANDMASTER) ench_power = grng->Random(7) + 6;
-
-                                    spell_item_to_enchant->m_enchantmentStrength = ench_power;
-                                    spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
-                                    _50C9A8_item_enchantment_timer = 256;
-                                    spell_failed = false;
-                                } else { // weapons or we won the lottery for special enchantment
-                                    int ench_found = 0;
-                                    int to_item_apply_sum = 0;
-                                    int ench_array[100] = { 0 };
-
-                                    // finds how many possible enchaments and adds up to item apply values
-                                    if (pItemTable->pSpecialEnchantments_count > 0) {
-                                        for (ITEM_ENCHANTMENT spec_ench_loop : pItemTable->pSpecialEnchantments.indices()) {
-                                            char *this_bon_state = pItemTable->pSpecialEnchantments[spec_ench_loop].pBonusStatement;
-                                            if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
-                                                if (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel == 3) continue;
-                                                if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER && (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel != 0))
-                                                    continue;
-                                                int this_to_apply = pItemTable->pSpecialEnchantments[spec_ench_loop].to_item_apply[this_equip_type];
-                                                to_item_apply_sum += this_to_apply;
-                                                if (this_to_apply) {
-                                                    ench_array[ench_found] = spec_ench_loop;
-                                                    ench_found++;
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    // pick a random ench
-                                    int item_apply_rand = grng->Random(to_item_apply_sum);
-                                    int target_item_apply_rand = item_apply_rand + 1;
-                                    int current_item_apply_sum = 0;
-                                    int step = 0;
-
-                                    // step through until we hit that ench
-                                    for (step = 0; step < ench_found; step++) {
-                                        current_item_apply_sum += pItemTable->pSpecialEnchantments[(ITEM_ENCHANTMENT)ench_array[step]].to_item_apply[this_equip_type];
-                                        if (current_item_apply_sum >= target_item_apply_rand) {
-                                            break;
-                                        }
-                                    }
-
-                                    // set item ench
-                                    spell_item_to_enchant->special_enchantment = (ITEM_ENCHANTMENT)ench_array[step];
-                                    spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
-                                    _50C9A8_item_enchantment_timer = 256;
-                                    spell_failed = false;
-                                }
-                            }
-                        }
-                    }
-
-                    if (spell_failed) {
-                        SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-                    break;
-                }
-
-                case SPELL_EARTH_STONE_TO_FLESH:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Petrified)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Petrified);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        if (pParty->pPlayers[i]
                                 .DiscardConditionIfLastsLongerThan(
-                                        Condition_Petrified,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
+                                    Condition_Sleep,
+                                    GameTime(pParty->GetPlayingTime() - GameTime::FromSeconds(amount))))
+                            pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
                     }
-                    break;
                 }
+                break;
+            }
 
-                case SPELL_EARTH_ROCK_BLAST:
-                {
+            case SPELL_WATER_POISON_SPRAY:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 1;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 7;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (amount == 1) {
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
                     pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = pParty->sRotationZ;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
                     if (pParty->bTurnBasedModeOn) {
                         pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
                     }
                     spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    break;
-                }
-
-                case SPELL_EARTH_DEATH_BLOSSOM:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    pSpellSprite.uType = SPRITE_SPELL_EARTH_DEATH_BLOSSOM;
+                } else {
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pParty->vPosition.x;
-                    pSpellSprite.vPosition.y = pParty->vPosition.y;
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.vPosition.z = pParty->vPosition.z + (signed int)pParty->uPartyHeight / 3;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.uFacing = (short)pParty->sRotationZ;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(pParty->sRotationZ, TrigLUT.uIntegerHalfPi / 2, spell_speed, 0) != -1 && pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_DETECT_LIFE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 1800 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 3600 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(amount)),
-                            spell_mastery, 0, 0, 0);
-                    break;
-                }
-
-                case SPELL_SPIRIT_FATE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 2 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 4 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 6 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    // LODWORD(spellduration) = 300;
-                    if (pCastSpell->spell_target_pid == 0) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .pPlayerBuffs[PLAYER_BUFF_FATE]
-                            .Apply(
-                                    GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
-                                    spell_mastery, amount, 0, 0);
-                    } else if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
-                        monster_id = PID_ID(pCastSpell->spell_target_pid);
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE].Apply(
-                                GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
-                                spell_mastery, amount, 0, 0);
-                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                        spell_fx_renderer
-                            ->_4A7E89_sparkles_on_actor_after_it_casts_buff(
-                                    &pActors[monster_id], 0);
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_REMOVE_CURSE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Cursed,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                            spell_fx_renderer->SetPlayerBuffAnim(
-                                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_PRESERVATION:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spellduration = 900 * (spell_level + 4);
-                    } else {
-                        spellduration = 300 * (spell_level + 12);
-                    }
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                        GameTime::FromSeconds(spellduration)),
-                                    spell_mastery, 0, 0, 0);
-                    } else {
-                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                            spell_fx_renderer->SetPlayerBuffAnim(
-                                    pCastSpell->uSpellID, pl_id);
-                            pParty->pPlayers[pl_id]
-                                .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                            GameTime::FromSeconds(spellduration)),
-                                        spell_mastery, 0, 0, 0);
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_TURN_UNDEAD:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                        spellduration = 60 * (spell_level + 3);
-                    } else {
-                        spellduration = 300 * spell_level + 180;
-                    }
-                    int mon_num = render->GetActorsInViewport(4096);
-                    spell_fx_renderer
-                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.White.C32(),
-                                192);
-                    // ++pSpellSprite.uType;
-                    pSpellSprite.uType = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                            ++spell_targeted_at) {
-                        if (MonsterStats::BelongsToSupertype(
-                                    pActors[_50BF30_actors_in_viewport_ids
-                                    [spell_targeted_at]]
-                                    .pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD)) {
-                            pSpellSprite.vPosition.x =
-                                pActors[_50BF30_actors_in_viewport_ids
-                                [spell_targeted_at]]
-                                .vPosition.x;
-                            pSpellSprite.vPosition.y =
-                                pActors[_50BF30_actors_in_viewport_ids
-                                [spell_targeted_at]]
-                                .vPosition.y;
-                            pSpellSprite.vPosition.z =
-                                pActors[_50BF30_actors_in_viewport_ids
-                                [spell_targeted_at]]
-                                .vPosition.z -
-                                    pActors[_50BF30_actors_in_viewport_ids
-                                    [spell_targeted_at]]
-                                    .uActorHeight *
-                                        -0.8;
-                            pSpellSprite.spell_target_pid = PID(
-                                    OBJECT_Actor,
-                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                            pSpellSprite.Create(0, 0, 0, 0);
-                            pActors
-                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .pActorBuffs[ACTOR_BUFF_AFRAID]
-                                    .Apply(GameTime(pParty->GetPlayingTime() +
-                                                GameTime::FromSeconds(spellduration)),
-                                            spell_mastery, 0, 0, 0);
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_RAISE_DEAD:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 0;
-                    } else {
-                        amount = 86400 * spell_level;
-                    }
-                    pOtherOverlayList->_4418B1(5080, pCastSpell->uPlayerID_2 + 100, 0, 65536);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Dead, GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Unconscious,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                                Condition_Weak, 0);
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_SHARED_LIFE:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 4 * spell_level;
-                    } else {
-                        amount = 3 * spell_level;
-                    }
-                    int active_pl_num = 0;
-                    signed int shared_life_count = amount;
-                    int mean_life = 0;
-                    int pl_array[4] {};
-                    for (uint pl_id = 1; pl_id <= 4; pl_id++) {
-                        if (!pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Eradicated))
-                            pl_array[active_pl_num++] = pl_id;
-                    }
-                    for (uint i = 0; i < active_pl_num; i++)
-                        shared_life_count += pPlayers[pl_array[i]]->sHealth;
-                    mean_life = (int64_t)((double)shared_life_count /
-                            (double)active_pl_num);
-                    for (uint i = 0; i < active_pl_num; i++) {
-                        pPlayers[pl_array[i]]->sHealth = mean_life;
-                        if (pPlayers[pl_array[i]]->sHealth >
-                                pPlayers[pl_array[i]]->GetMaxHealth())
-                            pPlayers[pl_array[i]]->sHealth =
-                                pPlayers[pl_array[i]]->GetMaxHealth();
-                        if (pPlayers[pl_array[i]]->sHealth > 0)
-                            pPlayers[pl_array[i]]->SetUnconcious(GameTime(0));
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pl_array[i] - 1);
-                    }
-                    break;
-                }
-
-                case SPELL_SPIRIT_RESSURECTION:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 180 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 10800 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 259200 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Eradicated) ||
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Eradicated);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Eradicated,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Dead,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Unconscious,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                                Condition_Weak, 1);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_CURE_PARALYSIS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_REMOVE_FEAR:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 180 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Fear, GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                    }
-
-                    break;
-                }
-
-                case SPELL_MIND_TELEPATHY:
-                {
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        monster_id = PID_ID(spell_targeted_at);
-                        if (!pActors[monster_id].ActorHasItem())
-                            pActors[monster_id].SetRandomGoldIfTheresNoItem();
-                        int gold_num = 0;
-                        if (pActors[monster_id].ActorHasItems[3].uItemID != ITEM_NULL) {
-                            if (pItemTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
-                                gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
-                        }
-                        ItemGen item;
-                        item.Reset();
-                        if (pActors[monster_id].uCarriedItemID != ITEM_NULL) {
-                            item.uItemID = pActors[monster_id].uCarriedItemID;
-                        } else {
-                            for (uint i = 0; i < 4; ++i) {
-                                if (pActors[monster_id].ActorHasItems[i].uItemID != ITEM_NULL &&
-                                        pItemTable
-                                        ->pItems[pActors[monster_id]
-                                        .ActorHasItems[i]
-                                        .uItemID]
-                                        .uEquipType != EQUIP_GOLD) {
-                                    memcpy(&item,
-                                            &pActors[monster_id].ActorHasItems[i],
-                                            sizeof(item));
-                                    spell_level = spell_level;
-                                }
-                            }
-                        }
-                        if (gold_num > 0) {
-                            if (item.uItemID != ITEM_NULL)
-                                GameUI_SetStatusBar(StringPrintf(
-                                            "(%s), and %d gold",
-                                            item.GetDisplayName().c_str(), gold_num));
-                            else
-                                GameUI_SetStatusBar(StringPrintf(
-                                            "%d gold", gold_num));
-                        } else {
-                            if (item.uItemID != ITEM_NULL) {
-                                GameUI_SetStatusBar(StringPrintf(
-                                            "(%s)", item.GetDisplayName().c_str()));
-                            } else {
-                                GameUI_SetStatusBar("nothing");
-                            }
-                        }
-
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].uActorHeight;
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod =
-                            target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_BERSERK:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 300 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 300 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 3600;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        // v730 = 836 * monster_id;
-                        if (pActors[monster_id].DoesDmgTypeDoDamage(
-                                    DMGT_MIND)) {
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_CHARM]
-                                .Reset();
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_ENSLAVED]
-                                .Reset();
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_BERSERK]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                            GameTime::FromSeconds(amount)),
-                                        spell_mastery, 0, 0, 0);
-                            pActors[monster_id].pMonsterInfo.uHostilityType =
-                                MonsterInfo::Hostility_Long;
-                        }
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z +
-                            pActors[monster_id].uActorHeight;
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod =
-                            target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_ENSLAVE:
-                {
-                    amount = 600 * spell_level;
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        monster_id = PID_ID(spell_targeted_at);
-                        // v730 = 836 * monster_id;
-                        if (MonsterStats::BelongsToSupertype(
-                                    pActors[monster_id].pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD)) {
-                            break;
-                        }
-                        if (pActors[monster_id].DoesDmgTypeDoDamage(
-                                    DMGT_MIND)) {
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_BERSERK]
-                                .Reset();
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_CHARM]
-                                .Reset();
-                            pActors[monster_id]
-                                .pActorBuffs[ACTOR_BUFF_ENSLAVED]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                            GameTime::FromSeconds(amount)),
-                                        spell_mastery, 0, 0, 0);
-                        }
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod =
-                            target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_MASS_FEAR:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 300 * spell_level;
-                    } else {
-                        amount = 180 * spell_level;
-                    }
-                    int mon_num = render->GetActorsInViewport(4096);
-                    spell_fx_renderer
-                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Night.C32(),
-                                192);
-                    // ++pSpellSprite.uType;
-                    pSpellSprite.uType = SPRITE_SPELL_MIND_MASS_FEAR_1;
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                            ++spell_targeted_at) {
-                        if (MonsterStats::BelongsToSupertype(
-                                    pActors[_50BF30_actors_in_viewport_ids
-                                    [spell_targeted_at]]
-                                    .pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD)) {
-                            break;
-                        }
-                        pSpellSprite.vPosition.x =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.z -
-                                (unsigned int)(int64_t)((double)pActors
-                                        [_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                        .uActorHeight *
-                                        -0.8);
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor,
-                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                        pSpellSprite.Create(0, 0, 0, 0);
-                        if (pActors
-                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .DoesDmgTypeDoDamage(DMGT_MIND)) {
-                            pActors
-                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .pActorBuffs[ACTOR_BUFF_AFRAID]
-                                    .Apply(GameTime(pParty->GetPlayingTime() +
-                                                GameTime::FromSeconds(amount)),
-                                            spell_mastery, 0, 0, 0);
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_MIND_CURE_INSANITY:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 0;
-                    } else {
-                        amount = 86400 * spell_level;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Insane)) {
-                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Insane);
-                        else
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Insane,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                                Condition_Weak, 0);
-                    }
-                    break;
-                }
-
-                case SPELL_EARTH_TELEKINESIS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 2 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 2 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 3 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 4 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    int obj_id = PID_ID(spell_targeted_at);
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Item) {
-                        if (pItemTable
-                                ->pItems[pSpriteObjects[obj_id]
-                                .containing_item.uItemID]
-                                .uEquipType == EQUIP_GOLD) {
-                            pParty->PartyFindsGold(
-                                    pSpriteObjects[obj_id]
-                                    .containing_item.special_enchantment,
-                                    0);
-                            viewparams->bRedrawGameUI = true;
-                        } else {
-                            GameUI_SetStatusBar(
-                                    LSTR_FMT_YOU_FOUND_ITEM,
-                                    pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName
-                                    );
-                            if (!pParty->AddItemToParty(
-                                        &pSpriteObjects[obj_id].containing_item))
-                                pParty->SetHoldingItem(
-                                        &pSpriteObjects[obj_id].containing_item);
-                        }
-                        SpriteObject::OnInteraction(obj_id);
-                    }
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor)
-                        pActors[obj_id].LootActor();
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Decoration) {
-                        OpenedTelekinesis = true;
-                        if (pLevelDecorations[obj_id].uEventID)
-                            EventProcessor(pLevelDecorations[obj_id].uEventID,
-                                    spell_targeted_at, 1);
-                        if (pLevelDecorations[std::to_underlying(pSpriteObjects[obj_id]
-                                    .containing_item.uItemID)] // TODO(captainurist): investigate, that's a very weird std::to_underlying call.
-                                .IsInteractive()) {
-                            activeLevelDecoration = &pLevelDecorations[obj_id];
-                            EventProcessor(
-                                    stru_5E4C90_MapPersistVars._decor_events
-                                    [pLevelDecorations[obj_id]._idx_in_stru123 -
-                                    75] +
-                                    380,
-                                    0, 1);
-                            activeLevelDecoration = nullptr;
-                        }
-                    }
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Face) {
-                        int event;
-                        OpenedTelekinesis = true;
-                        if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                            event = pIndoor->pFaceExtras[pIndoor->pFaces[obj_id].uFaceExtraID].uEventID;
-                        } else {
-                            event = pOutdoor->pBModels[spell_targeted_at >> 9].pFaces[obj_id & 0x3F].sCogTriggeredID;
-                        }
-                        EventProcessor(event, spell_targeted_at, 1);
-                    }
-                    break;
-                }
-
-                case SPELL_BODY_CURE_WEAKNESS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 60 * 3 * spell_level; // skill points * (3 minutes)
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 60 * 60 * spell_level; // skill points * (1 hour)
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 60 * 60 * 24 * spell_level; // skill points * (1 day)
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Weak);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Weak, GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_BODY_FIRST_AID:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 2 * spell_level + 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3 * spell_level + 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 4 * spell_level + 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 5 * spell_level + 5;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (!pCastSpell->spell_target_pid) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].Heal(amount);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    }
-                    if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
-                        monster_id = PID_ID(pCastSpell->spell_target_pid);
-                        if (pActors[monster_id].uAIState != Dead &&
-                                pActors[monster_id].uAIState != Dying &&
-                                pActors[monster_id].uAIState != Disabled &&
-                                pActors[monster_id].uAIState != Removed) {
-                            pActors[monster_id].sCurrentHP += amount;
-                            if (pActors[monster_id].sCurrentHP >
-                                    pActors[monster_id].pMonsterInfo.uHP)
-                                pActors[monster_id].sCurrentHP =
-                                    pActors[monster_id].pMonsterInfo.uHP;
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_BODY_CURE_POISON:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3600 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 86400 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 0;
-                            break;
-                        default:
-                            assert(false);
-                    }
-
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Weak) ||
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Medium) ||
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Severe)) {
-                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Weak);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Medium);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Severe);
-                        } else {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Poison_Weak,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Poison_Medium,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                            pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                .DiscardConditionIfLastsLongerThan(
-                                        Condition_Poison_Severe,
-                                        GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-                        }
-                    }
-                    break;
-                }
-
-                case SPELL_BODY_PROTECTION_FROM_MAGIC:
-                {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_PROTECTION_FROM_MAGIC].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(3600 * spell_level)),
-                            spell_mastery, spell_level, 0, 0);
-                    break;
-                }
-
-                case SPELL_BODY_HAMMERHANDS:
-                {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                            pParty->pPlayers[pl_id]
-                                .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
-                                .Apply(
-                                        GameTime(pParty->GetPlayingTime() +
-                                            GameTime::FromSeconds(3600 * spell_level)),
-                                        spell_mastery, spell_level, spell_level, 0);
-                        }
-                    } else {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                    GameTime::FromSeconds(3600 * spell_level)),
-                                spell_mastery, spell_level, spell_level, 0);
-                    }
-                    break;
-                }
-
-                case SPELL_BODY_POWER_CURE:
-                {
-                    for (uint pl_id = 0; pl_id < 4; ++pl_id) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pl_id);
-                        pParty->pPlayers[pl_id].Heal(5 * spell_level + 10);
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_DISPEL_MAGIC:
-                {
-                    sRecoveryTime -= spell_level;
-                    spell_fx_renderer
-                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.VibrantGreen.C32(),
-                                192);
-                    int mon_num = render->GetActorsInViewport(4096);
-                    // ++pSpellSprite.uType;
-                    pSpellSprite.uType = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                            ++spell_targeted_at) {
-                        pSpellSprite.vPosition.x =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.z -
-                                (int)((double)pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                        .uActorHeight *
-                                        -0.8);
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor,
-                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                        Actor::DamageMonsterFromParty(
-                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                                _50BF30_actors_in_viewport_ids[spell_targeted_at],
-                                &spell_velocity);
-                    }
-                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                            ++spell_targeted_at) {
-                        pSpellSprite.vPosition.x =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                            .vPosition.z -
-                                (unsigned int)(int64_t)((double)pActors
-                                        [_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                        .uActorHeight *
-                                        -0.8);
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor,
-                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                        pSpellSprite.Create(0, 0, 0, 0);
-                        for (SpellBuff &buff : pActors[_50BF30_actors_in_viewport_ids[spell_targeted_at]].pActorBuffs)
-                            buff.Reset();
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_SUMMON_ELEMENTAL:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 300 * spell_level;
-                            amount = 1;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 300 * spell_level;
-                            amount = 1;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 900 * spell_level;
-                            amount = 3;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 900 * spell_level;
-                            amount = 5;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    int mon_num = 0;
-                    for (uint monster_id = 0; monster_id < pActors.size(); monster_id++) {
-                        if (pActors[monster_id].uAIState != Dead &&
-                                pActors[monster_id].uAIState != Removed &&
-                                pActors[monster_id].uAIState != Disabled &&
-                                PID(OBJECT_Player, pCastSpell->uPlayerID) == pActors[monster_id].uSummonerID)
-                            ++mon_num;
-                    }
-                    if (mon_num >= amount) {
-                        SpellFailed(pCastSpell, LSTR_SUMMONS_LIMIT_REACHED);
-                        continue;
-                    }
-                    Spawn_Light_Elemental(pCastSpell->uPlayerID, spell_mastery, spellduration);
-                    break;
-                }
-
-                case SPELL_LIGHT_DAY_OF_THE_GODS:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 10800 * spell_level;
-                            amount = 3 * spell_level + 10;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 10800 * spell_level;
-                            amount = 3 * spell_level + 10;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 14400 * spell_level;
-                            amount = 4 * spell_level + 10;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 18000 * spell_level;
-                            amount = 5 * spell_level + 10;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    break;
-                }
-
-                case SPELL_LIGHT_PRISMATIC_LIGHT:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-                        SpellFailed(pCastSpell, LSTR_CANT_PRISMATIC_OUTDOORS);
-                        continue;
-                    }
-                    int mon_num = render->GetActorsInViewport(4096);
-                    // ++pSpellSprite.uType;
-                    pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    for (uint monster_id = 0; monster_id < mon_num; monster_id++) {
-                        pSpellSprite.vPosition.x =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.z -
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].uActorHeight * -0.8;
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[monster_id]);
-                        Actor::DamageMonsterFromParty(
-                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                                _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
-                    }
-                    spell_fx_renderer->_4A8BFC_prismatic_light();
-                    break;
-                }
-
-                case SPELL_LIGHT_DAY_OF_PROTECTION:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 14400 * spell_level;
-                            amount = 4 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 14400 * spell_level;
-                            amount = 4 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 14400 * spell_level;
-                            amount = 4 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 18000 * spell_level;
-                            amount = 5 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, amount, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, spell_level + 5, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                            spell_mastery, spell_level + 5, 0, 0);
-                    break;
-                }
-
-                case SPELL_LIGHT_HOUR_OF_POWER:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 4;
-                            amount = 4;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 4;
-                            amount = 4;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 12;
-                            amount = 12;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 20;
-                            amount = 15;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    bool player_weak = false;
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                        pParty->pPlayers[pl_id]
-                            .pPlayerBuffs[PLAYER_BUFF_BLESS]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                        GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                                    spell_mastery, spell_level + 5, 0, 0);
-                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
-                            player_weak = true;
-                        }
-                    }
-
-                    pParty->pPartyBuffs[PARTY_BUFF_HEROISM].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                            spell_mastery, spell_level + 5, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_SHIELD].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                            spell_mastery, 0, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_STONE_SKIN].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                            spell_mastery, spell_level + 5, 0, 0);
-                    if (!player_weak) {
-                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(
-                                GameTime(pParty->GetPlayingTime() +
-                                    GameTime::FromSeconds(
-                                        60 * (spell_level * spellduration + 60))),
-                                spell_mastery, spell_level + 5, 0, 0);
-                    }
-                    break;
-                }
-
-                case SPELL_LIGHT_DIVINE_INTERVENTION:
-                {
-                    if (pPlayer->uNumDivineInterventionCastsThisDay >= 3) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        pParty->pPlayers[pl_id].conditions.ResetAll();
-                        pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
-                        pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
-                    }
-                    if (pPlayer->sAgeModifier + 10 >= 120) {
-                        pPlayer->sAgeModifier = 120;
-                    } else {
-                        pPlayer->sAgeModifier = pPlayer->sAgeModifier + 10;
-                    }
-                    sRecoveryTime += -5 * spell_level;
-                    ++pPlayer->uNumDivineInterventionCastsThisDay;
-                    break;
-                }
-
-                case SPELL_DARK_REANIMATE:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 2 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 3 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 4 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 5 * spell_level;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    if (!pCastSpell->spell_target_pid) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(Condition_Zombie, 1);
-                            GameUI_ReloadPlayerPortraits(pCastSpell->uPlayerID_2, (pParty->pPlayers[pCastSpell->uPlayerID_2].GetSexByVoice() != 0) + 23);
-                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
-                            // TODO: why call SetCondition and then conditions.Set?
-                        }
-                        break;
-                    }
-                    monster_id = PID_ID(pCastSpell->spell_target_pid);
-                    if (monster_id == -1) {
-                        SpellFailed(pCastSpell, LSTR_NO_VALID_SPELL_TARGET);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-                    if (pActors[monster_id].sCurrentHP > 0 || pActors[monster_id].uAIState != Dead && pActors[monster_id].uAIState != Dying) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                        continue;
-                    }
-                    // ++pSpellSprite.uType;
-                    pSpellSprite.uType = SPRITE_SPELL_DARK_REANIMATE_1;
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z -
-                        (int)((double)pActors[monster_id].uActorHeight * -0.8);
-                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                    pSpellSprite.Create(0, 0, 0, 0);
-                    if (pActors[monster_id].pMonsterInfo.uLevel > amount) {
-                        break;
-                    }
-                    Actor::Resurrect(monster_id);
-                    pActors[monster_id].pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
-                    pActors[monster_id].pMonsterInfo.uTreasureDropChance = 0;
-                    pActors[monster_id].pMonsterInfo.uTreasureDiceRolls = 0;
-                    pActors[monster_id].pMonsterInfo.uTreasureDiceSides = 0;
-                    pActors[monster_id].pMonsterInfo.uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID;
-                    pActors[monster_id].pMonsterInfo.uTreasureType = 0;
-                    pActors[monster_id].uAlly = 9999;
-                    pActors[monster_id].ResetAggressor();  // ~0x80000
-                    pActors[monster_id].uGroup = 0;
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
-                    if (pActors[monster_id].sCurrentHP > 10 * amount) {
-                        pActors[monster_id].sCurrentHP = 10 * amount;
-                    }
-                    break;
-                }
-
-                case SPELL_DARK_SHARPMETAL:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            amount = 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            amount = 5;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            amount = 7;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            amount = 9;
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    // TODO(pskelton): was pParty->uPartyHeight / 2
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -2949,240 +1362,1827 @@ void CastSpellInfoHelpers::CastSpell() {
                         do {
                             pSpellSprite.uFacing = spell_spray_angle_start +
                                 target_direction.uYawAngle;
-                            if (pSpellSprite.Create(pSpellSprite.uFacing, target_direction.uPitchAngle, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
-                                        pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                            if (pSpellSprite.Create(
+                                        pSpellSprite.uFacing,
+                                        target_direction.uPitchAngle,
+                                        pObjectList
+                                        ->pObjects[pSpellSprite.uObjectDescID]
+                                        .uSpeed,
+                                        pCastSpell->uPlayerID + 1) != -1 &&
+                                    pParty->bTurnBasedModeOn) {
                                 ++pTurnEngine->pending_actions;
                             }
                             spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                        } while (spell_spray_angle_start <= spell_spray_angle_end);
+                        } while (spell_spray_angle_start <=
+                                spell_spray_angle_end);
                     }
-                    break;
+                }
+                break;
+            }
+
+            case SPELL_WATER_WATER_WALK:
+            {
+                if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana()) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:  // break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 3600 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, spell_overlay_id,
+                        pCastSpell->uPlayerID + 1);
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
+                }
+                break;
+            }
+
+            case SPELL_WATER_RECHARGE_ITEM:
+            {
+                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                if (item->GetItemEquipType() != EQUIP_WAND || item->IsBroken()) {
+                    _50C9D0_AfterEnchClickEventId = 113;
+                    _50C9D4_AfterEnchClickEventSecondParam = 0;
+                    _50C9D8_AfterEnchClickEventTimeout = 1;
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
                 }
 
-                case SPELL_DARK_CONTROL_UNDEAD:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 180 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 180 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 300 * spell_level;
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 29030400;
-                            break;
-                        default:
-                            assert(false);
+                double spell_recharge_factor;
+                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.5;  // 50 %
+                } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
+                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.69999999;  // 30 %
+                } else if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.80000001;  // 20 %
+                } else {
+                    spell_recharge_factor = 0.0;
+                }
+
+                if (spell_recharge_factor > 1.0) {
+                    spell_recharge_factor = 1.0;
+                }
+
+                int uNewCharges = item->uMaxCharges * spell_recharge_factor;
+                item->uMaxCharges = uNewCharges;
+                item->uNumCharges = uNewCharges;
+                if (uNewCharges <= 0) {
+                    _50C9D0_AfterEnchClickEventId = 113;
+                    _50C9D4_AfterEnchClickEventSecondParam = 0;
+                    _50C9D8_AfterEnchClickEventTimeout = 1;
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+
+                item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
+                _50C9A8_item_enchantment_timer = 256;
+                break;
+            }
+
+            case SPELL_WATER_ENCHANT_ITEM:
+            {
+                uRequiredMana = 0;
+                amount = 10 * spell_level;
+                bool item_not_broken = true;
+                bool spell_failed = true;
+                int rnd = grng->Random(100);
+                pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
+                ItemGen *spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
+                ITEM_EQUIP_TYPE this_equip_type = pItemTable->pItems[spell_item_to_enchant->uItemID].uEquipType;
+
+                // refs
+                // https://www.gog.com/forum/might_and_magic_series/a_little_enchant_item_testing_in_mm7
+                // http://www.pottsland.com/mm6/enchant.shtml
+                // also see STDITEMS.tx and SPCITEMS.txt in Events.lod
+
+                if ((spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT)) {
+                    __debugbreak(); // SPELL_WATER_ENCHANT_ITEM is a master level spell
+                }
+
+                if ((spell_mastery == PLAYER_SKILL_MASTERY_MASTER || spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) &&
+                        IsRegular(spell_item_to_enchant->uItemID) &&
+                        spell_item_to_enchant->special_enchantment == ITEM_ENCHANTMENT_NULL &&
+                        spell_item_to_enchant->uEnchantmentType == 0 &&
+                        spell_item_to_enchant->m_enchantmentStrength == 0 &&
+                        !spell_item_to_enchant->IsBroken()) {
+                    // break items with low value
+                    if ((spell_item_to_enchant->GetValue() < 450 && !IsWeapon(this_equip_type)) ||  // not weapons
+                            (spell_item_to_enchant->GetValue() < 250 && IsWeapon(this_equip_type))) {  // weapons
+                        if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
+                            spell_item_to_enchant->SetBroken();
+                        }
+                        item_not_broken = false;
+                    } else {
+                        // random item break
+                        if (rnd >= 10 * spell_level) {  // 10% chance of success per spell level
+                            if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
+                                spell_item_to_enchant->SetBroken();
+                            }
+                        } else {
+                            // Weapons are limited to special enchantments, but all other types can have either
+                            if (rnd < 80 && IsPassiveEquipment(this_equip_type)) { // chance to roll standard enchantment on non-weapons
+                                int ench_found = 0;
+                                int to_item_apply_sum = 0;
+                                int ench_array[100] = { 0 };
+
+                                // finds how many possible enchaments and adds up to item apply values
+                                // if (pItemTable->pEnchantments_count > 0) {
+                                for (int norm_ench_loop = 0; norm_ench_loop < 24; ++norm_ench_loop) {
+                                    char* this_bon_state = pItemTable->pEnchantments[norm_ench_loop].pBonusStat;
+                                    if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
+                                        int this_to_apply = pItemTable->pEnchantments[norm_ench_loop].to_item[this_equip_type];
+                                        to_item_apply_sum += this_to_apply;
+                                        if (this_to_apply) {
+                                            ench_array[ench_found] = norm_ench_loop;
+                                            ench_found++;
+                                        }
+                                    }
+                                }
+                                // }
+
+                                // pick a random ench
+                                int item_apply_rand = grng->Random(to_item_apply_sum);
+                                int target_item_apply_rand = item_apply_rand + 1;
+                                int current_item_apply_sum = 0;
+                                int step = 0;
+
+                                // step through until we hit that ench
+                                for (step = 0; step < ench_found; step++) {
+                                    current_item_apply_sum += pItemTable->pEnchantments[ench_array[step]].to_item[this_equip_type];
+                                    if (current_item_apply_sum >= target_item_apply_rand) {
+                                        break;
+                                    }
+                                }
+
+                                // assign ench and power
+                                spell_item_to_enchant->uEnchantmentType = (ITEM_ENCHANTMENT)ench_array[step];
+
+                                int ench_power = 0;
+                                // master 3-8  - guess work needs checking
+                                if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) ench_power = grng->Random(6) + 3;
+                                // gm 6-12   - guess work needs checking
+                                if (spell_mastery== PLAYER_SKILL_MASTERY_GRANDMASTER) ench_power = grng->Random(7) + 6;
+
+                                spell_item_to_enchant->m_enchantmentStrength = ench_power;
+                                spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
+                                _50C9A8_item_enchantment_timer = 256;
+                                spell_failed = false;
+                            } else { // weapons or we won the lottery for special enchantment
+                                int ench_found = 0;
+                                int to_item_apply_sum = 0;
+                                int ench_array[100] = { 0 };
+
+                                // finds how many possible enchaments and adds up to item apply values
+                                if (pItemTable->pSpecialEnchantments_count > 0) {
+                                    for (ITEM_ENCHANTMENT spec_ench_loop : pItemTable->pSpecialEnchantments.indices()) {
+                                        char *this_bon_state = pItemTable->pSpecialEnchantments[spec_ench_loop].pBonusStatement;
+                                        if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
+                                            if (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel == 3) continue;
+                                            if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER && (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel != 0))
+                                                continue;
+                                            int this_to_apply = pItemTable->pSpecialEnchantments[spec_ench_loop].to_item_apply[this_equip_type];
+                                            to_item_apply_sum += this_to_apply;
+                                            if (this_to_apply) {
+                                                ench_array[ench_found] = spec_ench_loop;
+                                                ench_found++;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // pick a random ench
+                                int item_apply_rand = grng->Random(to_item_apply_sum);
+                                int target_item_apply_rand = item_apply_rand + 1;
+                                int current_item_apply_sum = 0;
+                                int step = 0;
+
+                                // step through until we hit that ench
+                                for (step = 0; step < ench_found; step++) {
+                                    current_item_apply_sum += pItemTable->pSpecialEnchantments[(ITEM_ENCHANTMENT)ench_array[step]].to_item_apply[this_equip_type];
+                                    if (current_item_apply_sum >= target_item_apply_rand) {
+                                        break;
+                                    }
+                                }
+
+                                // set item ench
+                                spell_item_to_enchant->special_enchantment = (ITEM_ENCHANTMENT)ench_array[step];
+                                spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
+                                _50C9A8_item_enchantment_timer = 256;
+                                spell_failed = false;
+                            }
+                        }
                     }
-                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                        monster_id = PID_ID(spell_targeted_at);
-                        if (!MonsterStats::BelongsToSupertype(
-                                    pActors[monster_id].pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD)) {
-                            break;
-                        }
-                        if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
-                            SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                            pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
-                            continue;
-                        }
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
-                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Apply(
-                                GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                }
+
+                if (spell_failed) {
+                    SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                break;
+            }
+
+            case SPELL_EARTH_STONE_TO_FLESH:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Petrified)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Petrified);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Petrified,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                }
+                break;
+            }
+
+            case SPELL_EARTH_ROCK_BLAST:
+            {
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                pSpellSprite.uFacing = pParty->sRotationZ;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_EARTH_DEATH_BLOSSOM:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                pSpellSprite.uType = SPRITE_SPELL_EARTH_DEATH_BLOSSOM;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.vPosition.x = pParty->vPosition.x;
+                pSpellSprite.vPosition.y = pParty->vPosition.y;
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.vPosition.z = pParty->vPosition.z + (signed int)pParty->uPartyHeight / 3;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.uFacing = (short)pParty->sRotationZ;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                if (pSpellSprite.Create(pParty->sRotationZ, TrigLUT.uIntegerHalfPi / 2, spell_speed, 0) != -1 && pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_DETECT_LIFE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 1800 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 3600 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(amount)),
+                        spell_mastery, 0, 0, 0);
+                break;
+            }
+
+            case SPELL_SPIRIT_FATE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 2 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 4 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 6 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                // LODWORD(spellduration) = 300;
+                if (pCastSpell->spell_target_pid == 0) {
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .pPlayerBuffs[PLAYER_BUFF_FATE]
+                        .Apply(
+                                GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
+                                spell_mastery, amount, 0, 0);
+                } else if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
+                    monster_id = PID_ID(pCastSpell->spell_target_pid);
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
+                            spell_mastery, amount, 0, 0);
+                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                    spell_fx_renderer
+                        ->_4A7E89_sparkles_on_actor_after_it_casts_buff(
+                                &pActors[monster_id], 0);
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_REMOVE_CURSE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Cursed,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    }
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_PRESERVATION:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spellduration = 900 * (spell_level + 4);
+                } else {
+                    spellduration = 300 * (spell_level + 12);
+                }
+                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
+                        .Apply(GameTime(pParty->GetPlayingTime() +
+                                    GameTime::FromSeconds(spellduration)),
                                 spell_mastery, 0, 0, 0);
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod =
-                            target_direction.uDistance;
-                        pSpellSprite.uFacing = target_direction.uYawAngle;
-                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                } else {
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_id);
+                        pParty->pPlayers[pl_id]
+                            .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, 0, 0, 0);
+                    }
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_TURN_UNDEAD:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                    spellduration = 60 * (spell_level + 3);
+                } else {
+                    spellduration = 300 * spell_level + 180;
+                }
+                int mon_num = render->GetActorsInViewport(4096);
+                spell_fx_renderer
+                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.White.C32(),
+                            192);
+                // ++pSpellSprite.uType;
+                pSpellSprite.uType = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                        ++spell_targeted_at) {
+                    if (MonsterStats::BelongsToSupertype(
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .pMonsterInfo.uID,
+                                MONSTER_SUPERTYPE_UNDEAD)) {
+                        pSpellSprite.vPosition.x =
+                            pActors[_50BF30_actors_in_viewport_ids
+                            [spell_targeted_at]]
+                            .vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors[_50BF30_actors_in_viewport_ids
+                            [spell_targeted_at]]
+                            .vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors[_50BF30_actors_in_viewport_ids
+                            [spell_targeted_at]]
+                            .vPosition.z -
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .uActorHeight *
+                                    -0.8;
+                        pSpellSprite.spell_target_pid = PID(
+                                OBJECT_Actor,
+                                _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                        pSpellSprite.Create(0, 0, 0, 0);
+                        pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .pActorBuffs[ACTOR_BUFF_AFRAID]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(spellduration)),
+                                        spell_mastery, 0, 0, 0);
+                    }
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_RAISE_DEAD:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 0;
+                } else {
+                    amount = 86400 * spell_level;
+                }
+                pOtherOverlayList->_4418B1(5080, pCastSpell->uPlayerID_2 + 100, 0, 65536);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Dead, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Unconscious,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                            Condition_Weak, 0);
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_SHARED_LIFE:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 4 * spell_level;
+                } else {
+                    amount = 3 * spell_level;
+                }
+                int active_pl_num = 0;
+                signed int shared_life_count = amount;
+                int mean_life = 0;
+                int pl_array[4] {};
+                for (uint pl_id = 1; pl_id <= 4; pl_id++) {
+                    if (!pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Eradicated))
+                        pl_array[active_pl_num++] = pl_id;
+                }
+                for (uint i = 0; i < active_pl_num; i++)
+                    shared_life_count += pPlayers[pl_array[i]]->sHealth;
+                mean_life = (int64_t)((double)shared_life_count /
+                        (double)active_pl_num);
+                for (uint i = 0; i < active_pl_num; i++) {
+                    pPlayers[pl_array[i]]->sHealth = mean_life;
+                    if (pPlayers[pl_array[i]]->sHealth >
+                            pPlayers[pl_array[i]]->GetMaxHealth())
+                        pPlayers[pl_array[i]]->sHealth =
+                            pPlayers[pl_array[i]]->GetMaxHealth();
+                    if (pPlayers[pl_array[i]]->sHealth > 0)
+                        pPlayers[pl_array[i]]->SetUnconcious(GameTime(0));
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pl_array[i] - 1);
+                }
+                break;
+            }
+
+            case SPELL_SPIRIT_RESSURECTION:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 180 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 10800 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 259200 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Eradicated) ||
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Eradicated);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Eradicated,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Dead,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Unconscious,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                            Condition_Weak, 1);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                }
+                break;
+            }
+
+            case SPELL_MIND_CURE_PARALYSIS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                }
+                break;
+            }
+
+            case SPELL_MIND_REMOVE_FEAR:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 180 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Fear, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                }
+
+                break;
+            }
+
+            case SPELL_MIND_TELEPATHY:
+            {
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (!pActors[monster_id].ActorHasItem())
+                        pActors[monster_id].SetRandomGoldIfTheresNoItem();
+                    int gold_num = 0;
+                    if (pActors[monster_id].ActorHasItems[3].uItemID != ITEM_NULL) {
+                        if (pItemTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
+                            gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
+                    }
+                    ItemGen item;
+                    item.Reset();
+                    if (pActors[monster_id].uCarriedItemID != ITEM_NULL) {
+                        item.uItemID = pActors[monster_id].uCarriedItemID;
+                    } else {
+                        for (uint i = 0; i < 4; ++i) {
+                            if (pActors[monster_id].ActorHasItems[i].uItemID != ITEM_NULL &&
+                                    pItemTable
+                                    ->pItems[pActors[monster_id]
+                                    .ActorHasItems[i]
+                                    .uItemID]
+                                    .uEquipType != EQUIP_GOLD) {
+                                memcpy(&item,
+                                        &pActors[monster_id].ActorHasItems[i],
+                                        sizeof(item));
+                                spell_level = spell_level;
+                            }
+                        }
+                    }
+                    if (gold_num > 0) {
+                        if (item.uItemID != ITEM_NULL)
+                            GameUI_SetStatusBar(StringPrintf(
+                                        "(%s), and %d gold",
+                                        item.GetDisplayName().c_str(), gold_num));
+                        else
+                            GameUI_SetStatusBar(StringPrintf(
+                                        "%d gold", gold_num));
+                    } else {
+                        if (item.uItemID != ITEM_NULL) {
+                            GameUI_SetStatusBar(StringPrintf(
+                                        "(%s)", item.GetDisplayName().c_str()));
+                        } else {
+                            GameUI_SetStatusBar("nothing");
+                        }
+                    }
+
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].uActorHeight;
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod =
+                        target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                }
+                break;
+            }
+
+            case SPELL_MIND_BERSERK:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 300 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 300 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 3600;
+                        break;
+                    default:
+                        assert(false);
+                }
+                monster_id = PID_ID(spell_targeted_at);
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                    // v730 = 836 * monster_id;
+                    if (pActors[monster_id].DoesDmgTypeDoDamage(
+                                DMGT_MIND)) {
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_CHARM]
+                            .Reset();
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_ENSLAVED]
+                            .Reset();
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_BERSERK]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(amount)),
+                                    spell_mastery, 0, 0, 0);
+                        pActors[monster_id].pMonsterInfo.uHostilityType =
+                            MonsterInfo::Hostility_Long;
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z +
+                        pActors[monster_id].uActorHeight;
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod =
+                        target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                }
+                break;
+            }
+
+            case SPELL_MIND_ENSLAVE:
+            {
+                amount = 600 * spell_level;
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                    monster_id = PID_ID(spell_targeted_at);
+                    // v730 = 836 * monster_id;
+                    if (MonsterStats::BelongsToSupertype(
+                                pActors[monster_id].pMonsterInfo.uID,
+                                MONSTER_SUPERTYPE_UNDEAD)) {
+                        break;
+                    }
+                    if (pActors[monster_id].DoesDmgTypeDoDamage(
+                                DMGT_MIND)) {
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_BERSERK]
+                            .Reset();
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_CHARM]
+                            .Reset();
+                        pActors[monster_id]
+                            .pActorBuffs[ACTOR_BUFF_ENSLAVED]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(amount)),
+                                    spell_mastery, 0, 0, 0);
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod =
+                        target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                }
+                break;
+            }
+
+            case SPELL_MIND_MASS_FEAR:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 300 * spell_level;
+                } else {
+                    amount = 180 * spell_level;
+                }
+                int mon_num = render->GetActorsInViewport(4096);
+                spell_fx_renderer
+                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Night.C32(),
+                            192);
+                // ++pSpellSprite.uType;
+                pSpellSprite.uType = SPRITE_SPELL_MIND_MASS_FEAR_1;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                        ++spell_targeted_at) {
+                    if (MonsterStats::BelongsToSupertype(
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .pMonsterInfo.uID,
+                                MONSTER_SUPERTYPE_UNDEAD)) {
+                        break;
+                    }
+                    pSpellSprite.vPosition.x =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.x;
+                    pSpellSprite.vPosition.y =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.y;
+                    pSpellSprite.vPosition.z =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.z -
+                            (unsigned int)(int64_t)((double)pActors
+                                    [_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .uActorHeight *
+                                    -0.8);
+                    pSpellSprite.spell_target_pid =
+                        PID(OBJECT_Actor,
+                                _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                    pSpellSprite.Create(0, 0, 0, 0);
+                    if (pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .DoesDmgTypeDoDamage(DMGT_MIND)) {
+                        pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .pActorBuffs[ACTOR_BUFF_AFRAID]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(amount)),
+                                        spell_mastery, 0, 0, 0);
+                    }
+                }
+                break;
+            }
+
+            case SPELL_MIND_CURE_INSANITY:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 0;
+                } else {
+                    amount = 86400 * spell_level;
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Insane)) {
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Insane);
+                    else
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Insane,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                            Condition_Weak, 0);
+                }
+                break;
+            }
+
+            case SPELL_EARTH_TELEKINESIS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 2 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 2 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 3 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 4 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                int obj_id = PID_ID(spell_targeted_at);
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Item) {
+                    if (pItemTable
+                            ->pItems[pSpriteObjects[obj_id]
+                            .containing_item.uItemID]
+                            .uEquipType == EQUIP_GOLD) {
+                        pParty->PartyFindsGold(
+                                pSpriteObjects[obj_id]
+                                .containing_item.special_enchantment,
+                                0);
+                        viewparams->bRedrawGameUI = true;
+                    } else {
+                        GameUI_SetStatusBar(
+                                LSTR_FMT_YOU_FOUND_ITEM,
+                                pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName
+                                );
+                        if (!pParty->AddItemToParty(
+                                    &pSpriteObjects[obj_id].containing_item))
+                            pParty->SetHoldingItem(
+                                    &pSpriteObjects[obj_id].containing_item);
+                    }
+                    SpriteObject::OnInteraction(obj_id);
+                }
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor)
+                    pActors[obj_id].LootActor();
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Decoration) {
+                    OpenedTelekinesis = true;
+                    if (pLevelDecorations[obj_id].uEventID)
+                        EventProcessor(pLevelDecorations[obj_id].uEventID,
+                                spell_targeted_at, 1);
+                    if (pLevelDecorations[std::to_underlying(pSpriteObjects[obj_id]
+                                .containing_item.uItemID)] // TODO(captainurist): investigate, that's a very weird std::to_underlying call.
+                            .IsInteractive()) {
+                        activeLevelDecoration = &pLevelDecorations[obj_id];
+                        EventProcessor(
+                                stru_5E4C90_MapPersistVars._decor_events
+                                [pLevelDecorations[obj_id]._idx_in_stru123 -
+                                75] +
+                                380,
+                                0, 1);
+                        activeLevelDecoration = nullptr;
+                    }
+                }
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Face) {
+                    int event;
+                    OpenedTelekinesis = true;
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        event = pIndoor->pFaceExtras[pIndoor->pFaces[obj_id].uFaceExtraID].uEventID;
+                    } else {
+                        event = pOutdoor->pBModels[spell_targeted_at >> 9].pFaces[obj_id & 0x3F].sCogTriggeredID;
+                    }
+                    EventProcessor(event, spell_targeted_at, 1);
+                }
+                break;
+            }
+
+            case SPELL_BODY_CURE_WEAKNESS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 60 * 3 * spell_level; // skill points * (3 minutes)
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 60 * 60 * spell_level; // skill points * (1 hour)
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 60 * 60 * 24 * spell_level; // skill points * (1 day)
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Weak);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Weak, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                }
+                break;
+            }
+
+            case SPELL_BODY_FIRST_AID:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 2 * spell_level + 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3 * spell_level + 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 4 * spell_level + 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 5 * spell_level + 5;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (!pCastSpell->spell_target_pid) {
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].Heal(amount);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                }
+                if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
+                    monster_id = PID_ID(pCastSpell->spell_target_pid);
+                    if (pActors[monster_id].uAIState != Dead &&
+                            pActors[monster_id].uAIState != Dying &&
+                            pActors[monster_id].uAIState != Disabled &&
+                            pActors[monster_id].uAIState != Removed) {
+                        pActors[monster_id].sCurrentHP += amount;
+                        if (pActors[monster_id].sCurrentHP >
+                                pActors[monster_id].pMonsterInfo.uHP)
+                            pActors[monster_id].sCurrentHP =
+                                pActors[monster_id].pMonsterInfo.uHP;
+                    }
+                }
+                break;
+            }
+
+            case SPELL_BODY_CURE_POISON:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3600 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 86400 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 0;
+                        break;
+                    default:
+                        assert(false);
+                }
+
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Weak) ||
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Medium) ||
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Severe)) {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Weak);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Medium);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Severe);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Weak,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Medium,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Severe,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                }
+                break;
+            }
+
+            case SPELL_BODY_PROTECTION_FROM_MAGIC:
+            {
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_PROTECTION_FROM_MAGIC].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(3600 * spell_level)),
+                        spell_mastery, spell_level, 0, 0);
+                break;
+            }
+
+            case SPELL_BODY_HAMMERHANDS:
+            {
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        pParty->pPlayers[pl_id]
+                            .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
+                            .Apply(
+                                    GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(3600 * spell_level)),
+                                    spell_mastery, spell_level, spell_level, 0);
+                    }
+                } else {
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                pParty->pPlayers[pCastSpell->uPlayerID_2]
+                    .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
+                    .Apply(GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(3600 * spell_level)),
+                            spell_mastery, spell_level, spell_level, 0);
+                }
+                break;
+            }
+
+            case SPELL_BODY_POWER_CURE:
+            {
+                for (uint pl_id = 0; pl_id < 4; ++pl_id) {
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pl_id);
+                    pParty->pPlayers[pl_id].Heal(5 * spell_level + 10);
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_DISPEL_MAGIC:
+            {
+                sRecoveryTime -= spell_level;
+                spell_fx_renderer
+                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.VibrantGreen.C32(),
+                            192);
+                int mon_num = render->GetActorsInViewport(4096);
+                // ++pSpellSprite.uType;
+                pSpellSprite.uType = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                        ++spell_targeted_at) {
+                    pSpellSprite.vPosition.x =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.x;
+                    pSpellSprite.vPosition.y =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.y;
+                    pSpellSprite.vPosition.z =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.z -
+                            (int)((double)pActors[_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .uActorHeight *
+                                    -0.8);
+                    pSpellSprite.spell_target_pid =
+                        PID(OBJECT_Actor,
+                                _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                    Actor::DamageMonsterFromParty(
+                            PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                            _50BF30_actors_in_viewport_ids[spell_targeted_at],
+                            &spell_velocity);
+                }
+                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                        ++spell_targeted_at) {
+                    pSpellSprite.vPosition.x =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.x;
+                    pSpellSprite.vPosition.y =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.y;
+                    pSpellSprite.vPosition.z =
+                        pActors
+                        [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                        .vPosition.z -
+                            (unsigned int)(int64_t)((double)pActors
+                                    [_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .uActorHeight *
+                                    -0.8);
+                    pSpellSprite.spell_target_pid =
+                        PID(OBJECT_Actor,
+                                _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                    pSpellSprite.Create(0, 0, 0, 0);
+                    for (SpellBuff &buff : pActors[_50BF30_actors_in_viewport_ids[spell_targeted_at]].pActorBuffs)
+                        buff.Reset();
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_SUMMON_ELEMENTAL:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 300 * spell_level;
+                        amount = 1;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 300 * spell_level;
+                        amount = 1;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 900 * spell_level;
+                        amount = 3;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 900 * spell_level;
+                        amount = 5;
+                        break;
+                    default:
+                        assert(false);
+                }
+                int mon_num = 0;
+                for (uint monster_id = 0; monster_id < pActors.size(); monster_id++) {
+                    if (pActors[monster_id].uAIState != Dead &&
+                            pActors[monster_id].uAIState != Removed &&
+                            pActors[monster_id].uAIState != Disabled &&
+                            PID(OBJECT_Player, pCastSpell->uPlayerID) == pActors[monster_id].uSummonerID)
+                        ++mon_num;
+                }
+                if (mon_num >= amount) {
+                    SpellFailed(pCastSpell, LSTR_SUMMONS_LIMIT_REACHED);
+                    continue;
+                }
+                Spawn_Light_Elemental(pCastSpell->uPlayerID, spell_mastery, spellduration);
+                break;
+            }
+
+            case SPELL_LIGHT_DAY_OF_THE_GODS:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 10800 * spell_level;
+                        amount = 3 * spell_level + 10;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 10800 * spell_level;
+                        amount = 3 * spell_level + 10;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 14400 * spell_level;
+                        amount = 4 * spell_level + 10;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 18000 * spell_level;
+                        amount = 5 * spell_level + 10;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(
+                        pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                break;
+            }
+
+            case SPELL_LIGHT_PRISMATIC_LIGHT:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
+                    SpellFailed(pCastSpell, LSTR_CANT_PRISMATIC_OUTDOORS);
+                    continue;
+                }
+                int mon_num = render->GetActorsInViewport(4096);
+                // ++pSpellSprite.uType;
+                pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                for (uint monster_id = 0; monster_id < mon_num; monster_id++) {
+                    pSpellSprite.vPosition.x =
+                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.x;
+                    pSpellSprite.vPosition.y =
+                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.y;
+                    pSpellSprite.vPosition.z =
+                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.z -
+                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].uActorHeight * -0.8;
+                    pSpellSprite.spell_target_pid =
+                        PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[monster_id]);
+                    Actor::DamageMonsterFromParty(
+                            PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                            _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
+                }
+                spell_fx_renderer->_4A8BFC_prismatic_light();
+                break;
+            }
+
+            case SPELL_LIGHT_DAY_OF_PROTECTION:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 14400 * spell_level;
+                        amount = 4 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 14400 * spell_level;
+                        amount = 4 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 14400 * spell_level;
+                        amount = 4 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 18000 * spell_level;
+                        amount = 5 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, amount, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, spell_level + 5, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
+                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                        spell_mastery, spell_level + 5, 0, 0);
+                break;
+            }
+
+            case SPELL_LIGHT_HOUR_OF_POWER:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 4;
+                        amount = 4;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 4;
+                        amount = 4;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 12;
+                        amount = 12;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 20;
+                        amount = 15;
+                        break;
+                    default:
+                        assert(false);
+                }
+                bool player_weak = false;
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                    pParty->pPlayers[pl_id]
+                        .pPlayerBuffs[PLAYER_BUFF_BLESS]
+                        .Apply(GameTime(pParty->GetPlayingTime() +
+                                    GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                                spell_mastery, spell_level + 5, 0, 0);
+                    if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
+                        player_weak = true;
+                    }
+                }
+
+                pParty->pPartyBuffs[PARTY_BUFF_HEROISM].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                        spell_mastery, spell_level + 5, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_SHIELD].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                        spell_mastery, 0, 0, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_STONE_SKIN].Apply(
+                        GameTime(pParty->GetPlayingTime() +
+                            GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                        spell_mastery, spell_level + 5, 0, 0);
+                if (!player_weak) {
+                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(
+                                    60 * (spell_level * spellduration + 60))),
+                            spell_mastery, spell_level + 5, 0, 0);
+                }
+                break;
+            }
+
+            case SPELL_LIGHT_DIVINE_INTERVENTION:
+            {
+                if (pPlayer->uNumDivineInterventionCastsThisDay >= 3) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    pParty->pPlayers[pl_id].conditions.ResetAll();
+                    pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
+                    pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
+                }
+                if (pPlayer->sAgeModifier + 10 >= 120) {
+                    pPlayer->sAgeModifier = 120;
+                } else {
+                    pPlayer->sAgeModifier = pPlayer->sAgeModifier + 10;
+                }
+                sRecoveryTime += -5 * spell_level;
+                ++pPlayer->uNumDivineInterventionCastsThisDay;
+                break;
+            }
+
+            case SPELL_DARK_REANIMATE:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 2 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 3 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 4 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 5 * spell_level;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (!pCastSpell->spell_target_pid) {
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(Condition_Zombie, 1);
+                        GameUI_ReloadPlayerPortraits(pCastSpell->uPlayerID_2, (pParty->pPlayers[pCastSpell->uPlayerID_2].GetSexByVoice() != 0) + 23);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+                        // TODO: why call SetCondition and then conditions.Set?
                     }
                     break;
                 }
+                monster_id = PID_ID(pCastSpell->spell_target_pid);
+                if (monster_id == -1) {
+                    SpellFailed(pCastSpell, LSTR_NO_VALID_SPELL_TARGET);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                if (pActors[monster_id].sCurrentHP > 0 || pActors[monster_id].uAIState != Dead && pActors[monster_id].uAIState != Dying) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                // ++pSpellSprite.uType;
+                pSpellSprite.uType = SPRITE_SPELL_DARK_REANIMATE_1;
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z -
+                    (int)((double)pActors[monster_id].uActorHeight * -0.8);
+                pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                pSpellSprite.Create(0, 0, 0, 0);
+                if (pActors[monster_id].pMonsterInfo.uLevel > amount) {
+                    break;
+                }
+                Actor::Resurrect(monster_id);
+                pActors[monster_id].pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
+                pActors[monster_id].pMonsterInfo.uTreasureDropChance = 0;
+                pActors[monster_id].pMonsterInfo.uTreasureDiceRolls = 0;
+                pActors[monster_id].pMonsterInfo.uTreasureDiceSides = 0;
+                pActors[monster_id].pMonsterInfo.uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID;
+                pActors[monster_id].pMonsterInfo.uTreasureType = 0;
+                pActors[monster_id].uAlly = 9999;
+                pActors[monster_id].ResetAggressor();  // ~0x80000
+                pActors[monster_id].uGroup = 0;
+                pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
+                pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
+                if (pActors[monster_id].sCurrentHP > 10 * amount) {
+                    pActors[monster_id].sCurrentHP = 10 * amount;
+                }
+                break;
+            }
 
-                case SPELL_DARK_SACRIFICE:
-                {
-                    int hired_npc = 0;
-                    memset(&achieved_awards, 0, 4000);
-                    for (uint npc_id = 0; npc_id < 2; npc_id++) {
-                        if (!pParty->pHirelings[npc_id].pName.empty())
-                            achieved_awards[hired_npc++] = (AwardType)(npc_id + 1);
+            case SPELL_DARK_SHARPMETAL:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        amount = 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        amount = 5;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        amount = 7;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        amount = 9;
+                        break;
+                    default:
+                        assert(false);
+                }
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                // TODO(pskelton): was pParty->uPartyHeight / 2
+                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                pSpellSprite.spell_target_pid = spell_targeted_at;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                }
+                spell_spray_angle_start = ONE_THIRD_PI / -2;
+                spell_spray_angle_end = ONE_THIRD_PI / 2;
+                if (spell_spray_angle_start <= spell_spray_angle_end) {
+                    do {
+                        pSpellSprite.uFacing = spell_spray_angle_start +
+                            target_direction.uYawAngle;
+                        if (pSpellSprite.Create(pSpellSprite.uFacing, target_direction.uPitchAngle, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
+                                    pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                            ++pTurnEngine->pending_actions;
+                        }
+                        spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
+                    } while (spell_spray_angle_start <= spell_spray_angle_end);
+                }
+                break;
+            }
+
+            case SPELL_DARK_CONTROL_UNDEAD:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 180 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 180 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 300 * spell_level;
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 29030400;
+                        break;
+                    default:
+                        assert(false);
+                }
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (!MonsterStats::BelongsToSupertype(
+                                pActors[monster_id].pMonsterInfo.uID,
+                                MONSTER_SUPERTYPE_UNDEAD)) {
+                        break;
                     }
-
-                    if (pCastSpell->uPlayerID_2 != 4 && pCastSpell->uPlayerID_2 != 5 ||
-                            achieved_awards[pCastSpell->uPlayerID_2 - 4] <= 0 ||
-                            achieved_awards[pCastSpell->uPlayerID_2 - 4] >= 3) {
+                    if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
                         continue;
                     }
-                    int hireling_idx = achieved_awards[pCastSpell->uPlayerID_2 - 4] - 1;
-                    pParty->pHirelings[hireling_idx].dialogue_1_evt_id = 1;
-                    pParty->pHirelings[hireling_idx].dialogue_2_evt_id = 0;
-                    pParty->pHirelings[hireling_idx].dialogue_3_evt_id = pIconsFrameTable->GetIcon("spell96")->GetAnimLength();
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
-                        pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
-                    }
-                    DDM_DLV_Header *ddm_dlv = &pOutdoor->ddm;
-                    if (uCurrentlyLoadedLevelType != LEVEL_Outdoor) {
-                        ddm_dlv = &pIndoor->dlv;
-                    }
-                    ddm_dlv->uReputation += 15;
-                    if (ddm_dlv->uReputation > 10000) {
-                        ddm_dlv->uReputation = 10000;
-                    }
-                    break;
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, 0, 0, 0);
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod =
+                        target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                }
+                break;
+            }
+
+            case SPELL_DARK_SACRIFICE:
+            {
+                int hired_npc = 0;
+                memset(&achieved_awards, 0, 4000);
+                for (uint npc_id = 0; npc_id < 2; npc_id++) {
+                    if (!pParty->pHirelings[npc_id].pName.empty())
+                        achieved_awards[hired_npc++] = (AwardType)(npc_id + 1);
                 }
 
-                case SPELL_DARK_PAIN_REFLECTION:
-                {
-                    switch (spell_mastery) {
-                        case PLAYER_SKILL_MASTERY_NOVICE:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_EXPERT:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_MASTER:
-                            spellduration = 300 * (spell_level + 12);
-                            break;
-                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                            spellduration = 900 * (spell_level + 4);
-                            break;
-                        default:
-                            assert(false);
-                    }
-                    amount = spell_level + 5;
-                    if (spell_mastery != PLAYER_SKILL_MASTERY_MASTER && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                if (pCastSpell->uPlayerID_2 != 4 && pCastSpell->uPlayerID_2 != 5 ||
+                        achieved_awards[pCastSpell->uPlayerID_2 - 4] <= 0 ||
+                        achieved_awards[pCastSpell->uPlayerID_2 - 4] >= 3) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    pPlayer->CastSpellModifyMana(uRequiredMana); // decrease mana on failure
+                    continue;
+                }
+                int hireling_idx = achieved_awards[pCastSpell->uPlayerID_2 - 4] - 1;
+                pParty->pHirelings[hireling_idx].dialogue_1_evt_id = 1;
+                pParty->pHirelings[hireling_idx].dialogue_2_evt_id = 0;
+                pParty->pHirelings[hireling_idx].dialogue_3_evt_id = pIconsFrameTable->GetIcon("spell96")->GetAnimLength();
+                for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                    pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
+                    pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
+                }
+                DDM_DLV_Header *ddm_dlv = &pOutdoor->ddm;
+                if (uCurrentlyLoadedLevelType != LEVEL_Outdoor) {
+                    ddm_dlv = &pIndoor->dlv;
+                }
+                ddm_dlv->uReputation += 15;
+                if (ddm_dlv->uReputation > 10000) {
+                    ddm_dlv->uReputation = 10000;
+                }
+                break;
+            }
+
+            case SPELL_DARK_PAIN_REFLECTION:
+            {
+                switch (spell_mastery) {
+                    case PLAYER_SKILL_MASTERY_NOVICE:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_EXPERT:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_MASTER:
+                        spellduration = 300 * (spell_level + 12);
+                        break;
+                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                        spellduration = 900 * (spell_level + 4);
+                        break;
+                    default:
+                        assert(false);
+                }
+                amount = spell_level + 5;
+                if (spell_mastery != PLAYER_SKILL_MASTERY_MASTER && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
+                        .Apply(GameTime(pParty->GetPlayingTime() +
+                                    GameTime::FromSeconds(spellduration)),
+                                spell_mastery, amount, 0, 0);
+                } else {
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
+                        pParty->pPlayers[pl_id]
                             .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
                             .Apply(GameTime(pParty->GetPlayingTime() +
                                         GameTime::FromSeconds(spellduration)),
                                     spell_mastery, amount, 0, 0);
-                    } else {
-                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
-                            pParty->pPlayers[pl_id]
-                                .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                            GameTime::FromSeconds(spellduration)),
-                                        spell_mastery, amount, 0, 0);
-                        }
                     }
-                    break;
                 }
-
-                case SPELL_DARK_SOULDRINKER:
-                {
-                    int mon_num = render->GetActorsInViewport((int64_t)pCamera3D->GetMouseInfoDepth());
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    amount = 0;
-                    if (mon_num > 0) {
-                        amount = (mon_num * (7 * spell_level + 25));
-                        for (uint monster_id = 0; monster_id < mon_num;
-                                monster_id++) {
-                            pSpellSprite.vPosition.x =
-                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.x;
-                            pSpellSprite.vPosition.y =
-                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.y;
-                            pSpellSprite.vPosition.z =
-                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.z -
-                                (int)((double)pActors[_50BF30_actors_in_viewport_ids
-                                        [monster_id]]
-                                        .uActorHeight *
-                                        -0.8);
-                            pSpellSprite.spell_target_pid =
-                                PID(OBJECT_Actor,
-                                        _50BF30_actors_in_viewport_ids[monster_id]);
-                            Actor::DamageMonsterFromParty(
-                                    PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                                    _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
-                        }
-                    }
-                    int pl_num = 0;
-                    int pl_array[4] {};
-                    for (uint pl_id = 1; pl_id <= 4; ++pl_id) {
-                        if (!pPlayers[pl_id]->conditions.Has(Condition_Sleep) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Paralyzed) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Unconscious) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
-                                !pPlayers[pl_id]->conditions.Has(Condition_Eradicated)) {
-                            pl_array[pl_num++] = pl_id;
-                        }
-                    }
-                    for (uint j = 0; j < pl_num; j++) {
-                        pPlayers[pl_array[j]]->sHealth +=
-                            (int64_t)((double)(signed int)amount /
-                                    (double)pl_num);
-                        if (pPlayers[pl_array[j]]->sHealth > pPlayers[pl_array[j]]->GetMaxHealth())
-                            pPlayers[pl_array[j]]->sHealth = pPlayers[pl_array[j]]->GetMaxHealth();
-                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_array[j]);
-                    }
-                    spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Black.C32(), 64);
-                    break;
-                }
-
-                case SPELL_DARK_ARMAGEDDON:
-                {
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_CANT_ARMAGEDDON_INDOORS);
-                        continue;
-                    }
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        amount = 4;
-                    } else {
-                        amount = 3;
-                    }
-                    if (pPlayer->uNumArmageddonCasts >= amount ||
-                            pParty->armageddon_timer > 0) {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        continue;
-                    }
-                    pParty->armageddon_timer = 256;
-                    pParty->armageddonDamage = spell_level;
-                    ++pPlayer->uNumArmageddonCasts;
-                    if (pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    for (uint i = 0; i < 50; i++) {
-                        int rand_x = grng->Random(4096) - 2048;
-                        int rand_y = grng->Random(4096) - 2048;
-                        bool bOnWater = false;
-                        int terr_height = GetTerrainHeightsAroundParty2(
-                                rand_x + pParty->vPosition.x,
-                                rand_y + pParty->vPosition.y, &bOnWater, 0);
-                        SpriteObject::Drop_Item_At(
-                                SPRITE_SPELL_EARTH_ROCK_BLAST,
-                                rand_x + pParty->vPosition.x,
-                                rand_y + pParty->vPosition.y, terr_height + 16,
-                                grng->Random(500) + 500, 1, 0, 0, 0);
-                    }
-                    break;
-                }
-                default:
-                    continue;
+                break;
             }
 
-            spell_sound_flag = true;
-            pPlayer->CastSpellModifyMana(uRequiredMana);
+            case SPELL_DARK_SOULDRINKER:
+            {
+                int mon_num = render->GetActorsInViewport((int64_t)pCamera3D->GetMouseInfoDepth());
+                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                pSpellSprite.uSectorID = 0;
+                pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                pSpellSprite.uFacing = 0;
+                amount = 0;
+                if (mon_num > 0) {
+                    amount = (mon_num * (7 * spell_level + 25));
+                    for (uint monster_id = 0; monster_id < mon_num;
+                            monster_id++) {
+                        pSpellSprite.vPosition.x =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                            .vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                            .vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                            .vPosition.z -
+                            (int)((double)pActors[_50BF30_actors_in_viewport_ids
+                                    [monster_id]]
+                                    .uActorHeight *
+                                    -0.8);
+                        pSpellSprite.spell_target_pid =
+                            PID(OBJECT_Actor,
+                                    _50BF30_actors_in_viewport_ids[monster_id]);
+                        Actor::DamageMonsterFromParty(
+                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                                _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
+                    }
+                }
+                int pl_num = 0;
+                int pl_array[4] {};
+                for (uint pl_id = 1; pl_id <= 4; ++pl_id) {
+                    if (!pPlayers[pl_id]->conditions.Has(Condition_Sleep) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Paralyzed) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Unconscious) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
+                            !pPlayers[pl_id]->conditions.Has(Condition_Eradicated)) {
+                        pl_array[pl_num++] = pl_id;
+                    }
+                }
+                for (uint j = 0; j < pl_num; j++) {
+                    pPlayers[pl_array[j]]->sHealth +=
+                        (int64_t)((double)(signed int)amount /
+                                (double)pl_num);
+                    if (pPlayers[pl_array[j]]->sHealth > pPlayers[pl_array[j]]->GetMaxHealth())
+                        pPlayers[pl_array[j]]->sHealth = pPlayers[pl_array[j]]->GetMaxHealth();
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_array[j]);
+                }
+                spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Black.C32(), 64);
+                break;
+            }
+
+            case SPELL_DARK_ARMAGEDDON:
+            {
+                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    SpellFailed(pCastSpell, LSTR_CANT_ARMAGEDDON_INDOORS);
+                    continue;
+                }
+                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                    amount = 4;
+                } else {
+                    amount = 3;
+                }
+                if (pPlayer->uNumArmageddonCasts >= amount ||
+                        pParty->armageddon_timer > 0) {
+                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    continue;
+                }
+                pParty->armageddon_timer = 256;
+                pParty->armageddonDamage = spell_level;
+                ++pPlayer->uNumArmageddonCasts;
+                if (pParty->bTurnBasedModeOn) {
+                    ++pTurnEngine->pending_actions;
+                }
+                for (uint i = 0; i < 50; i++) {
+                    int rand_x = grng->Random(4096) - 2048;
+                    int rand_y = grng->Random(4096) - 2048;
+                    bool bOnWater = false;
+                    int terr_height = GetTerrainHeightsAroundParty2(
+                            rand_x + pParty->vPosition.x,
+                            rand_y + pParty->vPosition.y, &bOnWater, 0);
+                    SpriteObject::Drop_Item_At(
+                            SPRITE_SPELL_EARTH_ROCK_BLAST,
+                            rand_x + pParty->vPosition.x,
+                            rand_y + pParty->vPosition.y, terr_height + 16,
+                            grng->Random(500) + 500, 1, 0, 0, 0);
+                }
+                break;
+            }
+            default:
+                continue;
+        }
+
+        spell_sound_flag = true;
+        pPlayer->CastSpellModifyMana(uRequiredMana);
         }
 
         if (~pCastSpell->uFlags & ON_CAST_NoRecoverySpell) {

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -335,7 +335,8 @@ void CastSpellInfoHelpers::CastSpell() {
             spell_velocity.z = 0;
 
             if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                break;
+                // Not enough mana for current spell, check the next one
+                continue;
             }
 
             switch (pCastSpell->uSpellID) {
@@ -676,7 +677,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         _50C9D4_AfterEnchClickEventSecondParam = 0;
                         _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        break;
+                        continue;
                     }
 
                     switch (pCastSpell->uSpellID) {
@@ -895,6 +896,7 @@ void CastSpellInfoHelpers::CastSpell() {
                             spell_sound_flag = true;
                         } else {
                             SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                            continue;
                         }
                     }
                     break;
@@ -979,7 +981,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 case SPELL_FIRE_METEOR_SHOWER:
                 {
                     if (spell_mastery < PLAYER_SKILL_MASTERY_MASTER) {
-                        break;
+                        continue;
                     }
 
                     int meteor_num;
@@ -1167,10 +1169,11 @@ void CastSpellInfoHelpers::CastSpell() {
                 {
                     if (pParty->IsAirborne()) {
                         SpellFailed(pCastSpell, LSTR_CANT_JUMP_AIRBORNE);
-                        break;
+                        continue;
                     }
-                    for (uint pl_id = 0; pl_id < 4; pl_id++)
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
                         pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
+                    }
                     pParty->uFlags |= PARTY_FLAGS_1_LANDING;
                     pParty->uFallSpeed = 1000;
                     spell_sound_flag = true;
@@ -1218,11 +1221,11 @@ void CastSpellInfoHelpers::CastSpell() {
                 {
                     if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
                         SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
-                        break;
+                        continue;
                     }
                     if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() && !engine->config->debug.AllMagic.Get()) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        break;
+                        continue;
                     }
                     if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
                         amount = 1;
@@ -1406,7 +1409,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 {
                     if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana()) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                        break;
+                        continue;
                     }
                     switch (spell_mastery) {
                         case PLAYER_SKILL_MASTERY_NOVICE:  // break;
@@ -1429,8 +1432,9 @@ void CastSpellInfoHelpers::CastSpell() {
                             GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
                             spell_mastery, amount, spell_overlay_id,
                             pCastSpell->uPlayerID + 1);
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
                         pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
+                    }
                     spell_sound_flag = true;
                     break;
                 }
@@ -1513,8 +1517,9 @@ void CastSpellInfoHelpers::CastSpell() {
                         } else {
                             // random item break
                             if (rnd >= 10 * spell_level) {  // 10% chance of success per spell level
-                                if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED))
+                                if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
                                     spell_item_to_enchant->SetBroken();
+                                }
                             } else {
                                 // Weapons are limited to special enchantments, but all other types can have either
                                 if (rnd < 80 && IsPassiveEquipment(this_equip_type)) { // chance to roll standard enchantment on non-weapons
@@ -1546,7 +1551,9 @@ void CastSpellInfoHelpers::CastSpell() {
                                     // step through until we hit that ench
                                     for (step = 0; step < ench_found; step++) {
                                         current_item_apply_sum += pItemTable->pEnchantments[ench_array[step]].to_item[this_equip_type];
-                                        if (current_item_apply_sum >= target_item_apply_rand) break;
+                                        if (current_item_apply_sum >= target_item_apply_rand) {
+                                            break;
+                                        }
                                     }
 
                                     // assign ench and power
@@ -1595,7 +1602,9 @@ void CastSpellInfoHelpers::CastSpell() {
                                     // step through until we hit that ench
                                     for (step = 0; step < ench_found; step++) {
                                         current_item_apply_sum += pItemTable->pSpecialEnchantments[(ITEM_ENCHANTMENT)ench_array[step]].to_item_apply[this_equip_type];
-                                        if (current_item_apply_sum >= target_item_apply_rand) break;
+                                        if (current_item_apply_sum >= target_item_apply_rand) {
+                                            break;
+                                        }
                                     }
 
                                     // set item ench
@@ -1612,6 +1621,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (spell_sound_flag == 0) {
                         SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
                         pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
+                        continue;
                     }
                     break;
                 }
@@ -2222,8 +2232,9 @@ void CastSpellInfoHelpers::CastSpell() {
                         // v730 = 836 * monster_id;
                         if (MonsterStats::BelongsToSupertype(
                                     pActors[monster_id].pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD))
+                                    MONSTER_SUPERTYPE_UNDEAD)) {
                             break;
+                        }
                         if (pActors[monster_id].DoesDmgTypeDoDamage(
                                     DMGT_MIND)) {
                             pActors[monster_id]
@@ -2277,8 +2288,9 @@ void CastSpellInfoHelpers::CastSpell() {
                                     pActors[_50BF30_actors_in_viewport_ids
                                     [spell_targeted_at]]
                                     .pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD))
+                                    MONSTER_SUPERTYPE_UNDEAD)) {
                             break;
+                        }
                         pSpellSprite.vPosition.x =
                             pActors
                             [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
@@ -2561,14 +2573,10 @@ void CastSpellInfoHelpers::CastSpell() {
                 case SPELL_BODY_HAMMERHANDS:
                 {
                     if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, 1);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, 2);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                                pCastSpell->uSpellID, 3);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
                         for (uint pl_id = 0; pl_id < 4; pl_id++) {
                             pParty->pPlayers[pl_id]
                                 .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
@@ -2577,16 +2585,14 @@ void CastSpellInfoHelpers::CastSpell() {
                                             GameTime::FromSeconds(3600 * spell_level)),
                                         spell_mastery, spell_level, spell_level, 0);
                         }
-                        spell_sound_flag = true;
-                        break;
-                    }
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    } else {
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
                     pParty->pPlayers[pCastSpell->uPlayerID_2]
                         .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
                         .Apply(GameTime(pParty->GetPlayingTime() +
                                     GameTime::FromSeconds(3600 * spell_level)),
                                 spell_mastery, spell_level, spell_level, 0);
+                    }
                     spell_sound_flag = true;
                     break;
                 }
@@ -2968,7 +2974,9 @@ void CastSpellInfoHelpers::CastSpell() {
                         (int)((double)pActors[monster_id].uActorHeight * -0.8);
                     pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
                     pSpellSprite.Create(0, 0, 0, 0);
-                    if (pActors[monster_id].pMonsterInfo.uLevel > amount) break;
+                    if (pActors[monster_id].pMonsterInfo.uLevel > amount) {
+                        break;
+                    }
                     Actor::Resurrect(monster_id);
                     pActors[monster_id].pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
                     pActors[monster_id].pMonsterInfo.uTreasureDropChance = 0;
@@ -3055,8 +3063,9 @@ void CastSpellInfoHelpers::CastSpell() {
                         monster_id = PID_ID(spell_targeted_at);
                         if (!MonsterStats::BelongsToSupertype(
                                     pActors[monster_id].pMonsterInfo.uID,
-                                    MONSTER_SUPERTYPE_UNDEAD))
+                                    MONSTER_SUPERTYPE_UNDEAD)) {
                             break;
+                        }
                         if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
                             SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                             continue;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -305,237 +305,211 @@ void CastSpellInfoHelpers::CastSpell() {
 
             // do mana check here?
 
-        switch (pCastSpell->uSpellID) {
-            case SPELL_FIRE_TORCH_LIGHT:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 2;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 4;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
-                        GameTime(pParty->GetPlayingTime() + (GameTime::FromSeconds(3600 * spell_level))),
-                        spell_mastery, amount, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_FIRE_SPIKE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 7;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 9;
-                        break;
-                    default:
-                        assert(false);
-                }
-                int spikes_active = 0;
-                for (uint i = 0; i < pSpriteObjects.size(); ++i) {
-                    SpriteObject *object = &pSpriteObjects[i];
-                    if (object->uType &&
-                            object->spell_id == SPELL_FIRE_FIRE_SPIKE &&
-                            object->spell_caster_pid == PID(OBJECT_Player, pCastSpell->uPlayerID)) {
-                        ++spikes_active;
+            switch (pCastSpell->uSpellID) {
+                case SPELL_FIRE_TORCH_LIGHT:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 2;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 4;
+                            break;
+                        default:
+                            assert(false);
                     }
-                }
-                if (spikes_active > amount) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
+                            GameTime(pParty->GetPlayingTime() + (GameTime::FromSeconds(3600 * spell_level))),
+                            spell_mastery, amount, 0, 0);
+                    spell_sound_flag = true;
                     break;
                 }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = (short)target_direction.uYawAngle;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY + 10, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_AIR_IMPLOSION:
-            {
-                monster_id = PID_ID(spell_targeted_at);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (!spell_targeted_at) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                case SPELL_FIRE_FIRE_SPIKE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 7;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 9;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    int spikes_active = 0;
+                    for (uint i = 0; i < pSpriteObjects.size(); ++i) {
+                        SpriteObject *object = &pSpriteObjects[i];
+                        if (object->uType &&
+                                object->spell_id == SPELL_FIRE_FIRE_SPIKE &&
+                                object->spell_caster_pid == PID(OBJECT_Player, pCastSpell->uPlayerID)) {
+                            ++spikes_active;
+                        }
+                    }
+                    if (spikes_active > amount) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight / 2;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_EARTH_MASS_DISTORTION:
-            {
-                monster_id = PID_ID(spell_targeted_at);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                    pSpellSprite.uFacing = 0;
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
-                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_DESTROY_UNDEAD:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana) ||
-                        !spell_targeted_at ||
-                        PID_TYPE(spell_targeted_at) != OBJECT_Actor) {
-                    break;
-                }
-                // v730 = spell_targeted_at >> 3;
-                // HIDWORD(spellduration) =
-                // (int)&pActors[PID_ID(spell_targeted_at)];
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition.x = pActors[PID_ID(spell_targeted_at)].vPosition.x;
-                pSpellSprite.vPosition.y = pActors[PID_ID(spell_targeted_at)].vPosition.y;
-                pSpellSprite.vPosition.z = pActors[PID_ID(spell_targeted_at)].vPosition.z;
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = target_direction.uYawAngle;
-                pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                int obj_id = pSpellSprite.Create(0, 0, 0, 0);
-                if (!MonsterStats::BelongsToSupertype(pActors[PID_ID(spell_targeted_at)].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD)) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                Actor::DamageMonsterFromParty(PID(OBJECT_Item, obj_id), PID_ID(spell_targeted_at), &spell_velocity);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_FIRE_BOLT:
-            case SPELL_FIRE_FIREBALL:
-            case SPELL_FIRE_INCINERATE:
-            case SPELL_AIR_LIGHNING_BOLT:
-            case SPELL_WATER_ICE_BOLT:
-            case SPELL_WATER_ICE_BLAST:
-            case SPELL_EARTH_STUN:
-            case SPELL_EARTH_DEADLY_SWARM:
-            case SPELL_MIND_MIND_BLAST:
-            case SPELL_MIND_PSYCHIC_SHOCK:
-            case SPELL_BODY_HARM:
-            case SPELL_LIGHT_LIGHT_BOLT:
-            case SPELL_DARK_DRAGON_BREATH:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                } else {
-                    pSpellSprite.uSectorID = 0;
-                }
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = target_direction.uYawAngle;
-                if (pCastSpell->uSpellID == SPELL_AIR_LIGHNING_BOLT) {
-                    pSpellSprite.uAttributes |= SPRITE_SKIP_A_FRAME;
-                }
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_WATER_ACID_BURST:
-            case SPELL_EARTH_BLADES:
-            case SPELL_BODY_FLYING_FIST:
-            case SPELL_DARK_TOXIC_CLOUD:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                    pSpellSprite.uFacing = (short)target_direction.uYawAngle;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
+                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY + 10, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    spell_sound_flag = true;
                     break;
                 }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                // TODO(pskelton): was pParty->uPartyHeight / 2
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = target_direction.uYawAngle;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_LIGHT_SUNRAY:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor ||
-                        uCurrentlyLoadedLevelType == LEVEL_Outdoor &&
-                        (pParty->uCurrentHour < 5 || pParty->uCurrentHour >= 21)) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
+                case SPELL_AIR_IMPLOSION:
+                {
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (!spell_targeted_at) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.uSectorID = 0;
+                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                        pSpellSprite.uFacing = 0;
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight / 2;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                    }
+                    spell_sound_flag = true;
+                    break;
                 }
-                if (pPlayer->CanCastSpell(uRequiredMana)) {
+
+                case SPELL_EARTH_MASS_DISTORTION:
+                {
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.uSectorID = 0;
+                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                        pSpellSprite.uFacing = 0;
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
+                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_DESTROY_UNDEAD:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana) ||
+                            !spell_targeted_at ||
+                            PID_TYPE(spell_targeted_at) != OBJECT_Actor) {
+                        break;
+                    }
+                    // v730 = spell_targeted_at >> 3;
+                    // HIDWORD(spellduration) =
+                    // (int)&pActors[PID_ID(spell_targeted_at)];
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pActors[PID_ID(spell_targeted_at)].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[PID_ID(spell_targeted_at)].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[PID_ID(spell_targeted_at)].vPosition.z;
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                    int obj_id = pSpellSprite.Create(0, 0, 0, 0);
+                    if (!MonsterStats::BelongsToSupertype(pActors[PID_ID(spell_targeted_at)].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD)) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, obj_id), PID_ID(spell_targeted_at), &spell_velocity);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_FIRE_BOLT:
+                case SPELL_FIRE_FIREBALL:
+                case SPELL_FIRE_INCINERATE:
+                case SPELL_AIR_LIGHNING_BOLT:
+                case SPELL_WATER_ICE_BOLT:
+                case SPELL_WATER_ICE_BLAST:
+                case SPELL_EARTH_STUN:
+                case SPELL_EARTH_DEADLY_SWARM:
+                case SPELL_MIND_MIND_BLAST:
+                case SPELL_MIND_PSYCHIC_SHOCK:
+                case SPELL_BODY_HARM:
+                case SPELL_LIGHT_LIGHT_BOLT:
+                case SPELL_DARK_DRAGON_BREATH:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    } else {
+                        pSpellSprite.uSectorID = 0;
+                    }
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    if (pCastSpell->uSpellID == SPELL_AIR_LIGHNING_BOLT) {
+                        pSpellSprite.uAttributes |= SPRITE_SKIP_A_FRAME;
+                    }
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
+                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_WATER_ACID_BURST:
+                case SPELL_EARTH_BLADES:
+                case SPELL_BODY_FLYING_FIST:
+                case SPELL_DARK_TOXIC_CLOUD:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    // TODO(pskelton): was pParty->uPartyHeight / 2
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -549,504 +523,810 @@ void CastSpellInfoHelpers::CastSpell() {
                         ++pTurnEngine->pending_actions;
                     }
                     spell_sound_flag = true;
-                }
-                break;
-            }
-
-            case SPELL_LIGHT_PARALYZE:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
                     break;
                 }
-                monster_id = PID_ID(spell_targeted_at);
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
-                        pActors[monster_id].DoesDmgTypeDoDamage(DMGT_LIGHT)) {
-                    Actor::AI_Stand(PID_ID(spell_targeted_at), 4, 0x80, 0);
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3 * 60 * spell_level)), spell_mastery, 0, 0, 0);
-                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                    pActors[monster_id].vVelocity.x = 0;
-                    pActors[monster_id].vVelocity.y = 0;
-                    spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_EARTH_SLOW:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 180 * spell_level;
-                        amount = 2;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 300 * spell_level;
-                        amount = 2;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 300 * spell_level;
-                        amount = 4;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 300 * spell_level;
-                        amount = 8;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                // v721 = 836 * PID_ID(spell_targeted_at);
-                monster_id = PID_ID(spell_targeted_at);
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, 0, 0);
-                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                    spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_CHARM:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                monster_id = PID_ID(spell_targeted_at);
-                if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_MIND)) {
-                    uint power = 300 * spell_level;
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                        power = 600 * spell_level;
-                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
-                        power = 29030400;
+                case SPELL_LIGHT_SUNRAY:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor ||
+                            uCurrentlyLoadedLevelType == LEVEL_Outdoor &&
+                            (pParty->uCurrentHour < 5 || pParty->uCurrentHour >= 21)) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
                     }
+                    if (pPlayer->CanCastSpell(uRequiredMana)) {
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        if (pParty->bTurnBasedModeOn) {
+                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                        }
+                        spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                        if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                            ++pTurnEngine->pending_actions;
+                        }
+                        spell_sound_flag = true;
+                    }
+                    break;
+                }
 
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), spell_mastery, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                case SPELL_LIGHT_PARALYZE:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
+                            pActors[monster_id].DoesDmgTypeDoDamage(DMGT_LIGHT)) {
+                        Actor::AI_Stand(PID_ID(spell_targeted_at), 4, 0x80, 0);
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3 * 60 * spell_level)), spell_mastery, 0, 0, 0);
+                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                        pActors[monster_id].vVelocity.x = 0;
+                        pActors[monster_id].vVelocity.y = 0;
+                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_EARTH_SLOW:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 180 * spell_level;
+                            amount = 2;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 300 * spell_level;
+                            amount = 2;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 300 * spell_level;
+                            amount = 4;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 300 * spell_level;
+                            amount = 8;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    // v721 = 836 * PID_ID(spell_targeted_at);
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, 0, 0);
+                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_CHARM:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_MIND)) {
+                        uint power = 300 * spell_level;
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                            power = 600 * spell_level;
+                        } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
+                            power = 29030400;
+                        }
+
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), spell_mastery, 0, 0, 0);
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_DARK_SHRINKING_RAY:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    // spell_id different?
+                    InitSpellSprite( &pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
                     pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                     pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_SHRINKING_RAY:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                // spell_id different?
-                InitSpellSprite( &pSpellSprite, spell_level * 300, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = target_direction.uYawAngle;
-                pSpellSprite.spell_id = SPELL_FIRE_PROTECTION_FROM_FIRE;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_VAMPIRIC_WEAPON:
-            case SPELL_FIRE_FIRE_AURA:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-
-                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
-                item->UpdateTempBonus(pParty->GetPlayingTime());
-                if (item->uItemID == ITEM_BLASTER || item->uItemID == ITEM_BLASTER_RIFLE ||
-                        item->IsBroken() || pItemTable->IsMaterialNonCommon(item) || item->special_enchantment != ITEM_ENCHANTMENT_NULL || item->uEnchantmentType != 0 ||
-                        !IsWeapon(item->GetItemEquipType())) {
-                    _50C9D0_AfterEnchClickEventId = 113;
-                    _50C9D4_AfterEnchClickEventSecondParam = 0;
-                    _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    break;
-                }
-
-                switch (pCastSpell->uSpellID) {
-                    case SPELL_FIRE_FIRE_AURA:
-                        switch (spell_mastery) {
-                            case PLAYER_SKILL_MASTERY_NOVICE:
-                                item->special_enchantment = ITEM_ENCHANTMENT_OF_FIRE;
-                                break;
-                            case PLAYER_SKILL_MASTERY_EXPERT:
-                                item->special_enchantment = ITEM_ENCHANTMENT_OF_FLAME;
-                                break;
-                            case PLAYER_SKILL_MASTERY_MASTER:
-                            case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                                item->special_enchantment = ITEM_ENCHANTMENT_OF_INFERNOS;
-                                break;
-                            default:
-                                __debugbreak();
-                        }
-
-                        item->uAttributes |= ITEM_AURA_EFFECT_RED;
-                        break;
-                    case SPELL_DARK_VAMPIRIC_WEAPON:
-                        item->special_enchantment = ITEM_ENCHANTMENT_VAMPIRIC;
-                        item->uAttributes |= ITEM_AURA_EFFECT_PURPLE;
-                        break;
-                    default:
-                        __debugbreak();
-                }
-
-                if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    spellduration = 3600 * spell_level;
-                } else {
-                    spellduration = 0;
-                }
-
-                if (spellduration > 0) {
-                    item->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
-                    item->uAttributes |= ITEM_TEMP_BONUS;
-                }
-
-                _50C9A8_item_enchantment_timer = 256;
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_REGENERATION:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 1;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 1;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 10;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
-                    .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_PROTECTION_FROM_FIRE:
-            case SPELL_AIR_PROTECTION_FROM_AIR:
-            case SPELL_WATER_PROTECTION_FROM_WATER:
-            case SPELL_EARTH_PROTECTION_FROM_EARTH:
-            case SPELL_MIND_PROTECTION_FROM_MIND:
-            case SPELL_BODY_PROTECTION_FROM_BODY:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = std::to_underlying(spell_mastery) * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                switch (pCastSpell->uSpellID) {
-                    case SPELL_FIRE_PROTECTION_FROM_FIRE:
-                        buff_resist = PARTY_BUFF_RESIST_FIRE;
-                        break;
-                    case SPELL_AIR_PROTECTION_FROM_AIR:
-                        buff_resist = PARTY_BUFF_RESIST_AIR;
-                        break;
-                    case SPELL_WATER_PROTECTION_FROM_WATER:
-                        buff_resist = PARTY_BUFF_RESIST_WATER;
-                        break;
-                    case SPELL_EARTH_PROTECTION_FROM_EARTH:
-                        buff_resist = PARTY_BUFF_RESIST_EARTH;
-                        break;
-                    case SPELL_MIND_PROTECTION_FROM_MIND:
-                        buff_resist = PARTY_BUFF_RESIST_MIND;
-                        break;
-                    case SPELL_BODY_PROTECTION_FROM_BODY:
-                        buff_resist = PARTY_BUFF_RESIST_BODY;
-                        break;
-                    default:
-                        assert(false);
-                        continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-
-                pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_HASTE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 60 * (spell_level + 60);
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 60 * (spell_level + 60);
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 180 * (spell_level + 20);
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 240 * (spell_level + 15);
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (pPlayer->CanCastSpell(uRequiredMana)) {
-                    spell_sound_flag = true;
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak))
-                            spell_sound_flag = false;
+                    pSpellSprite.spell_id = SPELL_FIRE_PROTECTION_FROM_FIRE;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
                     }
-                    if (spell_sound_flag) {
-                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
+                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_DARK_VAMPIRIC_WEAPON:
+                case SPELL_FIRE_FIRE_AURA:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+
+                    ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                    item->UpdateTempBonus(pParty->GetPlayingTime());
+                    if (item->uItemID == ITEM_BLASTER || item->uItemID == ITEM_BLASTER_RIFLE ||
+                            item->IsBroken() || pItemTable->IsMaterialNonCommon(item) || item->special_enchantment != ITEM_ENCHANTMENT_NULL || item->uEnchantmentType != 0 ||
+                            !IsWeapon(item->GetItemEquipType())) {
+                        _50C9D0_AfterEnchClickEventId = 113;
+                        _50C9D4_AfterEnchClickEventSecondParam = 0;
+                        _50C9D8_AfterEnchClickEventTimeout = 128; // was 1, increased to make message readable
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        break;
+                    }
+
+                    switch (pCastSpell->uSpellID) {
+                        case SPELL_FIRE_FIRE_AURA:
+                            switch (spell_mastery) {
+                                case PLAYER_SKILL_MASTERY_NOVICE:
+                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_FIRE;
+                                    break;
+                                case PLAYER_SKILL_MASTERY_EXPERT:
+                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_FLAME;
+                                    break;
+                                case PLAYER_SKILL_MASTERY_MASTER:
+                                case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                                    item->special_enchantment = ITEM_ENCHANTMENT_OF_INFERNOS;
+                                    break;
+                                default:
+                                    __debugbreak();
+                            }
+
+                            item->uAttributes |= ITEM_AURA_EFFECT_RED;
+                            break;
+                        case SPELL_DARK_VAMPIRIC_WEAPON:
+                            item->special_enchantment = ITEM_ENCHANTMENT_VAMPIRIC;
+                            item->uAttributes |= ITEM_AURA_EFFECT_PURPLE;
+                            break;
+                        default:
+                            __debugbreak();
+                    }
+
+                    if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        spellduration = 3600 * spell_level;
+                    } else {
+                        spellduration = 0;
+                    }
+
+                    if (spellduration > 0) {
+                        item->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
+                        item->uAttributes |= ITEM_TEMP_BONUS;
+                    }
+
+                    _50C9A8_item_enchantment_timer = 256;
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_REGENERATION:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 1;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 1;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 10;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
+                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_PROTECTION_FROM_FIRE:
+                case SPELL_AIR_PROTECTION_FROM_AIR:
+                case SPELL_WATER_PROTECTION_FROM_WATER:
+                case SPELL_EARTH_PROTECTION_FROM_EARTH:
+                case SPELL_MIND_PROTECTION_FROM_MIND:
+                case SPELL_BODY_PROTECTION_FROM_BODY:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = std::to_underlying(spell_mastery) * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    switch (pCastSpell->uSpellID) {
+                        case SPELL_FIRE_PROTECTION_FROM_FIRE:
+                            buff_resist = PARTY_BUFF_RESIST_FIRE;
+                            break;
+                        case SPELL_AIR_PROTECTION_FROM_AIR:
+                            buff_resist = PARTY_BUFF_RESIST_AIR;
+                            break;
+                        case SPELL_WATER_PROTECTION_FROM_WATER:
+                            buff_resist = PARTY_BUFF_RESIST_WATER;
+                            break;
+                        case SPELL_EARTH_PROTECTION_FROM_EARTH:
+                            buff_resist = PARTY_BUFF_RESIST_EARTH;
+                            break;
+                        case SPELL_MIND_PROTECTION_FROM_MIND:
+                            buff_resist = PARTY_BUFF_RESIST_MIND;
+                            break;
+                        case SPELL_BODY_PROTECTION_FROM_BODY:
+                            buff_resist = PARTY_BUFF_RESIST_BODY;
+                            break;
+                        default:
+                            assert(false);
+                            continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+
+                    pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), spell_mastery, amount, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_HASTE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 60 * (spell_level + 60);
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 60 * (spell_level + 60);
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 180 * (spell_level + 20);
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 240 * (spell_level + 15);
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (pPlayer->CanCastSpell(uRequiredMana)) {
+                        spell_sound_flag = true;
+                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                            if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak))
+                                spell_sound_flag = false;
+                        }
+                        if (spell_sound_flag) {
+                            pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, 0, 0, 0);
+                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                            spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                        }
+                    }
+                    break;
+                }
+
+                case SPELL_SPIRIT_BLESS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 900 * (spell_level + 4);
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 3600 * (spell_level + 1);
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    amount = spell_level + 5;
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                        spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                            .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, spell_overlay_id, 0);
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_id);
+                        spell_overlay_id = pOtherOverlayList->_4418B1(
+                                10000, pl_id + 310, 0, 65536);
+                        pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                            .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, amount, spell_overlay_id, 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_SPIRIT_LASH:
+                {
+                    if (pPlayer->CanCastSpell(uRequiredMana) && spell_targeted_at &&
+                            PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        int monster_id = PID_ID(spell_targeted_at);
+                        dist_X = abs(pActors[monster_id].vPosition.x -
+                                pParty->vPosition.x);
+                        dist_Y = abs(pActors[monster_id].vPosition.y -
+                                pParty->vPosition.y);
+                        dist_Z = abs(pActors[monster_id].vPosition.z -
+                                pParty->vPosition.z);
+                        int count = int_get_vector_length(dist_X, dist_Y, dist_Z);
+                        if ((double)count <= 307.2) {
+                            InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                            pSpellSprite.uSectorID = 0;
+                            pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                            pSpellSprite.uFacing = 0;
+                            pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                            pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                            pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
+                            pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
+                            Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
+                            spell_sound_flag = true;
+                        } else {
+                            SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        }
+                    }
+                    break;
+                }
+
+                case SPELL_AIR_SHIELD:
+                case SPELL_EARTH_STONESKIN:
+                case SPELL_SPIRIT_HEROISM:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 900 * (spell_level + 4);
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 3600 * (spell_level + 1);
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    switch (pCastSpell->uSpellID) {
+                        case SPELL_AIR_SHIELD:
+                            amount = 0;
+                            buff_resist = PARTY_BUFF_SHIELD;
+                            break;
+                        case SPELL_EARTH_STONESKIN:
+                            amount = spell_level + 5;
+                            buff_resist = PARTY_BUFF_STONE_SKIN;
+                            break;
+                        case SPELL_SPIRIT_HEROISM:
+                            amount = spell_level + 5;
+                            buff_resist = PARTY_BUFF_HEROISM;
+                            break;
+                        default:
+                            assert(false);
+                            continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[buff_resist].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_IMMOLATION:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        spellduration = 600 * spell_level;
+                    } else {
+                        spellduration = 60 * spell_level;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(spellduration)),
+                            spell_mastery, spell_level, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_METEOR_SHOWER:
+                {
+                    if (spell_mastery < PLAYER_SKILL_MASTERY_MASTER) {
+                        break;
+                    }
+
+                    int meteor_num;
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        meteor_num = 20;
+                    } else {
+                        meteor_num = 16;
+                    }
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        SpellFailed(pCastSpell, LSTR_CANT_METEOR_SHOWER_INDOORS);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    obj_type = PID_TYPE(spell_targeted_at);
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (obj_type == OBJECT_Actor) {  // quick cast can specify target
+                        dist_X = pActors[monster_id].vPosition.x;
+                        dist_Y = pActors[monster_id].vPosition.y;
+                        dist_Z = pActors[monster_id].vPosition.z;
+                    } else {
+                        dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
+                        dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
+                        dist_Z = pParty->vPosition.z;
+                    }
+                    uint64_t k = 0;
+                    int j = 0;
+                    if (meteor_num > 0) {
+                        int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
+                        for (; meteor_num; meteor_num--) {
+                            uint32_t yaw, pitch;
+                            spell_targeted_at = grng->Random(1000);
+                            if (sqrt(((double)spell_targeted_at - 2500) *
+                                        ((double)spell_targeted_at - 2500) + j * j + k * k) <= 1.0) {
+                                yaw = 0;
+                                pitch = 0;
+                            } else {
+                                pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
+                                        (double)spell_targeted_at - 2500);
+                                yaw = TrigLUT.Atan2(j, k);
+                            }
+                            InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                            pSpellSprite.vPosition.x = dist_X;
+                            pSpellSprite.vPosition.y = dist_Y;
+                            pSpellSprite.vPosition.z = spell_targeted_at + dist_Z;
+                            pSpellSprite.uSectorID = 0;
+                            pSpellSprite.spell_target_pid = target_pid;
+                            pSpellSprite.field_60_distance_related_prolly_lod =
+                                stru_50C198._427546(spell_targeted_at + 2500);
+                            pSpellSprite.uFacing = yaw;
+                            if (pParty->bTurnBasedModeOn) {
+                                pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                            }
+                            if (pSpellSprite.Create(yaw, pitch, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 && pParty->bTurnBasedModeOn) {
+                                ++pTurnEngine->pending_actions;
+                            }
+                            j = grng->Random(1024) - 512;
+                            k = grng->Random(1024) - 512;
+                        }
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_FIRE_INFERNO:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
+                        SpellFailed(pCastSpell, LSTR_CANT_INFERNO_OUTDOORS);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int mon_num = render->GetActorsInViewport(4096);
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    for (uint i = 0; i < mon_num; i++) {
+                        pSpellSprite.vPosition.x = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.z -
+                            (unsigned int)(int64_t)((double)pActors
+                                    [_50BF30_actors_in_viewport_ids
+                                    [i]].uActorHeight * -0.8);
+                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[i]);
+                        Actor::DamageMonsterFromParty(
+                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                                _50BF30_actors_in_viewport_ids[i], &spell_velocity);
+                        spell_fx_renderer->RenderAsSprite(&pSpellSprite);
+                        spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.OrangeyRed.C32(), 0x40);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_AIR_WIZARD_EYE:
+                {
+                    spellduration = 3600 * spell_level;
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_overlay_id =
+                            pOtherOverlayList->_4418B1(2000, pl_id + 100, 0, 65536);
+                    }
+                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, 0, spell_overlay_id, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_AIR_FEATHER_FALL:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 300 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 3600 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        pOtherOverlayList->_4418B1(2010, pl_id + 100, 0, 65536);
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+
+                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, 0, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_AIR_SPARKS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 7;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 9;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
+                    spell_spray_angle_start = ONE_THIRD_PI / -2;
+                    spell_spray_angle_end = ONE_THIRD_PI / 2;
+                    while (spell_spray_angle_start <= spell_spray_angle_end) {
+                        pSpellSprite.uSpriteFrameID = grng->Random(64); // TODO(captainurist): this doesn't look like a frame id initialization
+                        pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
+                        if (pSpellSprite.Create(
+                                    (int16_t)(spell_spray_angle_start + (short)target_direction.uYawAngle),
+                                    target_direction.uPitchAngle,
+                                    pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
+                                    pCastSpell->uPlayerID + 1) != -1 &&
+                                pParty->bTurnBasedModeOn) {
+                            ++pTurnEngine->pending_actions;
+                        }
+                        spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_AIR_JUMP:
+                {
+                    if (pParty->IsAirborne()) {
+                        SpellFailed(pCastSpell, LSTR_CANT_JUMP_AIRBORNE);
+                        break;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++)
+                        pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
+                    pParty->uFlags |= PARTY_FLAGS_1_LANDING;
+                    pParty->uFallSpeed = 1000;
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_AIR_INVISIBILITY:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 600 * spell_level;
+                            amount = spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 600 * spell_level;
+                            amount = 2 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 600 * spell_level;
+                            amount = 3 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 3600 * spell_level;
+                            amount = 4 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (pParty->GetRedOrYellowAlert()) {
+                        SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
+                        continue;
+                    }
+                    if (pPlayer->CanCastSpell(uRequiredMana)) {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                        pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Apply(
+                                GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                                spell_mastery, amount, 0, 0);
+                        spell_sound_flag = true;
                     }
-                }
-                break;
-            }
-
-            case SPELL_SPIRIT_BLESS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 900 * (spell_level + 4);
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 3600 * (spell_level + 1);
-                        break;
-                    default:
-                        assert(false);
-                }
-                amount = spell_level + 5;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
                     break;
                 }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
-                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), spell_mastery, amount, spell_overlay_id, 0);
+
+                case SPELL_AIR_FLY:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
+                        break;
+                    }
+                    if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() && !engine->config->debug.AllMagic.Get()) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        break;
+                    }
+                    if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 1;
+                    } else {
+                        amount = 0;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++)
+                        pOtherOverlayList->_4418B1(2090, pl_id + 100, 0, 65536);
+                    spell_overlay_id = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
+                    pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)),
+                            spell_mastery, amount, spell_overlay_id,
+                            pCastSpell->uPlayerID + 1);
                     spell_sound_flag = true;
                     break;
                 }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pl_id);
-                    spell_overlay_id = pOtherOverlayList->_4418B1(
-                        10000, pl_id + 310, 0, 65536);
-                    pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
-                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                        spell_mastery, amount, spell_overlay_id, 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_SPIRIT_SPIRIT_LASH:
-            {
-                if (pPlayer->CanCastSpell(uRequiredMana) && spell_targeted_at &&
-                    PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    int monster_id = PID_ID(spell_targeted_at);
-                    dist_X = abs(pActors[monster_id].vPosition.x -
-                                 pParty->vPosition.x);
-                    dist_Y = abs(pActors[monster_id].vPosition.y -
-                                 pParty->vPosition.y);
-                    dist_Z = abs(pActors[monster_id].vPosition.z -
-                                 pParty->vPosition.z);
-                    int count = int_get_vector_length(dist_X, dist_Y, dist_Z);
-                    if ((double)count <= 307.2) {
-                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.uSectorID = 0;
-                        pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                        pSpellSprite.uFacing = 0;
-                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
-                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
-                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &spell_velocity);
-                        spell_sound_flag = true;
-                    } else {
-                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    }
-                }
-                break;
-            }
-
-            case SPELL_AIR_SHIELD:
-            case SPELL_EARTH_STONESKIN:
-            case SPELL_SPIRIT_HEROISM:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 900 * (spell_level + 4);
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 3600 * (spell_level + 1);
-                        break;
-                    default:
-                        assert(false);
-                }
-                switch (pCastSpell->uSpellID) {
-                    case SPELL_AIR_SHIELD:
-                        amount = 0;
-                        buff_resist = PARTY_BUFF_SHIELD;
-                        break;
-                    case SPELL_EARTH_STONESKIN:
-                        amount = spell_level + 5;
-                        buff_resist = PARTY_BUFF_STONE_SKIN;
-                        break;
-                    case SPELL_SPIRIT_HEROISM:
-                        amount = spell_level + 5;
-                        buff_resist = PARTY_BUFF_HEROISM;
-                        break;
-                    default:
-                        assert(false);
+                case SPELL_AIR_STARBURST:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        SpellFailed(pCastSpell, LSTR_CANT_STARBURST_INDOORS);
                         continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[buff_resist].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_IMMOLATION:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    spellduration = 600 * spell_level;
-                } else {
-                    spellduration = 60 * spell_level;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(spellduration)),
-                    spell_mastery, spell_level, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_METEOR_SHOWER:
-            {
-                if (spell_mastery < PLAYER_SKILL_MASTERY_MASTER) {
-                    break;
-                }
-
-                int meteor_num;
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    meteor_num = 20;
-                } else {
-                    meteor_num = 16;
-                }
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                    SpellFailed(pCastSpell, LSTR_CANT_METEOR_SHOWER_INDOORS);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                obj_type = PID_TYPE(spell_targeted_at);
-                monster_id = PID_ID(spell_targeted_at);
-                if (obj_type == OBJECT_Actor) {  // quick cast can specify target
-                    dist_X = pActors[monster_id].vPosition.x;
-                    dist_Y = pActors[monster_id].vPosition.y;
-                    dist_Z = pActors[monster_id].vPosition.z;
-                } else {
-                    dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
-                    dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
-                    dist_Z = pParty->vPosition.z;
-                }
-                uint64_t k = 0;
-                int j = 0;
-                if (meteor_num > 0) {
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    obj_type = PID_TYPE(spell_targeted_at);
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (obj_type == OBJECT_Actor) {
+                        dist_X = pActors[monster_id].vPosition.x;
+                        dist_Y = pActors[monster_id].vPosition.y;
+                        dist_Z = pActors[monster_id].vPosition.z;
+                    } else {
+                        dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
+                        dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
+                        dist_Z = pParty->vPosition.z;
+                    }
+                    uint64_t k = 0;
+                    int j = 0;
                     int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
-                    for (; meteor_num; meteor_num--) {
-                        uint32_t yaw, pitch;
+                    uint32_t yaw, pitch;
+                    for (uint star_num = 20; star_num; star_num--) {
                         spell_targeted_at = grng->Random(1000);
-                        if (sqrt(((double)spell_targeted_at - 2500) *
-                                     ((double)spell_targeted_at - 2500) + j * j + k * k) <= 1.0) {
+                        if (sqrt(((double)spell_targeted_at + (double)dist_Z -
+                                        (double)(dist_Z + 2500)) *
+                                    ((double)spell_targeted_at + (double)dist_Z -
+                                     (double)(dist_Z + 2500)) +
+                                    j * j + k * k) <= 1.0) {
                             yaw = 0;
                             pitch = 0;
                         } else {
                             pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
-                                                  (double)spell_targeted_at - 2500);
+                                    ((double)spell_targeted_at + (double)dist_Z -
+                                     (double)(dist_Z + 2500)));
                             yaw = TrigLUT.Atan2(j, k);
                         }
                         InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.vPosition.x = dist_X;
                         pSpellSprite.vPosition.y = dist_Y;
-                        pSpellSprite.vPosition.z = spell_targeted_at + dist_Z;
+                        pSpellSprite.vPosition.z = (int)(spell_targeted_at + (dist_Z + 2500));
                         pSpellSprite.uSectorID = 0;
                         pSpellSprite.spell_target_pid = target_pid;
                         pSpellSprite.field_60_distance_related_prolly_lod =
@@ -1055,374 +1335,1881 @@ void CastSpellInfoHelpers::CastSpell() {
                         if (pParty->bTurnBasedModeOn) {
                             pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
                         }
-                        if (pSpellSprite.Create(yaw, pitch, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 && pParty->bTurnBasedModeOn) {
+                        if (pSpellSprite.Create(yaw, pitch,
+                                    pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 &&
+                                pParty->bTurnBasedModeOn) {
                             ++pTurnEngine->pending_actions;
                         }
                         j = grng->Random(1024) - 512;
                         k = grng->Random(1024) - 512;
                     }
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_FIRE_INFERNO:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-                    SpellFailed(pCastSpell, LSTR_CANT_INFERNO_OUTDOORS);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                    spell_sound_flag = true;
                     break;
                 }
-                int mon_num = render->GetActorsInViewport(4096);
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                for (uint i = 0; i < mon_num; i++) {
-                    pSpellSprite.vPosition.x = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[_50BF30_actors_in_viewport_ids[i]].vPosition.z -
-                        (unsigned int)(int64_t)((double)pActors
-                                                           [_50BF30_actors_in_viewport_ids
-                                                                [i]].uActorHeight * -0.8);
-                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[i]);
-                    Actor::DamageMonsterFromParty(
-                        PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                        _50BF30_actors_in_viewport_ids[i], &spell_velocity);
-                    spell_fx_renderer->RenderAsSprite(&pSpellSprite);
-                    spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.OrangeyRed.C32(), 0x40);
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_AIR_WIZARD_EYE:
-            {
-                spellduration = 3600 * spell_level;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    spell_overlay_id =
-                        pOtherOverlayList->_4418B1(2000, pl_id + 100, 0, 65536);
-                }
-                pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, 0, spell_overlay_id, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_AIR_FEATHER_FALL:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 300 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 3600 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    pOtherOverlayList->_4418B1(2010, pl_id + 100, 0, 65536);
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-
-                pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, 0, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_AIR_SPARKS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 7;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 9;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_spray_angle_start = ONE_THIRD_PI / -2;
-                spell_spray_angle_end = ONE_THIRD_PI / 2;
-                while (spell_spray_angle_start <= spell_spray_angle_end) {
-                    pSpellSprite.uSpriteFrameID = grng->Random(64); // TODO(captainurist): this doesn't look like a frame id initialization
-                    pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
-                    if (pSpellSprite.Create(
-                        (int16_t)(spell_spray_angle_start + (short)target_direction.uYawAngle),
-                        target_direction.uPitchAngle,
-                        pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
-                        pCastSpell->uPlayerID + 1) != -1 &&
-                        pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
+                case SPELL_WATER_AWAKEN:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 180 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
                     }
-                    spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_AIR_JUMP:
-            {
-                if (pParty->IsAirborne()) {
-                    SpellFailed(pCastSpell, LSTR_CANT_JUMP_AIRBORNE);
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (int i = 0; i < 4; i++) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            if (pParty->pPlayers[i].conditions.Has(Condition_Sleep)) {
+                                pParty->pPlayers[i].conditions.Reset(Condition_Sleep);
+                                pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
+                            }
+                        } else {
+                            if (pParty->pPlayers[i]
+                                    .DiscardConditionIfLastsLongerThan(
+                                        Condition_Sleep,
+                                        GameTime(pParty->GetPlayingTime() - GameTime::FromSeconds(amount))))
+                                pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
+                        }
+                    }
+                    spell_sound_flag = true;
                     break;
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+
+                case SPELL_WATER_POISON_SPRAY:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 1;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 7;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (amount == 1) {
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        if (pParty->bTurnBasedModeOn) {
+                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                        }
+                        spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                        if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                            ++pTurnEngine->pending_actions;
+                        }
+                    } else {
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                        if (pParty->bTurnBasedModeOn) {
+                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                        }
+                        spell_spray_angle_start = ONE_THIRD_PI / -2;
+                        spell_spray_angle_end = ONE_THIRD_PI / 2;
+                        if (spell_spray_angle_start <= spell_spray_angle_end) {
+                            do {
+                                pSpellSprite.uFacing = spell_spray_angle_start +
+                                    target_direction.uYawAngle;
+                                if (pSpellSprite.Create(
+                                            pSpellSprite.uFacing,
+                                            target_direction.uPitchAngle,
+                                            pObjectList
+                                            ->pObjects[pSpellSprite.uObjectDescID]
+                                            .uSpeed,
+                                            pCastSpell->uPlayerID + 1) != -1 &&
+                                        pParty->bTurnBasedModeOn) {
+                                    ++pTurnEngine->pending_actions;
+                                }
+                                spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
+                            } while (spell_spray_angle_start <=
+                                    spell_spray_angle_end);
+                        }
+                    }
+                    spell_sound_flag = true;
                     break;
                 }
-                for (uint pl_id = 0; pl_id < 4; pl_id++)
-                    pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
-                pParty->uFlags |= PARTY_FLAGS_1_LANDING;
-                pParty->uFallSpeed = 1000;
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_AIR_INVISIBILITY:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 600 * spell_level;
-                        amount = spell_level;
+                case SPELL_WATER_WATER_WALK:
+                {
+                    if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana()) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 600 * spell_level;
-                        amount = 2 * spell_level;
+                    }
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:  // break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 3600 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
                         break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 600 * spell_level;
-                        amount = 3 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 3600 * spell_level;
-                        amount = 4 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (pParty->GetRedOrYellowAlert()) {
-                    SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
-                    continue;
-                }
-                if (pPlayer->CanCastSpell(uRequiredMana)) {
+                    }
+                    spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Apply(
-                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                        spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, spell_overlay_id,
+                            pCastSpell->uPlayerID + 1);
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
+                        pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
                     spell_sound_flag = true;
+                    break;
                 }
-                break;
-            }
 
-            case SPELL_AIR_FLY:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                    SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
-                    break;
-                }
-                if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() && !engine->config->debug.AllMagic.Get()) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    break;
-                }
-                if (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 1;
-                } else {
-                    amount = 0;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                for (uint pl_id = 0; pl_id < 4; pl_id++)
-                    pOtherOverlayList->_4418B1(2090, pl_id + 100, 0, 65536);
-                spell_overlay_id = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
-                pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)),
-                    spell_mastery, amount, spell_overlay_id,
-                    pCastSpell->uPlayerID + 1);
-                spell_sound_flag = true;
-                break;
-            }
+                case SPELL_WATER_RECHARGE_ITEM:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
 
-            case SPELL_AIR_STARBURST:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                    SpellFailed(pCastSpell, LSTR_CANT_STARBURST_INDOORS);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                obj_type = PID_TYPE(spell_targeted_at);
-                monster_id = PID_ID(spell_targeted_at);
-                if (obj_type == OBJECT_Actor) {
-                    dist_X = pActors[monster_id].vPosition.x;
-                    dist_Y = pActors[monster_id].vPosition.y;
-                    dist_Z = pActors[monster_id].vPosition.z;
-                } else {
-                    dist_X = pParty->vPosition.x + 2048 * pCamera3D->fRotationZCosine;
-                    dist_Y = pParty->vPosition.y + 2048 * pCamera3D->fRotationZSine;
-                    dist_Z = pParty->vPosition.z;
-                }
-                uint64_t k = 0;
-                int j = 0;
-                int target_pid = obj_type == OBJECT_Actor ? spell_targeted_at : 0;
-                uint32_t yaw, pitch;
-                for (uint star_num = 20; star_num; star_num--) {
-                    spell_targeted_at = grng->Random(1000);
-                    if (sqrt(((double)spell_targeted_at + (double)dist_Z -
-                              (double)(dist_Z + 2500)) *
-                                 ((double)spell_targeted_at + (double)dist_Z -
-                                  (double)(dist_Z + 2500)) +
-                             j * j + k * k) <= 1.0) {
-                        yaw = 0;
-                        pitch = 0;
+                    ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                    if (item->GetItemEquipType() != EQUIP_WAND || item->IsBroken()) {
+                        _50C9D0_AfterEnchClickEventId = 113;
+                        _50C9D4_AfterEnchClickEventSecondParam = 0;
+                        _50C9D8_AfterEnchClickEventTimeout = 1;
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+
+                    double spell_recharge_factor;
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.5;  // 50 %
+                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
+                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.69999999;  // 30 %
+                    } else if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.80000001;  // 20 %
                     } else {
-                        pitch = TrigLUT.Atan2((int64_t)sqrt((float)(j * j + k * k)),
-                                            ((double)spell_targeted_at + (double)dist_Z -
-                                                (double)(dist_Z + 2500)));
-                        yaw = TrigLUT.Atan2(j, k);
+                        spell_recharge_factor = 0.0;
                     }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = dist_X;
-                    pSpellSprite.vPosition.y = dist_Y;
-                    pSpellSprite.vPosition.z = (int)(spell_targeted_at + (dist_Z + 2500));
-                    pSpellSprite.uSectorID = 0;
-                    pSpellSprite.spell_target_pid = target_pid;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        stru_50C198._427546(spell_targeted_at + 2500);
-                    pSpellSprite.uFacing = yaw;
-                    if (pParty->bTurnBasedModeOn) {
-                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                    }
-                    if (pSpellSprite.Create(yaw, pitch,
-                                            pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed, 0) != -1 &&
-                                                pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
-                    }
-                    j = grng->Random(1024) - 512;
-                    k = grng->Random(1024) - 512;
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_WATER_AWAKEN:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 180 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                    if (spell_recharge_factor > 1.0) {
+                        spell_recharge_factor = 1.0;
+                    }
+
+                    int uNewCharges = item->uMaxCharges * spell_recharge_factor;
+                    item->uMaxCharges = uNewCharges;
+                    item->uNumCharges = uNewCharges;
+                    if (uNewCharges <= 0) {
+                        _50C9D0_AfterEnchClickEventId = 113;
+                        _50C9D4_AfterEnchClickEventSecondParam = 0;
+                        _50C9D8_AfterEnchClickEventTimeout = 1;
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+
+                    item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
+                    _50C9A8_item_enchantment_timer = 256;
+                    spell_sound_flag = true;
                     break;
                 }
-                for (int i = 0; i < 4; i++) {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        if (pParty->pPlayers[i].conditions.Has(Condition_Sleep)) {
-                            pParty->pPlayers[i].conditions.Reset(Condition_Sleep);
-                            pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
+
+                case SPELL_WATER_ENCHANT_ITEM:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+
+                    uRequiredMana = 0;
+                    amount = 10 * spell_level;
+                    bool item_not_broken = true;
+                    int rnd = grng->Random(100);
+                    pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
+                    ItemGen *spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
+                    ITEM_EQUIP_TYPE this_equip_type = pItemTable->pItems[spell_item_to_enchant->uItemID].uEquipType;
+
+                    // refs
+                    // https://www.gog.com/forum/might_and_magic_series/a_little_enchant_item_testing_in_mm7
+                    // http://www.pottsland.com/mm6/enchant.shtml
+                    // also see STDITEMS.tx and SPCITEMS.txt in Events.lod
+
+                    if ((spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT)) __debugbreak(); // SPELL_WATER_ENCHANT_ITEM is a master level spell
+
+                    if ((spell_mastery == PLAYER_SKILL_MASTERY_MASTER || spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) &&
+                            IsRegular(spell_item_to_enchant->uItemID) &&
+                            spell_item_to_enchant->special_enchantment == ITEM_ENCHANTMENT_NULL &&
+                            spell_item_to_enchant->uEnchantmentType == 0 &&
+                            spell_item_to_enchant->m_enchantmentStrength == 0 &&
+                            !spell_item_to_enchant->IsBroken()) {
+                        // break items with low value
+                        if ((spell_item_to_enchant->GetValue() < 450 && !IsWeapon(this_equip_type)) ||  // not weapons
+                                (spell_item_to_enchant->GetValue() < 250 && IsWeapon(this_equip_type))) {  // weapons
+                            if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
+                                spell_item_to_enchant->SetBroken();
+                            }
+                            item_not_broken = false;
+                        } else {
+                            // random item break
+                            if (rnd >= 10 * spell_level) {  // 10% chance of success per spell level
+                                if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED))
+                                    spell_item_to_enchant->SetBroken();
+                            } else {
+                                // Weapons are limited to special enchantments, but all other types can have either
+                                if (rnd < 80 && IsPassiveEquipment(this_equip_type)) { // chance to roll standard enchantment on non-weapons
+                                    int ench_found = 0;
+                                    int to_item_apply_sum = 0;
+                                    int ench_array[100] = { 0 };
+
+                                    // finds how many possible enchaments and adds up to item apply values
+                                    // if (pItemTable->pEnchantments_count > 0) {
+                                    for (int norm_ench_loop = 0; norm_ench_loop < 24; ++norm_ench_loop) {
+                                        char* this_bon_state = pItemTable->pEnchantments[norm_ench_loop].pBonusStat;
+                                        if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
+                                            int this_to_apply = pItemTable->pEnchantments[norm_ench_loop].to_item[this_equip_type];
+                                            to_item_apply_sum += this_to_apply;
+                                            if (this_to_apply) {
+                                                ench_array[ench_found] = norm_ench_loop;
+                                                ench_found++;
+                                            }
+                                        }
+                                    }
+                                    // }
+
+                                    // pick a random ench
+                                    int item_apply_rand = grng->Random(to_item_apply_sum);
+                                    int target_item_apply_rand = item_apply_rand + 1;
+                                    int current_item_apply_sum = 0;
+                                    int step = 0;
+
+                                    // step through until we hit that ench
+                                    for (step = 0; step < ench_found; step++) {
+                                        current_item_apply_sum += pItemTable->pEnchantments[ench_array[step]].to_item[this_equip_type];
+                                        if (current_item_apply_sum >= target_item_apply_rand) break;
+                                    }
+
+                                    // assign ench and power
+                                    spell_item_to_enchant->uEnchantmentType = (ITEM_ENCHANTMENT)ench_array[step];
+
+                                    int ench_power = 0;
+                                    // master 3-8  - guess work needs checking
+                                    if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) ench_power = grng->Random(6) + 3;
+                                    // gm 6-12   - guess work needs checking
+                                    if (spell_mastery== PLAYER_SKILL_MASTERY_GRANDMASTER) ench_power = grng->Random(7) + 6;
+
+                                    spell_item_to_enchant->m_enchantmentStrength = ench_power;
+                                    spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
+                                    _50C9A8_item_enchantment_timer = 256;
+                                    spell_sound_flag = true;
+                                    break;
+                                } else { // weapons or we won the lottery for special enchantment
+                                    int ench_found = 0;
+                                    int to_item_apply_sum = 0;
+                                    int ench_array[100] = { 0 };
+
+                                    // finds how many possible enchaments and adds up to item apply values
+                                    if (pItemTable->pSpecialEnchantments_count > 0) {
+                                        for (ITEM_ENCHANTMENT spec_ench_loop : pItemTable->pSpecialEnchantments.indices()) {
+                                            char *this_bon_state = pItemTable->pSpecialEnchantments[spec_ench_loop].pBonusStatement;
+                                            if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
+                                                if (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel == 3) continue;
+                                                if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER && (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel != 0))
+                                                    continue;
+                                                int this_to_apply = pItemTable->pSpecialEnchantments[spec_ench_loop].to_item_apply[this_equip_type];
+                                                to_item_apply_sum += this_to_apply;
+                                                if (this_to_apply) {
+                                                    ench_array[ench_found] = spec_ench_loop;
+                                                    ench_found++;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // pick a random ench
+                                    int item_apply_rand = grng->Random(to_item_apply_sum);
+                                    int target_item_apply_rand = item_apply_rand + 1;
+                                    int current_item_apply_sum = 0;
+                                    int step = 0;
+
+                                    // step through until we hit that ench
+                                    for (step = 0; step < ench_found; step++) {
+                                        current_item_apply_sum += pItemTable->pSpecialEnchantments[(ITEM_ENCHANTMENT)ench_array[step]].to_item_apply[this_equip_type];
+                                        if (current_item_apply_sum >= target_item_apply_rand) break;
+                                    }
+
+                                    // set item ench
+                                    spell_item_to_enchant->special_enchantment = (ITEM_ENCHANTMENT)ench_array[step];
+                                    spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
+                                    _50C9A8_item_enchantment_timer = 256;
+                                    spell_sound_flag = true;
+                                    break;
+                                }
+                            }
                         }
-                    } else {
-                        if (pParty->pPlayers[i]
-                                .DiscardConditionIfLastsLongerThan(
-                                    Condition_Sleep,
-                                    GameTime(pParty->GetPlayingTime() - GameTime::FromSeconds(amount))))
-                            pParty->pPlayers[i].PlaySound(SPEECH_Awaken, 0);
                     }
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_WATER_POISON_SPRAY:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 1;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 7;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                    if (spell_sound_flag == 0) {
+                        SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
+                    }
                     break;
                 }
-                if (amount == 1) {
+
+                case SPELL_WATER_TOWN_PORTAL:
+                {
+                    amount = 10 * spell_level;
+                    if (pPlayer->sMana < (signed int)uRequiredMana) {
+                        break;
+                    }
+                    if (pParty->uFlags & (PARTY_FLAGS_1_ALERT_RED |
+                                PARTY_FLAGS_1_ALERT_YELLOW) &&
+                            spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER ||
+                            grng->Random(100) >= amount && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    town_portal_caster_id = pCastSpell->uPlayerID;
+                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastTownPortal, 0,
+                            0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_WATER_LLOYDS_BEACON:
+                {
+                    if (pCurrentMapName == "d05.blv") {  // Arena
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (pPlayer->sMana >= (signed int)uRequiredMana) {
+                        pEventTimer->Pause();
+                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
+                        lloyds_beacon_spell_level = (signed int)(604800 * spell_level);
+                        _506348_current_lloyd_playerid = pCastSpell->uPlayerID;
+                        ::uRequiredMana = uRequiredMana;
+                        ::sRecoveryTime = sRecoveryTime;
+                        lloyds_beacon_sound_id = pCastSpell->sound_id;
+                        lloyds_beacon_spell_id = pCastSpell->uSpellID;
+                        pCastSpell->uFlags |= ON_CAST_NoRecoverySpell;
+                    }
+                    break;
+                }
+
+                case SPELL_EARTH_STONE_TO_FLESH:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Petrified)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Petrified);
+                            spell_sound_flag = true;
+                            break;
+                        }
+
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Petrified,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_EARTH_ROCK_BLAST:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
                     pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
+                    pSpellSprite.uFacing = pParty->sRotationZ;
                     if (pParty->bTurnBasedModeOn) {
                         pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
                     }
                     spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
+                    if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                } else {
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_EARTH_DEATH_BLOSSOM:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    pSpellSprite.uType = SPRITE_SPELL_EARTH_DEATH_BLOSSOM;
                     InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition.x = pParty->vPosition.x;
+                    pSpellSprite.vPosition.y = pParty->vPosition.y;
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.vPosition.z = pParty->vPosition.z + (signed int)pParty->uPartyHeight / 3;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.uFacing = (short)pParty->sRotationZ;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
+                    spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(pParty->sRotationZ, TrigLUT.uIntegerHalfPi / 2, spell_speed, 0) != -1 && pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_DETECT_LIFE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 1800 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 3600 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(amount)),
+                            spell_mastery, 0, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_FATE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 2 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 4 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 6 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    // LODWORD(spellduration) = 300;
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (pCastSpell->spell_target_pid == 0) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .pPlayerBuffs[PLAYER_BUFF_FATE]
+                            .Apply(
+                                    GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
+                                    spell_mastery, amount, 0, 0);
+                        spell_sound_flag = true;
+                        break;
+                    } else if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
+                        monster_id = PID_ID(pCastSpell->spell_target_pid);
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE].Apply(
+                                GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
+                                spell_mastery, amount, 0, 0);
+                        pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
+                        spell_fx_renderer
+                            ->_4A7E89_sparkles_on_actor_after_it_casts_buff(
+                                    &pActors[monster_id], 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_REMOVE_CURSE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Cursed,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
+                            spell_sound_flag = true;
+                            break;
+                        }
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_PRESERVATION:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
+                        spellduration = 900 * (spell_level + 4);
+                    else
+                        spellduration = 300 * (spell_level + 12);
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, 0, 0, 0);
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_id);
+                        pParty->pPlayers[pl_id]
+                            .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, 0, 0, 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_TURN_UNDEAD:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
+                        spellduration = 60 * (spell_level + 3);
+                    } else {
+                        spellduration = 300 * spell_level + 180;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int mon_num = render->GetActorsInViewport(4096);
+                    spell_fx_renderer
+                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.White.C32(),
+                                192);
+                    // ++pSpellSprite.uType;
+                    pSpellSprite.uType = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                            ++spell_targeted_at) {
+                        if (MonsterStats::BelongsToSupertype(
+                                    pActors[_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .pMonsterInfo.uID,
+                                    MONSTER_SUPERTYPE_UNDEAD)) {
+                            pSpellSprite.vPosition.x =
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .vPosition.x;
+                            pSpellSprite.vPosition.y =
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .vPosition.y;
+                            pSpellSprite.vPosition.z =
+                                pActors[_50BF30_actors_in_viewport_ids
+                                [spell_targeted_at]]
+                                .vPosition.z -
+                                    pActors[_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .uActorHeight *
+                                        -0.8;
+                            pSpellSprite.spell_target_pid = PID(
+                                    OBJECT_Actor,
+                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                            pSpellSprite.Create(0, 0, 0, 0);
+                            pActors
+                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                                .pActorBuffs[ACTOR_BUFF_AFRAID]
+                                    .Apply(GameTime(pParty->GetPlayingTime() +
+                                                GameTime::FromSeconds(spellduration)),
+                                            spell_mastery, 0, 0, 0);
+                        }
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_RAISE_DEAD:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 0;
+                    } else {
+                        amount = 86400 * spell_level;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    pOtherOverlayList->_4418B1(5080, pCastSpell->uPlayerID_2 + 100,
+                            0, 65536);
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
+                    } else {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Dead, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Unconscious,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                            Condition_Weak, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_SHARED_LIFE:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 4 * spell_level;
+                    } else {
+                        amount = 3 * spell_level;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int active_pl_num = 0;
+                    signed int shared_life_count = amount;
+                    int mean_life = 0;
+                    int pl_array[4] {};
+                    for (uint pl_id = 1; pl_id <= 4; pl_id++) {
+                        if (!pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Eradicated))
+                            pl_array[active_pl_num++] = pl_id;
+                    }
+                    for (uint i = 0; i < active_pl_num; i++)
+                        shared_life_count += pPlayers[pl_array[i]]->sHealth;
+                    mean_life = (int64_t)((double)shared_life_count /
+                            (double)active_pl_num);
+                    for (uint i = 0; i < active_pl_num; i++) {
+                        pPlayers[pl_array[i]]->sHealth = mean_life;
+                        if (pPlayers[pl_array[i]]->sHealth >
+                                pPlayers[pl_array[i]]->GetMaxHealth())
+                            pPlayers[pl_array[i]]->sHealth =
+                                pPlayers[pl_array[i]]->GetMaxHealth();
+                        if (pPlayers[pl_array[i]]->sHealth > 0)
+                            pPlayers[pl_array[i]]->SetUnconcious(GameTime(0));
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_array[i] - 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_SPIRIT_RESSURECTION:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 180 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 10800 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 259200 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Eradicated) ||
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Eradicated);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
+                        } else {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Eradicated,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Dead,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Unconscious,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        }
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                                Condition_Weak, 1);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_CURE_PARALYSIS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
+                        spell_sound_flag = true;
+                        break;
+                    }
+
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .DiscardConditionIfLastsLongerThan(
+                                Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
+                                    GameTime::FromSeconds(amount)));
+
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_REMOVE_FEAR:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 180 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
+                        spell_sound_flag = true;
+                        break;
+                    }
+
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .DiscardConditionIfLastsLongerThan(
+                                Condition_Fear, GameTime(pParty->GetPlayingTime() -
+                                    GameTime::FromSeconds(amount)));
+
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_TELEPATHY:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        monster_id = PID_ID(spell_targeted_at);
+                        if (!pActors[monster_id].ActorHasItem())
+                            pActors[monster_id].SetRandomGoldIfTheresNoItem();
+                        int gold_num = 0;
+                        if (pActors[monster_id].ActorHasItems[3].uItemID != ITEM_NULL) {
+                            if (pItemTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
+                                gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
+                        }
+                        ItemGen item;
+                        item.Reset();
+                        if (pActors[monster_id].uCarriedItemID != ITEM_NULL) {
+                            item.uItemID = pActors[monster_id].uCarriedItemID;
+                        } else {
+                            for (uint i = 0; i < 4; ++i) {
+                                if (pActors[monster_id].ActorHasItems[i].uItemID != ITEM_NULL &&
+                                        pItemTable
+                                        ->pItems[pActors[monster_id]
+                                        .ActorHasItems[i]
+                                        .uItemID]
+                                        .uEquipType != EQUIP_GOLD) {
+                                    memcpy(&item,
+                                            &pActors[monster_id].ActorHasItems[i],
+                                            sizeof(item));
+                                    spell_level = spell_level;
+                                }
+                            }
+                        }
+                        if (gold_num > 0) {
+                            if (item.uItemID != ITEM_NULL)
+                                GameUI_SetStatusBar(StringPrintf(
+                                            "(%s), and %d gold",
+                                            item.GetDisplayName().c_str(), gold_num));
+                            else
+                                GameUI_SetStatusBar(StringPrintf(
+                                            "%d gold", gold_num));
+                        } else {
+                            if (item.uItemID != ITEM_NULL) {
+                                GameUI_SetStatusBar(StringPrintf(
+                                            "(%s)", item.GetDisplayName().c_str()));
+                            } else {
+                                GameUI_SetStatusBar("nothing");
+                            }
+                        }
+
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].uActorHeight;
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod =
+                            target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_BERSERK:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 300 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 300 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 3600;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    monster_id = PID_ID(spell_targeted_at);
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        // v730 = 836 * monster_id;
+                        if (pActors[monster_id].DoesDmgTypeDoDamage(
+                                    DMGT_MIND)) {
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_CHARM]
+                                .Reset();
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_ENSLAVED]
+                                .Reset();
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_BERSERK]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(amount)),
+                                        spell_mastery, 0, 0, 0);
+                            pActors[monster_id].pMonsterInfo.uHostilityType =
+                                MonsterInfo::Hostility_Long;
+                        }
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z +
+                            pActors[monster_id].uActorHeight;
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod =
+                            target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_ENSLAVE:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    amount = 600 * spell_level;
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        monster_id = PID_ID(spell_targeted_at);
+                        // v730 = 836 * monster_id;
+                        if (MonsterStats::BelongsToSupertype(
+                                    pActors[monster_id].pMonsterInfo.uID,
+                                    MONSTER_SUPERTYPE_UNDEAD))
+                            break;
+                        if (pActors[monster_id].DoesDmgTypeDoDamage(
+                                    DMGT_MIND)) {
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_BERSERK]
+                                .Reset();
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_CHARM]
+                                .Reset();
+                            pActors[monster_id]
+                                .pActorBuffs[ACTOR_BUFF_ENSLAVED]
+                                .Apply(GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(amount)),
+                                        spell_mastery, 0, 0, 0);
+                        }
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod =
+                            target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_MASS_FEAR:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 300 * spell_level;
+                    } else {
+                        amount = 180 * spell_level;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int mon_num = render->GetActorsInViewport(4096);
+                    spell_fx_renderer
+                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Night.C32(),
+                                192);
+                    // ++pSpellSprite.uType;
+                    pSpellSprite.uType = SPRITE_SPELL_MIND_MASS_FEAR_1;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                            ++spell_targeted_at) {
+                        if (MonsterStats::BelongsToSupertype(
+                                    pActors[_50BF30_actors_in_viewport_ids
+                                    [spell_targeted_at]]
+                                    .pMonsterInfo.uID,
+                                    MONSTER_SUPERTYPE_UNDEAD))
+                            break;
+                        pSpellSprite.vPosition.x =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.z -
+                                (unsigned int)(int64_t)((double)pActors
+                                        [_50BF30_actors_in_viewport_ids
+                                        [spell_targeted_at]]
+                                        .uActorHeight *
+                                        -0.8);
+                        pSpellSprite.spell_target_pid =
+                            PID(OBJECT_Actor,
+                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                        pSpellSprite.Create(0, 0, 0, 0);
+                        if (pActors
+                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                                .DoesDmgTypeDoDamage(DMGT_MIND)) {
+                            pActors
+                                [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                                .pActorBuffs[ACTOR_BUFF_AFRAID]
+                                    .Apply(GameTime(pParty->GetPlayingTime() +
+                                                GameTime::FromSeconds(amount)),
+                                            spell_mastery, 0, 0, 0);
+                        }
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_MIND_CURE_INSANITY:
+                {
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 0;
+                    } else {
+                        amount = 86400 * spell_level;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Insane)) {
+                        if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Insane);
+                        else
+                            pParty->pPlayers[pCastSpell->uPlayerID_2]
+                                .DiscardConditionIfLastsLongerThan(
+                                        Condition_Insane,
+                                        GameTime(pParty->GetPlayingTime() -
+                                            GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
+                                Condition_Weak, 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_EARTH_TELEKINESIS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 2 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 2 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 3 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 4 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int obj_id = PID_ID(spell_targeted_at);
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Item) {
+                        if (pItemTable
+                                ->pItems[pSpriteObjects[obj_id]
+                                .containing_item.uItemID]
+                                .uEquipType == EQUIP_GOLD) {
+                            pParty->PartyFindsGold(
+                                    pSpriteObjects[obj_id]
+                                    .containing_item.special_enchantment,
+                                    0);
+                            viewparams->bRedrawGameUI = true;
+                        } else {
+                            GameUI_SetStatusBar(
+                                    LSTR_FMT_YOU_FOUND_ITEM,
+                                    pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName
+                                    );
+                            if (!pParty->AddItemToParty(
+                                        &pSpriteObjects[obj_id].containing_item))
+                                pParty->SetHoldingItem(
+                                        &pSpriteObjects[obj_id].containing_item);
+                        }
+                        SpriteObject::OnInteraction(obj_id);
+                    }
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor)
+                        pActors[obj_id].LootActor();
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Decoration) {
+                        OpenedTelekinesis = true;
+                        if (pLevelDecorations[obj_id].uEventID)
+                            EventProcessor(pLevelDecorations[obj_id].uEventID,
+                                    spell_targeted_at, 1);
+                        if (pLevelDecorations[std::to_underlying(pSpriteObjects[obj_id]
+                                    .containing_item.uItemID)] // TODO(captainurist): investigate, that's a very weird std::to_underlying call.
+                                .IsInteractive()) {
+                            activeLevelDecoration = &pLevelDecorations[obj_id];
+                            EventProcessor(
+                                    stru_5E4C90_MapPersistVars._decor_events
+                                    [pLevelDecorations[obj_id]._idx_in_stru123 -
+                                    75] +
+                                    380,
+                                    0, 1);
+                            activeLevelDecoration = nullptr;
+                        }
+                    }
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Face) {
+                        int event;
+                        OpenedTelekinesis = true;
+                        if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                            event = pIndoor->pFaceExtras[pIndoor->pFaces[obj_id].uFaceExtraID].uEventID;
+                        } else {
+                            event = pOutdoor->pBModels[spell_targeted_at >> 9].pFaces[obj_id & 0x3F].sCogTriggeredID;
+                        }
+                        EventProcessor(event, spell_targeted_at, 1);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_CURE_WEAKNESS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 180 * spell_level;
+                            break;  // 3 минуты * количество очков навыка
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;  // 1 час * количество очков навыка
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Weak);
+                            spell_sound_flag = true;
+                            break;
+                        }
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Weak, GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_FIRST_AID:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 2 * spell_level + 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3 * spell_level + 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 4 * spell_level + 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 5 * spell_level + 5;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (!pCastSpell->spell_target_pid) {
+                        pParty->pPlayers[pCastSpell->uPlayerID_2].Heal(amount);
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    }
+                    if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
+                        monster_id = PID_ID(pCastSpell->spell_target_pid);
+                        if (pActors[monster_id].uAIState != Dead &&
+                                pActors[monster_id].uAIState != Dying &&
+                                pActors[monster_id].uAIState != Disabled &&
+                                pActors[monster_id].uAIState != Removed) {
+                            pActors[monster_id].sCurrentHP += amount;
+                            if (pActors[monster_id].sCurrentHP >
+                                    pActors[monster_id].pMonsterInfo.uHP)
+                                pActors[monster_id].sCurrentHP =
+                                    pActors[monster_id].pMonsterInfo.uHP;
+                        }
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_CURE_POISON:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3600 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 86400 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 0;
+                            break;
+                        default:
+                            assert(false);
+                    }
+
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Weak) ||
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Medium) ||
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Severe)) {
+                        if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Weak);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Medium);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Severe);
+                            spell_sound_flag = true;
+                            break;
+                        }
+
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Weak,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Medium,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .DiscardConditionIfLastsLongerThan(
+                                    Condition_Poison_Severe,
+                                    GameTime(pParty->GetPlayingTime() -
+                                        GameTime::FromSeconds(amount)));
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_PROTECTION_FROM_MAGIC:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[PARTY_BUFF_PROTECTION_FROM_MAGIC].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(3600 * spell_level)),
+                            spell_mastery, spell_level, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_HAMMERHANDS:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, 0);
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, 1);
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, 2);
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, 3);
+                        for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                            pParty->pPlayers[pl_id]
+                                .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
+                                .Apply(
+                                        GameTime(pParty->GetPlayingTime() +
+                                            GameTime::FromSeconds(3600 * spell_level)),
+                                        spell_mastery, spell_level, spell_level, 0);
+                        }
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2]
+                        .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
+                        .Apply(GameTime(pParty->GetPlayingTime() +
+                                    GameTime::FromSeconds(3600 * spell_level)),
+                                spell_mastery, spell_level, spell_level, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_BODY_POWER_CURE:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                    for (uint pl_id = 0; pl_id < 4; ++pl_id) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pl_id);
+                        pParty->pPlayers[pl_id].Heal(5 * spell_level + 10);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_DISPEL_MAGIC:
+                {
+                    sRecoveryTime -= spell_level;
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                    spell_fx_renderer
+                        ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.VibrantGreen.C32(),
+                                192);
+                    int mon_num = render->GetActorsInViewport(4096);
+                    // ++pSpellSprite.uType;
+                    pSpellSprite.uType = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                            ++spell_targeted_at) {
+                        pSpellSprite.vPosition.x =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.z -
+                                (int)((double)pActors[_50BF30_actors_in_viewport_ids
+                                        [spell_targeted_at]]
+                                        .uActorHeight *
+                                        -0.8);
+                        pSpellSprite.spell_target_pid =
+                            PID(OBJECT_Actor,
+                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                        Actor::DamageMonsterFromParty(
+                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                                _50BF30_actors_in_viewport_ids[spell_targeted_at],
+                                &spell_velocity);
+                    }
+                    for (spell_targeted_at = 0; spell_targeted_at < mon_num;
+                            ++spell_targeted_at) {
+                        pSpellSprite.vPosition.x =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors
+                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
+                            .vPosition.z -
+                                (unsigned int)(int64_t)((double)pActors
+                                        [_50BF30_actors_in_viewport_ids
+                                        [spell_targeted_at]]
+                                        .uActorHeight *
+                                        -0.8);
+                        pSpellSprite.spell_target_pid =
+                            PID(OBJECT_Actor,
+                                    _50BF30_actors_in_viewport_ids[spell_targeted_at]);
+                        pSpellSprite.Create(0, 0, 0, 0);
+                        for (SpellBuff &buff : pActors[_50BF30_actors_in_viewport_ids[spell_targeted_at]].pActorBuffs)
+                            buff.Reset();
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_SUMMON_ELEMENTAL:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 300 * spell_level;
+                            amount = 1;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 300 * spell_level;
+                            amount = 1;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 900 * spell_level;
+                            amount = 3;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 900 * spell_level;
+                            amount = 5;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    int mon_num = 0;
+                    for (uint monster_id = 0; monster_id < pActors.size(); monster_id++) {
+                        if (pActors[monster_id].uAIState != Dead &&
+                                pActors[monster_id].uAIState != Removed &&
+                                pActors[monster_id].uAIState != Disabled &&
+                                PID(OBJECT_Player, pCastSpell->uPlayerID) == pActors[monster_id].uSummonerID)
+                            ++mon_num;
+                    }
+                    if (mon_num >= amount) {
+                        SpellFailed(pCastSpell, LSTR_SUMMONS_LIMIT_REACHED);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                    Spawn_Light_Elemental(pCastSpell->uPlayerID, spell_mastery, spellduration);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_DAY_OF_THE_GODS:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 10800 * spell_level;
+                            amount = 3 * spell_level + 10;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 10800 * spell_level;
+                            amount = 3 * spell_level + 10;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 14400 * spell_level;
+                            amount = 4 * spell_level + 10;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 18000 * spell_level;
+                            amount = 5 * spell_level + 10;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(
+                            pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_PRISMATIC_LIGHT:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
+                        SpellFailed(pCastSpell, LSTR_CANT_PRISMATIC_OUTDOORS);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    int mon_num = render->GetActorsInViewport(4096);
+                    // ++pSpellSprite.uType;
+                    pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    for (uint monster_id = 0; monster_id < mon_num; monster_id++) {
+                        pSpellSprite.vPosition.x =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.x;
+                        pSpellSprite.vPosition.y =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.y;
+                        pSpellSprite.vPosition.z =
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.z -
+                            pActors[_50BF30_actors_in_viewport_ids[monster_id]].uActorHeight * -0.8;
+                        pSpellSprite.spell_target_pid =
+                            PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[monster_id]);
+                        Actor::DamageMonsterFromParty(
+                                PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                                _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
+                    }
+                    spell_fx_renderer->_4A8BFC_prismatic_light();
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_DAY_OF_PROTECTION:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 14400 * spell_level;
+                            amount = 4 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 14400 * spell_level;
+                            amount = 4 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 14400 * spell_level;
+                            amount = 4 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 18000 * spell_level;
+                            amount = 5 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, amount, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, spell_level + 5, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
+                            GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                            spell_mastery, spell_level + 5, 0, 0);
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_HOUR_OF_POWER:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 4;
+                            amount = 4;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 4;
+                            amount = 4;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 12;
+                            amount = 12;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 20;
+                            amount = 15;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    bool player_weak = false;
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
+                        pParty->pPlayers[pl_id]
+                            .pPlayerBuffs[PLAYER_BUFF_BLESS]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                                    spell_mastery, spell_level + 5, 0, 0);
+                        if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
+                            player_weak = true;
+                        }
+                    }
+
+                    pParty->pPartyBuffs[PARTY_BUFF_HEROISM].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                            spell_mastery, spell_level + 5, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_SHIELD].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                            spell_mastery, 0, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_STONE_SKIN].Apply(
+                            GameTime(pParty->GetPlayingTime() +
+                                GameTime::FromSeconds(300 * amount * spell_level + 60)),
+                            spell_mastery, spell_level + 5, 0, 0);
+                    if (!player_weak) {
+                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(
+                                GameTime(pParty->GetPlayingTime() +
+                                    GameTime::FromSeconds(
+                                        60 * (spell_level * spellduration + 60))),
+                                spell_mastery, spell_level + 5, 0, 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_LIGHT_DIVINE_INTERVENTION:
+                {
+                    if (pPlayer->uNumDivineInterventionCastsThisDay >= 3) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        pParty->pPlayers[pl_id].conditions.ResetAll();
+                        pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
+                        pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
+                    }
+                    if (pPlayer->sAgeModifier + 10 >= 120)
+                        pPlayer->sAgeModifier = 120;
+                    else
+                        pPlayer->sAgeModifier = pPlayer->sAgeModifier + 10;
+                    sRecoveryTime += -5 * spell_level;
+                    ++pPlayer->uNumDivineInterventionCastsThisDay;
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_DARK_REANIMATE:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 2 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 3 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 4 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 5 * spell_level;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (!pCastSpell->spell_target_pid) {
+                        spell_fx_renderer->SetPlayerBuffAnim(
+                                pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                        if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(Condition_Zombie, 1);
+                            GameUI_ReloadPlayerPortraits(pCastSpell->uPlayerID_2, (pParty->pPlayers[pCastSpell->uPlayerID_2].GetSexByVoice() != 0) + 23);
+                            pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+                            // TODO: why call SetCondition and then conditions.Set?
+                        }
+                        break;
+                    }
+                    monster_id = PID_ID(pCastSpell->spell_target_pid);
+                    if (monster_id == -1) {
+                        SpellFailed(pCastSpell, LSTR_NO_VALID_SPELL_TARGET);
+                        continue;
+                    }
+                    if (pActors[monster_id].sCurrentHP > 0 || pActors[monster_id].uAIState != Dead && pActors[monster_id].uAIState != Dying) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    // ++pSpellSprite.uType;
+                    pSpellSprite.uType = SPRITE_SPELL_DARK_REANIMATE_1;
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z -
+                        (int)((double)pActors[monster_id].uActorHeight * -0.8);
+                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                    pSpellSprite.Create(0, 0, 0, 0);
+                    if (pActors[monster_id].pMonsterInfo.uLevel > amount) break;
+                    Actor::Resurrect(monster_id);
+                    pActors[monster_id].pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
+                    pActors[monster_id].pMonsterInfo.uTreasureDropChance = 0;
+                    pActors[monster_id].pMonsterInfo.uTreasureDiceRolls = 0;
+                    pActors[monster_id].pMonsterInfo.uTreasureDiceSides = 0;
+                    pActors[monster_id].pMonsterInfo.uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID;
+                    pActors[monster_id].pMonsterInfo.uTreasureType = 0;
+                    pActors[monster_id].uAlly = 9999;
+                    pActors[monster_id].ResetAggressor();  // ~0x80000
+                    pActors[monster_id].uGroup = 0;
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
+                    if (pActors[monster_id].sCurrentHP > 10 * amount) {
+                        pActors[monster_id].sCurrentHP = 10 * amount;
+                    }
+                    spell_sound_flag = true;
+                    break;
+                }
+
+                case SPELL_DARK_SHARPMETAL:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            amount = 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            amount = 5;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            amount = 7;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            amount = 9;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    // TODO(pskelton): was pParty->uPartyHeight / 2
                     pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -1435,2043 +3222,256 @@ void CastSpellInfoHelpers::CastSpell() {
                     if (spell_spray_angle_start <= spell_spray_angle_end) {
                         do {
                             pSpellSprite.uFacing = spell_spray_angle_start +
-                                                   target_direction.uYawAngle;
-                            if (pSpellSprite.Create(
-                                pSpellSprite.uFacing,
-                                target_direction.uPitchAngle,
-                                pObjectList
-                                ->pObjects[pSpellSprite.uObjectDescID]
-                                .uSpeed,
-                                pCastSpell->uPlayerID + 1) != -1 &&
-                                pParty->bTurnBasedModeOn) {
+                                target_direction.uYawAngle;
+                            if (pSpellSprite.Create(pSpellSprite.uFacing, target_direction.uPitchAngle, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
+                                        pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
                                 ++pTurnEngine->pending_actions;
                             }
                             spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                        } while (spell_spray_angle_start <=
-                                 spell_spray_angle_end);
+                        } while (spell_spray_angle_start <= spell_spray_angle_end);
                     }
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_WATER_WATER_WALK:
-            {
-                if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana()) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                    spell_sound_flag = true;
                     break;
                 }
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:  // break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 600 * spell_level;
+
+                case SPELL_DARK_CONTROL_UNDEAD:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
                         break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 3600 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, spell_overlay_id,
-                    pCastSpell->uPlayerID + 1);
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
-                    pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_WATER_RECHARGE_ITEM:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-
-                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
-                if (item->GetItemEquipType() != EQUIP_WAND || item->IsBroken()) {
-                    _50C9D0_AfterEnchClickEventId = 113;
-                    _50C9D4_AfterEnchClickEventSecondParam = 0;
-                    _50C9D8_AfterEnchClickEventTimeout = 1;
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-
-                double spell_recharge_factor;
-                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.5;  // 50 %
-                } else if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) {
-                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.69999999;  // 30 %
-                } else if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    spell_recharge_factor = (double)spell_level * 0.0099999998 + 0.80000001;  // 20 %
-                } else {
-                    spell_recharge_factor = 0.0;
-                }
-
-                if (spell_recharge_factor > 1.0) {
-                    spell_recharge_factor = 1.0;
-                }
-
-                int uNewCharges = item->uMaxCharges * spell_recharge_factor;
-                item->uMaxCharges = uNewCharges;
-                item->uNumCharges = uNewCharges;
-                if (uNewCharges <= 0) {
-                    _50C9D0_AfterEnchClickEventId = 113;
-                    _50C9D4_AfterEnchClickEventSecondParam = 0;
-                    _50C9D8_AfterEnchClickEventTimeout = 1;
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-
-                item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
-                _50C9A8_item_enchantment_timer = 256;
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_WATER_ENCHANT_ITEM:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-
-                uRequiredMana = 0;
-                amount = 10 * spell_level;
-                bool item_not_broken = true;
-                int rnd = grng->Random(100);
-                pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
-                ItemGen *spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
-                ITEM_EQUIP_TYPE this_equip_type = pItemTable->pItems[spell_item_to_enchant->uItemID].uEquipType;
-
-                // refs
-                // https://www.gog.com/forum/might_and_magic_series/a_little_enchant_item_testing_in_mm7
-                // http://www.pottsland.com/mm6/enchant.shtml
-                // also see STDITEMS.tx and SPCITEMS.txt in Events.lod
-
-                if ((spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT)) __debugbreak(); // SPELL_WATER_ENCHANT_ITEM is a master level spell
-
-                if ((spell_mastery == PLAYER_SKILL_MASTERY_MASTER || spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) &&
-                    IsRegular(spell_item_to_enchant->uItemID) &&
-                    spell_item_to_enchant->special_enchantment == ITEM_ENCHANTMENT_NULL &&
-                    spell_item_to_enchant->uEnchantmentType == 0 &&
-                    spell_item_to_enchant->m_enchantmentStrength == 0 &&
-                    !spell_item_to_enchant->IsBroken()) {
-                    // break items with low value
-                    if ((spell_item_to_enchant->GetValue() < 450 && !IsWeapon(this_equip_type)) ||  // not weapons
-                        (spell_item_to_enchant->GetValue() < 250 && IsWeapon(this_equip_type))) {  // weapons
-                        if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED)) {
-                            spell_item_to_enchant->SetBroken();
+                    }
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 180 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 180 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 300 * spell_level;
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 29030400;
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        monster_id = PID_ID(spell_targeted_at);
+                        if (!MonsterStats::BelongsToSupertype(
+                                    pActors[monster_id].pMonsterInfo.uID,
+                                    MONSTER_SUPERTYPE_UNDEAD))
+                            break;
+                        if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
+                            SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                            continue;
                         }
-                        item_not_broken = false;
-                    } else {
-                        // random item break
-                        if (rnd >= 10 * spell_level) {  // 10% chance of success per spell level
-                            if (!(spell_item_to_enchant->uAttributes & ITEM_HARDENED))
-                                spell_item_to_enchant->SetBroken();
-                        } else {
-                            // Weapons are limited to special enchantments, but all other types can have either
-                            if (rnd < 80 && IsPassiveEquipment(this_equip_type)) { // chance to roll standard enchantment on non-weapons
-                                int ench_found = 0;
-                                int to_item_apply_sum = 0;
-                                int ench_array[100] = { 0 };
-
-                                // finds how many possible enchaments and adds up to item apply values
-                                // if (pItemTable->pEnchantments_count > 0) {
-                                    for (int norm_ench_loop = 0; norm_ench_loop < 24; ++norm_ench_loop) {
-                                        char* this_bon_state = pItemTable->pEnchantments[norm_ench_loop].pBonusStat;
-                                        if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
-                                            int this_to_apply = pItemTable->pEnchantments[norm_ench_loop].to_item[this_equip_type];
-                                            to_item_apply_sum += this_to_apply;
-                                            if (this_to_apply) {
-                                                ench_array[ench_found] = norm_ench_loop;
-                                                ench_found++;
-                                            }
-                                        }
-                                    }
-                                // }
-
-                                // pick a random ench
-                                int item_apply_rand = grng->Random(to_item_apply_sum);
-                                int target_item_apply_rand = item_apply_rand + 1;
-                                int current_item_apply_sum = 0;
-                                int step = 0;
-
-                                // step through until we hit that ench
-                                for (step = 0; step < ench_found; step++) {
-                                    current_item_apply_sum += pItemTable->pEnchantments[ench_array[step]].to_item[this_equip_type];
-                                    if (current_item_apply_sum >= target_item_apply_rand) break;
-                                }
-
-                                // assign ench and power
-                                spell_item_to_enchant->uEnchantmentType = (ITEM_ENCHANTMENT)ench_array[step];
-
-                                int ench_power = 0;
-                                // master 3-8  - guess work needs checking
-                                if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER) ench_power = grng->Random(6) + 3;
-                                // gm 6-12   - guess work needs checking
-                                if (spell_mastery== PLAYER_SKILL_MASTERY_GRANDMASTER) ench_power = grng->Random(7) + 6;
-
-                                spell_item_to_enchant->m_enchantmentStrength = ench_power;
-                                spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
-                                _50C9A8_item_enchantment_timer = 256;
-                                spell_sound_flag = true;
-                                break;
-                            } else { // weapons or we won the lottery for special enchantment
-                                int ench_found = 0;
-                                int to_item_apply_sum = 0;
-                                int ench_array[100] = { 0 };
-
-                                // finds how many possible enchaments and adds up to item apply values
-                                if (pItemTable->pSpecialEnchantments_count > 0) {
-                                    for (ITEM_ENCHANTMENT spec_ench_loop : pItemTable->pSpecialEnchantments.indices()) {
-                                        char *this_bon_state = pItemTable->pSpecialEnchantments[spec_ench_loop].pBonusStatement;
-                                        if (this_bon_state != NULL && (this_bon_state[0] != '\0')) {
-                                            if (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel == 3) continue;
-                                            if (spell_mastery == PLAYER_SKILL_MASTERY_MASTER && (pItemTable->pSpecialEnchantments[spec_ench_loop].iTreasureLevel != 0))
-                                                continue;
-                                            int this_to_apply = pItemTable->pSpecialEnchantments[spec_ench_loop].to_item_apply[this_equip_type];
-                                            to_item_apply_sum += this_to_apply;
-                                            if (this_to_apply) {
-                                                ench_array[ench_found] = spec_ench_loop;
-                                                ench_found++;
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // pick a random ench
-                                int item_apply_rand = grng->Random(to_item_apply_sum);
-                                int target_item_apply_rand = item_apply_rand + 1;
-                                int current_item_apply_sum = 0;
-                                int step = 0;
-
-                                // step through until we hit that ench
-                                for (step = 0; step < ench_found; step++) {
-                                    current_item_apply_sum += pItemTable->pSpecialEnchantments[(ITEM_ENCHANTMENT)ench_array[step]].to_item_apply[this_equip_type];
-                                    if (current_item_apply_sum >= target_item_apply_rand) break;
-                                }
-
-                                // set item ench
-                                spell_item_to_enchant->special_enchantment = (ITEM_ENCHANTMENT)ench_array[step];
-                                spell_item_to_enchant->uAttributes |= ITEM_AURA_EFFECT_BLUE;
-                                _50C9A8_item_enchantment_timer = 256;
-                                spell_sound_flag = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (spell_sound_flag == 0) {
-                    SpellFailed(pCastSpell, item_not_broken ? LSTR_SPELL_FAILED : LSTR_ITEM_TOO_LAME);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_SpellFailed, 0);
-                }
-                break;
-            }
-
-            case SPELL_WATER_TOWN_PORTAL:
-            {
-                amount = 10 * spell_level;
-                if (pPlayer->sMana < (signed int)uRequiredMana) {
-                    break;
-                }
-                if (pParty->uFlags & (PARTY_FLAGS_1_ALERT_RED |
-                                      PARTY_FLAGS_1_ALERT_YELLOW) &&
-                        spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER ||
-                    grng->Random(100) >= amount && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                town_portal_caster_id = pCastSpell->uPlayerID;
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastTownPortal, 0,
-                                                    0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_WATER_LLOYDS_BEACON:
-            {
-                if (pCurrentMapName == "d05.blv") {  // Arena
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (pPlayer->sMana >= (signed int)uRequiredMana) {
-                    pEventTimer->Pause();
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
-                    lloyds_beacon_spell_level = (signed int)(604800 * spell_level);
-                    _506348_current_lloyd_playerid = pCastSpell->uPlayerID;
-                    ::uRequiredMana = uRequiredMana;
-                    ::sRecoveryTime = sRecoveryTime;
-                    lloyds_beacon_sound_id = pCastSpell->sound_id;
-                    lloyds_beacon_spell_id = pCastSpell->uSpellID;
-                    pCastSpell->uFlags |= ON_CAST_NoRecoverySpell;
-                }
-                break;
-            }
-
-            case SPELL_EARTH_STONE_TO_FLESH:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Petrified)) {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Petrified);
-                        spell_sound_flag = true;
-                        break;
-                    }
-
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                                Condition_Petrified,
-                                GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_EARTH_ROCK_BLAST:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                pSpellSprite.uFacing = pParty->sRotationZ;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(pParty->sRotationZ, pParty->sRotationY, spell_speed, pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_EARTH_DEATH_BLOSSOM:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                pSpellSprite.uType = SPRITE_SPELL_EARTH_DEATH_BLOSSOM;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.vPosition.x = pParty->vPosition.x;
-                pSpellSprite.vPosition.y = pParty->vPosition.y;
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.vPosition.z = pParty->vPosition.z + (signed int)pParty->uPartyHeight / 3;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.uFacing = (short)pParty->sRotationZ;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(pParty->sRotationZ, TrigLUT.uIntegerHalfPi / 2, spell_speed, 0) != -1 && pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_DETECT_LIFE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 1800 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 3600 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(amount)),
-                    spell_mastery, 0, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_FATE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 2 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 4 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 6 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                // LODWORD(spellduration) = 300;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (pCastSpell->spell_target_pid == 0) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .pPlayerBuffs[PLAYER_BUFF_FATE]
-                        .Apply(
-                            GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
-                            spell_mastery, amount, 0, 0);
-                    spell_sound_flag = true;
-                    break;
-                } else if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
-                    monster_id = PID_ID(pCastSpell->spell_target_pid);
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE].Apply(
-                        GameTime(pParty->GetPlayingTime() + GameTime::FromMinutes(5)),
-                        spell_mastery, amount, 0, 0);
-                    pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                    spell_fx_renderer
-                        ->_4A7E89_sparkles_on_actor_after_it_casts_buff(
-                            &pActors[monster_id], 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_REMOVE_CURSE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                    spell_sound_flag = true;
-                    break;
-                }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Cursed);
-                } else {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Cursed,
-                            GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Cursed)) {
-                        spell_sound_flag = true;
-                        break;
-                    }
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_PRESERVATION:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
-                    spellduration = 900 * (spell_level + 4);
-                else
-                    spellduration = 300 * (spell_level + 12);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(spellduration)),
-                               spell_mastery, 0, 0, 0);
-                    spell_sound_flag = true;
-                    break;
-                }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pl_id);
-                    pParty->pPlayers[pl_id]
-                        .pPlayerBuffs[PLAYER_BUFF_PRESERVATION]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(spellduration)),
-                               spell_mastery, 0, 0, 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_TURN_UNDEAD:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_NOVICE || spell_mastery == PLAYER_SKILL_MASTERY_EXPERT) {
-                    spellduration = 60 * (spell_level + 3);
-                } else {
-                    spellduration = 300 * spell_level + 180;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int mon_num = render->GetActorsInViewport(4096);
-                spell_fx_renderer
-                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.White.C32(),
-                                                                     192);
-                // ++pSpellSprite.uType;
-                pSpellSprite.uType = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                     ++spell_targeted_at) {
-                    if (MonsterStats::BelongsToSupertype(
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                .pMonsterInfo.uID,
-                            MONSTER_SUPERTYPE_UNDEAD)) {
-                        pSpellSprite.vPosition.x =
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                .vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                .vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                .vPosition.z -
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                    .uActorHeight *
-                                -0.8;
-                        pSpellSprite.spell_target_pid = PID(
-                            OBJECT_Actor,
-                            _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                        pSpellSprite.Create(0, 0, 0, 0);
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .pActorBuffs[ACTOR_BUFF_AFRAID]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                           GameTime::FromSeconds(spellduration)),
-                                       spell_mastery, 0, 0, 0);
-                    }
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_RAISE_DEAD:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 0;
-                } else {
-                    amount = 86400 * spell_level;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                pOtherOverlayList->_4418B1(5080, pCastSpell->uPlayerID_2 + 100,
-                                           0, 65536);
-                if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                    spell_sound_flag = true;
-                    break;
-                }
-                pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
-                } else {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Dead, GameTime(pParty->GetPlayingTime() -
-                                                GameTime::FromSeconds(amount)));
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                                Condition_Unconscious,
-                                GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                }
-                pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                    Condition_Weak, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_SHARED_LIFE:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 4 * spell_level;
-                } else {
-                    amount = 3 * spell_level;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int active_pl_num = 0;
-                signed int shared_life_count = amount;
-                int mean_life = 0;
-                int pl_array[4] {};
-                for (uint pl_id = 1; pl_id <= 4; pl_id++) {
-                    if (!pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Eradicated))
-                        pl_array[active_pl_num++] = pl_id;
-                }
-                for (uint i = 0; i < active_pl_num; i++)
-                    shared_life_count += pPlayers[pl_array[i]]->sHealth;
-                mean_life = (int64_t)((double)shared_life_count /
-                                             (double)active_pl_num);
-                for (uint i = 0; i < active_pl_num; i++) {
-                    pPlayers[pl_array[i]]->sHealth = mean_life;
-                    if (pPlayers[pl_array[i]]->sHealth >
-                        pPlayers[pl_array[i]]->GetMaxHealth())
-                        pPlayers[pl_array[i]]->sHealth =
-                            pPlayers[pl_array[i]]->GetMaxHealth();
-                    if (pPlayers[pl_array[i]]->sHealth > 0)
-                        pPlayers[pl_array[i]]->SetUnconcious(GameTime(0));
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pl_array[i] - 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_SPIRIT_RESSURECTION:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 180 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 10800 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 259200 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Eradicated) ||
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Eradicated);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Dead);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Unconscious);
-                    } else {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                Condition_Eradicated,
-                                GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                Condition_Dead,
-                                GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                    Condition_Unconscious,
-                                    GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-                    }
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                        Condition_Weak, 1);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].sHealth = 1;
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_CURE_PARALYSIS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Paralyzed)) {
-                    spell_sound_flag = true;
-                    break;
-                }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Paralyzed);
-                    spell_sound_flag = true;
-                    break;
-                }
-
-                pParty->pPlayers[pCastSpell->uPlayerID_2]
-                    .DiscardConditionIfLastsLongerThan(
-                        Condition_Paralyzed, GameTime(pParty->GetPlayingTime() -
-                                                 GameTime::FromSeconds(amount)));
-
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_REMOVE_FEAR:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 180 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Fear)) {
-                    spell_sound_flag = true;
-                    break;
-                }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Fear);
-                    spell_sound_flag = true;
-                    break;
-                }
-
-                pParty->pPlayers[pCastSpell->uPlayerID_2]
-                    .DiscardConditionIfLastsLongerThan(
-                        Condition_Fear, GameTime(pParty->GetPlayingTime() -
-                                            GameTime::FromSeconds(amount)));
-
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_TELEPATHY:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (!pActors[monster_id].ActorHasItem())
-                        pActors[monster_id].SetRandomGoldIfTheresNoItem();
-                    int gold_num = 0;
-                    if (pActors[monster_id].ActorHasItems[3].uItemID != ITEM_NULL) {
-                        if (pItemTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
-                            gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
-                    }
-                    ItemGen item;
-                    item.Reset();
-                    if (pActors[monster_id].uCarriedItemID != ITEM_NULL) {
-                        item.uItemID = pActors[monster_id].uCarriedItemID;
-                    } else {
-                        for (uint i = 0; i < 4; ++i) {
-                            if (pActors[monster_id].ActorHasItems[i].uItemID != ITEM_NULL &&
-                                    pItemTable
-                                        ->pItems[pActors[monster_id]
-                                                     .ActorHasItems[i]
-                                                     .uItemID]
-                                        .uEquipType != EQUIP_GOLD) {
-                                memcpy(&item,
-                                       &pActors[monster_id].ActorHasItems[i],
-                                       sizeof(item));
-                                spell_level = spell_level;
-                            }
-                        }
-                    }
-                    if (gold_num > 0) {
-                        if (item.uItemID != ITEM_NULL)
-                            GameUI_SetStatusBar(StringPrintf(
-                                "(%s), and %d gold",
-                                item.GetDisplayName().c_str(), gold_num));
-                        else
-                            GameUI_SetStatusBar(StringPrintf(
-                                "%d gold", gold_num));
-                    } else {
-                        if (item.uItemID != ITEM_NULL) {
-                            GameUI_SetStatusBar(StringPrintf(
-                                "(%s)", item.GetDisplayName().c_str()));
-                        } else {
-                            GameUI_SetStatusBar("nothing");
-                        }
-                    }
-
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].uActorHeight;
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_BERSERK:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 300 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 300 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 3600;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                monster_id = PID_ID(spell_targeted_at);
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    // v730 = 836 * monster_id;
-                    if (pActors[monster_id].DoesDmgTypeDoDamage(
-                            DMGT_MIND)) {
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_CHARM]
-                            .Reset();
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_ENSLAVED]
-                            .Reset();
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_BERSERK]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                       GameTime::FromSeconds(amount)),
-                                   spell_mastery, 0, 0, 0);
-                        pActors[monster_id].pMonsterInfo.uHostilityType =
-                            MonsterInfo::Hostility_Long;
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z +
-                                               pActors[monster_id].uActorHeight;
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_ENSLAVE:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                amount = 600 * spell_level;
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    monster_id = PID_ID(spell_targeted_at);
-                    // v730 = 836 * monster_id;
-                    if (MonsterStats::BelongsToSupertype(
-                            pActors[monster_id].pMonsterInfo.uID,
-                            MONSTER_SUPERTYPE_UNDEAD))
-                        break;
-                    if (pActors[monster_id].DoesDmgTypeDoDamage(
-                            DMGT_MIND)) {
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_BERSERK]
-                            .Reset();
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_CHARM]
-                            .Reset();
-                        pActors[monster_id]
-                            .pActorBuffs[ACTOR_BUFF_ENSLAVED]
-                            .Apply(GameTime(pParty->GetPlayingTime() +
-                                       GameTime::FromSeconds(amount)),
-                                   spell_mastery, 0, 0, 0);
-                    }
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_MASS_FEAR:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 300 * spell_level;
-                } else {
-                    amount = 180 * spell_level;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int mon_num = render->GetActorsInViewport(4096);
-                spell_fx_renderer
-                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Night.C32(),
-                                                                     192);
-                // ++pSpellSprite.uType;
-                pSpellSprite.uType = SPRITE_SPELL_MIND_MASS_FEAR_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                     ++spell_targeted_at) {
-                    if (MonsterStats::BelongsToSupertype(
-                            pActors[_50BF30_actors_in_viewport_ids
-                                        [spell_targeted_at]]
-                                .pMonsterInfo.uID,
-                            MONSTER_SUPERTYPE_UNDEAD))
-                        break;
-                    pSpellSprite.vPosition.x =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.x;
-                    pSpellSprite.vPosition.y =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.y;
-                    pSpellSprite.vPosition.z =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.z -
-                        (unsigned int)(int64_t)((double)pActors
-                                                           [_50BF30_actors_in_viewport_ids
-                                                                [spell_targeted_at]]
-                                                               .uActorHeight *
-                                                       -0.8);
-                    pSpellSprite.spell_target_pid =
-                        PID(OBJECT_Actor,
-                            _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                    pSpellSprite.Create(0, 0, 0, 0);
-                    if (pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .DoesDmgTypeDoDamage(DMGT_MIND)) {
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .pActorBuffs[ACTOR_BUFF_AFRAID]
-                                .Apply(GameTime(pParty->GetPlayingTime() +
-                                           GameTime::FromSeconds(amount)),
-                                       spell_mastery, 0, 0, 0);
-                    }
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_MIND_CURE_INSANITY:
-            {
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 0;
-                } else {
-                    amount = 86400 * spell_level;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Insane)) {
-                    if (!pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak))
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].PlaySound(SPEECH_Weak, 0);
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER)
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Insane);
-                    else
-                        pParty->pPlayers[pCastSpell->uPlayerID_2]
-                            .DiscardConditionIfLastsLongerThan(
-                                Condition_Insane,
-                                GameTime(pParty->GetPlayingTime() -
-                                    GameTime::FromSeconds(amount)));
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(
-                        Condition_Weak, 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_EARTH_TELEKINESIS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 2 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 2 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 3 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 4 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int obj_id = PID_ID(spell_targeted_at);
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Item) {
-                    if (pItemTable
-                            ->pItems[pSpriteObjects[obj_id]
-                                         .containing_item.uItemID]
-                            .uEquipType == EQUIP_GOLD) {
-                        pParty->PartyFindsGold(
-                            pSpriteObjects[obj_id]
-                                .containing_item.special_enchantment,
-                            0);
-                        viewparams->bRedrawGameUI = true;
-                    } else {
-                        GameUI_SetStatusBar(
-                            LSTR_FMT_YOU_FOUND_ITEM,
-                            pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName
-                        );
-                        if (!pParty->AddItemToParty(
-                                &pSpriteObjects[obj_id].containing_item))
-                            pParty->SetHoldingItem(
-                                &pSpriteObjects[obj_id].containing_item);
-                    }
-                    SpriteObject::OnInteraction(obj_id);
-                }
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor)
-                    pActors[obj_id].LootActor();
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Decoration) {
-                    OpenedTelekinesis = true;
-                    if (pLevelDecorations[obj_id].uEventID)
-                        EventProcessor(pLevelDecorations[obj_id].uEventID,
-                                       spell_targeted_at, 1);
-                    if (pLevelDecorations[std::to_underlying(pSpriteObjects[obj_id]
-                                              .containing_item.uItemID)] // TODO(captainurist): investigate, that's a very weird std::to_underlying call.
-                            .IsInteractive()) {
-                        activeLevelDecoration = &pLevelDecorations[obj_id];
-                        EventProcessor(
-                            stru_5E4C90_MapPersistVars._decor_events
-                                    [pLevelDecorations[obj_id]._idx_in_stru123 -
-                                     75] +
-                                380,
-                            0, 1);
-                        activeLevelDecoration = nullptr;
-                    }
-                }
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Face) {
-                    int event;
-                    OpenedTelekinesis = true;
-                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        event = pIndoor->pFaceExtras[pIndoor->pFaces[obj_id].uFaceExtraID].uEventID;
-                    } else {
-                        event = pOutdoor->pBModels[spell_targeted_at >> 9].pFaces[obj_id & 0x3F].sCogTriggeredID;
-                    }
-                    EventProcessor(event, spell_targeted_at, 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_CURE_WEAKNESS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 180 * spell_level;
-                        break;  // 3 минуты * количество очков навыка
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;  // 1 час * количество очков навыка
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Weak)) {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Weak);
-                        spell_sound_flag = true;
-                        break;
-                    }
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Weak, GameTime(pParty->GetPlayingTime() -
-                                                GameTime::FromSeconds(amount)));
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_FIRST_AID:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 2 * spell_level + 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3 * spell_level + 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 4 * spell_level + 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 5 * spell_level + 5;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (!pCastSpell->spell_target_pid) {
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].Heal(amount);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                }
-                if (PID_TYPE(pCastSpell->spell_target_pid) == OBJECT_Actor) {
-                    monster_id = PID_ID(pCastSpell->spell_target_pid);
-                    if (pActors[monster_id].uAIState != Dead &&
-                        pActors[monster_id].uAIState != Dying &&
-                        pActors[monster_id].uAIState != Disabled &&
-                        pActors[monster_id].uAIState != Removed) {
-                        pActors[monster_id].sCurrentHP += amount;
-                        if (pActors[monster_id].sCurrentHP >
-                            pActors[monster_id].pMonsterInfo.uHP)
-                            pActors[monster_id].sCurrentHP =
-                                pActors[monster_id].pMonsterInfo.uHP;
-                    }
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_CURE_POISON:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3600 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 86400 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 0;
-                        break;
-                    default:
-                        assert(false);
-                }
-
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Weak) ||
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Medium) ||
-                    pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Poison_Severe)) {
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Weak);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Medium);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Reset(Condition_Poison_Severe);
-                        spell_sound_flag = true;
-                        break;
-                    }
-
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Poison_Weak,
-                            GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Poison_Medium,
-                            GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .DiscardConditionIfLastsLongerThan(
-                            Condition_Poison_Severe,
-                            GameTime(pParty->GetPlayingTime() -
-                                GameTime::FromSeconds(amount)));
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_PROTECTION_FROM_MAGIC:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_PROTECTION_FROM_MAGIC].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(3600 * spell_level)),
-                    spell_mastery, spell_level, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_BODY_HAMMERHANDS:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, 3);
-                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        pParty->pPlayers[pl_id]
-                            .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
-                            .Apply(
-                                GameTime(pParty->GetPlayingTime() +
-                                    GameTime::FromSeconds(3600 * spell_level)),
-                                spell_mastery, spell_level, spell_level, 0);
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
+                        pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Apply(
+                                GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
+                                spell_mastery, 0, 0, 0);
+                        InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
+                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                        pSpellSprite.spell_target_pid = spell_targeted_at;
+                        pSpellSprite.field_60_distance_related_prolly_lod =
+                            target_direction.uDistance;
+                        pSpellSprite.uFacing = target_direction.uYawAngle;
+                        pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
+                        pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
                     }
                     spell_sound_flag = true;
                     break;
                 }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                pParty->pPlayers[pCastSpell->uPlayerID_2]
-                    .pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS]
-                    .Apply(GameTime(pParty->GetPlayingTime() +
-                               GameTime::FromSeconds(3600 * spell_level)),
-                           spell_mastery, spell_level, spell_level, 0);
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_BODY_POWER_CURE:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                for (uint pl_id = 0; pl_id < 4; ++pl_id) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pl_id);
-                    pParty->pPlayers[pl_id].Heal(5 * spell_level + 10);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_DISPEL_MAGIC:
-            {
-                sRecoveryTime -= spell_level;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                spell_fx_renderer
-                    ->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.VibrantGreen.C32(),
-                                                                     192);
-                int mon_num = render->GetActorsInViewport(4096);
-                // ++pSpellSprite.uType;
-                pSpellSprite.uType = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                     ++spell_targeted_at) {
-                    pSpellSprite.vPosition.x =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.x;
-                    pSpellSprite.vPosition.y =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.y;
-                    pSpellSprite.vPosition.z =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.z -
-                        (int)((double)pActors[_50BF30_actors_in_viewport_ids
-                                                  [spell_targeted_at]]
-                                  .uActorHeight *
-                              -0.8);
-                    pSpellSprite.spell_target_pid =
-                        PID(OBJECT_Actor,
-                            _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                    Actor::DamageMonsterFromParty(
-                        PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                        _50BF30_actors_in_viewport_ids[spell_targeted_at],
-                        &spell_velocity);
-                }
-                for (spell_targeted_at = 0; spell_targeted_at < mon_num;
-                     ++spell_targeted_at) {
-                    pSpellSprite.vPosition.x =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.x;
-                    pSpellSprite.vPosition.y =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.y;
-                    pSpellSprite.vPosition.z =
-                        pActors
-                            [_50BF30_actors_in_viewport_ids[spell_targeted_at]]
-                                .vPosition.z -
-                        (unsigned int)(int64_t)((double)pActors
-                                                           [_50BF30_actors_in_viewport_ids
-                                                                [spell_targeted_at]]
-                                                               .uActorHeight *
-                                                       -0.8);
-                    pSpellSprite.spell_target_pid =
-                        PID(OBJECT_Actor,
-                            _50BF30_actors_in_viewport_ids[spell_targeted_at]);
-                    pSpellSprite.Create(0, 0, 0, 0);
-                    for (SpellBuff &buff : pActors[_50BF30_actors_in_viewport_ids[spell_targeted_at]].pActorBuffs)
-                        buff.Reset();
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_SUMMON_ELEMENTAL:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 300 * spell_level;
-                        amount = 1;
+                case SPELL_DARK_SACRIFICE:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
                         break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 300 * spell_level;
-                        amount = 1;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 900 * spell_level;
-                        amount = 3;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 900 * spell_level;
-                        amount = 5;
-                        break;
-                    default:
-                        assert(false);
-                }
-                int mon_num = 0;
-                for (uint monster_id = 0; monster_id < pActors.size(); monster_id++) {
-                    if (pActors[monster_id].uAIState != Dead &&
-                        pActors[monster_id].uAIState != Removed &&
-                        pActors[monster_id].uAIState != Disabled &&
-                        PID(OBJECT_Player, pCastSpell->uPlayerID) == pActors[monster_id].uSummonerID)
-                        ++mon_num;
-                }
-                if (mon_num >= amount) {
-                    SpellFailed(pCastSpell, LSTR_SUMMONS_LIMIT_REACHED);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                Spawn_Light_Elemental(pCastSpell->uPlayerID, spell_mastery, spellduration);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_DAY_OF_THE_GODS:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 10800 * spell_level;
-                        amount = 3 * spell_level + 10;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 10800 * spell_level;
-                        amount = 3 * spell_level + 10;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 14400 * spell_level;
-                        amount = 4 * spell_level + 10;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 18000 * spell_level;
-                        amount = 5 * spell_level + 10;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(
-                    pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_PRISMATIC_LIGHT:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-                    SpellFailed(pCastSpell, LSTR_CANT_PRISMATIC_OUTDOORS);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int mon_num = render->GetActorsInViewport(4096);
-                // ++pSpellSprite.uType;
-                pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                for (uint monster_id = 0; monster_id < mon_num; monster_id++) {
-                    pSpellSprite.vPosition.x =
-                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.x;
-                    pSpellSprite.vPosition.y =
-                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.y;
-                    pSpellSprite.vPosition.z =
-                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].vPosition.z -
-                        pActors[_50BF30_actors_in_viewport_ids[monster_id]].uActorHeight * -0.8;
-                    pSpellSprite.spell_target_pid =
-                        PID(OBJECT_Actor, _50BF30_actors_in_viewport_ids[monster_id]);
-                    Actor::DamageMonsterFromParty(
-                        PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                        _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
-                }
-                spell_fx_renderer->_4A8BFC_prismatic_light();
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_DAY_OF_PROTECTION:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 14400 * spell_level;
-                        amount = 4 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 14400 * spell_level;
-                        amount = 4 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 14400 * spell_level;
-                        amount = 4 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 18000 * spell_level;
-                        amount = 5 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, amount, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, spell_level + 5, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                    spell_mastery, spell_level + 5, 0, 0);
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_HOUR_OF_POWER:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 4;
-                        amount = 4;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 4;
-                        amount = 4;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 12;
-                        amount = 12;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 20;
-                        amount = 15;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                bool player_weak = false;
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
-                    pParty->pPlayers[pl_id]
-                        .pPlayerBuffs[PLAYER_BUFF_BLESS]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                               spell_mastery, spell_level + 5, 0, 0);
-                    if (pParty->pPlayers[pl_id].conditions.Has(Condition_Weak)) {
-                        player_weak = true;
                     }
-                }
-
-                pParty->pPartyBuffs[PARTY_BUFF_HEROISM].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                    spell_mastery, spell_level + 5, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_SHIELD].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                    spell_mastery, 0, 0, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_STONE_SKIN].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(300 * amount * spell_level + 60)),
-                    spell_mastery, spell_level + 5, 0, 0);
-                if (!player_weak) {
-                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(
-                        GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(
-                                60 * (spell_level * spellduration + 60))),
-                        spell_mastery, spell_level + 5, 0, 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_LIGHT_DIVINE_INTERVENTION:
-            {
-                if (pPlayer->uNumDivineInterventionCastsThisDay >= 3) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    pParty->pPlayers[pl_id].conditions.ResetAll();
-                    pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
-                    pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
-                }
-                if (pPlayer->sAgeModifier + 10 >= 120)
-                    pPlayer->sAgeModifier = 120;
-                else
-                    pPlayer->sAgeModifier = pPlayer->sAgeModifier + 10;
-                sRecoveryTime += -5 * spell_level;
-                ++pPlayer->uNumDivineInterventionCastsThisDay;
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_REANIMATE:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 2 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 3 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 4 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 5 * spell_level;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (!pCastSpell->spell_target_pid) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    if (pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Has(Condition_Dead)) {
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].SetCondition(Condition_Zombie, 1);
-                        GameUI_ReloadPlayerPortraits(pCastSpell->uPlayerID_2, (pParty->pPlayers[pCastSpell->uPlayerID_2].GetSexByVoice() != 0) + 23);
-                        pParty->pPlayers[pCastSpell->uPlayerID_2].conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
-                        // TODO: why call SetCondition and then conditions.Set?
+                    int hired_npc = 0;
+                    memset(&achieved_awards, 0, 4000);
+                    for (uint npc_id = 0; npc_id < 2; npc_id++) {
+                        if (!pParty->pHirelings[npc_id].pName.empty())
+                            achieved_awards[hired_npc++] = (AwardType)(npc_id + 1);
                     }
-                    break;
-                }
-                monster_id = PID_ID(pCastSpell->spell_target_pid);
-                if (monster_id == -1) {
-                    SpellFailed(pCastSpell, LSTR_NO_VALID_SPELL_TARGET);
-                    continue;
-                }
-                if (pActors[monster_id].sCurrentHP > 0 || pActors[monster_id].uAIState != Dead && pActors[monster_id].uAIState != Dying) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                // ++pSpellSprite.uType;
-                pSpellSprite.uType = SPRITE_SPELL_DARK_REANIMATE_1;
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z -
-                    (int)((double)pActors[monster_id].uActorHeight * -0.8);
-                pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
-                pSpellSprite.Create(0, 0, 0, 0);
-                if (pActors[monster_id].pMonsterInfo.uLevel > amount) break;
-                Actor::Resurrect(monster_id);
-                pActors[monster_id].pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
-                pActors[monster_id].pMonsterInfo.uTreasureDropChance = 0;
-                pActors[monster_id].pMonsterInfo.uTreasureDiceRolls = 0;
-                pActors[monster_id].pMonsterInfo.uTreasureDiceSides = 0;
-                pActors[monster_id].pMonsterInfo.uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID;
-                pActors[monster_id].pMonsterInfo.uTreasureType = 0;
-                pActors[monster_id].uAlly = 9999;
-                pActors[monster_id].ResetAggressor();  // ~0x80000
-                pActors[monster_id].uGroup = 0;
-                pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
-                pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
-                if (pActors[monster_id].sCurrentHP > 10 * amount) {
-                    pActors[monster_id].sCurrentHP = 10 * amount;
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_DARK_SHARPMETAL:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        amount = 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        amount = 5;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        amount = 7;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        amount = 9;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                // TODO(pskelton): was pParty->uPartyHeight / 2
-                pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                }
-                spell_spray_angle_start = ONE_THIRD_PI / -2;
-                spell_spray_angle_end = ONE_THIRD_PI / 2;
-                if (spell_spray_angle_start <= spell_spray_angle_end) {
-                    do {
-                        pSpellSprite.uFacing = spell_spray_angle_start +
-                                               target_direction.uYawAngle;
-                        if (pSpellSprite.Create(pSpellSprite.uFacing, target_direction.uPitchAngle, pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed,
-                            pCastSpell->uPlayerID + 1) != -1 && pParty->bTurnBasedModeOn) {
-                            ++pTurnEngine->pending_actions;
-                        }
-                        spell_spray_angle_start += ONE_THIRD_PI / (amount - 1);
-                    } while (spell_spray_angle_start <= spell_spray_angle_end);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_CONTROL_UNDEAD:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 180 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 180 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 300 * spell_level;
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 29030400;
-                        break;
-                    default:
-                        assert(false);
-                }
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
-                    monster_id = PID_ID(spell_targeted_at);
-                    if (!MonsterStats::BelongsToSupertype(
-                            pActors[monster_id].pMonsterInfo.uID,
-                            MONSTER_SUPERTYPE_UNDEAD))
-                        break;
-                    if (!pActors[monster_id].DoesDmgTypeDoDamage(DMGT_DARK)) {
+                    if (pCastSpell->uPlayerID_2 != 4 && pCastSpell->uPlayerID_2 != 5 ||
+                            achieved_awards[pCastSpell->uPlayerID_2 - 4] <= 0 ||
+                            achieved_awards[pCastSpell->uPlayerID_2 - 4] >= 3) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         continue;
                     }
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Apply(
-                        GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)),
-                        spell_mastery, 0, 0, 0);
-                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
-                    pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
-                    pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
-                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                    pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        target_direction.uDistance;
-                    pSpellSprite.uFacing = target_direction.uYawAngle;
-                    pSpellSprite.uAttributes |= SPRITE_ATTACHED_TO_HEAD;
-                    pSpellSprite.Create(0, 0, 0, pCastSpell->uPlayerID + 1);
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_SACRIFICE:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                int hired_npc = 0;
-                memset(&achieved_awards, 0, 4000);
-                for (uint npc_id = 0; npc_id < 2; npc_id++) {
-                    if (!pParty->pHirelings[npc_id].pName.empty())
-                        achieved_awards[hired_npc++] = (AwardType)(npc_id + 1);
-                }
-
-                if (pCastSpell->uPlayerID_2 != 4 && pCastSpell->uPlayerID_2 != 5 ||
-                    achieved_awards[pCastSpell->uPlayerID_2 - 4] <= 0 ||
-                    achieved_awards[pCastSpell->uPlayerID_2 - 4] >= 3) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                int hireling_idx = achieved_awards[pCastSpell->uPlayerID_2 - 4] - 1;
-                pParty->pHirelings[hireling_idx].dialogue_1_evt_id = 1;
-                pParty->pHirelings[hireling_idx].dialogue_2_evt_id = 0;
-                pParty->pHirelings[hireling_idx].dialogue_3_evt_id = pIconsFrameTable->GetIcon("spell96")->GetAnimLength();
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
-                    pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
-                }
-                DDM_DLV_Header *ddm_dlv = &pOutdoor->ddm;
-                if (uCurrentlyLoadedLevelType != LEVEL_Outdoor) {
-                    ddm_dlv = &pIndoor->dlv;
-                }
-                ddm_dlv->uReputation += 15;
-                if (ddm_dlv->uReputation > 10000) {
-                    ddm_dlv->uReputation = 10000;
-                }
-                spell_sound_flag = true;
-                break;
-            }
-
-            case SPELL_DARK_PAIN_REFLECTION:
-            {
-                switch (spell_mastery) {
-                    case PLAYER_SKILL_MASTERY_NOVICE:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_EXPERT:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_MASTER:
-                        spellduration = 300 * (spell_level + 12);
-                        break;
-                    case PLAYER_SKILL_MASTERY_GRANDMASTER:
-                        spellduration = 900 * (spell_level + 4);
-                        break;
-                    default:
-                        assert(false);
-                }
-                amount = spell_level + 5;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
-                    break;
-                }
-                if (spell_mastery != PLAYER_SKILL_MASTERY_MASTER && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(spellduration)),
-                               spell_mastery, amount, 0, 0);
+                    int hireling_idx = achieved_awards[pCastSpell->uPlayerID_2 - 4] - 1;
+                    pParty->pHirelings[hireling_idx].dialogue_1_evt_id = 1;
+                    pParty->pHirelings[hireling_idx].dialogue_2_evt_id = 0;
+                    pParty->pHirelings[hireling_idx].dialogue_3_evt_id = pIconsFrameTable->GetIcon("spell96")->GetAnimLength();
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        pParty->pPlayers[pl_id].sHealth = pParty->pPlayers[pl_id].GetMaxHealth();
+                        pParty->pPlayers[pl_id].sMana = pParty->pPlayers[pl_id].GetMaxMana();
+                    }
+                    DDM_DLV_Header *ddm_dlv = &pOutdoor->ddm;
+                    if (uCurrentlyLoadedLevelType != LEVEL_Outdoor) {
+                        ddm_dlv = &pIndoor->dlv;
+                    }
+                    ddm_dlv->uReputation += 15;
+                    if (ddm_dlv->uReputation > 10000) {
+                        ddm_dlv->uReputation = 10000;
+                    }
                     spell_sound_flag = true;
                     break;
                 }
-                for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
-                    pParty->pPlayers[pl_id]
-                        .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(spellduration)),
-                               spell_mastery, amount, 0, 0);
-                }
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_DARK_SOULDRINKER:
-            {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                case SPELL_DARK_PAIN_REFLECTION:
+                {
+                    switch (spell_mastery) {
+                        case PLAYER_SKILL_MASTERY_NOVICE:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_EXPERT:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_MASTER:
+                            spellduration = 300 * (spell_level + 12);
+                            break;
+                        case PLAYER_SKILL_MASTERY_GRANDMASTER:
+                            spellduration = 900 * (spell_level + 4);
+                            break;
+                        default:
+                            assert(false);
+                    }
+                    amount = spell_level + 5;
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
+                    }
+                    if (spell_mastery != PLAYER_SKILL_MASTERY_MASTER && spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                        pParty->pPlayers[pCastSpell->uPlayerID_2]
+                            .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, amount, 0, 0);
+                        spell_sound_flag = true;
+                        break;
+                    }
+                    for (uint pl_id = 0; pl_id < 4; pl_id++) {
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_id);
+                        pParty->pPlayers[pl_id]
+                            .pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION]
+                            .Apply(GameTime(pParty->GetPlayingTime() +
+                                        GameTime::FromSeconds(spellduration)),
+                                    spell_mastery, amount, 0, 0);
+                    }
+                    spell_sound_flag = true;
                     break;
                 }
 
-                int mon_num = render->GetActorsInViewport((int64_t)pCamera3D->GetMouseInfoDepth());
-                InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                pSpellSprite.uSectorID = 0;
-                pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                pSpellSprite.uFacing = 0;
-                amount = 0;
-                if (mon_num > 0) {
-                    amount = (mon_num * (7 * spell_level + 25));
-                    for (uint monster_id = 0; monster_id < mon_num;
-                         monster_id++) {
-                        pSpellSprite.vPosition.x =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors[_50BF30_actors_in_viewport_ids[monster_id]]
-                                .vPosition.z -
-                            (int)((double)pActors[_50BF30_actors_in_viewport_ids
-                                                      [monster_id]]
-                                      .uActorHeight *
-                                  -0.8);
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor,
-                                _50BF30_actors_in_viewport_ids[monster_id]);
-                        Actor::DamageMonsterFromParty(
-                            PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                            _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
+                case SPELL_DARK_SOULDRINKER:
+                {
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) {
+                        break;
                     }
-                }
-                int pl_num = 0;
-                int pl_array[4] {};
-                for (uint pl_id = 1; pl_id <= 4; ++pl_id) {
-                    if (!pPlayers[pl_id]->conditions.Has(Condition_Sleep) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Paralyzed) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Unconscious) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
-                        !pPlayers[pl_id]->conditions.Has(Condition_Eradicated)) {
-                        pl_array[pl_num++] = pl_id;
-                    }
-                }
-                for (uint j = 0; j < pl_num; j++) {
-                    pPlayers[pl_array[j]]->sHealth +=
-                        (int64_t)((double)(signed int)amount /
-                                         (double)pl_num);
-                    if (pPlayers[pl_array[j]]->sHealth > pPlayers[pl_array[j]]->GetMaxHealth())
-                        pPlayers[pl_array[j]]->sHealth = pPlayers[pl_array[j]]->GetMaxHealth();
-                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_array[j]);
-                }
-                spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Black.C32(), 64);
-                spell_sound_flag = true;
-                break;
-            }
 
-            case SPELL_DARK_ARMAGEDDON:
-            {
-                if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                    SpellFailed(pCastSpell, LSTR_CANT_ARMAGEDDON_INDOORS);
-                    continue;
+                    int mon_num = render->GetActorsInViewport((int64_t)pCamera3D->GetMouseInfoDepth());
+                    InitSpellSprite( &pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.uSectorID = 0;
+                    pSpellSprite.field_60_distance_related_prolly_lod = 0;
+                    pSpellSprite.uFacing = 0;
+                    amount = 0;
+                    if (mon_num > 0) {
+                        amount = (mon_num * (7 * spell_level + 25));
+                        for (uint monster_id = 0; monster_id < mon_num;
+                                monster_id++) {
+                            pSpellSprite.vPosition.x =
+                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                                .vPosition.x;
+                            pSpellSprite.vPosition.y =
+                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                                .vPosition.y;
+                            pSpellSprite.vPosition.z =
+                                pActors[_50BF30_actors_in_viewport_ids[monster_id]]
+                                .vPosition.z -
+                                (int)((double)pActors[_50BF30_actors_in_viewport_ids
+                                        [monster_id]]
+                                        .uActorHeight *
+                                        -0.8);
+                            pSpellSprite.spell_target_pid =
+                                PID(OBJECT_Actor,
+                                        _50BF30_actors_in_viewport_ids[monster_id]);
+                            Actor::DamageMonsterFromParty(
+                                    PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
+                                    _50BF30_actors_in_viewport_ids[monster_id], &spell_velocity);
+                        }
+                    }
+                    int pl_num = 0;
+                    int pl_array[4] {};
+                    for (uint pl_id = 1; pl_id <= 4; ++pl_id) {
+                        if (!pPlayers[pl_id]->conditions.Has(Condition_Sleep) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Paralyzed) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Unconscious) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Dead) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Petrified) &&
+                                !pPlayers[pl_id]->conditions.Has(Condition_Eradicated)) {
+                            pl_array[pl_num++] = pl_id;
+                        }
+                    }
+                    for (uint j = 0; j < pl_num; j++) {
+                        pPlayers[pl_array[j]]->sHealth +=
+                            (int64_t)((double)(signed int)amount /
+                                    (double)pl_num);
+                        if (pPlayers[pl_array[j]]->sHealth > pPlayers[pl_array[j]]->GetMaxHealth())
+                            pPlayers[pl_array[j]]->sHealth = pPlayers[pl_array[j]]->GetMaxHealth();
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pl_array[j]);
+                    }
+                    spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.Black.C32(), 64);
+                    spell_sound_flag = true;
+                    break;
                 }
-                if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    amount = 4;
-                } else {
-                    amount = 3;
+
+                case SPELL_DARK_ARMAGEDDON:
+                {
+                    if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
+                        SpellFailed(pCastSpell, LSTR_CANT_ARMAGEDDON_INDOORS);
+                        continue;
+                    }
+                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
+                        amount = 4;
+                    } else {
+                        amount = 3;
+                    }
+                    if (pPlayer->uNumArmageddonCasts >= amount ||
+                            pParty->armageddon_timer > 0) {
+                        SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        continue;
+                    }
+                    if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                    pParty->armageddon_timer = 256;
+                    pParty->armageddonDamage = spell_level;
+                    ++pPlayer->uNumArmageddonCasts;
+                    if (pParty->bTurnBasedModeOn) {
+                        ++pTurnEngine->pending_actions;
+                    }
+                    for (uint i = 0; i < 50; i++) {
+                        int rand_x = grng->Random(4096) - 2048;
+                        int rand_y = grng->Random(4096) - 2048;
+                        bool bOnWater = false;
+                        int terr_height = GetTerrainHeightsAroundParty2(
+                                rand_x + pParty->vPosition.x,
+                                rand_y + pParty->vPosition.y, &bOnWater, 0);
+                        SpriteObject::Drop_Item_At(
+                                SPRITE_SPELL_EARTH_ROCK_BLAST,
+                                rand_x + pParty->vPosition.x,
+                                rand_y + pParty->vPosition.y, terr_height + 16,
+                                grng->Random(500) + 500, 1, 0, 0, 0);
+                    }
+                    spell_sound_flag = true;
+                    break;
                 }
-                if (pPlayer->uNumArmageddonCasts >= amount ||
-                    pParty->armageddon_timer > 0) {
-                    SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
-                    continue;
-                }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                pParty->armageddon_timer = 256;
-                pParty->armageddonDamage = spell_level;
-                ++pPlayer->uNumArmageddonCasts;
-                if (pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
-                }
-                for (uint i = 0; i < 50; i++) {
-                    int rand_x = grng->Random(4096) - 2048;
-                    int rand_y = grng->Random(4096) - 2048;
-                    bool bOnWater = false;
-                    int terr_height = GetTerrainHeightsAroundParty2(
-                        rand_x + pParty->vPosition.x,
-                        rand_y + pParty->vPosition.y, &bOnWater, 0);
-                    SpriteObject::Drop_Item_At(
-                        SPRITE_SPELL_EARTH_ROCK_BLAST,
-                        rand_x + pParty->vPosition.x,
-                        rand_y + pParty->vPosition.y, terr_height + 16,
-                        grng->Random(500) + 500, 1, 0, 0, 0);
-                }
-                spell_sound_flag = true;
-                break;
+                default:
+                    break;
             }
-            default:
-                break;
-        }
         }
 
         if (~pCastSpell->uFlags & ON_CAST_NoRecoverySpell) {

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2305,12 +2305,11 @@ char byte_4FAA24;  // turn over break??
 
 // std::array<unsigned int, 480> pSRZBufferLineOffsets;
 std::array<char, 777> books_num_items_per_page;
-int lloyds_beacon_spell_id;  // dword_506338
-int lloyds_beacon_sound_id;  // dword_50633C
+int LloydsBeaconSpellId;
 signed int sRecoveryTime;    // idb
 unsigned int uRequiredMana;  // idb
 int _506348_current_lloyd_playerid;
-int64_t lloyds_beacon_spell_level;  // qword_506350 604800 *sepell level
+int LloydsBeaconSpellLevel;  // 604800 * spell level
 int MapBookOpen;
 int books_page_number;
 int books_primary_item_per_page;
@@ -2358,7 +2357,7 @@ stru367 PortalFace;
 std::array<int, 100> dword_50BC10;
 std::array<int, 100> dword_50BDA0;
 std::array<int, 100> _50BF30_actors_in_viewport_ids;
-char town_portal_caster_id;
+char TownPortalCasterId;
 int some_active_character;
 std::array<unsigned int, 5> pIconIDs_Turn;
 unsigned int uIconID_TurnStop;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -117,12 +117,11 @@ extern int dword_4FA9B4[];
 
 // extern std::array<unsigned int, 480> pSRZBufferLineOffsets;
 extern std::array<char, 777> books_num_items_per_page;
-extern int lloyds_beacon_spell_id;  // dword_506338
-extern int lloyds_beacon_sound_id;  // dword_50633C
+extern int LloydsBeaconSpellId;
 extern signed int sRecoveryTime;    // idb
 extern unsigned int uRequiredMana;  // idb
 extern int _506348_current_lloyd_playerid;
-extern int64_t lloyds_beacon_spell_level;  // qword_506350
+extern int LloydsBeaconSpellLevel;
 extern int MapBookOpen;
 // extern Texture_MM7 *dword_50640C[];
 extern int
@@ -173,7 +172,7 @@ extern struct stru367 PortalFace;
 extern std::array<int, 100> dword_50BC10;
 extern std::array<int, 100> dword_50BDA0;
 extern std::array<int, 100> _50BF30_actors_in_viewport_ids;
-extern char town_portal_caster_id;
+extern char TownPortalCasterId;
 extern int some_active_character;
 extern std::array<unsigned int, 5> pIconIDs_Turn;
 extern unsigned int uIconID_TurnStop;


### PR DESCRIPTION
Made refactoring of main spell casting function, which consist of:
- Cleaning up hex-rays variables
- Move common code out of switch cases, some into separate functions and some just out of switch
- Move code a little in general

Note:
Github diff view is not treating indentation changes adequately. I specially made switch indentation in separate commit but it still may be difficult to read. If needed I can make commit that removes indentation and add it back later.