### PR TITLE
Test for #427 works

### DIFF
--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -198,6 +198,8 @@ void Party::Zero() {
 
     // hirelings
     pHirelings.fill(NPCData());
+
+    playerAlreadyPicked.fill(false); // TODO(captainurist): belongs in a different place?
 }
 
 // inlined

--- a/src/Engine/Plugins/CMakeLists.txt
+++ b/src/Engine/Plugins/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PLUGINS_HEADERS EngineController.h
                     EngineControlState.h
                     EngineControlStateHandle.h
                     EngineDeterministicPlugin.h
+                    EngineTracePlaybackFlags.h
                     EngineTracePlugin.h
                     EngineTracer.h)
 

--- a/src/Engine/Plugins/EngineController.cpp
+++ b/src/Engine/Plugins/EngineController.cpp
@@ -101,12 +101,14 @@ void EngineController::goToMainMenu() {
     if (GetCurrentMenuID() == MENU_MAIN)
         return;
 
-    while (pArcomageGame->bGameInProgress) {
+    assert(!pArcomageGame->bGameInProgress); // Going from Arcomage to main menu is not implemented yet.
+
+    if (current_screen_type == CURRENT_SCREEN::SCREEN_CHARACTERS) {
         pressAndReleaseKey(PlatformKey::Escape);
         tick(1);
     }
 
-    while (current_screen_type == CURRENT_SCREEN::SCREEN_HOUSE) {
+    if (current_screen_type == CURRENT_SCREEN::SCREEN_HOUSE) {
         pressAndReleaseKey(PlatformKey::Escape);
         tick(1);
     }

--- a/src/Engine/Plugins/EngineController.cpp
+++ b/src/Engine/Plugins/EngineController.cpp
@@ -103,6 +103,11 @@ void EngineController::goToMainMenu() {
 
     assert(!pArcomageGame->bGameInProgress); // Going from Arcomage to main menu is not implemented yet.
 
+    if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) {
+        pressAndReleaseKey(PlatformKey::Escape);
+        tick(1);
+    }
+
     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHARACTERS) {
         pressAndReleaseKey(PlatformKey::Escape);
         tick(1);

--- a/src/Engine/Plugins/EngineTracePlaybackFlags.h
+++ b/src/Engine/Plugins/EngineTracePlaybackFlags.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Utility/Flags.h"
+
+enum class EngineTracePlaybackFlag {
+    TRACE_PLAYBACK_SKIP_RANDOM_CHECKS = 0x1,
+    TRACE_PLAYBACK_SKIP_TIME_CHECKS = 0x2,
+};
+using enum EngineTracePlaybackFlag;
+MM_DECLARE_FLAGS(EngineTracePlaybackFlags, EngineTracePlaybackFlag)
+MM_DECLARE_OPERATORS_FOR_FLAGS(EngineTracePlaybackFlags)

--- a/src/Engine/Plugins/EngineTracer.cpp
+++ b/src/Engine/Plugins/EngineTracer.cpp
@@ -107,7 +107,8 @@ void EngineTracer::playTrace(EngineController *game, const std::string &savePath
     _deterministicPlugin->resetDeterministicState();
     _keyboardController->reset(); // Reset all pressed buttons.
 
-    postLoadCallback();
+    if (postLoadCallback)
+        postLoadCallback();
 
     for (std::unique_ptr<PlatformEvent> &event : trace.events) {
         if (event->type == EVENT_PAINT) {

--- a/src/Engine/Plugins/EngineTracer.h
+++ b/src/Engine/Plugins/EngineTracer.h
@@ -8,6 +8,8 @@
 
 #include "Utility/Flags.h"
 
+#include "EngineTracePlaybackFlags.h"
+
 class EngineController;
 class EngineTracePlugin;
 class EngineDeterministicPlugin;
@@ -73,10 +75,12 @@ class EngineTracer : private PlatformApplicationAware {
      * @param game                      Engine controller.
      * @param savePath                  Path to save file.
      * @param tracePath                 Path to trace file.
+     * @param flags                     Playback flags.
      * @param postLoadCallback          Callback to call once the savegame is loaded.
      * @see EngineControlPlugin
      */
-    void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath, std::function<void()> postLoadCallback = {});
+    void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath,
+                   EngineTracePlaybackFlags flags = 0, std::function<void()> postLoadCallback = {});
 
  private:
     friend class PlatformIntrospection;

--- a/src/Engine/Plugins/EngineTracer.h
+++ b/src/Engine/Plugins/EngineTracer.h
@@ -76,7 +76,7 @@ class EngineTracer : private PlatformApplicationAware {
      * @param postLoadCallback          Callback to call once the savegame is loaded.
      * @see EngineControlPlugin
      */
-    void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath, std::function<void()> postLoadCallback);
+    void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath, std::function<void()> postLoadCallback = {});
 
  private:
     friend class PlatformIntrospection;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -18,7 +18,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 1433fce638059fb1e1f616a8c56cfd5bc35d6b63
+        GIT_TAG 7c9c17e250b049df4315ca0859780f1bffa81d37
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Testing/Game/TestController.cpp
+++ b/test/Testing/Game/TestController.cpp
@@ -23,12 +23,18 @@ void TestController::loadGameFromTestData(const std::string &name) {
 }
 
 void TestController::playTraceFromTestData(const std::string &saveName, const std::string &traceName, std::function<void()> postLoadCallback) {
+    playTraceFromTestData(saveName, traceName, 0, std::move(postLoadCallback));
+}
+
+void TestController::playTraceFromTestData(const std::string &saveName, const std::string &traceName,
+                                           EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback) {
     // TODO(captainurist): we need to overhaul our usage of path::string, path::u8string, path::generic_string,
     // pick one, and spell it out explicitly in HACKING
     ::application->get<EngineTracer>()->playTrace(
         _controller,
         (_testDataPath / saveName).string(),
         (_testDataPath / traceName).string(),
+        flags,
         std::move(postLoadCallback)
     );
 }

--- a/test/Testing/Game/TestController.h
+++ b/test/Testing/Game/TestController.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <functional>
 
+#include "Engine/Plugins/EngineTracePlaybackFlags.h"
+
 class EngineController;
 class EngineTracer;
 
@@ -13,6 +15,7 @@ class TestController {
 
     void loadGameFromTestData(const std::string &name);
     void playTraceFromTestData(const std::string &saveName, const std::string &traceName, std::function<void()> postLoadCallback = {});
+    void playTraceFromTestData(const std::string &saveName, const std::string &traceName, EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback = {});
 
     void prepareForNextTest();
 

--- a/test/Testing/Game/TestController.h
+++ b/test/Testing/Game/TestController.h
@@ -12,7 +12,7 @@ class TestController {
     TestController(EngineController *controller, const std::string &testDataPath);
 
     void loadGameFromTestData(const std::string &name);
-    void playTraceFromTestData(const std::string &saveName, const std::string &traceName, std::function<void()> postLoadCallback);
+    void playTraceFromTestData(const std::string &saveName, const std::string &traceName, std::function<void()> postLoadCallback = {});
 
     void prepareForNextTest();
 

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -122,15 +122,18 @@ static void check427Buffs(std::initializer_list<int> players, bool hasBuff) {
 GAME_TEST(Issues, Issue427) {
     // Test that some of the buff spells that start to affect whole party starting from certain mastery work correctly.
 
+    // TODO(captainurist): this triggers a random state check failure when played back after the tests above,
+    // but doesn't trigger when played back alone. Investigate, remove TRACE_PLAYBACK_SKIP_RANDOM_CHECKS.
+
     // In this test mastery is not enough for the whole party buff
-    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json");
+    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
 
     // Check that spell targeting works correctly - 1st char is getting the buffs.
     check427Buffs({0}, true);
     check427Buffs({1, 2, 3}, false);
 
     // In this test mastery is enough for the whole party
-    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json");
+    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
 
     // Check that all character have buffs
     check427Buffs({0, 1, 2, 3}, true);

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -110,48 +110,31 @@ GAME_TEST(Issues, Issue417) {
     test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json", [] {});
 }
 
-GAME_TEST(Issues, Issue427a) {
-    // Test that some of buff spells that start to affect whole party starting from certain mastery work correctly
-    // In this test mastery is not enough for the whole party
-    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", [&] {});
-    // Check that only one character have buffs
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), false);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), false);
+static void check427Buffs(int player, bool hasBuff) {
+    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), hasBuff);
+    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), hasBuff);
+    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), hasBuff);
+    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), hasBuff);
 }
 
-GAME_TEST(Issues, Issue427b) {
-    // Test that some of buff spells that start to affect whole party starting from certain mastery work correctly
+GAME_TEST(Issues, Issue427) {
+    // Test that some of the buff spells that start to affect whole party starting from certain mastery work correctly.
+
+    // In this test mastery is not enough for the whole party buff
+    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", [&] {});
+
+    // Check that spell targeting works correctly - 1st char is getting the buffs.
+    check427Buffs(0, true);
+    check427Buffs(1, false);
+    check427Buffs(2, false);
+    check427Buffs(3, false);
+
     // In this test mastery is enough for the whole party
     test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json", [&] {});
+
     // Check that all character have buffs
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[0].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[1].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[2].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), true);
-    EXPECT_EQ(pParty->pPlayers[3].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), true);
+    check427Buffs(0, true);
+    check427Buffs(1, true);
+    check427Buffs(2, true);
+    check427Buffs(3, true);
 }

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -110,11 +110,11 @@ GAME_TEST(Issues, Issue417) {
     test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json");
 }
 
-static void check427Buffs(std::initializer_list<int> players, bool hasBuff) {
+static void check427Buffs(const char *ctx, std::initializer_list<int> players, bool hasBuff) {
     for (int player : players) {
         for (PLAYER_BUFFS buff : {PLAYER_BUFF_BLESS, PLAYER_BUFF_PRESERVATION, PLAYER_BUFF_HAMMERHANDS, PLAYER_BUFF_PAIN_REFLECTION}) {
             EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[buff].Active(), hasBuff)
-                << "(with player=" << player << " and buff=" << buff << ")";
+                << "(with ctx=" << ctx << ", player=" << player << ", buff=" << buff << ")";
         }
     }
 }
@@ -129,12 +129,13 @@ GAME_TEST(Issues, Issue427) {
     test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
 
     // Check that spell targeting works correctly - 1st char is getting the buffs.
-    check427Buffs({0}, true);
-    check427Buffs({1, 2, 3}, false);
+    check427Buffs("a", {0}, true);
+    check427Buffs("a", {1, 2, 3}, false);
 
     // In this test mastery is enough for the whole party
     test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
 
     // Check that all character have buffs
-    check427Buffs({0, 1, 2, 3}, true);
+    // check427Buffs("b", {0, 1, 2, 3}, true);
+    // TODO(captainurist): currently fails ^, looks like random state desync is to blame
 }

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -110,11 +110,13 @@ GAME_TEST(Issues, Issue417) {
     test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json");
 }
 
-static void check427Buffs(int player, bool hasBuff) {
-    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_BLESS].Active(), hasBuff);
-    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_PRESERVATION].Active(), hasBuff);
-    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_HAMMERHANDS].Active(), hasBuff);
-    EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[PLAYER_BUFF_PAIN_REFLECTION].Active(), hasBuff);
+static void check427Buffs(std::initializer_list<int> players, bool hasBuff) {
+    for (int player : players) {
+        for (PLAYER_BUFFS buff : {PLAYER_BUFF_BLESS, PLAYER_BUFF_PRESERVATION, PLAYER_BUFF_HAMMERHANDS, PLAYER_BUFF_PAIN_REFLECTION}) {
+            EXPECT_EQ(pParty->pPlayers[player].pPlayerBuffs[buff].Active(), hasBuff)
+                << "(with player=" << player << " and buff=" << buff << ")";
+        }
+    }
 }
 
 GAME_TEST(Issues, Issue427) {
@@ -124,17 +126,12 @@ GAME_TEST(Issues, Issue427) {
     test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json");
 
     // Check that spell targeting works correctly - 1st char is getting the buffs.
-    check427Buffs(0, true);
-    check427Buffs(1, false);
-    check427Buffs(2, false);
-    check427Buffs(3, false);
+    check427Buffs({0}, true);
+    check427Buffs({1, 2, 3}, false);
 
     // In this test mastery is enough for the whole party
     test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json");
 
     // Check that all character have buffs
-    check427Buffs(0, true);
-    check427Buffs(1, true);
-    check427Buffs(2, true);
-    check427Buffs(3, true);
+    check427Buffs({0, 1, 2, 3}, true);
 }

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -15,7 +15,7 @@ GAME_TEST(Items, GenerateItem) {
 GAME_TEST(Prs, Pr314) {
     // Check that character creating menu works.
     // Trace pretty much presses all the buttons and opens all the popups possible.
-    test->playTraceFromTestData("pr_314.mm7", "pr_314.json", [] {});
+    test->playTraceFromTestData("pr_314.mm7", "pr_314.json");
 
     for (int i = 0; i < 4; i++)
         EXPECT_EQ(pParty->pPlayers[i].uLuck, 20);
@@ -60,7 +60,7 @@ GAME_TEST(Issues, Issue315) {
 
 GAME_TEST(Issues, Issue403) {
     // Entering Lincoln shouldn't crash.
-    test->playTraceFromTestData("issue_403.mm7", "issue_403.json", [] {});
+    test->playTraceFromTestData("issue_403.mm7", "issue_403.json");
 }
 
 GAME_TEST(Prs, Pr347) {
@@ -76,7 +76,7 @@ GAME_TEST(Issues, Issue388) {
     pArcomageGame->_targetFPS = 500;
     // Trace enters tavern, plays arcomage, plays a couple of cards then exits and leaves tavern
     CURRENT_SCREEN oldscreen = CURRENT_SCREEN::SCREEN_GAME;
-    test->playTraceFromTestData("issue_388.mm7", "issue_388.json", [&] {oldscreen = current_screen_type; });
+    test->playTraceFromTestData("issue_388.mm7", "issue_388.json", [&] { oldscreen = current_screen_type; });
     // we should return to game screen
     EXPECT_EQ(oldscreen, current_screen_type);
     // with arcomage exit flag
@@ -86,7 +86,7 @@ GAME_TEST(Issues, Issue388) {
 
 GAME_TEST(Issues, Issue402) {
     // Attacking while wearing wetsuits shouldn't assert.
-    test->playTraceFromTestData("issue_402.mm7", "issue_402.json", [] {});
+    test->playTraceFromTestData("issue_402.mm7", "issue_402.json");
 }
 
 GAME_TEST(Issues, Issue408) {
@@ -106,8 +106,8 @@ GAME_TEST(Issues, Issue408) {
 
 GAME_TEST(Issues, Issue417) {
     // testing that portal nodes looping doesnt assert
-    test->playTraceFromTestData("issue_417a.mm7", "issue_417a.json", [] {});
-    test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json", [] {});
+    test->playTraceFromTestData("issue_417a.mm7", "issue_417a.json");
+    test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json");
 }
 
 static void check427Buffs(int player, bool hasBuff) {
@@ -121,7 +121,7 @@ GAME_TEST(Issues, Issue427) {
     // Test that some of the buff spells that start to affect whole party starting from certain mastery work correctly.
 
     // In this test mastery is not enough for the whole party buff
-    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", [&] {});
+    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json");
 
     // Check that spell targeting works correctly - 1st char is getting the buffs.
     check427Buffs(0, true);
@@ -130,7 +130,7 @@ GAME_TEST(Issues, Issue427) {
     check427Buffs(3, false);
 
     // In this test mastery is enough for the whole party
-    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json", [&] {});
+    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json");
 
     // Check that all character have buffs
     check427Buffs(0, true);

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -122,20 +122,16 @@ static void check427Buffs(const char *ctx, std::initializer_list<int> players, b
 GAME_TEST(Issues, Issue427) {
     // Test that some of the buff spells that start to affect whole party starting from certain mastery work correctly.
 
-    // TODO(captainurist): this triggers a random state check failure when played back after the tests above,
-    // but doesn't trigger when played back alone. Investigate, remove TRACE_PLAYBACK_SKIP_RANDOM_CHECKS.
-
     // In this test mastery is not enough for the whole party buff
-    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
+    test->playTraceFromTestData("issue_427a.mm7", "issue_427a.json");
 
     // Check that spell targeting works correctly - 1st char is getting the buffs.
     check427Buffs("a", {0}, true);
     check427Buffs("a", {1, 2, 3}, false);
 
     // In this test mastery is enough for the whole party
-    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
+    test->playTraceFromTestData("issue_427b.mm7", "issue_427b.json");
 
     // Check that all character have buffs
-    // check427Buffs("b", {0, 1, 2, 3}, true);
-    // TODO(captainurist): currently fails ^, looks like random state desync is to blame
+    check427Buffs("b", {0, 1, 2, 3}, true);
 }


### PR DESCRIPTION
* `playerAlreadyPicked` was carried over between saves, this was leading to problems.
* Added some more code to `EngineController::goToMainMenu` to properly handle different screens.
* `EngineTracer::playTrace` now has flags to skip random state checks. These mainly come in handy when investigating problems.
* Terser code for  Issue427 test.