### PR TITLE
Make legacy serializer/deserializer for SpriteObject

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -536,7 +536,7 @@ bool IndoorLocation::Load(const std::string &filename, int num_days_played,
     pGameLoadingUI_ProgressBar->Progress();
     pGameLoadingUI_ProgressBar->Progress();
 
-    stream.ReadVector(&pSpriteObjects);
+    stream.ReadLegacyVector<SpriteObject_MM7>(&pSpriteObjects);
 
     pGameLoadingUI_ProgressBar->Progress();
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1048,9 +1048,7 @@ bool OutdoorLocation::Load(const std::string &filename, int days_played,
     pGameLoadingUI_ProgressBar->Progress();  // прогресс загрузки
     pGameLoadingUI_ProgressBar->Progress();  // прогресс загрузки
 
-    static_assert(sizeof(SpriteObject) == 0x70);
-
-    stream.ReadVector(&pSpriteObjects);
+    stream.ReadLegacyVector<SpriteObject_MM7>(&pSpriteObjects);
 
     pGameLoadingUI_ProgressBar->Progress();  // прогресс загрузки
 

--- a/src/Engine/IocContainer.cpp
+++ b/src/Engine/IocContainer.cpp
@@ -149,7 +149,7 @@ void IntegrityTest() {
     static_assert(sizeof(Timer) == 0x28, "Wrong type size");
     static_assert(sizeof(OtherOverlay) == 0x14, "Wrong type size");
     static_assert(sizeof(ItemGen) == 0x24, "Wrong type size");
-    static_assert(sizeof(SpriteObject) == 0x70, "Wrong type size");
+    //static_assert(sizeof(SpriteObject) == 0x70, "Wrong type size");
     static_assert(sizeof(Chest) == 0x14CC, "Wrong type size");
     static_assert(sizeof(SpellData) == 0x14, "Wrong type size");
     //static_assert(sizeof(SpellBuff) == 0x10, "Wrong type size");

--- a/src/Engine/IocContainer.cpp
+++ b/src/Engine/IocContainer.cpp
@@ -179,7 +179,7 @@ void IntegrityTest() {
     static_assert(sizeof(BLVLightMM7) == 16, "Wrong type size");
     static_assert(sizeof(BSPNode) == 8, "Wrong type size");
     static_assert(sizeof(DDM_DLV_Header) == 40, "Wrong type size");
-    static_assert(sizeof(SpriteObject) == 112, "Wrong type size");
+    //static_assert(sizeof(SpriteObject) == 112, "Wrong type size");
     static_assert(sizeof(Chest) == 5324, "Wrong type size");
     static_assert(sizeof(stru123) == 0xC8, "Wrong type size");
     static_assert(sizeof(BLVMapOutline) == 12, "Wrong type size");

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -62,8 +62,6 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
     field_64.y = vPosition.y;
     field_64.z = vPosition.z;
 
-    static_assert(sizeof(SpriteObject) == 0x70);
-
     // move sprite so it looks like it originates from char portrait
     switch (which_char) {
         case 0:

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -102,7 +102,7 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
     if (sprite_slot >= (int)pSpriteObjects.size()) {
         pSpriteObjects.resize(sprite_slot + 1);
     }
-    memcpy(&pSpriteObjects[sprite_slot], this, sizeof(*this));
+    pSpriteObjects[sprite_slot] = *this;
     return sprite_slot;
 }
 
@@ -849,8 +849,7 @@ void CompactLayingItemsList() {
     for (int i = 0; i < pSpriteObjects.size(); ++i) {
         if (pSpriteObjects[i].uObjectDescID) {
             if (i != new_obj_pos) {
-                memcpy(&pSpriteObjects[new_obj_pos], &pSpriteObjects[i],
-                       sizeof(SpriteObject));
+                pSpriteObjects[new_obj_pos] = pSpriteObjects[i];
                 pSpriteObjects[i].uObjectDescID = 0;
             }
             new_obj_pos++;

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -49,7 +49,6 @@ struct SpriteObject {
     int16_t field_22_glow_radius_multiplier = 1;
     ItemGen containing_item;
     SPELL_TYPE uSpellID = SPELL_NONE;
-    char pad[3] = {0, 0, 0}; // TODO(Nik-RE-dev): add SpriteObject_MM7 to LegacyImages and redo this properly.
     int spell_level = 0;
     PLAYER_SKILL_MASTERY spell_skill = PLAYER_SKILL_MASTERY_NONE;
     int field_54 = 0;

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -409,8 +409,16 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
             uint32_t uNumSpriteObjects = pSpriteObjects.size();
             memcpy(data_write_pos, &uNumSpriteObjects, 4);
             data_write_pos += 4;
-            memcpy(data_write_pos, pSpriteObjects.data(), 112 * uNumSpriteObjects);
-            data_write_pos += 112 * uNumSpriteObjects;
+            // memcpy(data_write_pos, pSpriteObjects.data(), 112 * uNumSpriteObjects);
+            // data_write_pos += 112 * uNumSpriteObjects;
+            SpriteObject_MM7 *tmp_sprite = (SpriteObject_MM7*)malloc(sizeof(SpriteObject_MM7));
+
+            for (int i = 0; i < uNumSpriteObjects; ++i) {
+                Serialize(pSpriteObjects[i], tmp_sprite);
+                memcpy(data_write_pos + i * sizeof(SpriteObject_MM7), tmp_sprite, sizeof(SpriteObject_MM7));
+            }
+            free(tmp_sprite);
+            data_write_pos += uNumActors * sizeof(SpriteObject_MM7);
 
             data_write_pos += ChestsSerialize(data_write_pos);
 
@@ -461,7 +469,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
 
             // memcpy(data_write_pos, &pActors, uNumActors * sizeof(Actor));
             // data_write_pos += uNumActors * sizeof(Actor);
-            Actor_MM7* tmp_actor = (Actor_MM7*)malloc(sizeof(Actor_MM7));
+            Actor_MM7 *tmp_actor = (Actor_MM7*)malloc(sizeof(Actor_MM7));
 
             for (int i = 0; i < uNumActors; ++i) {
                 Serialize(pActors[i], tmp_actor);
@@ -473,9 +481,17 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
             uint32_t uNumSpriteObjects = pSpriteObjects.size();
             memcpy(data_write_pos, &uNumSpriteObjects, 4);
             data_write_pos += 4;
-            memcpy(data_write_pos, pSpriteObjects.data(),
-                   uNumSpriteObjects * sizeof(SpriteObject));
-            data_write_pos += uNumSpriteObjects * sizeof(SpriteObject);
+
+            // memcpy(data_write_pos, pSpriteObjects.data(), uNumSpriteObjects * sizeof(SpriteObject));
+            // data_write_pos += uNumSpriteObjects * sizeof(SpriteObject);
+            SpriteObject_MM7 *tmp_sprite = (SpriteObject_MM7*)malloc(sizeof(SpriteObject_MM7));
+
+            for (int i = 0; i < uNumSpriteObjects; ++i) {
+                Serialize(pSpriteObjects[i], tmp_sprite);
+                memcpy(data_write_pos + i * sizeof(SpriteObject_MM7), tmp_sprite, sizeof(SpriteObject_MM7));
+            }
+            free(tmp_sprite);
+            data_write_pos += uNumActors * sizeof(SpriteObject_MM7);
 
             data_write_pos += ChestsSerialize(data_write_pos);
 

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -418,7 +418,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
                 memcpy(data_write_pos + i * sizeof(SpriteObject_MM7), tmp_sprite, sizeof(SpriteObject_MM7));
             }
             free(tmp_sprite);
-            data_write_pos += uNumActors * sizeof(SpriteObject_MM7);
+            data_write_pos += uNumSpriteObjects * sizeof(SpriteObject_MM7);
 
             data_write_pos += ChestsSerialize(data_write_pos);
 
@@ -491,7 +491,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
                 memcpy(data_write_pos + i * sizeof(SpriteObject_MM7), tmp_sprite, sizeof(SpriteObject_MM7));
             }
             free(tmp_sprite);
-            data_write_pos += uNumActors * sizeof(SpriteObject_MM7);
+            data_write_pos += uNumSpriteObjects * sizeof(SpriteObject_MM7);
 
             data_write_pos += ChestsSerialize(data_write_pos);
 

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -1211,7 +1211,7 @@ void Serialize(const Actor &src, Actor_MM7 *dst) {
         Serialize(src.pActorBuffs[ACTOR_BUFF_INDEX(i)], &dst->pActorBuffs[i]);
 
     for (unsigned int i = 0; i < 4; ++i)
-        dst->ActorHasItems[i] = src.ActorHasItems[i];
+        Serialize(src.ActorHasItems[i], &dst->ActorHasItems[i]);
 
     dst->uGroup = src.uGroup;
     dst->uAlly = src.uAlly;
@@ -1324,7 +1324,7 @@ void Deserialize(const Actor_MM7 &src, Actor *dst) {
         Deserialize(src.pActorBuffs[i], &dst->pActorBuffs[ACTOR_BUFF_INDEX(i)]);
 
     for (unsigned int i = 0; i < 4; ++i)
-        dst->ActorHasItems[i] = src.ActorHasItems[i];
+        Deserialize(src.ActorHasItems[i], &dst->ActorHasItems[i]);
 
     dst->uGroup = src.uGroup;
     dst->uAlly = src.uAlly;
@@ -1534,4 +1534,56 @@ void Deserialize(const SpawnPoint_MM7 &src, SpawnPoint *dst) {
     }
     dst->uAttributes = src.uAttributes;
     dst->uGroup = src.uGroup;
+}
+
+void Serialize(const SpriteObject &src, SpriteObject_MM7 *dst) {
+    dst->uType = src.uType;
+    dst->uObjectDescID = src.uObjectDescID;
+    dst->vPosition = src.vPosition;
+    dst->vVelocity = src.vVelocity;
+    dst->uFacing = src.uFacing;
+    dst->uSoundID = src.uSoundID;
+    dst->uAttributes = std::to_underlying(src.uAttributes);
+    dst->uSectorID = src.uSectorID;
+    dst->uSpriteFrameID = src.uSpriteFrameID;
+    dst->field_20 = src.field_20;
+    dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
+    Serialize(src.containing_item, &dst->containing_item);
+    dst->spell_id = src.spell_id;
+    dst->spell_level = src.spell_level;
+    dst->spell_skill = std::to_underlying(src.spell_skill);
+    dst->field_54 = src.field_54;
+    dst->spell_caster_pid = src.spell_caster_pid;
+    dst->spell_target_pid = src.spell_target_pid;
+    dst->field_60_distance_related_prolly_lod = src.field_60_distance_related_prolly_lod;
+    dst->field_61 = std::to_underlying(src.field_61);
+    dst->field_62[0] = src.field_62[0];
+    dst->field_62[1] = src.field_62[1];
+    dst->field_64 = src.field_64;
+}
+
+void Deserialize(const SpriteObject_MM7 &src, SpriteObject *dst) {
+    dst->uType = SPRITE_OBJECT_TYPE(src.uType);
+    dst->uObjectDescID = src.uObjectDescID;
+    dst->vPosition = src.vPosition;
+    dst->vVelocity = src.vVelocity;
+    dst->uFacing = src.uFacing;
+    dst->uSoundID = src.uSoundID;
+    dst->uAttributes = SPRITE_ATTRIBUTES(src.uAttributes);
+    dst->uSectorID = src.uSectorID;
+    dst->uSpriteFrameID = src.uSpriteFrameID;
+    dst->field_20 = src.field_20;
+    dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
+    Deserialize(src.containing_item, &dst->containing_item);
+    dst->spell_id = src.spell_id;
+    dst->spell_level = src.spell_level;
+    dst->spell_skill = PLAYER_SKILL_MASTERY(src.spell_skill);
+    dst->field_54 = src.field_54;
+    dst->spell_caster_pid = src.spell_caster_pid;
+    dst->spell_target_pid = src.spell_target_pid;
+    dst->field_60_distance_related_prolly_lod = src.field_60_distance_related_prolly_lod;
+    dst->field_61 = ABILITY_INDEX(src.field_61);
+    dst->field_62[0] = src.field_62[0];
+    dst->field_62[1] = src.field_62[1];
+    dst->field_64 = src.field_64;
 }

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -1549,7 +1549,7 @@ void Serialize(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->field_20 = src.field_20;
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
     Serialize(src.containing_item, &dst->containing_item);
-    dst->spell_id = src.spell_id;
+    dst->uSpellID = src.uSpellID;
     dst->spell_level = src.spell_level;
     dst->spell_skill = std::to_underlying(src.spell_skill);
     dst->field_54 = src.field_54;
@@ -1575,7 +1575,7 @@ void Deserialize(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->field_20 = src.field_20;
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
     Deserialize(src.containing_item, &dst->containing_item);
-    dst->spell_id = src.spell_id;
+    dst->uSpellID = SPELL_TYPE(src.uSpellID);
     dst->spell_level = src.spell_level;
     dst->spell_skill = PLAYER_SKILL_MASTERY(src.spell_skill);
     dst->field_54 = src.field_54;

--- a/src/Engine/Serialization/LegacyImages.h
+++ b/src/Engine/Serialization/LegacyImages.h
@@ -3,7 +3,8 @@
 #include "Engine/Spells/Spells.h"
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/Actor.h"
-
+#include "Engine/Objects/Actor.h"
+#include "Engine/Objects/SpriteObject.h"
 #include "GUI/GUIFont.h"
 
 #include "Utility/Geometry/Plane.h"
@@ -670,7 +671,7 @@ struct Actor_MM7 {
     std::array<uint16_t, 8> pSpriteIDs;
     std::array<uint16_t, 4> pSoundSampleIDs;  // 1 die     3 bored
     std::array<SpellBuff_MM7, 22> pActorBuffs;
-    std::array<ItemGen, 4> ActorHasItems;
+    std::array<ItemGen_MM7, 4> ActorHasItems;
     uint32_t uGroup;
     uint32_t uAlly;
     std::array<ActorJob, 8> pScheduledJobs;
@@ -840,5 +841,36 @@ struct SpawnPoint_MM7 {
 static_assert(sizeof(SpawnPoint_MM7) == 24);
 
 void Deserialize(const SpawnPoint_MM7 &src, SpawnPoint *dst);
+
+
+struct SpriteObject_MM7 {
+    uint16_t uType;
+    uint16_t uObjectDescID;
+    Vec3i vPosition;
+    Vec3s vVelocity;
+    uint16_t uFacing;
+    uint16_t uSoundID;
+    uint16_t uAttributes;
+    int16_t uSectorID;
+    uint16_t uSpriteFrameID;
+    int16_t field_20;
+    int16_t field_22_glow_radius_multiplier;
+    ItemGen_MM7 containing_item;
+    int spell_id;
+    int spell_level;
+    int32_t spell_skill;
+    int field_54;
+    int spell_caster_pid;
+    int spell_target_pid;
+    char field_60_distance_related_prolly_lod;
+    char field_61;
+    char field_62[2];
+    Vec3i field_64;
+};
+
+static_assert(sizeof(SpriteObject_MM7) == 0x70);
+
+void Serialize(const SpriteObject &src, SpriteObject_MM7 *dst);
+void Deserialize(const SpriteObject_MM7 &src, SpriteObject *dst);
 
 #pragma pack(pop)

--- a/src/Engine/Serialization/LegacyImages.h
+++ b/src/Engine/Serialization/LegacyImages.h
@@ -3,7 +3,6 @@
 #include "Engine/Spells/Spells.h"
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/Actor.h"
-#include "Engine/Objects/Actor.h"
 #include "Engine/Objects/SpriteObject.h"
 #include "GUI/GUIFont.h"
 

--- a/src/Engine/Serialization/LegacyImages.h
+++ b/src/Engine/Serialization/LegacyImages.h
@@ -856,7 +856,7 @@ struct SpriteObject_MM7 {
     int16_t field_20;
     int16_t field_22_glow_radius_multiplier;
     ItemGen_MM7 containing_item;
-    int spell_id;
+    int uSpellID;
     int spell_level;
     int32_t spell_skill;
     int field_54;


### PR DESCRIPTION
Remove dependency of internal SpriteObject structure on structure of same object from MM7.
Also remove padding introduced in previous PR.

P.S. One of the structure field used ItemGen struct which is also defined in legacy code, changed it to legacy struct.