### PR TITLE
Spells refactor, 2nd iteration

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1102,7 +1102,7 @@ void Game::EventLoop() {
                     } else {
                         pParty->field_6E4_set0_unused = 0;
                         pParty->field_6E0_set0_unused = 0;
-                        CastSpellInfoHelpers::CancelSpellCastInProgress();
+                        CastSpellInfoHelpers::cancelSpellCastInProgress();
                         DialogueEnding();
                         pEventTimer->Pause();
                         pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_Box);
@@ -1642,8 +1642,8 @@ void Game::EventLoop() {
                         (pPlayer2 = pPlayers[uActiveCharacter],
                          pPlayer2->uTimeToRecovery))
                         continue;
-                    RegisterSpellOrSpellLikeSkill(pPlayer2->uQuickSpell, uActiveCharacter - 1,
-                                                  0, 0, uActiveCharacter);
+                    pushSpellOrRangedAttack(pPlayer2->uQuickSpell, uActiveCharacter - 1,
+                                            0, 0, uActiveCharacter);
                     continue;
                 }
 
@@ -2025,14 +2025,14 @@ void Game::EventLoop() {
 
                 case UIMSG_CastSpellFromBook:
                     if (pTurnEngine->turn_stage != TE_MOVEMENT) {
-                        RegisterSpellOrSpellLikeSkill(static_cast<SPELL_TYPE>(uMessageParam), v199, 0, 0, 0);
+                        pushSpellOrRangedAttack(static_cast<SPELL_TYPE>(uMessageParam), v199, 0, 0, 0);
                     }
                     continue;
 
                 case UIMSG_SpellScrollUse:
                     __debugbreak();
                     if (pTurnEngine->turn_stage != TE_MOVEMENT) {
-                        RegisterScrollSpell(static_cast<SPELL_TYPE>(uMessageParam), v199);
+                        pushScrollSpell(static_cast<SPELL_TYPE>(uMessageParam), v199);
                     }
                     continue;
                 case UIMSG_SpellBookWindow:
@@ -2548,7 +2548,7 @@ void Game::EventLoop() {
             }
         }
     }
-    CastSpellInfoHelpers::CastSpell();
+    CastSpellInfoHelpers::castSpell();
 }
 
 //----- (0046A14B) --------------------------------------------------------

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1102,7 +1102,7 @@ void Game::EventLoop() {
                     } else {
                         pParty->field_6E4_set0_unused = 0;
                         pParty->field_6E0_set0_unused = 0;
-                        CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
+                        CastSpellInfoHelpers::CancelSpellCastInProgress();
                         DialogueEnding();
                         pEventTimer->Pause();
                         pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_Box);
@@ -1642,9 +1642,8 @@ void Game::EventLoop() {
                         (pPlayer2 = pPlayers[uActiveCharacter],
                          pPlayer2->uTimeToRecovery))
                         continue;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        (SPELL_TYPE)pPlayer2->uQuickSpell, uActiveCharacter - 1,
-                        0, 0, uActiveCharacter);
+                    RegisterSpellOrSpellLikeSkill((SPELL_TYPE)pPlayer2->uQuickSpell, uActiveCharacter - 1,
+                                                  0, 0, uActiveCharacter);
                     continue;
                 }
 
@@ -2024,16 +2023,16 @@ void Game::EventLoop() {
                 }
 
                 case UIMSG_CastSpellFromBook:
-                    if (pTurnEngine->turn_stage != TE_MOVEMENT)
-                        _42777D_CastSpell_UseWand_ShootArrow(
-                            (SPELL_TYPE)uMessageParam, v199, 0, 0, 0);
+                    if (pTurnEngine->turn_stage != TE_MOVEMENT) {
+                        RegisterSpellOrSpellLikeSkill((SPELL_TYPE)uMessageParam, v199, 0, 0, 0);
+                    }
                     continue;
 
                 case UIMSG_SpellScrollUse:
                     __debugbreak();
-                    if (pTurnEngine->turn_stage != TE_MOVEMENT)
-                        _42777D_CastSpell_UseWand_ShootArrow(
-                            (SPELL_TYPE)uMessageParam, v199, 133, ON_CAST_CastViaScroll, 0);
+                    if (pTurnEngine->turn_stage != TE_MOVEMENT) {
+                        RegisterScrollSpell((SPELL_TYPE)uMessageParam, v199);
+                    }
                     continue;
                 case UIMSG_SpellBookWindow:
                     if (pTurnEngine->turn_stage == TE_MOVEMENT) continue;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -782,7 +782,7 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
     pEventTimer->Pause();
     pMiscTimer->Pause();
     pParty->uFlags |= PARTY_FLAGS_1_ForceRedraw;
-    CastSpellInfoHelpers::CancelSpellCastInProgress();
+    CastSpellInfoHelpers::cancelSpellCastInProgress();
     engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
     DoPrepareWorld(false, (_0_box_loading_1_fullscreen == 0) + 1);
     pMiscTimer->Resume();
@@ -1838,7 +1838,7 @@ void RegeneratePartyHealthMana() {
             spellSprite.spell_level = pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].uPower;
             spellSprite.spell_skill = pParty->ImmolationSkillLevel();
             spellSprite.uType = SPRITE_SPELL_FIRE_IMMOLATION;
-            spellSprite.spell_id = SPELL_FIRE_IMMOLATION;
+            spellSprite.uSpellID = SPELL_FIRE_IMMOLATION;
             spellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(SpellSpriteMapping[SPELL_FIRE_IMMOLATION]);
             spellSprite.field_60_distance_related_prolly_lod = 0;
             spellSprite.uAttributes = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -782,7 +782,7 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
     pEventTimer->Pause();
     pMiscTimer->Pause();
     pParty->uFlags |= PARTY_FLAGS_1_ForceRedraw;
-    CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
+    CastSpellInfoHelpers::CancelSpellCastInProgress();
     engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
     DoPrepareWorld(false, (_0_box_loading_1_fullscreen == 0) + 1);
     pMiscTimer->Resume();

--- a/src/Engine/MapInfo.cpp
+++ b/src/Engine/MapInfo.cpp
@@ -304,7 +304,7 @@ void MapInfo::SpawnRandomTreasure(SpawnPoint *a2) {
     a1a.vPosition.x = a2->vPosition.x;
     a1a.spell_skill = PLAYER_SKILL_MASTERY_NONE;
     a1a.spell_level = 0;
-    a1a.spell_id = 0;
+    a1a.uSpellID = SPELL_NONE;
     a1a.spell_target_pid = 0;
     a1a.spell_caster_pid = 0;
     a1a.uSpriteFrameID = 0;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -272,7 +272,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             a1.uType = SpellSpriteMapping[uSpellID];
             a1.uObjectDescID = GetObjDescId(uSpellID);
             a1.containing_item.Reset();
-            a1.spell_id = uSpellID;
+            a1.uSpellID = uSpellID;
             a1.spell_level = uSkillMastery;
             a1.vPosition.x = actorPtr->vPosition.x;
             a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
@@ -358,7 +358,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 a1.vPosition.x = pParty->vPosition.x;
                 a1.vPosition.y = pParty->vPosition.y;
                 a1.vPosition.z = v30 + v114;
-                a1.spell_id = SPELL_FIRE_METEOR_SHOWER;
+                a1.uSpellID = SPELL_FIRE_METEOR_SHOWER;
                 a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
                 a1.uAttributes = 0;
                 a1.uSectorID = 0;
@@ -408,7 +408,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             a1.uObjectDescID = GetObjDescId(uSpellID);
 
             a1.containing_item.Reset();
-            a1.spell_id = SPELL_AIR_SPARKS;
+            a1.uSpellID = SPELL_AIR_SPARKS;
             a1.spell_level = uSkillMastery;
             a1.vPosition.x = actorPtr->vPosition.x;
             a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
@@ -642,7 +642,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                    (v70 - 1);
             a1.uObjectDescID = GetObjDescId(uSpellID);
             a1.containing_item.Reset();
-            a1.spell_id = uSpellID;
+            a1.uSpellID = uSpellID;
             a1.spell_level = uSkillMastery;
             a1.vPosition.x = actorPtr->vPosition.x;
             a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
@@ -803,7 +803,7 @@ void Actor::AI_RangedAttack(unsigned int uActorID, struct AIDirection *pDir,
         return;
     }
     a1.containing_item.Reset();
-    a1.spell_id = 0;
+    a1.uSpellID = SPELL_NONE;
     a1.vPosition.x = pActors[uActorID].vPosition.x;
     a1.vPosition.y = pActors[uActorID].vPosition.y;
     a1.vPosition.z = pActors[uActorID].vPosition.z + (pActors[uActorID].uActorHeight * 0.75);
@@ -855,7 +855,7 @@ void Actor::Explode(unsigned int uActorID) {  // death explosion for some actors
     a1.uType = SPRITE_OBJECT_EXPLODE;
     a1.uObjectDescID = pObjectList->ObjectIDByItemID(a1.uType);
     a1.containing_item.Reset();
-    a1.spell_id = 0;
+    a1.uSpellID = SPELL_NONE;
     a1.spell_level = 0;
     a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
     a1.vPosition.x = pActors[uActorID].vPosition.x;
@@ -1396,7 +1396,7 @@ void Actor::StealFrom(unsigned int uActorID) {
 
     pPlayer = &pParty->pPlayers[uActiveCharacter - 1];
     if (pPlayer->CanAct()) {
-        CastSpellInfoHelpers::CancelSpellCastInProgress();
+        CastSpellInfoHelpers::cancelSpellCastInProgress();
         v4 = 0;
         v5 = pMapStats->GetMapInfo(pCurrentMapName);
         if (v5) v4 = pMapStats->pInfos[v5]._steal_perm;
@@ -3229,7 +3229,7 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
         }
     } else {
         v61 = projectileSprite->field_60_distance_related_prolly_lod;
-        if (projectileSprite->spell_id != SPELL_DARK_SOULDRINKER) {
+        if (projectileSprite->uSpellID != SPELL_DARK_SOULDRINKER) {
             int d1 = abs(pParty->vPosition.x - projectileSprite->vPosition.x);
             int d2 = abs(pParty->vPosition.y - projectileSprite->vPosition.y);
             int d3 = abs(pParty->vPosition.z - projectileSprite->vPosition.z);
@@ -3243,7 +3243,7 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
                 v61 = 1;
         }
 
-        switch (projectileSprite->spell_id) {
+        switch (projectileSprite->uSpellID) {
             case SPELL_LASER_PROJECTILE:
                 // TODO: should be changed to GetActual* equivalents?
                 v61 = 1;
@@ -3309,10 +3309,10 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
 
             default:
                 attackElement = (DAMAGE_TYPE)player->GetSpellSchool(
-                    static_cast<SPELL_TYPE>(projectileSprite->spell_id));
+                    projectileSprite->uSpellID);
                 IsAdditionalDamagePossible = false;
                 uDamageAmount = CalcSpellDamage(
-                    static_cast<SPELL_TYPE>(projectileSprite->spell_id),
+                    projectileSprite->uSpellID,
                     projectileSprite->spell_level,
                     projectileSprite->spell_skill, pMonster->sCurrentHP);
                 break;
@@ -5166,9 +5166,9 @@ void ItemDamageFromActor(unsigned int uObjID, unsigned int uActorID,
 
     if (!pActors[uActorID].IsNotAlive()) {
         if (PID_TYPE(uObjID) == OBJECT_Item) {
-            if (pSpriteObjects[PID_ID(uObjID)].spell_id) {
+            if (pSpriteObjects[PID_ID(uObjID)].uSpellID) {
                 v6 = CalcSpellDamage(
-                    static_cast<SPELL_TYPE>(pSpriteObjects[PID_ID(uObjID)].spell_id),
+                    pSpriteObjects[PID_ID(uObjID)].uSpellID,
                     pSpriteObjects[PID_ID(uObjID)].spell_level,
                     pSpriteObjects[PID_ID(uObjID)].spell_skill,
                     pActors[uActorID].sCurrentHP);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1318,7 +1318,7 @@ int Actor::_43B3E0_CalcDamage(ABILITY_INDEX dmgSource) {
     int damageDiceRolls;
     int damageDiceSides;
     int damageBonus;
-    uint8_t spellID;
+    SPELL_TYPE spellID;
     int spellPower = 0;
     PLAYER_SKILL skill;
     PLAYER_SKILL_LEVEL skillLevel = 0;
@@ -3272,7 +3272,7 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
                 attackElement =
                     (DAMAGE_TYPE)player->GetSpellSchool(SPELL_EARTH_BLADES);
                 uDamageAmount = CalcSpellDamage(
-                    39, projectileSprite->spell_level,
+                    SPELL_EARTH_BLADES, projectileSprite->spell_level,
                     projectileSprite->spell_skill, pMonster->sCurrentHP);
                 if (pMonster->pActorBuffs[ACTOR_BUFF_SHIELD].Active())
                     uDamageAmount >>= 1;
@@ -3309,10 +3309,11 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
 
             default:
                 attackElement = (DAMAGE_TYPE)player->GetSpellSchool(
-                    projectileSprite->spell_id);
+                    static_cast<SPELL_TYPE>(projectileSprite->spell_id));
                 IsAdditionalDamagePossible = false;
                 uDamageAmount = CalcSpellDamage(
-                    projectileSprite->spell_id, projectileSprite->spell_level,
+                    static_cast<SPELL_TYPE>(projectileSprite->spell_id),
+                    projectileSprite->spell_level,
                     projectileSprite->spell_skill, pMonster->sCurrentHP);
                 break;
         }
@@ -5167,7 +5168,7 @@ void ItemDamageFromActor(unsigned int uObjID, unsigned int uActorID,
         if (PID_TYPE(uObjID) == OBJECT_Item) {
             if (pSpriteObjects[PID_ID(uObjID)].spell_id) {
                 v6 = CalcSpellDamage(
-                    pSpriteObjects[PID_ID(uObjID)].spell_id,
+                    static_cast<SPELL_TYPE>(pSpriteObjects[PID_ID(uObjID)].spell_id),
                     pSpriteObjects[PID_ID(uObjID)].spell_level,
                     pSpriteObjects[PID_ID(uObjID)].spell_skill,
                     pActors[uActorID].sCurrentHP);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1396,7 +1396,7 @@ void Actor::StealFrom(unsigned int uActorID) {
 
     pPlayer = &pParty->pPlayers[uActiveCharacter - 1];
     if (pPlayer->CanAct()) {
-        CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
+        CastSpellInfoHelpers::CancelSpellCastInProgress();
         v4 = 0;
         v5 = pMapStats->GetMapInfo(pCurrentMapName);
         if (v5) v4 = pMapStats->pInfos[v5]._steal_perm;

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -128,7 +128,7 @@ bool Chest::Open(int uChestID) {
             pSpellObject.containing_item.Reset();
             pSpellObject.spell_skill = PLAYER_SKILL_MASTERY_NONE;
             pSpellObject.spell_level = 0;
-            pSpellObject.spell_id = 0;
+            pSpellObject.uSpellID = SPELL_NONE;
             pSpellObject.field_54 = 0;
             pSpellObject.uType = pSpriteID[pRandom];
             pSpellObject.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellObject.uType);

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -1286,13 +1286,13 @@ int UseNPCSkill(NPCProf profession) {
         } break;
 
         case Acolyte:
-            RegisterNPCSpell(SPELL_SPIRIT_BLESS);
+            pushNPCSpell(SPELL_SPIRIT_BLESS);
             break;
         case Piper:
-            RegisterNPCSpell(SPELL_SPIRIT_HEROISM);
+            pushNPCSpell(SPELL_SPIRIT_HEROISM);
             break;
         case FallenWizard:
-            RegisterNPCSpell(SPELL_LIGHT_HOUR_OF_POWER);
+            pushNPCSpell(SPELL_LIGHT_HOUR_OF_POWER);
             break;
 
         case Teacher:

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -1286,13 +1286,13 @@ int UseNPCSkill(NPCProf profession) {
         } break;
 
         case Acolyte:
-            _42777D_CastSpell_UseWand_ShootArrow(SPELL_SPIRIT_BLESS, 0, 133, 0, 0);
+            RegisterNPCSpell(SPELL_SPIRIT_BLESS);
             break;
         case Piper:
-            _42777D_CastSpell_UseWand_ShootArrow(SPELL_SPIRIT_HEROISM, 0, 133, 0, 0);
+            RegisterNPCSpell(SPELL_SPIRIT_HEROISM);
             break;
         case FallenWizard:
-            _42777D_CastSpell_UseWand_ShootArrow(SPELL_LIGHT_HOUR_OF_POWER, 0, 133, 0, 0);
+            RegisterNPCSpell(SPELL_LIGHT_HOUR_OF_POWER);
             break;
 
         case Teacher:

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -2132,7 +2132,7 @@ int Player::ReceiveSpecialAttackEffect(
 // 48DCF6: using guessed type char var_94[140];
 
 //----- (0048E1A3) --------------------------------------------------------
-unsigned int Player::GetSpellSchool(unsigned int uSpellID) {
+unsigned int Player::GetSpellSchool(SPELL_TYPE uSpellID) {
     return pSpellStats->pInfos[uSpellID].uSchool;
 }
 
@@ -4239,10 +4239,7 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
 
         // TODO(captainurist): deal away with casts.
         SPELL_TYPE scroll_id = (SPELL_TYPE)(std::to_underlying(pParty->pPickedItem.uItemID) - 299);
-        if (scroll_id == SPELL_WATER_ENCHANT_ITEM ||
-            scroll_id == SPELL_FIRE_FIRE_AURA ||
-            scroll_id == SPELL_DARK_VAMPIRIC_WEAPON ||
-            scroll_id == SPELL_WATER_RECHARGE_ITEM) {
+        if (IsSpellTargetsItem(scroll_id)) {
             mouse->RemoveHoldingItem();
             pGUIWindow_CurrentMenu->Release();
             current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
@@ -7021,7 +7018,8 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
             int damagetype;
             if (uActorType != OBJECT_Player ||spritefrom->spell_id != SPELL_BOW_ARROW) {
                 int playerMaxHp = playerPtr->GetMaxHealth();
-                damage = CalcSpellDamage(spritefrom->spell_id, spritefrom->spell_level,
+                damage = CalcSpellDamage(static_cast<SPELL_TYPE>(spritefrom->spell_id),
+                                         spritefrom->spell_level,
                                          spritefrom->spell_skill, playerMaxHp);
                 damagetype = pSpellStats->pInfos[spritefrom->spell_id].uSchool;
             } else {
@@ -7162,7 +7160,8 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
             if (uActorType != OBJECT_Player ||
                 spritefrom->spell_id != SPELL_BOW_ARROW) {
                 int playerMaxHp = playerPtr->GetMaxHealth();
-                damage = CalcSpellDamage(spritefrom->spell_id, spritefrom->spell_level,
+                damage = CalcSpellDamage(static_cast<SPELL_TYPE>(spritefrom->spell_id),
+                                         spritefrom->spell_level,
                                          spritefrom->spell_skill, playerMaxHp);
                 damagetype = pSpellStats->pInfos[spritefrom->spell_id].uSchool;
             } else {

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -4239,12 +4239,12 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
 
         // TODO(captainurist): deal away with casts.
         SPELL_TYPE scroll_id = (SPELL_TYPE)(std::to_underlying(pParty->pPickedItem.uItemID) - 299);
-        if (IsSpellTargetsItem(scroll_id)) {
+        if (isSpellTargetsItem(scroll_id)) {
             mouse->RemoveHoldingItem();
             pGUIWindow_CurrentMenu->Release();
             current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
             viewparams->bRedrawGameUI = 1;
-            RegisterScrollSpell(scroll_id, player_num - 1);
+            pushScrollSpell(scroll_id, player_num - 1);
         } else {
             mouse->RemoveHoldingItem();
             pMessageQueue_50C9E8->AddGUIMessage(UIMSG_SpellScrollUse, scroll_id, player_num - 1);
@@ -7016,12 +7016,12 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
 
             int damage;
             int damagetype;
-            if (uActorType != OBJECT_Player ||spritefrom->spell_id != SPELL_BOW_ARROW) {
+            if (uActorType != OBJECT_Player ||spritefrom->uSpellID != SPELL_BOW_ARROW) {
                 int playerMaxHp = playerPtr->GetMaxHealth();
-                damage = CalcSpellDamage(static_cast<SPELL_TYPE>(spritefrom->spell_id),
+                damage = CalcSpellDamage(spritefrom->uSpellID,
                                          spritefrom->spell_level,
                                          spritefrom->spell_skill, playerMaxHp);
-                damagetype = pSpellStats->pInfos[spritefrom->spell_id].uSchool;
+                damagetype = pSpellStats->pInfos[spritefrom->uSpellID].uSchool;
             } else {
                 damage = pParty->pPlayers[uActorID].CalculateRangedDamageTo(0);
                 damagetype = 0;
@@ -7158,12 +7158,12 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
             int damage;
             int damagetype;
             if (uActorType != OBJECT_Player ||
-                spritefrom->spell_id != SPELL_BOW_ARROW) {
+                spritefrom->uSpellID != SPELL_BOW_ARROW) {
                 int playerMaxHp = playerPtr->GetMaxHealth();
-                damage = CalcSpellDamage(static_cast<SPELL_TYPE>(spritefrom->spell_id),
+                damage = CalcSpellDamage(spritefrom->uSpellID,
                                          spritefrom->spell_level,
                                          spritefrom->spell_skill, playerMaxHp);
-                damagetype = pSpellStats->pInfos[spritefrom->spell_id].uSchool;
+                damagetype = pSpellStats->pInfos[spritefrom->uSpellID].uSchool;
             } else {
                 damage = pParty->pPlayers[uActorID].CalculateRangedDamageTo(0);
                 damagetype = 0;
@@ -7535,7 +7535,7 @@ void Player::_42ECB5_PlayerAttacksActor() {
     Player* player = &pParty->pPlayers[uActiveCharacter - 1];
     if (!player->CanAct()) return;
 
-    CastSpellInfoHelpers::CancelSpellCastInProgress();
+    CastSpellInfoHelpers::cancelSpellCastInProgress();
     // v3 = 0;
     if (pParty->Invisible())
         pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Reset();
@@ -7606,16 +7606,15 @@ void Player::_42ECB5_PlayerAttacksActor() {
          melee_attack = false;
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
-        RegisterSpellOrSpellLikeSkill(SPELL_LASER_PROJECTILE,
-                                      uActiveCharacter - 1, 0, 0,
-                                      uActiveCharacter + 8);
+        pushSpellOrRangedAttack(SPELL_LASER_PROJECTILE,
+                                uActiveCharacter - 1, 0, 0,
+                                uActiveCharacter + 8);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         int main_hand_idx = player->pEquipment.uMainHand;
-        RegisterSpellOrSpellLikeSkill(
-            WandSpellIds[player->pInventoryItemList[main_hand_idx - 1].uItemID],
-            uActiveCharacter - 1, 8, 0, uActiveCharacter + 8);
+        pushSpellOrRangedAttack(WandSpellIds[player->pInventoryItemList[main_hand_idx - 1].uItemID],
+                                uActiveCharacter - 1, 8, 0, uActiveCharacter + 8);
 
         if (!--player->pInventoryItemList[main_hand_idx - 1].uNumCharges)
             player->pEquipment.uMainHand = 0;
@@ -7635,7 +7634,7 @@ void Player::_42ECB5_PlayerAttacksActor() {
                 uActiveCharacter);
     } else if (bow_idx) {
         shooting_bow = true;
-        RegisterSpellOrSpellLikeSkill(SPELL_BOW_ARROW, uActiveCharacter - 1, 0, 0, 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, uActiveCharacter - 1, 0, 0, 0);
     } else {
         melee_attack = true;
         // ; // actor out of range or no actor; no ranged weapon so melee
@@ -7704,7 +7703,7 @@ void Player::_42FA66_do_explosive_impact(int xpos, int ypos, int zpos, int a4,
     SpriteObject a1a;
     a1a.uType = SPRITE_OBJECT_EXPLODE;
     a1a.containing_item.Reset();
-    a1a.spell_id = SPELL_FIRE_FIREBALL;
+    a1a.uSpellID = SPELL_FIRE_FIREBALL;
     a1a.spell_level = 8;
     a1a.spell_skill = PLAYER_SKILL_MASTERY_MASTER;
     a1a.uObjectDescID = pObjectList->ObjectIDByItemID(a1a.uType);

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -4239,14 +4239,15 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
 
         // TODO(captainurist): deal away with casts.
         SPELL_TYPE scroll_id = (SPELL_TYPE)(std::to_underlying(pParty->pPickedItem.uItemID) - 299);
-        if (scroll_id == 30 || scroll_id == 4 || scroll_id == 91 ||
-            scroll_id == 28) {  // Enchant Item scroll, Vampiric Weapon scroll
-                                // ,Recharge Item ,Fire Aura
+        if (scroll_id == SPELL_WATER_ENCHANT_ITEM ||
+            scroll_id == SPELL_FIRE_FIRE_AURA ||
+            scroll_id == SPELL_DARK_VAMPIRIC_WEAPON ||
+            scroll_id == SPELL_WATER_RECHARGE_ITEM) {
             mouse->RemoveHoldingItem();
             pGUIWindow_CurrentMenu->Release();
             current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
             viewparams->bRedrawGameUI = 1;
-            _42777D_CastSpell_UseWand_ShootArrow(scroll_id, player_num - 1, 0x85u, ON_CAST_CastViaScroll, 0);
+            RegisterScrollSpell(scroll_id, player_num - 1);
         } else {
             mouse->RemoveHoldingItem();
             pMessageQueue_50C9E8->AddGUIMessage(UIMSG_SpellScrollUse, scroll_id, player_num - 1);
@@ -7535,7 +7536,7 @@ void Player::_42ECB5_PlayerAttacksActor() {
     Player* player = &pParty->pPlayers[uActiveCharacter - 1];
     if (!player->CanAct()) return;
 
-    CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
+    CastSpellInfoHelpers::CancelSpellCastInProgress();
     // v3 = 0;
     if (pParty->Invisible())
         pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Reset();
@@ -7606,14 +7607,14 @@ void Player::_42ECB5_PlayerAttacksActor() {
          melee_attack = false;
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
-        _42777D_CastSpell_UseWand_ShootArrow(SPELL_LASER_PROJECTILE,
-                                             uActiveCharacter - 1, 0, 0,
-                                             uActiveCharacter + 8);
+        RegisterSpellOrSpellLikeSkill(SPELL_LASER_PROJECTILE,
+                                      uActiveCharacter - 1, 0, 0,
+                                      uActiveCharacter + 8);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         int main_hand_idx = player->pEquipment.uMainHand;
-        _42777D_CastSpell_UseWand_ShootArrow(
+        RegisterSpellOrSpellLikeSkill(
             wand_spell_ids[player->pInventoryItemList[main_hand_idx - 1].uItemID],
             uActiveCharacter - 1, 8, 0, uActiveCharacter + 8);
 
@@ -7635,7 +7636,7 @@ void Player::_42ECB5_PlayerAttacksActor() {
                 uActiveCharacter);
     } else if (bow_idx) {
         shooting_bow = true;
-        _42777D_CastSpell_UseWand_ShootArrow(SPELL_BOW_ARROW, uActiveCharacter - 1, 0, 0, 0);
+        RegisterSpellOrSpellLikeSkill(SPELL_BOW_ARROW, uActiveCharacter - 1, 0, 0, 0);
     } else {
         melee_attack = true;
         // ; // actor out of range or no actor; no ranged weapon so melee

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -215,7 +215,7 @@ struct Player {
     void Heal(int amount);
     int ReceiveDamage(signed int amount, DAMAGE_TYPE dmg_type);
     int ReceiveSpecialAttackEffect(int attType, Actor* pActor);
-    unsigned int GetSpellSchool(unsigned int uSpellID);
+    unsigned int GetSpellSchool(SPELL_TYPE uSpellID);
     int GetAttackRecoveryTime(bool bRangedAttack);
 
     int GetHealth() const { return this->sHealth; }

--- a/src/Engine/Objects/PlayerEnums.h
+++ b/src/Engine/Objects/PlayerEnums.h
@@ -234,6 +234,18 @@ inline void SetSkillMastery(PLAYER_SKILL *skill_value, PLAYER_SKILL_MASTERY mast
     }
 }
 
+/**
+ * Construct player skill value using skill mastery and skill level
+ */
+inline PLAYER_SKILL ConstructSkillValue(PLAYER_SKILL_MASTERY mastery, PLAYER_SKILL_LEVEL level) {
+    PLAYER_SKILL skill = 0;
+
+    SetSkillMastery(&skill, mastery);
+    SetSkillLevel(&skill, level);
+
+    return skill;
+}
+
 #pragma warning(push)
 #pragma warning(disable : 4341) // TODO(captainurist): msvc mis-warns here, just drop this warning altogether for msvc
 /*  328 */

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -1041,6 +1041,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
                 //            word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
                 //            - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125,
                 //            v124, 0, -1, 0, v97, 0, 0);
+                // Originally used "spell_id - 1" but currently it will result in wrong sound on spell impact.
                 pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                              PID(OBJECT_Item, uLayingItemID), true);
                 return 0;

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -1190,7 +1190,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v97, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].master,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID), true);
             return 0;
         }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -1468,7 +1468,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
                     //                v125 = v143 + 1;
                     //                pAudioPlayer->PlaySound((SoundID)v125,
                     //                v115, 0, -1, 0, v114, 0, 0);
-                    pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+                    pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                                  PID(OBJECT_Item, uLayingItemID), true);
                 } else {
                     SpriteObject::OnInteraction(uLayingItemID);
@@ -1544,7 +1544,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
                 //            v125 = v143 + 1;
                 //            pAudioPlayer->PlaySound((SoundID)v125, v115, 0,
                 //            -1, 0, v114, 0, 0);
-                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                              PID(OBJECT_Item, uLayingItemID), true);
             } else {
                 SpriteObject::OnInteraction(uLayingItemID);

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -885,7 +885,7 @@ void SpriteObject::_46BEF1_apply_spells_aoe() {
 
             if (v11 >= v7 * v7 + v9 * v9 + v10 * v10) {
                 if (pActors[i].DoesDmgTypeDoDamage(DMGT_DARK)) {
-                    pActors[i].pActorBuffs[ACTOR_BUFF_INDEX(this->spell_id)].Apply(
+                    pActors[i].pActorBuffs[ACTOR_BUFF_INDEX(this->uSpellID)].Apply(
                         GameTime(pParty->GetPlayingTime() +
                             GameTime::FromSeconds(this->spell_level)),
                         this->spell_skill, 4, 0, 0);
@@ -909,7 +909,7 @@ bool SpriteObject::Drop_Item_At(SPRITE_OBJECT_TYPE sprite, int x,
                sizeof(pSpellObject.containing_item));
     pSpellObject.spell_skill = PLAYER_SKILL_MASTERY_NONE;
     pSpellObject.spell_level = 0;
-    pSpellObject.spell_id = 0;
+    pSpellObject.uSpellID = SPELL_NONE;
     pSpellObject.field_54 = 0;
     pSpellObject.uType = sprite;
     pSpellObject.uObjectDescID = pObjectList->ObjectIDByItemID(sprite);
@@ -957,7 +957,7 @@ void SpriteObject::Create_Splash_Object(int x, int y, int z) {  // splash on wat
     a1.containing_item.Reset();
     a1.spell_skill = PLAYER_SKILL_MASTERY_NONE;
     a1.spell_level = 0;
-    a1.spell_id = 0;
+    a1.uSpellID = SPELL_NONE;
     a1.field_54 = 0;
     a1.uType = SPRITE_WATER_SPLASH;
     a1.uObjectDescID = pObjectList->ObjectIDByItemID(a1.uType);
@@ -1038,10 +1038,10 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
                     v97 = (int16_t)pSpriteObjects[uLayingItemID].uSoundID + 4;
                 }
                 //            v125 =
-                //            word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
+                //            word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].
                 //            - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125,
                 //            v124, 0, -1, 0, v97, 0, 0);
-                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id - 1,
+                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID - 1,
                                              PID(OBJECT_Item, uLayingItemID));
                 return 0;
             }
@@ -1105,7 +1105,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
                 //            word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id]
                 //            + 1; pAudioPlayer->PlaySound((SoundID)v125, v124,
                 //            0, -1, 0, v16, 0, 0);
-                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+                pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                              PID(OBJECT_Item, uLayingItemID));
                 return 0;
             }
@@ -1190,7 +1190,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v97, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1238,7 +1238,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v16, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1264,7 +1264,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v16, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1296,7 +1296,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125,
             //        pSpriteObjects[uLayingItemID].vPosition.x, 0, -1, 0, v78,
             //        0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1328,7 +1328,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v16, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1358,7 +1358,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125,
             //        pSpriteObjects[uLayingItemID].vPosition.x, 0, -1, 0, v78,
             //        0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1389,7 +1389,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v97, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1418,7 +1418,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v97, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1478,7 +1478,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             v150 = 0;
             v137 = pSpriteObjects[uLayingItemID].spell_level;
             skillMastery = pSpriteObjects[uLayingItemID].spell_skill;
-            v136 = pSpriteObjects[uLayingItemID].spell_id;
+            v136 = pSpriteObjects[uLayingItemID].uSpellID;
             if (pSpriteObjects[uLayingItemID].uType == SPRITE_SPELL_DARK_SHRINKING_RAY) {
                 v150 = 2;
                 if (skillMastery == PLAYER_SKILL_MASTERY_EXPERT) {
@@ -1524,7 +1524,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             }
             pSpriteObjects[uLayingItemID].spell_level = 0;
             pSpriteObjects[uLayingItemID].spell_skill = PLAYER_SKILL_MASTERY_NONE;
-            pSpriteObjects[uLayingItemID].spell_id = 0;
+            pSpriteObjects[uLayingItemID].uSpellID = SPELL_NONE;
             if (!v138) {
                 pSpriteObjects[uLayingItemID].uType = (SPRITE_OBJECT_TYPE)(pSpriteObjects[uLayingItemID].uType + 1);
                 pSpriteObjects[uLayingItemID].uObjectDescID = pObjectList->ObjectIDByItemID(pSpriteObjects[uLayingItemID].uType);
@@ -1573,7 +1573,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v124, 0,
             //        -1, 0, v97, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }
@@ -1656,7 +1656,7 @@ bool _46BFFA_update_spell_fx(unsigned int uLayingItemID, int pid) {
             //        word_4EE088_sound_ids[pSpriteObjects[uLayingItemID].spell_id
             //        - 1] + 1; pAudioPlayer->PlaySound((SoundID)v125, v102, 0,
             //        -1, 0, v47, 0, 0);
-            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].spell_id,
+            pAudioPlayer->PlaySpellSound(pSpriteObjects[uLayingItemID].uSpellID,
                                          PID(OBJECT_Item, uLayingItemID));
             return 0;
         }

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -48,7 +48,8 @@ struct SpriteObject {
     int16_t field_20 = 0;
     int16_t field_22_glow_radius_multiplier = 1;
     ItemGen containing_item;
-    int spell_id = 0;
+    SPELL_TYPE uSpellID = SPELL_NONE;
+    char pad[3] = {0, 0, 0}; // TODO(Nik-RE-dev): add SpriteObject_MM7 to LegacyImages and redo this properly.
     int spell_level = 0;
     PLAYER_SKILL_MASTERY spell_skill = PLAYER_SKILL_MASTERY_NONE;
     int field_54 = 0;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -3543,6 +3543,8 @@ void RegisterSpellOrSpellLikeSkill(SPELL_TYPE spell,
                 UIMSG_ScrollNPCPanel, 1, InputAction::Invalid, "", {ui_btn_npc_right});
             pGUIWindow_CastTargetedSpell->CreateButton({491, 149}, {64, 74}, 1, 0, UIMSG_HiredNPC_CastSpell, 4, InputAction::SelectNPC1);
             pGUIWindow_CastTargetedSpell->CreateButton({561, 149}, {64, 74}, 1, 0, UIMSG_HiredNPC_CastSpell, 5, InputAction::SelectNPC2);
+            // Next line was added to do something with picked item on Sacrifice cast
+            pParty->PickedItem_PlaceInInventory_or_Drop();
         }
     }
 }

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -171,32 +171,7 @@ void CastSpellInfoHelpers::CastSpell() {
             spell_level = GetSkillLevel(pCastSpell->forced_spell_skill_level);
             spell_mastery = GetSkillMastery(pCastSpell->forced_spell_skill_level);
         } else {
-            if (pCastSpell->uSpellID < SPELL_AIR_WIZARD_EYE) {
-                which_skill = PLAYER_SKILL_FIRE;
-            } else if (pCastSpell->uSpellID < SPELL_WATER_AWAKEN) {
-                which_skill = PLAYER_SKILL_AIR;
-            } else if (pCastSpell->uSpellID < SPELL_EARTH_STUN) {
-                which_skill = PLAYER_SKILL_WATER;
-            } else if (pCastSpell->uSpellID < SPELL_SPIRIT_DETECT_LIFE) {
-                which_skill = PLAYER_SKILL_EARTH;
-            } else if (pCastSpell->uSpellID < SPELL_MIND_REMOVE_FEAR) {
-                which_skill = PLAYER_SKILL_SPIRIT;
-            } else if (pCastSpell->uSpellID < SPELL_BODY_CURE_WEAKNESS) {
-                which_skill = PLAYER_SKILL_MIND;
-            } else if (pCastSpell->uSpellID < SPELL_LIGHT_LIGHT_BOLT) {
-                which_skill = PLAYER_SKILL_BODY;
-            } else if (pCastSpell->uSpellID < SPELL_DARK_REANIMATE) {
-                which_skill = PLAYER_SKILL_LIGHT;
-            } else if (pCastSpell->uSpellID < SPELL_BOW_ARROW) {
-                which_skill = PLAYER_SKILL_DARK;
-            } else if (pCastSpell->uSpellID == SPELL_BOW_ARROW) {
-                which_skill = PLAYER_SKILL_BOW;
-            } else if (pCastSpell->uSpellID == SPELL_101 ||
-                pCastSpell->uSpellID == SPELL_LASER_PROJECTILE) {
-                which_skill = PLAYER_SKILL_BLASTER;
-            } else {
-                assert(false && "Unknown spell");
-            }
+            which_skill = GetSkillTypeForSpell(pCastSpell->uSpellID);
 
             spell_level = pPlayer->GetActualSkillLevel(which_skill);
             spell_mastery = pPlayer->GetActualSkillMastery(which_skill);
@@ -3330,7 +3305,6 @@ void CastSpellInfoHelpers::CancelSpellCastInProgress() {
     for (size_t i = 0; i < CastSpellInfoCount; i++) {
         if (pCastSpellInfo[i].uSpellID != SPELL_NONE &&
             pCastSpellInfo[i].uFlags & ON_CAST_CastingInProgress) {
-
             // Only one targeted spell can exist in queue.
             assert(!targeted_spell_canceled);
 

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -11,8 +11,19 @@
 #include "Spells.h"
 
 namespace CastSpellInfoHelpers {
-    void CancelSpellCastInProgress();
-    void CastSpell();
+    /**
+     * Cast spell processing.
+     *
+     * @offset 0x00427E01
+     */
+    void castSpell();
+
+    /**
+     * Remove all targeted spells from spell queue.
+     *
+     * @offset 0x00427D48
+     */
+    void cancelSpellCastInProgress();
 };  // namespace CastSpellInfoHelpers
 
 class GUIWindow;
@@ -62,12 +73,51 @@ struct CastSpellInfo {
     int sound_id;
 };
 
-void RegisterSpellOrSpellLikeSkill(SPELL_TYPE spell,
-                                   unsigned int uPlayerID,
-                                   PLAYER_SKILL skill_value,
-                                   SpellCastFlags flags,
-                                   int a6);
+/**
+ * General function that registers spell or skill implemented
+ * through spell casting mechanism to be cast/performed later.
+ *
+ * Actual casting will be performed with event queue processing.
+ *
+ * If spell is targeted then corresponding target mode is entered
+ * and actual casting will be performed after target is picked.
+ * Registered targeted spells will have one of the flags
+ * listed in ON_CAST_CastingInProgress and this flag will be removed
+ * in event queue if correct target is picked.
+ *
+ * @offset 0x0042777D
+ *
+ * @param spell          ID of spell.
+ * @param uPlayerID      ID of player casting spell.
+ * @param skill_value    Skill value (mastery+skill level) spell is casted with.
+ * @param flags          Spell flags. Can be empty or have several flags.
+ * @param a6             ???
+ */
+void pushSpellOrRangedAttack(SPELL_TYPE spell,
+                             unsigned int uPlayerID,
+                             PLAYER_SKILL skill_value,
+                             SpellCastFlags flags,
+                             int a6);
 
-void RegisterTempleSpell(SPELL_TYPE spell);
-void RegisterNPCSpell(SPELL_TYPE spell);
-void RegisterScrollSpell(SPELL_TYPE spell, unsigned int uPlayerID);
+/**
+ * Register spell cast on party with temple donation.
+ * Temple spells are cast with MASTER mastery of skill level equal to the day of week.
+ *
+ * @param spell        ID of spell.
+ */
+void pushTempleSpell(SPELL_TYPE spell);
+
+/**
+ * Register spell cast by NPC companions.
+ *
+ * @param spell        ID of spell.
+ */
+void pushNPCSpell(SPELL_TYPE spell);
+
+/**
+ * Register spell cast through scroll.
+ *
+ * @param spell        ID of spell.
+ * @param uPlayerID    ID of player casting spell.
+ */
+void pushScrollSpell(SPELL_TYPE spell, unsigned int uPlayerID);

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -11,8 +11,8 @@
 #include "Spells.h"
 
 namespace CastSpellInfoHelpers {
-void Cancel_Spell_Cast_In_Progress();
-void CastSpell();
+    void CancelSpellCastInProgress();
+    void CastSpell();
 };  // namespace CastSpellInfoHelpers
 
 class GUIWindow;
@@ -21,7 +21,7 @@ class GUIWindow;
 enum class SpellCastFlag : uint16_t {
     ON_CAST_CastViaScroll = 0x0001,
     ON_CAST_WholeParty_BigImprovementAnim = 0x0002,
-    ON_CAST_0x0004 = 0x0004,
+    // 0x0004 unused
     ON_CAST_TargetCrosshair = 0x0008,
     ON_CAST_TargetIsParty = 0x0010,
     ON_CAST_NoRecoverySpell = 0x0020,
@@ -29,14 +29,18 @@ enum class SpellCastFlag : uint16_t {
     ON_CAST_Enchantment = 0x0080,
     ON_CAST_MonsterSparkles = 0x0100,
     ON_CAST_DarkSacrifice = 0x0200,
+
     ON_CAST_CastingInProgress =
         ON_CAST_WholeParty_BigImprovementAnim | ON_CAST_TargetCrosshair |
         ON_CAST_Telekenesis | ON_CAST_Enchantment | ON_CAST_MonsterSparkles |
-        ON_CAST_DarkSacrifice,
+        ON_CAST_DarkSacrifice
 };
 using enum SpellCastFlag;
 MM_DECLARE_FLAGS(SpellCastFlags, SpellCastFlag)
 MM_DECLARE_OPERATORS_FOR_FLAGS(SpellCastFlags)
+
+// Scrolls or NPC spells casted with MASTER mastery of skill level 5
+static const PLAYER_SKILL SCROLL_OR_NPC_SPELL_SKILL_VALUE = ConstructSkillValue(PLAYER_SKILL_MASTERY_MASTER, 5);
 
 /*  271 */
 #pragma pack(push, 1)
@@ -58,7 +62,12 @@ struct CastSpellInfo {
 };
 #pragma pack(pop)
 
-void _42777D_CastSpell_UseWand_ShootArrow(SPELL_TYPE spell,
-                                          unsigned int uPlayerID,
-                                          PLAYER_SKILL skill_value, SpellCastFlags flags,
-                                          int a6);
+void RegisterSpellOrSpellLikeSkill(SPELL_TYPE spell,
+                                   unsigned int uPlayerID,
+                                   PLAYER_SKILL skill_value,
+                                   SpellCastFlags flags,
+                                   int a6);
+
+void RegisterTempleSpell(SPELL_TYPE spell);
+void RegisterNPCSpell(SPELL_TYPE spell);
+void RegisterScrollSpell(SPELL_TYPE spell, unsigned int uPlayerID);

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -172,118 +172,132 @@ SpellData::SpellData(int16_t inNormalMana,
       bonusSkillDamage(inBonusSkillDamage),
       stats(inStats) {}
 
-// 9 spellbook pages  11 spells per page 9*11 =99 +1 zero struct at 0. It
-// counted from 1!
-std::array<SpellData, SPELL_REGULAR_COUNT> pSpellDatas = {{
-    SpellData(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+/**
+ * Description of spells.
+ *
+ *                                                 Mana Novice
+ *                                                 |   Mana Expert
+ *                                                 |   |   Mana Master
+ *                                                 |   |   |   Mana Grandmaster
+ *                                                 |   |   |   |     Recovery Novice
+ *                                                 |   |   |   |     |     Recovery Expert
+ *                                                 |   |   |   |     |     |     Recovery Master
+ *                                                 |   |   |   |     |     |     |     Recovery Grandmaster
+ *                                                 |   |   |   |     |     |     |     |   Base Damage
+ *                                                 |   |   |   |     |     |     |     |   |   Bonus Skill Damage
+ *                                                 |   |   |   |     |     |     |     |   |   |  Stats
+ *                                                 |   |   |   |     |     |     |     |   |   |  |
+ *                                                 |   |   |   |     |     |     |     |   |   |  |
+ */
+IndexedArray<SpellData, SPELL_REGULAR_FIRST, SPELL_REGULAR_LAST> pSpellDatas = {
+    {SPELL_FIRE_TORCH_LIGHT,            SpellData( 1,  1,  1,  1,   60,   60,   60,   40,  0,  0, 0)},
+    {SPELL_FIRE_FIRE_BOLT,              SpellData( 2,  2,  2,  2,  110,  110,  100,   90,  0,  3, 0)},
+    {SPELL_FIRE_PROTECTION_FROM_FIRE,   SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_FIRE_FIRE_AURA,              SpellData( 4,  4,  4,  4,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_FIRE_HASTE,                  SpellData( 5,  5,  5,  5,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_FIRE_FIREBALL,               SpellData( 8 , 8,  8,  8,  100,  100,   90,   80,  0,  6, 0)},
+    {SPELL_FIRE_FIRE_SPIKE,             SpellData(10, 10, 10, 10,  150,  150,  150,  150,  0,  6, 0)},
+    {SPELL_FIRE_IMMOLATION,             SpellData(15, 15, 15, 15,  120,  120,  120,  120,  0,  6, 0)},
+    {SPELL_FIRE_METEOR_SHOWER,          SpellData(20, 20, 20, 20,  100,  100,  100,   90,  8,  1, 0)},
+    {SPELL_FIRE_INFERNO,                SpellData(25, 25, 25, 25,  100,  100,  100,   90, 12,  1, 0)},
+    {SPELL_FIRE_INCINERATE,             SpellData(30, 30, 30, 30,   90,   90,   90,   90, 15, 15, 0)},
 
-    SpellData(1, 1, 1, 1, 60, 60, 60, 40, 0, 0, 0),  // 0 fire
-    SpellData(2, 2, 2, 2, 110, 110, 100, 90, 0, 3, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(5, 5, 5, 5, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 100, 100, 90, 80, 0, 6, 0),
-    SpellData(10, 10, 10, 10, 150, 150, 150, 150, 0, 6, 0),
-    SpellData(15, 15, 15, 15, 120, 120, 120, 120, 0, 6, 0),
-    SpellData(20, 20, 20, 20, 100, 100, 100, 90, 8, 1, 0),
-    SpellData(25, 25, 25, 25, 100, 100, 100, 90, 12, 1, 0),
-    SpellData(30, 30, 30, 30, 90, 90, 90, 90, 15, 15, 0),
+    {SPELL_AIR_WIZARD_EYE,              SpellData( 1,  1,  1,  0,   60,   60,   60,   60,  0,  0, 0)},
+    {SPELL_AIR_FEATHER_FALL,            SpellData( 2,  2,  2,  2,  120,  120,  120,  100,  0,  0, 0)},
+    {SPELL_AIR_PROTECTION_FROM_AIR,     SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_AIR_SPARKS,                  SpellData( 4,  4,  4,  4,  110,  100,   90,   80,  2,  1, 0)},
+    {SPELL_AIR_JUMP,                    SpellData( 5,  5,  5,  5,   90,   90,   70,   50,  0,  0, 0)},
+    {SPELL_AIR_SHIELD,                  SpellData( 8,  8,  8,  8,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_AIR_LIGHNING_BOLT,           SpellData(10, 10, 10, 10,  100,  100,   90,   70,  0,  8, 0)},
+    {SPELL_AIR_INVISIBILITY,            SpellData(15, 15, 15, 15,  200,  200,  200,  200,  0,  0, 0)},
+    {SPELL_AIR_IMPLOSION,               SpellData(20, 20, 20, 20,  100,  100,  100,   90, 10, 10, 0)},
+    {SPELL_AIR_FLY,                     SpellData(25, 25, 25, 25,  250,  250,  250,  250,  0,  0, 0)},
+    {SPELL_AIR_STARBURST,               SpellData(30, 30, 30, 30,   90,   90,   90,   90, 20,  1, 0)},
 
-    SpellData(1, 1, 1, 0, 60, 60, 60, 60, 0, 0, 0),  // 1 air
-    SpellData(2, 2, 2, 2, 120, 120, 120, 100, 0, 0, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 110, 100, 90, 80, 2, 1, 0),
-    SpellData(5, 5, 5, 5, 90, 90, 70, 50, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(10, 10, 10, 10, 100, 100, 90, 70, 0, 8, 0),
-    SpellData(15, 15, 15, 15, 200, 200, 200, 200, 0, 0, 0),
-    SpellData(20, 20, 20, 20, 100, 100, 100, 90, 10, 10, 0),
-    SpellData(25, 25, 25, 25, 250, 250, 250, 250, 0, 0, 0),
-    SpellData(30, 30, 30, 30, 90, 90, 90, 90, 20, 1, 0),
+    {SPELL_WATER_AWAKEN,                SpellData( 1,  1,  1,  1,   60,   60,   60,   20,  0,  0, 0)},
+    {SPELL_WATER_POISON_SPRAY,          SpellData( 2,  2,  2,  2,  110,  100,   90,   70,  2,  2, 0)},
+    {SPELL_WATER_PROTECTION_FROM_WATER, SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_WATER_ICE_BOLT,              SpellData( 4,  4,  4,  4,  110,  100,   90,   80,  0,  4, 0)},
+    {SPELL_WATER_WATER_WALK,            SpellData( 5,  5,  5,  5,  150,  150,  150,  150,  0,  0, 0)},
+    {SPELL_WATER_RECHARGE_ITEM,         SpellData( 8,  8,  8,  8,  200,  200,  200,  200,  0,  0, 0)},
+    {SPELL_WATER_ACID_BURST,            SpellData(10, 10, 10, 10,  100,  100,   90,   80,  9,  9, 0)},
+    {SPELL_WATER_ENCHANT_ITEM,          SpellData(15, 15, 15, 15,  140,  140,  140,  140,  0,  0, 0)},
+    {SPELL_WATER_TOWN_PORTAL,           SpellData(20, 20, 20, 20,  200,  200,  200,  200,  0,  0, 0)},
+    {SPELL_WATER_ICE_BLAST,             SpellData(25, 25, 25, 25,   80,   80,   80,   80, 12,  3, 0)},
+    {SPELL_WATER_LLOYDS_BEACON,         SpellData(30, 30, 30, 30,  250,  250,  250,  250,  0,  0, 0)},
 
-    SpellData(1, 1, 1, 1, 60, 60, 60, 20, 0, 0, 0),  // 2 water
-    SpellData(2, 2, 2, 2, 110, 100, 90, 70, 2, 2, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 110, 100, 90, 80, 0, 4, 0),
-    SpellData(5, 5, 5, 5, 150, 150, 150, 150, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 200, 200, 200, 200, 0, 0, 0),
-    SpellData(10, 10, 10, 10, 100, 100, 90, 80, 9, 9, 0),
-    SpellData(15, 15, 15, 15, 140, 140, 140, 140, 0, 0, 0),
-    SpellData(20, 20, 20, 20, 200, 200, 200, 200, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 80, 80, 80, 80, 12, 3, 0),
-    SpellData(30, 30, 30, 30, 250, 250, 250, 250, 0, 0, 0),
+    {SPELL_EARTH_STUN,                  SpellData( 1,  1,  1,  1,   80,   80,   80,   80,  0,  0, 0)},
+    {SPELL_EARTH_SLOW,                  SpellData( 2,  2,  2,  2,  100,  100,  100,  100,  0,  0, 0)},
+    {SPELL_EARTH_PROTECTION_FROM_EARTH, SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_EARTH_DEADLY_SWARM,          SpellData( 4,  4,  4,  4,  110,  100,   90,   80,  5,  3, 0)},
+    {SPELL_EARTH_STONESKIN,             SpellData( 5,  5,  5,  5,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_EARTH_BLADES,                SpellData( 8,  8,  8,  8,  100,  100,   90,   80,  0,  9, 0)},
+    {SPELL_EARTH_STONE_TO_FLESH,        SpellData(10, 10, 10, 10,  140,  140,  140,  140,  0,  0, 0)},
+    {SPELL_EARTH_ROCK_BLAST,            SpellData(15, 15, 15, 15,   90,   90,   90,   80,  0,  8, 0)},
+    {SPELL_EARTH_TELEKINESIS,           SpellData(20, 20, 20, 20,  150,  150,  150,  150,  0,  0, 0)},
+    {SPELL_EARTH_DEATH_BLOSSOM,         SpellData(25, 25, 25, 25,  100,  100,  100,   90, 20,  1, 0)},
+    {SPELL_EARTH_MASS_DISTORTION,       SpellData(30, 30, 30, 30,   90,   90,   90,   90, 25,  0, 0)},
 
-    SpellData(1, 1, 1, 1, 80, 80, 80, 80, 0, 0, 0),  // 3 earth
-    SpellData(2, 2, 2, 2, 100, 100, 100, 100, 0, 0, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 110, 100, 90, 80, 5, 3, 0),
-    SpellData(5, 5, 5, 5, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 100, 100, 90, 80, 0, 9, 0),
-    SpellData(10, 10, 10, 10, 140, 140, 140, 140, 0, 0, 0),
-    SpellData(15, 15, 15, 15, 90, 90, 90, 80, 0, 8, 0),
-    SpellData(20, 20, 20, 20, 150, 150, 150, 150, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 100, 100, 100, 90, 20, 1, 0),
-    SpellData(30, 30, 30, 30, 90, 90, 90, 90, 25, 0, 0),
+    {SPELL_SPIRIT_DETECT_LIFE,          SpellData( 1,  1,  1,  1,  100,  100,  100,  100,  0,  0, 0)},
+    {SPELL_SPIRIT_BLESS,                SpellData( 2,  2,  2,  2,  100,  100,  100,  100,  0,  0, 0)},
+    {SPELL_SPIRIT_FATE,                 SpellData( 3,  3,  3,  3,   90,   90,   90,   90,  0,  0, 0)},
+    {SPELL_SPIRIT_TURN_UNDEAD,          SpellData( 4,  4,  4,  4,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_SPIRIT_REMOVE_CURSE,         SpellData( 5,  5,  5,  5,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_SPIRIT_PRESERVATION,         SpellData( 8,  8,  8,  8,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_SPIRIT_HEROISM,              SpellData(10, 10, 10, 10,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_SPIRIT_SPIRIT_LASH,          SpellData(15, 15, 15, 15,  100,  100,  100,  100, 10,  8, 0)},
+    {SPELL_SPIRIT_RAISE_DEAD,           SpellData(20, 20, 20, 20,  240,  240,  240,  240,  0,  0, 0)},
+    {SPELL_SPIRIT_SHARED_LIFE,          SpellData(25, 25, 25, 25,  150,  150,  150,  150,  0,  0, 0)},
+    {SPELL_SPIRIT_RESSURECTION,         SpellData(30, 30, 30, 30, 1000, 1000, 1000, 1000,  0,  0, 0)},
 
-    SpellData(1, 1, 1, 1, 100, 100, 100, 100, 0, 0, 0),  // 4 spirit
-    SpellData(2, 2, 2, 2, 100, 100, 100, 100, 0, 0, 0),
-    SpellData(3, 3, 3, 3, 90, 90, 90, 90, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(5, 5, 5, 5, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(10, 10, 10, 10, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(15, 15, 15, 15, 100, 100, 100, 100, 10, 8, 0),
-    SpellData(20, 20, 20, 20, 240, 240, 240, 240, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 150, 150, 150, 150, 0, 0, 0),
-    SpellData(30, 30, 30, 30, 1000, 1000, 1000, 1000, 0, 0, 0),
+    {SPELL_MIND_REMOVE_FEAR,            SpellData( 1,  1,  1,  1,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_MIND_MIND_BLAST,             SpellData( 2,  2,  2,  2,  110,  110,  110,  110,  3,  3, 0)},
+    {SPELL_MIND_PROTECTION_FROM_MIND,   SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_MIND_TELEPATHY,              SpellData( 4,  4,  4,  4,  110,  100,   90,   80,  0,  0, 0)},
+    {SPELL_MIND_CHARM,                  SpellData( 5,  5,  5,  5,  100,  100,  100,  100,  0,  0, 0)},
+    {SPELL_MIND_CURE_PARALYSIS,         SpellData( 8,  8,  8,  8,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_MIND_BERSERK,                SpellData(10, 10, 10, 10,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_MIND_MASS_FEAR,              SpellData(15, 15, 15, 15,   80,   80,   80,   80,  0,  0, 0)},
+    {SPELL_MIND_CURE_INSANITY,          SpellData(20, 20, 20, 20,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_MIND_PSYCHIC_SHOCK,          SpellData(25, 25, 25, 25,  110,  110,  110,  100, 12,  1, 0)},
+    {SPELL_MIND_ENSLAVE,                SpellData(30, 30, 30, 30,  120,  120,  120,  120,  0,  0, 0)},
 
-    SpellData(1, 1, 1, 1, 120, 120, 120, 120, 0, 0, 0),  // 5 mind
-    SpellData(2, 2, 2, 2, 110, 110, 110, 110, 3, 3, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 110, 100, 90, 80, 0, 0, 0),
-    SpellData(5, 5, 5, 5, 100, 100, 100, 100, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(10, 10, 10, 10, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(15, 15, 15, 15, 80, 80, 80, 80, 0, 0, 0),
-    SpellData(20, 20, 20, 20, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 110, 110, 110, 100, 12, 1, 0),
-    SpellData(30, 30, 30, 30, 120, 120, 120, 120, 0, 0, 0),
+    {SPELL_BODY_CURE_WEAKNESS,          SpellData( 1,  1,  1,  1,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_FIRST_AID,              SpellData( 2,  2,  2,  2,  100,  100,  100,  100,  0,  0, 0)},
+    {SPELL_BODY_PROTECTION_FROM_BODY,   SpellData( 3,  3,  3,  3,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_HARM,                   SpellData( 4,  4,  4,  4,  110,  100,   90,   80,  8,  2, 0)},
+    {SPELL_BODY_REGENERATION,           SpellData( 5,  5,  5,  5,  110,  110,  110,  110,  0,  0, 0)},
+    {SPELL_BODY_CURE_POISON,            SpellData( 8,  8,  8,  8,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_HAMMERHANDS,            SpellData(10, 10, 10, 10,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_CURE_DISEASE,           SpellData(15, 15, 15, 15,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_PROTECTION_FROM_MAGIC,  SpellData(20, 20, 20, 20,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_BODY_FLYING_FIST,            SpellData(25, 25, 25, 25,  110,  110,  110,  100, 30,  5, 0)},
+    {SPELL_BODY_POWER_CURE,             SpellData(30, 30, 30, 30,  100,  100,  100,  100,  0,  0, 0)},
 
-    SpellData(1, 1, 1, 1, 120, 120, 120, 120, 0, 0, 0),  // 6 body
-    SpellData(2, 2, 2, 2, 100, 100, 100, 100, 0, 0, 0),
-    SpellData(3, 3, 3, 3, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(4, 4, 4, 4, 110, 100, 90, 80, 8, 2, 0),
-    SpellData(5, 5, 5, 5, 110, 110, 110, 110, 0, 0, 0),
-    SpellData(8, 8, 8, 8, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(10, 10, 10, 10, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(15, 15, 15, 15, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(20, 20, 20, 20, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 110, 110, 110, 100, 30, 5, 0),
-    SpellData(30, 30, 30, 30, 100, 100, 100, 100, 0, 0, 0),
+    {SPELL_LIGHT_LIGHT_BOLT,            SpellData( 5,  5,  5,  5,  110,  100,   90,   80,  0,  4, 0)},
+    {SPELL_LIGHT_DESTROY_UNDEAD,        SpellData(10, 10, 10, 10,  120,  110,  100,   90, 16, 16, 0)},
+    {SPELL_LIGHT_DISPEL_MAGIC,          SpellData(15, 15, 15, 15,  120,  110,  100,   90,  0,  0, 0)},
+    {SPELL_LIGHT_PARALYZE,              SpellData(20, 20, 20, 20,  160,  140,  120,  100,  0,  0, 0)},
+    {SPELL_LIGHT_SUMMON_ELEMENTAL,      SpellData(25, 25, 25, 25,  140,  140,  140,  140,  0,  0, 0)},
+    {SPELL_LIGHT_DAY_OF_THE_GODS,       SpellData(30, 30, 30, 30,  500,  500,  500,  500,  0,  0, 0)},
+    {SPELL_LIGHT_PRISMATIC_LIGHT,       SpellData(35, 35, 35, 35,  135,  135,  120,  100, 25,  1, 0)},
+    {SPELL_LIGHT_DAY_OF_PROTECTION,     SpellData(40, 40, 40, 40,  500,  500,  500,  500,  0,  0, 0)},
+    {SPELL_LIGHT_HOUR_OF_POWER,         SpellData(45, 45, 45, 45,  250,  250,  250,  250,  0,  0, 0)},
+    {SPELL_LIGHT_SUNRAY,                SpellData(50, 50, 50, 50,  150,  150,  150,  135, 20, 20, 0)},
+    {SPELL_LIGHT_DIVINE_INTERVENTION,   SpellData(55, 55, 55, 55,  300,  300,  300,  300,  0,  0, 0)},
 
-    SpellData(5, 5, 5, 5, 110, 100, 90, 80, 0, 4, 0),  // 7 light
-    SpellData(10, 10, 10, 10, 120, 110, 100, 90, 16, 16, 0),
-    SpellData(15, 15, 15, 15, 120, 110, 100, 90, 0, 0, 0),
-    SpellData(20, 20, 20, 20, 160, 140, 120, 100, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 140, 140, 140, 140, 0, 0, 0),
-    SpellData(30, 30, 30, 30, 500, 500, 500, 500, 0, 0, 0),
-    SpellData(35, 35, 35, 35, 135, 135, 120, 100, 25, 1, 0),
-    SpellData(40, 40, 40, 40, 500, 500, 500, 500, 0, 0, 0),
-    SpellData(45, 45, 45, 45, 250, 250, 250, 250, 0, 0, 0),
-    SpellData(50, 50, 50, 50, 150, 150, 150, 135, 20, 20, 0),
-    SpellData(55, 55, 55, 55, 300, 300, 300, 300, 0, 0, 0),
-
-    SpellData(10, 10, 10, 10, 140, 140, 140, 140, 0, 0, 0),  // 8 dark
-    SpellData(15, 15, 15, 15, 120, 110, 100, 90, 25, 10, 0),
-    SpellData(20, 20, 20, 20, 120, 100, 90, 120, 0, 0, 0),
-    SpellData(25, 25, 25, 25, 120, 120, 120, 120, 0, 0, 0),
-    SpellData(30, 30, 30, 30, 90, 90, 80, 70, 6, 6, 0),
-    SpellData(35, 35, 35, 35, 120, 120, 100, 80, 0, 0, 0),
-    SpellData(40, 40, 40, 40, 110, 110, 110, 110, 0, 0, 0),
-    SpellData(45, 45, 45, 45, 200, 200, 200, 150, 0, 0, 0),
-    SpellData(50, 50, 50, 50, 120, 120, 120, 100, 0, 25, 0),
-    SpellData(55, 55, 55, 55, 250, 250, 250, 250, 50, 1, 0),
-    SpellData(60, 60, 60, 60, 300, 300, 300, 300, 25, 8, 0)}};
+    {SPELL_DARK_REANIMATE,              SpellData(10, 10, 10, 10,  140,  140,  140,  140,  0,  0, 0)},
+    {SPELL_DARK_TOXIC_CLOUD,            SpellData(15, 15, 15, 15,  120,  110,  100,   90, 25, 10, 0)},
+    {SPELL_DARK_VAMPIRIC_WEAPON,        SpellData(20, 20, 20, 20,  120,  100,   90,  120,  0,  0, 0)},
+    {SPELL_DARK_SHRINKING_RAY,          SpellData(25, 25, 25, 25,  120,  120,  120,  120,  0,  0, 0)},
+    {SPELL_DARK_SHARPMETAL,             SpellData(30, 30, 30, 30,   90,   90,   80,   70,  6,  6, 0)},
+    {SPELL_DARK_CONTROL_UNDEAD,         SpellData(35, 35, 35, 35,  120,  120,  100,   80,  0,  0, 0)},
+    {SPELL_DARK_PAIN_REFLECTION,        SpellData(40, 40, 40, 40,  110,  110,  110,  110,  0,  0, 0)},
+    {SPELL_DARK_SACRIFICE,              SpellData(45, 45, 45, 45,  200,  200,  200,  150,  0,  0, 0)},
+    {SPELL_DARK_DRAGON_BREATH,          SpellData(50, 50, 50, 50,  120,  120,  120,  100,  0, 25, 0)},
+    {SPELL_DARK_ARMAGEDDON,             SpellData(55, 55, 55, 55,  250,  250,  250,  250, 50,  1, 0)},
+    {SPELL_DARK_SOULDRINKER,            SpellData(60, 60, 60, 60,  300,  300,  300,  300, 25,  8, 0)}
+};
 
 IndexedArray<SPELL_TYPE, ITEM_FIRST_WAND, ITEM_LAST_WAND> WandSpellIds = {
     // 135 Wand of Fire               136 Wand of Sparks             137 Wand of
@@ -435,27 +449,30 @@ void SpellStats::Initialize() {
     pSpellsTXT_Raw = pEvents_LOD->LoadCompressedTexture("spells.txt").string_view();
 
     strtok(pSpellsTXT_Raw.data(), "\r");
-    for (int i = 1; i < SPELL_REGULAR_COUNT; ++i) {
-        if (((i % 11) - 1) == 0) strtok(NULL, "\r");
+    for (int i = SPELL_REGULAR_FIRST; i < SPELL_REGULAR_COUNT; ++i) {
+        SPELL_TYPE uSpellID = static_cast<SPELL_TYPE>(i);
+        if (((i % 11) - 1) == 0) {
+            strtok(NULL, "\r");
+        }
         test_string = strtok(NULL, "\r") + 1;
 
         auto tokens = Tokenize(test_string, '\t');
 
-        pInfos[i].pName = RemoveQuotes(tokens[2]);
+        pInfos[uSpellID].pName = RemoveQuotes(tokens[2]);
         auto findResult = spellSchoolMaps.find(tokens[3]);
-        pInfos[i].uSchool = findResult == spellSchoolMaps.end()
+        pInfos[uSpellID].uSchool = findResult == spellSchoolMaps.end()
                                 ? SPELL_SCHOOL_NONE
                                 : findResult->second;
-        pInfos[i].pShortName = RemoveQuotes(tokens[4]);
-        pInfos[i].pDescription = RemoveQuotes(tokens[5]);
-        pInfos[i].pBasicSkillDesc = RemoveQuotes(tokens[6]);
-        pInfos[i].pExpertSkillDesc = RemoveQuotes(tokens[7]);
-        pInfos[i].pMasterSkillDesc = RemoveQuotes(tokens[8]);
-        pInfos[i].pGrandmasterSkillDesc = RemoveQuotes(tokens[9]);
-        pSpellDatas[i].stats |= strchr(tokens[10], 'm') || strchr(tokens[10], 'M') ? 1 : 0;
-        pSpellDatas[i].stats |= strchr(tokens[10], 'e') || strchr(tokens[10], 'E') ? 2 : 0;
-        pSpellDatas[i].stats |= strchr(tokens[10], 'c') || strchr(tokens[10], 'C') ? 4 : 0;
-        pSpellDatas[i].stats |= strchr(tokens[10], 'x') || strchr(tokens[10], 'X') ? 8 : 0;
+        pInfos[uSpellID].pShortName = RemoveQuotes(tokens[4]);
+        pInfos[uSpellID].pDescription = RemoveQuotes(tokens[5]);
+        pInfos[uSpellID].pBasicSkillDesc = RemoveQuotes(tokens[6]);
+        pInfos[uSpellID].pExpertSkillDesc = RemoveQuotes(tokens[7]);
+        pInfos[uSpellID].pMasterSkillDesc = RemoveQuotes(tokens[8]);
+        pInfos[uSpellID].pGrandmasterSkillDesc = RemoveQuotes(tokens[9]);
+        pSpellDatas[uSpellID].stats |= strchr(tokens[10], 'm') || strchr(tokens[10], 'M') ? 1 : 0;
+        pSpellDatas[uSpellID].stats |= strchr(tokens[10], 'e') || strchr(tokens[10], 'E') ? 2 : 0;
+        pSpellDatas[uSpellID].stats |= strchr(tokens[10], 'c') || strchr(tokens[10], 'C') ? 4 : 0;
+        pSpellDatas[uSpellID].stats |= strchr(tokens[10], 'x') || strchr(tokens[10], 'X') ? 8 : 0;
     }
 }
 
@@ -781,18 +798,18 @@ void EventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAY
 /**
  * @offset 0x427769
  */
-bool IsSpellQuickCastableOnShiftClick(unsigned int uSpellID) {
+bool IsSpellQuickCastableOnShiftClick(SPELL_TYPE uSpellID) {
     return (pSpellDatas[uSpellID].stats & 0xC) != 0;
 }
 /**
  * @offset 0x43AFE3
  */
-int CalcSpellDamage(int spellId, PLAYER_SKILL_LEVEL spellLevel, PLAYER_SKILL_MASTERY skillMastery, int currentHp) {
+int CalcSpellDamage(SPELL_TYPE uSpellID, PLAYER_SKILL_LEVEL spellLevel, PLAYER_SKILL_MASTERY skillMastery, int currentHp) {
     int result;       // eax@1
     unsigned int diceSides;  // [sp-4h] [bp-8h]@9
 
     result = 0;
-    if (spellId == SPELL_FIRE_FIRE_SPIKE) {
+    if (uSpellID == SPELL_FIRE_FIRE_SPIKE) {
         switch (skillMastery) {
             case PLAYER_SKILL_MASTERY_NOVICE:
             case PLAYER_SKILL_MASTERY_EXPERT:
@@ -808,10 +825,10 @@ int CalcSpellDamage(int spellId, PLAYER_SKILL_LEVEL spellLevel, PLAYER_SKILL_MAS
                 return 0;
         }
         result = grng->RandomDice(spellLevel, diceSides);
-    } else if (spellId == SPELL_EARTH_MASS_DISTORTION) {
+    } else if (uSpellID == SPELL_EARTH_MASS_DISTORTION) {
         result = currentHp * (pSpellDatas[SPELL_EARTH_MASS_DISTORTION].baseDamage + 2 * spellLevel) / 100;
     } else {
-        result = pSpellDatas[spellId].baseDamage + grng->RandomDice(spellLevel, pSpellDatas[spellId].bonusSkillDamage);
+        result = pSpellDatas[uSpellID].baseDamage + grng->RandomDice(spellLevel, pSpellDatas[uSpellID].bonusSkillDamage);
     }
 
     return result;

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -529,7 +529,7 @@ void EventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAY
         case SPELL_EARTH_DEATH_BLOSSOM:
             spell_sprites.uType = SpellSpriteMapping[uSpellID];
             spell_sprites.containing_item.Reset();
-            spell_sprites.spell_id = uSpellID;
+            spell_sprites.uSpellID = uSpellID;
             spell_sprites.spell_level = skillLevel;
             spell_sprites.spell_skill = skillMastery;
             spell_sprites.uObjectDescID = pObjectList->ObjectIDByItemID(spell_sprites.uType);

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -144,7 +144,7 @@ enum SPELL_TYPE : uint8_t {
 /**
  * Is spell target is item in inventory?
  */
-inline bool IsSpellTargetsItem(SPELL_TYPE uSpellID) {
+inline bool isSpellTargetsItem(SPELL_TYPE uSpellID) {
     return uSpellID == SPELL_WATER_ENCHANT_ITEM ||
            uSpellID == SPELL_FIRE_FIRE_AURA ||
            uSpellID == SPELL_DARK_VAMPIRIC_WEAPON ||
@@ -154,39 +154,37 @@ inline bool IsSpellTargetsItem(SPELL_TYPE uSpellID) {
 /**
  * Get skill used for casting given spell.
  */
-inline PLAYER_SKILL_TYPE GetSkillTypeForSpell(SPELL_TYPE uSpellID) {
-    PLAYER_SKILL_TYPE result_skill;
-
+inline PLAYER_SKILL_TYPE getSkillTypeForSpell(SPELL_TYPE uSpellID) {
     assert(uSpellID != SPELL_NONE);
 
     if (uSpellID < SPELL_AIR_WIZARD_EYE) {
-        result_skill = PLAYER_SKILL_FIRE;
+        return PLAYER_SKILL_FIRE;
     } else if (uSpellID < SPELL_WATER_AWAKEN) {
-        result_skill = PLAYER_SKILL_AIR;
+        return PLAYER_SKILL_AIR;
     } else if (uSpellID < SPELL_EARTH_STUN) {
-        result_skill = PLAYER_SKILL_WATER;
+        return PLAYER_SKILL_WATER;
     } else if (uSpellID < SPELL_SPIRIT_DETECT_LIFE) {
-        result_skill = PLAYER_SKILL_EARTH;
+        return PLAYER_SKILL_EARTH;
     } else if (uSpellID < SPELL_MIND_REMOVE_FEAR) {
-        result_skill = PLAYER_SKILL_SPIRIT;
+        return PLAYER_SKILL_SPIRIT;
     } else if (uSpellID < SPELL_BODY_CURE_WEAKNESS) {
-        result_skill = PLAYER_SKILL_MIND;
+        return PLAYER_SKILL_MIND;
     } else if (uSpellID < SPELL_LIGHT_LIGHT_BOLT) {
-        result_skill = PLAYER_SKILL_BODY;
+        return PLAYER_SKILL_BODY;
     } else if (uSpellID < SPELL_DARK_REANIMATE) {
-        result_skill = PLAYER_SKILL_LIGHT;
+        return PLAYER_SKILL_LIGHT;
     } else if (uSpellID < SPELL_BOW_ARROW) {
-        result_skill = PLAYER_SKILL_DARK;
+        return PLAYER_SKILL_DARK;
     } else if (uSpellID == SPELL_BOW_ARROW) {
-        result_skill = PLAYER_SKILL_BOW;
+        return PLAYER_SKILL_BOW;
     } else if (uSpellID == SPELL_101 ||
                uSpellID == SPELL_LASER_PROJECTILE) {
-        result_skill = PLAYER_SKILL_BLASTER;
+        return PLAYER_SKILL_BLASTER;
     } else {
         assert(false && "Unknown spell");
     }
 
-    return result_skill;
+    return PLAYER_SKILL_INVALID;
 }
 
 enum SPELL_SCHOOL : int {

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -157,6 +157,8 @@ inline bool IsSpellTargetsItem(SPELL_TYPE uSpellID) {
 inline PLAYER_SKILL_TYPE GetSkillTypeForSpell(SPELL_TYPE uSpellID) {
     PLAYER_SKILL_TYPE result_skill;
 
+    assert(uSpellID != SPELL_NONE);
+
     if (uSpellID < SPELL_AIR_WIZARD_EYE) {
         result_skill = PLAYER_SKILL_FIRE;
     } else if (uSpellID < SPELL_WATER_AWAKEN) {

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -248,7 +248,7 @@ struct SpellStats {
 #pragma pack(push, 1)
 class SpellData {
  public:
-    SpellData() {SpellData(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);}
+    SpellData():SpellData(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) {}
     SpellData(int16_t inNormalMana, int16_t inExpertLevelMana,
               int16_t inMasterLevelMana, int16_t inMagisterLevelMana,
               int16_t inNormalLevelRecovery, int16_t inExpertLevelRecovery,

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -124,6 +124,7 @@ enum SPELL_TYPE : uint8_t {
     SPELL_DARK_SOULDRINKER = 99,
 
     // TODO(captainurist): use IndexedArray where this one is referenced
+    SPELL_REGULAR_FIRST = SPELL_FIRE_TORCH_LIGHT,
     SPELL_REGULAR_LAST = SPELL_DARK_SOULDRINKER,
     SPELL_REGULAR_COUNT = SPELL_REGULAR_LAST + 1,
 
@@ -139,6 +140,52 @@ enum SPELL_TYPE : uint8_t {
     SPELL_152 = 152,
     SPELL_DISEASE = 153
 };
+
+/**
+ * Is spell target is item in inventory?
+ */
+inline bool IsSpellTargetsItem(SPELL_TYPE uSpellID) {
+    return uSpellID == SPELL_WATER_ENCHANT_ITEM ||
+           uSpellID == SPELL_FIRE_FIRE_AURA ||
+           uSpellID == SPELL_DARK_VAMPIRIC_WEAPON ||
+           uSpellID == SPELL_WATER_RECHARGE_ITEM;
+}
+
+/**
+ * Get skill used for casting given spell.
+ */
+inline PLAYER_SKILL_TYPE GetSkillTypeForSpell(SPELL_TYPE uSpellID) {
+    PLAYER_SKILL_TYPE result_skill;
+
+    if (uSpellID < SPELL_AIR_WIZARD_EYE) {
+        result_skill = PLAYER_SKILL_FIRE;
+    } else if (uSpellID < SPELL_WATER_AWAKEN) {
+        result_skill = PLAYER_SKILL_AIR;
+    } else if (uSpellID < SPELL_EARTH_STUN) {
+        result_skill = PLAYER_SKILL_WATER;
+    } else if (uSpellID < SPELL_SPIRIT_DETECT_LIFE) {
+        result_skill = PLAYER_SKILL_EARTH;
+    } else if (uSpellID < SPELL_MIND_REMOVE_FEAR) {
+        result_skill = PLAYER_SKILL_SPIRIT;
+    } else if (uSpellID < SPELL_BODY_CURE_WEAKNESS) {
+        result_skill = PLAYER_SKILL_MIND;
+    } else if (uSpellID < SPELL_LIGHT_LIGHT_BOLT) {
+        result_skill = PLAYER_SKILL_BODY;
+    } else if (uSpellID < SPELL_DARK_REANIMATE) {
+        result_skill = PLAYER_SKILL_LIGHT;
+    } else if (uSpellID < SPELL_BOW_ARROW) {
+        result_skill = PLAYER_SKILL_DARK;
+    } else if (uSpellID == SPELL_BOW_ARROW) {
+        result_skill = PLAYER_SKILL_BOW;
+    } else if (uSpellID == SPELL_101 ||
+               uSpellID == SPELL_LASER_PROJECTILE) {
+        result_skill = PLAYER_SKILL_BLASTER;
+    } else {
+        assert(false && "Unknown spell");
+    }
+
+    return result_skill;
+}
 
 enum SPELL_SCHOOL : int {
     SPELL_SCHOOL_FIRE = 0,
@@ -201,6 +248,7 @@ struct SpellStats {
 #pragma pack(push, 1)
 class SpellData {
  public:
+    SpellData() {SpellData(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);}
     SpellData(int16_t inNormalMana, int16_t inExpertLevelMana,
               int16_t inMasterLevelMana, int16_t inMagisterLevelMana,
               int16_t inNormalLevelRecovery, int16_t inExpertLevelRecovery,
@@ -258,11 +306,11 @@ extern struct SpellStats *pSpellStats;
 extern std::array<std::array<struct SpellBookIconPos, 12>, 9> pIconPos;
 
 extern IndexedArray<SPRITE_OBJECT_TYPE, SPELL_ANY_WITH_SPRITE_FIRST, SPELL_ANY_WITH_SPRITE_LAST> SpellSpriteMapping;  // 4E3ACC
-extern std::array<SpellData, SPELL_REGULAR_COUNT> pSpellDatas;
+extern IndexedArray<SpellData, SPELL_REGULAR_FIRST, SPELL_REGULAR_LAST> pSpellDatas;
 extern IndexedArray<SPELL_TYPE, ITEM_FIRST_WAND, ITEM_LAST_WAND> WandSpellIds;
 
-int CalcSpellDamage(int spellId, PLAYER_SKILL_LEVEL spellLevel, PLAYER_SKILL_MASTERY skillMastery, int currentHp);
-bool IsSpellQuickCastableOnShiftClick(unsigned int uSpellID);
+int CalcSpellDamage(SPELL_TYPE uSpellID, PLAYER_SKILL_LEVEL spellLevel, PLAYER_SKILL_MASTERY skillMastery, int currentHp);
+bool IsSpellQuickCastableOnShiftClick(SPELL_TYPE uSpellID);
 void EventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAYER_SKILL_LEVEL skillLevel, int fromx,
                     int fromy, int fromz, int tox, int toy, int toz);  // sub_448DF8
 

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -670,7 +670,7 @@ void CharacterUI_ReleaseButtons();
 
 unsigned int GetSkillColor(unsigned int uPlayerClass, PLAYER_SKILL_TYPE uPlayerSkillType, PLAYER_SKILL_MASTERY skill_mastery);
 
-void DrawSpellDescriptionPopup(int spell_index);
+void DrawSpellDescriptionPopup(int spell_index_in_book);
 
 void UI_OnMouseRightClick(int mouse_x, int mouse_y);
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -2173,7 +2173,6 @@ void TempleDialog() {
     int pTextHeight;              // eax@11
     uint16_t pTextColor;  // ax@21
     DDM_DLV_Header *ddm;          // edi@29
-    unsigned int v30;             // edx@36
     GUIButton *pButton;           // edi@64
     uint8_t index;        // [sp+1B7h] [bp-Dh]@64
     int v64;                      // [sp+1B8h] [bp-Ch]@6
@@ -2342,38 +2341,19 @@ void TempleDialog() {
             }
             if ((uint8_t)byte_F8B1EF[uActiveCharacter] == pParty->uCurrentDayOfMonth % 7) {
                 if (ddm->uReputation <= -5) {
-                    v30 = pParty->uCurrentDayOfMonth % 7 + 1;
-                    v30 |= 0x80;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        SPELL_AIR_WIZARD_EYE, uActiveCharacter - 1, v30, ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                    RegisterTempleSpell(SPELL_AIR_WIZARD_EYE);
                 }
                 if (ddm->uReputation <= -10) {
-                    v30 = pParty->uCurrentDayOfMonth % 7 + 1;
-                    v30 |= 0x80;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        SPELL_SPIRIT_PRESERVATION, uActiveCharacter - 1, v30,
-                        ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                    RegisterTempleSpell(SPELL_SPIRIT_PRESERVATION);
                 }
                 if (ddm->uReputation <= -15) {
-                    v30 = pParty->uCurrentDayOfMonth % 7 + 1;
-                    v30 |= 0x80;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        SPELL_BODY_PROTECTION_FROM_MAGIC, uActiveCharacter - 1,
-                        v30, ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                    RegisterTempleSpell(SPELL_BODY_PROTECTION_FROM_MAGIC);
                 }
                 if (ddm->uReputation <= -20) {
-                    v30 = pParty->uCurrentDayOfMonth % 7 + 1;
-                    v30 |= 0x80;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        SPELL_LIGHT_HOUR_OF_POWER, uActiveCharacter - 1, v30,
-                        ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                    RegisterTempleSpell(SPELL_LIGHT_HOUR_OF_POWER);
                 }
                 if (ddm->uReputation <= -25) {
-                    v30 = pParty->uCurrentDayOfMonth % 7 + 1;
-                    v30 |= 0x80;
-                    _42777D_CastSpell_UseWand_ShootArrow(
-                        SPELL_LIGHT_DAY_OF_PROTECTION, uActiveCharacter - 1,
-                        v30, ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                    RegisterTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
                 }
             }
             ++byte_F8B1EF[uActiveCharacter];

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -2341,19 +2341,19 @@ void TempleDialog() {
             }
             if ((uint8_t)byte_F8B1EF[uActiveCharacter] == pParty->uCurrentDayOfMonth % 7) {
                 if (ddm->uReputation <= -5) {
-                    RegisterTempleSpell(SPELL_AIR_WIZARD_EYE);
+                    pushTempleSpell(SPELL_AIR_WIZARD_EYE);
                 }
                 if (ddm->uReputation <= -10) {
-                    RegisterTempleSpell(SPELL_SPIRIT_PRESERVATION);
+                    pushTempleSpell(SPELL_SPIRIT_PRESERVATION);
                 }
                 if (ddm->uReputation <= -15) {
-                    RegisterTempleSpell(SPELL_BODY_PROTECTION_FROM_MAGIC);
+                    pushTempleSpell(SPELL_BODY_PROTECTION_FROM_MAGIC);
                 }
                 if (ddm->uReputation <= -20) {
-                    RegisterTempleSpell(SPELL_LIGHT_HOUR_OF_POWER);
+                    pushTempleSpell(SPELL_LIGHT_HOUR_OF_POWER);
                 }
                 if (ddm->uReputation <= -25) {
-                    RegisterTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
+                    pushTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
                 }
             }
             ++byte_F8B1EF[uActiveCharacter];

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1290,19 +1290,16 @@ void CharacterUI_StatsTab_ShowHint() {
 }
 
 //----- (00410B28) --------------------------------------------------------
-void DrawSpellDescriptionPopup(int spell_index) {
+void DrawSpellDescriptionPopup(int spell_index_in_book) {
     SpellInfo *spell;             // esi@1
     unsigned int v3;              // eax@2
     long v5;                      // ecx@4
     GUIWindow spell_info_window;  // [sp+Ch] [bp-68h]@4
 
     Pointi pt = mouse->GetCursorPos();
+    SPELL_TYPE spell_id = static_cast<SPELL_TYPE>(spell_index_in_book + 11 * pPlayers[uActiveCharacter]->lastOpenedSpellbookPage + 1);
 
-    spell =
-        &pSpellStats
-             ->pInfos[spell_index +
-                      11 * pPlayers[uActiveCharacter]->lastOpenedSpellbookPage +
-                      1];
+    spell = &pSpellStats->pInfos[spell_id];
     if (pt.y <= 250)
         v3 = pt.y + 30;
     else
@@ -1353,9 +1350,7 @@ void DrawSpellDescriptionPopup(int spell_index) {
 
     auto str2 = StringPrintf(
         "%s\n%d", localization->GetString(LSTR_SP_COST),
-        pSpellDatas[spell_index +
-                    11 * pPlayers[uActiveCharacter]->lastOpenedSpellbookPage + 1]
-            .mana_per_skill[std::to_underlying(skill_mastery) - 1]);
+        pSpellDatas[spell_id].mana_per_skill[std::to_underlying(skill_mastery) - 1]);
     spell_info_window.DrawTitleText(
         pFontComic, 12,
         spell_info_window.uFrameHeight - pFontComic->GetHeight() - 16, 0, str2,

--- a/src/GUI/UI/UIShops.cpp
+++ b/src/GUI/UI/UIShops.cpp
@@ -1495,7 +1495,7 @@ void sub_4B1523_showSpellbookInfo(ITEM_TYPE spellItemId) {
     int v14;              // [sp+70h] [bp-4h]@4
 
     // TODO(captainurist): deal away with casts.
-    int spellId = std::to_underlying(spellItemId) - 399;
+    SPELL_TYPE spellId = static_cast<SPELL_TYPE>(std::to_underlying(spellItemId) - 399);
     int spellLevel = (std::to_underlying(spellItemId) - 400) % 11 + 1;
     unsigned int spellSchool = 4 * (std::to_underlying(spellItemId) - 400) / 11;
 

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -191,7 +191,7 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                             debug_non_combat_recovery_mul * (double)pPlayers[uActiveCharacter]->GetAttackRecoveryTime(false) * flt_debugrecmod3
                         );
                     }
-                    CastSpellInfoHelpers::CancelSpellCastInProgress();
+                    CastSpellInfoHelpers::cancelSpellCastInProgress();
                     pTurnEngine->ApplyPlayerAction();
                 }
             }
@@ -227,7 +227,7 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             }
 
             SPELL_TYPE quickSpellNumber = pPlayers[uActiveCharacter]->uQuickSpell;
-            PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(GetSkillTypeForSpell(quickSpellNumber));
+            PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
 
             int uRequiredMana = 0;
             if (!engine->config->debug.AllMagic.Get()) {

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -226,8 +226,8 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                 break;
             }
 
-            uint8_t quickSpellNumber = pPlayers[uActiveCharacter]->uQuickSpell;
-            PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(static_cast<PLAYER_SKILL_TYPE>(quickSpellNumber / 11 + 12));
+            SPELL_TYPE quickSpellNumber = pPlayers[uActiveCharacter]->uQuickSpell;
+            PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(GetSkillTypeForSpell(quickSpellNumber));
 
             int uRequiredMana = 0;
             if (!engine->config->debug.AllMagic.Get()) {

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -191,7 +191,7 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                             debug_non_combat_recovery_mul * (double)pPlayers[uActiveCharacter]->GetAttackRecoveryTime(false) * flt_debugrecmod3
                         );
                     }
-                    CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
+                    CastSpellInfoHelpers::CancelSpellCastInProgress();
                     pTurnEngine->ApplyPlayerAction();
                 }
             }


### PR DESCRIPTION
1) Rename function _42777D_CastSpell_UseWand_ShootArrow and create several specialized wrappers above it.
2) Use IndexedArray for pSpellDatas. This requires changing several functions arguments to SPELL_TYPE and adding some static_cast to SPELL_TYPE. Specifically for one of the field that comes from SpriteObject structure.
3) Comment out removing spell from queue when scheduling spell cast with active spell marked with ON_CAST_CastingInProgress because it is removed immediately after that with CancelSpellCastInProgress function.
4) Add comments and some other minor improvements.