### PR TITLE
Resolved some gamepad-related TODOs in Platform code

### DIFF
--- a/src/Application/GameKeyboardController.cpp
+++ b/src/Application/GameKeyboardController.cpp
@@ -22,16 +22,16 @@ bool GameKeyboardController::IsKeyDown(PlatformKey key) const {
     return isKeyDown_[key];
 }
 
-void GameKeyboardController::ProcessKeyPressEvent(const PlatformKeyEvent *event) {
-    if (isKeyDown_[event->key])
+void GameKeyboardController::ProcessKeyPressEvent(PlatformKey key) {
+    if (isKeyDown_[key])
         return; // Auto repeat
 
-    isKeyDown_[event->key] = true;
-    isKeyDownReported_[event->key] = false;
+    isKeyDown_[key] = true;
+    isKeyDownReported_[key] = false;
 }
 
-void GameKeyboardController::ProcessKeyReleaseEvent(const PlatformKeyEvent *event) {
-    isKeyDown_[event->key] = false;
+void GameKeyboardController::ProcessKeyReleaseEvent(PlatformKey key) {
+    isKeyDown_[key] = false;
 }
 
 void GameKeyboardController::reset() {

--- a/src/Application/GameKeyboardController.h
+++ b/src/Application/GameKeyboardController.h
@@ -8,8 +8,6 @@
 
 #include "Io/IKeyboardController.h"
 
-class PlatformKeyEvent;
-
 // TODO(captainurist): deriving from PlatformApplicationAware is a temporary (and ugly!) measure.
 // We need it so that `EngineTracer` can call reset. Just turn this one into an event filter!
 class GameKeyboardController: public Io::IKeyboardController, public PlatformApplicationAware {
@@ -19,8 +17,8 @@ class GameKeyboardController: public Io::IKeyboardController, public PlatformApp
     virtual bool ConsumeKeyPress(PlatformKey key) override;
     virtual bool IsKeyDown(PlatformKey key) const override;
 
-    void ProcessKeyPressEvent(const PlatformKeyEvent *event);
-    void ProcessKeyReleaseEvent(const PlatformKeyEvent *event);
+    void ProcessKeyPressEvent(PlatformKey key);
+    void ProcessKeyReleaseEvent(PlatformKey key);
 
     void reset();
 

--- a/src/Application/GameWindowHandler.h
+++ b/src/Application/GameWindowHandler.h
@@ -17,7 +17,6 @@ using Io::Mouse;
 namespace Application {
 class GameConfig;
 
-// Handles events from game window (OSWindow)
 class GameWindowHandler : public PlatformEventFilter {
  public:
     GameWindowHandler();
@@ -56,6 +55,9 @@ class GameWindowHandler : public PlatformEventFilter {
     void OnActivated();
     void OnDeactivated();
 
+    void handleKeyPress(PlatformKey key, PlatformModifiers mods, bool isAutoRepeat);
+    void handleKeyRelease(PlatformKey key);
+
     virtual bool keyPressEvent(const PlatformKeyEvent *event) override;
     virtual bool keyReleaseEvent(const PlatformKeyEvent *event) override;
     virtual bool mouseMoveEvent(const PlatformMouseEvent *event) override;
@@ -66,12 +68,14 @@ class GameWindowHandler : public PlatformEventFilter {
     virtual bool resizeEvent(const PlatformResizeEvent *event) override;
     virtual bool activationEvent(const PlatformWindowEvent *event) override;
     virtual bool closeEvent(const PlatformWindowEvent *event) override;
-    virtual bool gamepadDeviceEvent(const PlatformGamepadDeviceEvent *event) override;
+    virtual bool gamepadConnectionEvent(const PlatformGamepadEvent *event) override;
+    virtual bool gamepadKeyPressEvent(const PlatformGamepadKeyEvent *event) override;
+    virtual bool gamepadKeyReleaseEvent(const PlatformGamepadKeyEvent *event) override;
+    virtual bool gamepadAxisEvent(const PlatformGamepadAxisEvent *event) override;
 
  private:
     std::shared_ptr<Mouse> mouse = nullptr;
     std::unique_ptr<GameKeyboardController> keyboardController_;
-    std::unordered_map<uint32_t, std::unique_ptr<PlatformGamepad>> gamepads_;
 };
 
 }  // namespace Application

--- a/src/Library/Application/PlatformApplication.h
+++ b/src/Library/Application/PlatformApplication.h
@@ -46,6 +46,7 @@ class PlatformApplication {
     PlatformOpenGLContext *openGLContext();
     PlatformEventHandler *eventHandler();
 
+    // TODO(captainurist): rename plugin->component? the functionality here pretty much matches the ecs
     template<class T>
     void install(T *plugin) {
         installInternal(typeid(T), plugin);

--- a/src/Library/Trace/EventTrace.cpp
+++ b/src/Library/Trace/EventTrace.cpp
@@ -29,14 +29,6 @@ MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(PlatformEventType, CASE_SENSITIVE, {
 })
 MM_DEFINE_JSON_LEXICAL_SERIALIZATION_FUNCTIONS(PlatformEventType)
 
-MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(PlatformKeyType, CASE_SENSITIVE, {
-    {KEY_TYPE_KEYBOARD_BUTTON, "keyboard"},
-    {KEY_TYPE_GAMEPAD_BUTTON, "gamepadButton"},
-    {KEY_TYPE_GAMEPAD_AXIS, "gamepadAxis"},
-    {KEY_TYPE_GAMEPAD_TRIGGER, "gamepadTrigger"}
-})
-MM_DEFINE_JSON_LEXICAL_SERIALIZATION_FUNCTIONS(PlatformKeyType)
-
 MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(PlatformMouseButton, CASE_SENSITIVE, {
     {BUTTON_NONE, "none"},
     {BUTTON_LEFT, "left"},
@@ -75,10 +67,7 @@ MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(PlatformEvent, (
 
 MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(PlatformKeyEvent, (
     (type, "type"),
-    (id, "id"),
     (key, "key"),
-    (keyType, "keyType"),
-    (keyValue, "keyValue"),
     (mods, "mods"),
     (isAutoRepeat, "isAutoRepeat")
 ))
@@ -107,11 +96,6 @@ MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(PlatformResizeEvent, (
     (size, "size")
 ))
 
-MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(PlatformGamepadDeviceEvent, (
-    (type, "type"),
-    (id, "id")
-))
-
 MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(PaintEvent, (
     (type, "type"),
     (tickCount, "tickCount"),
@@ -124,10 +108,6 @@ inline void DispatchByEventType(PlatformEventType type, Callable &&callable) {
     case EVENT_KEY_PRESS:
     case EVENT_KEY_RELEASE:
         callable(static_cast<PlatformKeyEvent *>(nullptr));
-        break;
-    case EVENT_GAMEPAD_CONNECTED:
-    case EVENT_GAMEPAD_DISCONNECTED:
-        callable(static_cast<PlatformGamepadDeviceEvent *>(nullptr));
         break;
     case EVENT_MOUSE_BUTTON_PRESS:
     case EVENT_MOUSE_BUTTON_RELEASE:
@@ -151,7 +131,7 @@ inline void DispatchByEventType(PlatformEventType type, Callable &&callable) {
         callable(static_cast<PaintEvent *>(nullptr));
         break;
     default:
-        return;
+        return; // No gamepad events.
     }
 }
 

--- a/src/Platform/Filters/PlatformEventFilter.cpp
+++ b/src/Platform/Filters/PlatformEventFilter.cpp
@@ -15,9 +15,6 @@ PlatformEventFilter::PlatformEventFilter(PlatformEventWildcard eventTypes) {
 
 bool PlatformEventFilter::event(const PlatformEvent *event) {
     switch (event->type) {
-    case EVENT_GAMEPAD_CONNECTED:
-    case EVENT_GAMEPAD_DISCONNECTED:
-        return gamepadDeviceEvent(static_cast<const PlatformGamepadDeviceEvent *>(event));
     case EVENT_KEY_PRESS:
         return keyPressEvent(static_cast<const PlatformKeyEvent *>(event));
     case EVENT_KEY_RELEASE:
@@ -39,6 +36,15 @@ bool PlatformEventFilter::event(const PlatformEvent *event) {
         return activationEvent(static_cast<const PlatformWindowEvent *>(event));
     case EVENT_WINDOW_CLOSE_REQUEST:
         return closeEvent(static_cast<const PlatformWindowEvent *>(event));
+    case EVENT_GAMEPAD_CONNECTED:
+    case EVENT_GAMEPAD_DISCONNECTED:
+        return gamepadConnectionEvent(static_cast<const PlatformGamepadEvent *>(event));
+    case EVENT_GAMEPAD_KEY_PRESS:
+        return gamepadKeyPressEvent(static_cast<const PlatformGamepadKeyEvent *>(event));
+    case EVENT_GAMEPAD_KEY_RELEASE:
+        return gamepadKeyReleaseEvent(static_cast<const PlatformGamepadKeyEvent *>(event));
+    case EVENT_GAMEPAD_AXIS:
+        return gamepadAxisEvent(static_cast<const PlatformGamepadAxisEvent *>(event));
     case EVENT_NATIVE:
         return nativeEvent(static_cast<const PlatformNativeEvent *>(event));
     default:
@@ -86,7 +92,19 @@ bool PlatformEventFilter::closeEvent(const PlatformWindowEvent *) {
     return false;
 }
 
-bool PlatformEventFilter::gamepadDeviceEvent(const PlatformGamepadDeviceEvent *) {
+bool PlatformEventFilter::gamepadConnectionEvent(const PlatformGamepadEvent *) {
+    return false;
+}
+
+bool PlatformEventFilter::gamepadKeyPressEvent(const PlatformGamepadKeyEvent *) {
+    return false;
+}
+
+bool PlatformEventFilter::gamepadKeyReleaseEvent(const PlatformGamepadKeyEvent *) {
+    return false;
+}
+
+bool PlatformEventFilter::gamepadAxisEvent(const PlatformGamepadAxisEvent *) {
     return false;
 }
 

--- a/src/Platform/Filters/PlatformEventFilter.h
+++ b/src/Platform/Filters/PlatformEventFilter.h
@@ -31,7 +31,10 @@ class PlatformEventFilter {
     virtual bool resizeEvent(const PlatformResizeEvent *event);
     virtual bool activationEvent(const PlatformWindowEvent *event);
     virtual bool closeEvent(const PlatformWindowEvent *event);
-    virtual bool gamepadDeviceEvent(const PlatformGamepadDeviceEvent *event);
+    virtual bool gamepadConnectionEvent(const PlatformGamepadEvent *event);
+    virtual bool gamepadKeyPressEvent(const PlatformGamepadKeyEvent *event);
+    virtual bool gamepadKeyReleaseEvent(const PlatformGamepadKeyEvent *event);
+    virtual bool gamepadAxisEvent(const PlatformGamepadAxisEvent *event);
     virtual bool nativeEvent(const PlatformNativeEvent *event);
 
  private:

--- a/src/Platform/Platform.h
+++ b/src/Platform/Platform.h
@@ -9,10 +9,6 @@
 
 #include "PlatformEnums.h"
 
-#ifdef CreateWindow
-#   undef CreateWindow
-#endif
-
 class PlatformEvent;
 class PlatformWindow;
 class PlatformEventLoop;
@@ -92,14 +88,15 @@ class Platform {
      */
     virtual std::unique_ptr<PlatformEventLoop> createEventLoop() = 0;
 
-    // TODO(captainurist): virtual PlatformGamepadInfo gamepadInfo(uint32_t id) const = 0;
     /**
-     * Creates a new gamepad.
+     * This function lists the gamepads currently connected to the system. The gamepad objects themselves are owned
+     * by the platform and are destroyed automatically when disconnected. If you're caching them in your code, then
+     * make sure to subscribe to `EVENT_GAMEPAD_DISCONNECTED`, it is guaranteed to fire before the gamepad object
+     * is destroyed.
      *
-     * @param id                        Gamepad identifier from event.
-     * @return                          Newly created gamepad, or `nullptr` on error.
+     * @return                          All gamepads connected to the system.
      */
-    virtual std::unique_ptr<PlatformGamepad> createGamepad(uint32_t id) = 0;
+    virtual std::vector<PlatformGamepad *> gamepads() = 0;
 
     /**
      * Shows / hides system cursor (on top of all windows created by this platform).

--- a/src/Platform/PlatformEnums.h
+++ b/src/Platform/PlatformEnums.h
@@ -11,19 +11,57 @@
 
 enum class PlatformEventType {
     EVENT_INVALID = -1,
+
+    /** Key pressed, sent as `PlatformKeyEvent`. */
     EVENT_KEY_PRESS = 0,
+
+    /** Key released, sent as `PlatformKeyEvent`. */
     EVENT_KEY_RELEASE,
-    EVENT_GAMEPAD_CONNECTED,
-    EVENT_GAMEPAD_DISCONNECTED,
+
+    /** Mouse button pressed, sent as `PlatformMouseEvent`. */
     EVENT_MOUSE_BUTTON_PRESS,
+
+    /** Mouse button released, sent as `PlatformMouseEvent`. */
     EVENT_MOUSE_BUTTON_RELEASE,
+
+    /** Mouse pointer moved, sent as `PlatformMouseEvent`. */
     EVENT_MOUSE_MOVE,
+
+    /** Mouse wheel rotated, sent as `PlatformWheelEvent`. */
     EVENT_MOUSE_WHEEL,
+
+    /** Window moved, sent as `PlatformMoveEvent`. */
     EVENT_WINDOW_MOVE,
+
+    /** Window resized, sent as `PlatformResizeEvent`. */
     EVENT_WINDOW_RESIZE,
+
+    /** Window activated (gained focus), sent as `PlatformWindowEvent`. */
     EVENT_WINDOW_ACTIVATE,
+
+    /** Window deactivated (lost focus), sent as `PlatformWindowEvent`. */
     EVENT_WINDOW_DEACTIVATE,
+
+    /** Window close was requested (e.g. by pressing the window close button), sent as `PlatformWindowEvent`. */
     EVENT_WINDOW_CLOSE_REQUEST,
+
+    /** Gamepad was added to the system, sent as `PlatformGamepadEvent`. */
+    EVENT_GAMEPAD_CONNECTED,
+
+    /** Gamepad was removed from the system, sent as `PlatformGamepadEvent`. */
+    EVENT_GAMEPAD_DISCONNECTED,
+
+    /** Gamepad key pressed, sent as `PlatformGamepadKeyEvent`. */
+    EVENT_GAMEPAD_KEY_PRESS,
+
+    /** Gamepad key released, sent as `PlatformGamepadKeyEvent`. */
+    EVENT_GAMEPAD_KEY_RELEASE,
+
+    /** Gamepad axis event, sent as `PlatformGamepadAxisEvent`. */
+    EVENT_GAMEPAD_AXIS,
+
+    /** Native event, sent as `PlatformNativeEvent` only when platform was built with
+     * `MM_PLATFORM_SEND_NATIVE_EVENTS` defined. */
     EVENT_NATIVE,
 
     EVENT_FIRST = EVENT_KEY_PRESS,
@@ -167,16 +205,6 @@ enum class PlatformKey : int {
 
     None = Count
 };
-
-enum class PlatformKeyType : int {
-    KEY_TYPE_KEYBOARD_BUTTON,
-    KEY_TYPE_GAMEPAD_BUTTON,
-    KEY_TYPE_GAMEPAD_AXIS,
-    KEY_TYPE_GAMEPAD_TRIGGER
-};
-using enum PlatformKeyType;
-
-typedef float PlatformKeyValue;
 
 enum class PlatformModifier : uint32_t {
     MOD_SHIFT   = 0x00000001,

--- a/src/Platform/PlatformEventHandler.cpp
+++ b/src/Platform/PlatformEventHandler.cpp
@@ -2,10 +2,6 @@
 
 void PlatformEventHandler::event(const PlatformEvent *event) {
     switch (event->type) {
-    case EVENT_GAMEPAD_CONNECTED:
-    case EVENT_GAMEPAD_DISCONNECTED:
-        gamepadDeviceEvent(static_cast<const PlatformGamepadDeviceEvent *>(event));
-        return;
     case EVENT_KEY_PRESS:
         keyPressEvent(static_cast<const PlatformKeyEvent *>(event));
         return;
@@ -37,6 +33,19 @@ void PlatformEventHandler::event(const PlatformEvent *event) {
     case EVENT_WINDOW_CLOSE_REQUEST:
         closeEvent(static_cast<const PlatformWindowEvent *>(event));
         return;
+    case EVENT_GAMEPAD_CONNECTED:
+    case EVENT_GAMEPAD_DISCONNECTED:
+        gamepadConnectionEvent(static_cast<const PlatformGamepadEvent *>(event));
+        return;
+    case EVENT_GAMEPAD_KEY_PRESS:
+        gamepadKeyPressEvent(static_cast<const PlatformGamepadKeyEvent *>(event));
+        return;
+    case EVENT_GAMEPAD_KEY_RELEASE:
+        gamepadKeyReleaseEvent(static_cast<const PlatformGamepadKeyEvent *>(event));
+        return;
+    case EVENT_GAMEPAD_AXIS:
+        gamepadAxisEvent(static_cast<const PlatformGamepadAxisEvent *>(event));
+        return;
     case EVENT_NATIVE:
         nativeEvent(static_cast<const PlatformNativeEvent *>(event));
         return;
@@ -55,5 +64,8 @@ void PlatformEventHandler::moveEvent(const PlatformMoveEvent *) {}
 void PlatformEventHandler::resizeEvent(const PlatformResizeEvent *) {}
 void PlatformEventHandler::activationEvent(const PlatformWindowEvent *) {}
 void PlatformEventHandler::closeEvent(const PlatformWindowEvent *) {}
-void PlatformEventHandler::gamepadDeviceEvent(const PlatformGamepadDeviceEvent *) {}
+void PlatformEventHandler::gamepadConnectionEvent(const PlatformGamepadEvent *) {}
+void PlatformEventHandler::gamepadKeyPressEvent(const PlatformGamepadKeyEvent *) {}
+void PlatformEventHandler::gamepadKeyReleaseEvent(const PlatformGamepadKeyEvent *) {}
+void PlatformEventHandler::gamepadAxisEvent(const PlatformGamepadAxisEvent *) {}
 void PlatformEventHandler::nativeEvent(const PlatformNativeEvent *) {}

--- a/src/Platform/PlatformEventHandler.h
+++ b/src/Platform/PlatformEventHandler.h
@@ -25,6 +25,9 @@ class PlatformEventHandler {
     virtual void resizeEvent(const PlatformResizeEvent *event);
     virtual void activationEvent(const PlatformWindowEvent *event);
     virtual void closeEvent(const PlatformWindowEvent *event);
-    virtual void gamepadDeviceEvent(const PlatformGamepadDeviceEvent *event);
+    virtual void gamepadConnectionEvent(const PlatformGamepadEvent *event);
+    virtual void gamepadKeyPressEvent(const PlatformGamepadKeyEvent *event);
+    virtual void gamepadKeyReleaseEvent(const PlatformGamepadKeyEvent *event);
+    virtual void gamepadAxisEvent(const PlatformGamepadAxisEvent *event);
     virtual void nativeEvent(const PlatformNativeEvent *event);
 };

--- a/src/Platform/PlatformEvents.h
+++ b/src/Platform/PlatformEvents.h
@@ -7,10 +7,8 @@
 
 #include "PlatformEnums.h"
 
-#undef KeyPress
-#undef KeyRelease
-
 class PlatformWindow;
+class PlatformGamepad;
 
 class PlatformEvent {
  public:
@@ -24,22 +22,13 @@ class PlatformWindowEvent: public PlatformEvent {
     PlatformWindow *window = nullptr;
 };
 
-/**
- * `KeyPress` or `KeyRelease` event.
- */
 class PlatformKeyEvent: public PlatformWindowEvent {
  public:
-    uint32_t id; // TODO(captainurist): move into a separate PlatformGamepadEvent
     PlatformKey key;
-    PlatformKeyType keyType;
-    PlatformKeyValue keyValue;
     PlatformModifiers mods;
     bool isAutoRepeat = false;
 };
 
-/**
- * `MouseButtonPress`, `MouseButtonRelease` or `MouseMove` event.
- */
 class PlatformMouseEvent: public PlatformWindowEvent {
  public:
     PlatformMouseButton button; // Button that caused this event, or BUTTON_NONE for move events.
@@ -48,39 +37,40 @@ class PlatformMouseEvent: public PlatformWindowEvent {
     bool isDoubleClick = false;
 };
 
-/**
- * `MouseWheel`
- */
 class PlatformWheelEvent: public PlatformWindowEvent {
  public:
     Pointi angleDelta; // 1 unit = 1/8 degree.
-    bool inverted; // Whether delta values delivered with the event are inverted.
+
+    // TODO(captainurist): why are we even exposing this? drop!
+    bool inverted = false; // Whether delta values delivered with the event are inverted.
 };
 
-/**
- * `WindowMove`
- */
 class PlatformMoveEvent: public PlatformWindowEvent {
  public:
     Pointi pos; // New position of the window.
 };
 
-/**
- * `WindowResize`
- */
 class PlatformResizeEvent: public PlatformWindowEvent {
  public:
     Sizei size; // New size of the window.
 };
 
-class PlatformGamepadDeviceEvent: public PlatformEvent {
+class PlatformGamepadEvent: public PlatformEvent {
  public:
-    uint32_t id;
+    PlatformGamepad *gamepad = nullptr;
 };
 
-/**
- * `NativeEvent`, sent only when platform is built with `MM_PLATFORM_SEND_NATIVE_EVENTS` defined.
- */
+class PlatformGamepadKeyEvent: public PlatformGamepadEvent {
+ public:
+    PlatformKey key; // TODO(captainurist): PlatformGamepadKey
+};
+
+class PlatformGamepadAxisEvent: public PlatformGamepadEvent {
+ public:
+    PlatformKey axis; // TODO(captainurist): PlatformGamepadAxis
+    float value = 0.0; // In [-1, 1] range.
+};
+
 class PlatformNativeEvent: public PlatformEvent {
  public:
     const void *nativeEvent = nullptr; // Pointer to a native event, in our case this is `SDL_Event`. Never `nullptr`.

--- a/src/Platform/PlatformGamepad.h
+++ b/src/Platform/PlatformGamepad.h
@@ -3,13 +3,19 @@
 #include <string>
 #include <memory>
 
-// TODO(captainurist): this should be just a POD
 class PlatformGamepad {
  public:
     virtual ~PlatformGamepad() = default;
 
-    virtual std::string model() const = 0;
-    virtual std::string serial() const = 0;
+    // TODO(captainurist): add rumble methods here!
 
-    virtual uint32_t id() const = 0;
+    /**
+     * @return                          Model of this gamepad.
+     */
+    virtual std::string model() const = 0;
+
+    /**
+     * @return                          Serial number of this gamepad.
+     */
+    virtual std::string serial() const = 0;
 };

--- a/src/Platform/Proxy/ProxyGamepad.cpp
+++ b/src/Platform/Proxy/ProxyGamepad.cpp
@@ -9,7 +9,3 @@ std::string ProxyGamepad::model() const {
 std::string ProxyGamepad::serial() const {
     return nonNullBase()->serial();
 }
-
-uint32_t ProxyGamepad::id() const {
-    return nonNullBase()->id();
-}

--- a/src/Platform/Proxy/ProxyGamepad.h
+++ b/src/Platform/Proxy/ProxyGamepad.h
@@ -13,5 +13,4 @@ class ProxyGamepad: public ProxyBase<PlatformGamepad> {
 
     virtual std::string model() const override;
     virtual std::string serial() const override;
-    virtual uint32_t id() const override;
 };

--- a/src/Platform/Proxy/ProxyPlatform.cpp
+++ b/src/Platform/Proxy/ProxyPlatform.cpp
@@ -2,7 +2,6 @@
 
 #include <cassert>
 
-#include "Platform/PlatformGamepad.h"
 #include "Platform/PlatformWindow.h"
 #include "Platform/PlatformEventLoop.h"
 
@@ -16,8 +15,8 @@ std::unique_ptr<PlatformEventLoop> ProxyPlatform::createEventLoop() {
     return nonNullBase()->createEventLoop();
 }
 
-std::unique_ptr<PlatformGamepad> ProxyPlatform::createGamepad(uint32_t id) {
-    return nonNullBase()->createGamepad(id);
+std::vector<PlatformGamepad *> ProxyPlatform::gamepads() {
+    return nonNullBase()->gamepads();
 }
 
 void ProxyPlatform::setCursorShown(bool cursorShown) {

--- a/src/Platform/Proxy/ProxyPlatform.h
+++ b/src/Platform/Proxy/ProxyPlatform.h
@@ -16,7 +16,7 @@ class ProxyPlatform : public ProxyBase<Platform> {
 
     virtual std::unique_ptr<PlatformWindow> createWindow() override;
     virtual std::unique_ptr<PlatformEventLoop> createEventLoop() override;
-    virtual std::unique_ptr<PlatformGamepad> createGamepad(uint32_t id) override;
+    virtual std::vector<PlatformGamepad *> gamepads() override;
     virtual void setCursorShown(bool cursorShown) override;
     virtual bool isCursorShown() const override;
     virtual std::vector<Recti> displayGeometries() const override;

--- a/src/Platform/Sdl/SdlEnumTranslation.cpp
+++ b/src/Platform/Sdl/SdlEnumTranslation.cpp
@@ -143,53 +143,17 @@ PlatformKey translateSdlGamepadButton(SDL_GameControllerButton button) {
     }
 }
 
-std::pair<PlatformKey, PlatformKeyType> translateSdlGamepadAxis(SDL_GameControllerAxis axis, float value) {
-    PlatformKey key = PlatformKey::None;
-    PlatformKeyType keyType = KEY_TYPE_GAMEPAD_AXIS;
-
+PlatformKey translateSdlGamepadAxis(SDL_GameControllerAxis axis) {
     switch (axis) {
-    case SDL_CONTROLLER_AXIS_LEFTX:
-        if (value > 0.0f)
-            key = PlatformKey::Gamepad_LeftStick_Right;
-        else if (value < 0.0f)
-            key = PlatformKey::Gamepad_LeftStick_Left;
-
-        break;
-    case SDL_CONTROLLER_AXIS_LEFTY:
-        if (value > 0.0f)
-            key = PlatformKey::Gamepad_LeftStick_Down;
-        else if (value < 0.0f)
-            key = PlatformKey::Gamepad_LeftStick_Up;
-
-        break;
-    case SDL_CONTROLLER_AXIS_RIGHTX:
-        if (value > 0.0f)
-            key = PlatformKey::Gamepad_RightStick_Right;
-        else if (value < 0.0f)
-            key = PlatformKey::Gamepad_RightStick_Left;
-
-        break;
-    case SDL_CONTROLLER_AXIS_RIGHTY:
-        if (value > 0.0f)
-            key = PlatformKey::Gamepad_RightStick_Down;
-        else if (value < 0.0f)
-            key = PlatformKey::Gamepad_RightStick_Up;
-
-        break;
-    case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
-        key = PlatformKey::Gamepad_L2;
-        keyType = KEY_TYPE_GAMEPAD_TRIGGER;
-        break;
-    case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:
-        key = PlatformKey::Gamepad_R2;
-        keyType = KEY_TYPE_GAMEPAD_TRIGGER;
-        break;
-
+    case SDL_CONTROLLER_AXIS_LEFTX:         return PlatformKey::Gamepad_LeftStick_Right;
+    case SDL_CONTROLLER_AXIS_LEFTY:         return PlatformKey::Gamepad_LeftStick_Down;
+    case SDL_CONTROLLER_AXIS_RIGHTX:        return PlatformKey::Gamepad_RightStick_Right;
+    case SDL_CONTROLLER_AXIS_RIGHTY:        return PlatformKey::Gamepad_RightStick_Down;
+    case SDL_CONTROLLER_AXIS_TRIGGERLEFT:   return PlatformKey::Gamepad_L2;
+    case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:  return PlatformKey::Gamepad_R2;
     default:
-        break;
+        return PlatformKey::None;
     }
-
-    return {key, keyType};
 }
 
 PlatformModifiers translateSdlMods(uint16_t mods) {

--- a/src/Platform/Sdl/SdlEnumTranslation.h
+++ b/src/Platform/Sdl/SdlEnumTranslation.h
@@ -9,7 +9,7 @@
 
 PlatformKey translateSdlKey(SDL_Scancode key);
 PlatformKey translateSdlGamepadButton(SDL_GameControllerButton button);
-std::pair<PlatformKey, PlatformKeyType> translateSdlGamepadAxis(SDL_GameControllerAxis axis, float value);
+PlatformKey translateSdlGamepadAxis(SDL_GameControllerAxis axis);
 PlatformModifiers translateSdlMods(uint16_t mods);
 PlatformMouseButton translateSdlMouseButton(uint8_t mouseButton);
 PlatformMouseButtons translateSdlMouseButtons(uint32_t mouseButtons);

--- a/src/Platform/Sdl/SdlEventLoop.h
+++ b/src/Platform/Sdl/SdlEventLoop.h
@@ -30,7 +30,8 @@ class SdlEventLoop: public PlatformEventLoop {
     void dispatchWindowEvent(PlatformEventHandler *eventHandler, const SDL_WindowEvent *event);
     void dispatchWindowMoveEvent(PlatformEventHandler *eventHandler, const SDL_WindowEvent *event);
     void dispatchWindowResizeEvent(PlatformEventHandler *eventHandler, const SDL_WindowEvent *event);
-    void dispatchGamepadDeviceEvent(PlatformEventHandler *eventHandler, const SDL_ControllerDeviceEvent *event);
+    void dispatchGamepadConnectedEvent(PlatformEventHandler *eventHandler, const SDL_ControllerDeviceEvent *event);
+    void dispatchGamepadDisconnectedEvent(PlatformEventHandler *eventHandler, const SDL_ControllerDeviceEvent *event);
     void dispatchGamepadButtonEvent(PlatformEventHandler *eventHandler, const SDL_ControllerButtonEvent *event);
     void dispatchGamepadAxisEvent(PlatformEventHandler *eventHandler, const SDL_ControllerAxisEvent *event);
 

--- a/src/Platform/Sdl/SdlGamepad.cpp
+++ b/src/Platform/Sdl/SdlGamepad.cpp
@@ -4,19 +4,17 @@
 
 #include "SdlPlatformSharedState.h"
 
-SdlGamepad::SdlGamepad(SdlPlatformSharedState *state, SDL_GameController *gamepad, uint32_t id):
-    _state(state), _gamepad(gamepad), _id(id) {
+SdlGamepad::SdlGamepad(SdlPlatformSharedState *state, SDL_GameController *gamepad, SDL_JoystickID id): _state(state), _gamepad(gamepad), _id(id) {
     assert(state);
     assert(gamepad);
 }
 
 SdlGamepad::~SdlGamepad() {
-    _state->unregisterGamepad(this);
     SDL_GameControllerClose(_gamepad);
 }
 
 std::string SdlGamepad::model() const {
-    const char *model = SDL_GameControllerName(sdlHandle());
+    const char *model = SDL_GameControllerName(_gamepad);
     if (model != NULL)
         return model;
 
@@ -26,17 +24,10 @@ std::string SdlGamepad::model() const {
 std::string SdlGamepad::serial() const {
     // TODO: Just update SDL
 #if SDL_VERSION_ATLEAST(2, 0, 14)
-    const char *serial = SDL_GameControllerGetSerial(sdlHandle());
+    const char *serial = SDL_GameControllerGetSerial(_gamepad);
     if (serial != NULL)
         return serial;
 #endif
 
     return {};
-}
-
-int32_t SdlGamepad::gamepadSdlId() {
-    SDL_Joystick *joystick = SDL_GameControllerGetJoystick(sdlHandle());
-    int32_t joystickId =  SDL_JoystickInstanceID(joystick);
-
-    return joystickId;
 }

--- a/src/Platform/Sdl/SdlGamepad.h
+++ b/src/Platform/Sdl/SdlGamepad.h
@@ -11,24 +11,18 @@ class SdlPlatformSharedState;
 
 class SdlGamepad: public PlatformGamepad {
  public:
-    SdlGamepad(SdlPlatformSharedState *state, SDL_GameController *gamepad, uint32_t id);
+    SdlGamepad(SdlPlatformSharedState *state, SDL_GameController *gamepad, SDL_JoystickID id);
     virtual ~SdlGamepad();
 
     virtual std::string model() const override;
     virtual std::string serial() const override;
 
-    uint32_t id() const override {
+    SDL_JoystickID id() {
         return _id;
     }
-
-    SDL_GameController *sdlHandle() const {
-        return _gamepad;
-    }
-
-    int32_t gamepadSdlId();
 
  private:
     SdlPlatformSharedState *_state = nullptr;
     SDL_GameController *_gamepad = nullptr;
-    uint32_t _id = 0;
+    SDL_JoystickID _id = 0;
 };

--- a/src/Platform/Sdl/SdlPlatform.h
+++ b/src/Platform/Sdl/SdlPlatform.h
@@ -17,7 +17,8 @@ class SdlPlatform: public Platform {
 
     virtual std::unique_ptr<PlatformWindow> createWindow() override;
     virtual std::unique_ptr<PlatformEventLoop> createEventLoop() override;
-    virtual std::unique_ptr<PlatformGamepad> createGamepad(uint32_t id) override;
+
+    virtual std::vector<PlatformGamepad *> gamepads() override;
 
     virtual void setCursorShown(bool cursorShown) override;
     virtual bool isCursorShown() const override;
@@ -31,11 +32,6 @@ class SdlPlatform: public Platform {
     virtual std::string winQueryRegistry(const std::wstring &path) const override;
 
     virtual std::string storagePath(const PlatformStorage type) const override;
-
- private:
-    friend class SdlWindow;
-    friend class SdlEventLoop;
-    friend class SdlGamepad;
 
  private:
     bool _initialized = false;

--- a/src/Platform/Sdl/SdlPlatformSharedState.cpp
+++ b/src/Platform/Sdl/SdlPlatformSharedState.cpp
@@ -76,7 +76,10 @@ SdlGamepad *SdlPlatformSharedState::initializeGamepad(int gamepadId) {
         logSdlError("SDL_JoystickInstanceID");
         return nullptr;
     }
-    assert(!_gamepadById.contains(id)); // However, the code below will work fine even if id is there.
+
+    // TODO(captainurist): The assert below triggers with @pskelton's xbox controller, and it shouldn't trigger.
+    // Figure out why it happens and either fix the bug in our logic, or add a comment here describing what's happening.
+    // assert(!_gamepadById.contains(id));
 
     return _gamepadById.emplace(id, std::make_unique<SdlGamepad>(this, gamepad.release(), id)).first->second.get();
 }

--- a/src/Platform/Sdl/SdlPlatformSharedState.cpp
+++ b/src/Platform/Sdl/SdlPlatformSharedState.cpp
@@ -26,13 +26,13 @@ void SdlPlatformSharedState::logSdlError(const char *sdlFunctionName) {
 }
 
 void SdlPlatformSharedState::registerWindow(SdlWindow *window) {
-    assert(!_windowById.contains(window->Id()));
-    _windowById[window->Id()] = window;
+    assert(!_windowById.contains(window->id()));
+    _windowById[window->id()] = window;
 }
 
 void SdlPlatformSharedState::unregisterWindow(SdlWindow *window) {
-    assert(_windowById.contains(window->Id()));
-    _windowById.erase(window->Id());
+    assert(_windowById.contains(window->id()));
+    _windowById.erase(window->id());
 }
 
 std::vector<uint32_t> SdlPlatformSharedState::allWindowIds() const {
@@ -47,49 +47,54 @@ SdlWindow *SdlPlatformSharedState::window(uint32_t id) const {
     return ValueOr(_windowById, id, nullptr);
 }
 
-void SdlPlatformSharedState::registerGamepad(SdlGamepad *gamepad) {
-    int32_t id = nextFreeGamepadId();
-    assert(id >= 0);
-
-    _gamepadById[id] = gamepad;
-}
-
-void SdlPlatformSharedState::unregisterGamepad(SdlGamepad *gamepad) {
-    for (auto it = _gamepadById.begin(); it != _gamepadById.end(); it++) {
-        if (gamepad == it->second) {
-            _gamepadById.erase(it);
-            return;
-        }
-    }
-
-    assert(0); //shouldn't happen
-}
-
-int32_t SdlPlatformSharedState::getGamepadIdBySdlId(uint32_t id) {
-    int32_t ret = -1;
-
-    for (auto it = _gamepadById.begin(); it != _gamepadById.end(); it++) {
-        SdlGamepad *gamepad = it->second;
-        if (gamepad->gamepadSdlId() == id)
-            return gamepad->id();
-    }
-
-    return ret;
-}
-
-SdlGamepad *SdlPlatformSharedState::gamepad(uint32_t id) const {
-    assert(_gamepadById.contains(id));
-    return ValueOr(_gamepadById, id, nullptr);
-}
-
-int32_t SdlPlatformSharedState::nextFreeGamepadId() {
-    int32_t ret = -1;
+void SdlPlatformSharedState::initializeGamepads() {
     for (int i = 0; i < SDL_NumJoysticks(); i++) {
-        if (!_gamepadById.contains(i)) {
-            ret = i;
-            break;
-        }
+        if (!SDL_IsGameController(i))
+            continue;
+
+        initializeGamepad(i);
+    }
+}
+
+SdlGamepad *SdlPlatformSharedState::initializeGamepad(int gamepadId) {
+    assert(SDL_IsGameController(gamepadId));
+
+    std::unique_ptr<SDL_GameController, void(*)(SDL_GameController *)> gamepad(SDL_GameControllerOpen(gamepadId), &SDL_GameControllerClose);
+    if (!gamepad) {
+        logSdlError("SDL_GameControllerOpen");
+        return nullptr;
     }
 
-    return ret;
+    SDL_Joystick *joystick = SDL_GameControllerGetJoystick(gamepad.get());
+    if (!joystick) {
+        logSdlError("SDL_GameControllerGetJoystick");
+        return nullptr;
+    }
+
+    SDL_JoystickID id = SDL_JoystickInstanceID(joystick);
+    if (id < 0) {
+        logSdlError("SDL_JoystickInstanceID");
+        return nullptr;
+    }
+    assert(!_gamepadById.contains(id)); // However, the code below will work fine even if id is there.
+
+    return _gamepadById.emplace(id, std::make_unique<SdlGamepad>(this, gamepad.release(), id)).first->second.get();
+}
+
+void SdlPlatformSharedState::deinitializeGamepad(SDL_JoystickID id) {
+    assert(_gamepadById.contains(id));
+
+    _gamepadById.erase(id);
+}
+
+std::vector<PlatformGamepad *> SdlPlatformSharedState::allGamepads() const {
+    std::vector<PlatformGamepad *> result;
+    for (const auto &[_, gamepad] : _gamepadById)
+        result.push_back(gamepad.get());
+    return result;
+}
+
+SdlGamepad *SdlPlatformSharedState::gamepad(SDL_JoystickID id) const {
+    auto pos = _gamepadById.find(id);
+    return pos == _gamepadById.end() ? nullptr : pos->second.get();
 }

--- a/src/Platform/Sdl/SdlPlatformSharedState.h
+++ b/src/Platform/Sdl/SdlPlatformSharedState.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <SDL.h>
+
 #include <cstdint>
 #include <vector>
 #include <unordered_map>
@@ -22,22 +24,17 @@ class SdlPlatformSharedState {
 
     void registerWindow(SdlWindow *window);
     void unregisterWindow(SdlWindow *window);
-
-    void registerGamepad(SdlGamepad *gamepad);
-    void unregisterGamepad(SdlGamepad *gamepad);
-
-    /* We are using our own id numbering to prevent id jumping and also we can't rely on cdevice.which as SDL doesn't guarantee that it won't change.
-     * In another words connection event can be received with one cdevice.which and disconnect event with completely different cdevice.which.
-     * So these two functions and additionally SdlGamepad::JoystickId implements that. */
-    int32_t getGamepadIdBySdlId(uint32_t id);
-    int32_t nextFreeGamepadId();
-
     std::vector<uint32_t> allWindowIds() const;
     SdlWindow *window(uint32_t id) const;
-    SdlGamepad *gamepad(uint32_t id) const;
+
+    void initializeGamepads();
+    SdlGamepad *initializeGamepad(int gamepadId); // Note: it's gamepad id, not joystick id.
+    void deinitializeGamepad(SDL_JoystickID id); // And here it's joystick id, which is a different from a gamepad id!
+    std::vector<PlatformGamepad *> allGamepads() const;
+    SdlGamepad *gamepad(SDL_JoystickID id) const;
 
  private:
     PlatformLogger *_logger = nullptr;
     std::unordered_map<uint32_t, SdlWindow *> _windowById;
-    std::unordered_map<uint32_t, SdlGamepad *> _gamepadById;
+    std::unordered_map<SDL_JoystickID, std::unique_ptr<SdlGamepad>> _gamepadById;
 };

--- a/src/Platform/Sdl/SdlWindow.cpp
+++ b/src/Platform/Sdl/SdlWindow.cpp
@@ -14,8 +14,7 @@
 #include "SdlEnumTranslation.h"
 #include "SdlOpenGLContext.h"
 
-SdlWindow::SdlWindow(SdlPlatformSharedState *state, SDL_Window *window, uint32_t id):
-    _state(state), _window(window), _id(id) {
+SdlWindow::SdlWindow(SdlPlatformSharedState *state, SDL_Window *window, uint32_t id): _state(state), _window(window), _id(id) {
     assert(state);
     assert(window);
     assert(id);

--- a/src/Platform/Sdl/SdlWindow.h
+++ b/src/Platform/Sdl/SdlWindow.h
@@ -47,12 +47,8 @@ class SdlWindow : public PlatformWindow {
 
     virtual std::unique_ptr<PlatformOpenGLContext> createOpenGLContext(const PlatformOpenGLOptions &options) override;
 
-    uint32_t Id() const {
+    uint32_t id() const {
         return _id;
-    }
-
-    SDL_Window *SdlHandle() const {
-        return _window;
     }
 
  private:


### PR DESCRIPTION
I don't have a gamepad to test this. So I might've broken something, but I tried really hard not to.

What changed:
* Gamepad events are now separate from keyboard events.
* `PlatformGamepad *` is passed in all gamepad events, and I got rid of gamepad ids that were exposed as part of the API.
* `PlatformGamepad` instances are managed by the `Platform`, which makes sense as one should be created for each gamepad connected to the system, and the user doesn't really have any control over their lifetimes.