### PR TITLE
Spells refactor, 3rd iteration

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1423,7 +1423,7 @@ void Game::EventLoop() {
                         pGUIWindow_CurrentMenu->Release();
                         pGUIWindow_CurrentMenu = 0;
                     } else {
-                        pPlayer9->SetBeacon(uMessageParam, LloydsBeaconSpellLevel);
+                        pPlayer9->SetBeacon(uMessageParam, LloydsBeaconSpellDuration);
                     }
                     continue;
                 case UIMSG_ClickTownInTP:

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -294,7 +294,7 @@ void CastSpellInfoHelpers::CastSpell() {
             if (pPlayer->CanCastSpell(uRequiredMana)) {
                 int success_chance_percent = 10 * spell_level;
                 if (spell_mastery != PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                    if (pParty->uFlags & (PARTY_FLAGS_1_ALERT_RED | PARTY_FLAGS_1_ALERT_YELLOW) ||
+                    if (pParty->GetRedOrYellowAlert() ||
                             grng->Random(100) >= success_chance_percent) {
                         SpellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         continue;
@@ -1197,7 +1197,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 case SPELL_AIR_FLY:
                 {
                     if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-                        SpellFailed(pCastSpell, LSTR_HOSTILE_CREATURES_NEARBY);
+                        SpellFailed(pCastSpell, LSTR_CANT_FLY_INDOORS);
                         continue;
                     }
                     if (!pPlayers[pCastSpell->uPlayerID + 1]->GetMaxMana() &&
@@ -1390,7 +1390,7 @@ void CastSpellInfoHelpers::CastSpell() {
                             assert(false);
                     }
 
-                    // Mana drain was flag was not initialized here previously
+                    // Mana drain was was not initialized here previously
                     int mana_drain = (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) ? 1 : 0;
                     int spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -329,8 +329,6 @@ void CastSpellInfoHelpers::CastSpell() {
                 continue;
             }
         } else {
-            Vec3i spell_velocity = Vec3i(0, 0, 0);
-
             if (!pPlayer->CanCastSpell(uRequiredMana)) {
                 // Not enough mana for current spell, check the next one
                 pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
@@ -419,6 +417,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         continue;
                     }
                     if (PID_TYPE(spell_targeted_at) == OBJECT_Actor) {
+                        Vec3i spell_velocity = Vec3i(0, 0, 0);
                         InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.uSectorID = 0;
                         pSpellSprite.field_60_distance_related_prolly_lod = 0;
@@ -434,6 +433,7 @@ void CastSpellInfoHelpers::CastSpell() {
                 {
                     int monster_id = PID_ID(spell_targeted_at);
                     if (pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
+                        Vec3i spell_velocity = Vec3i(0, 0, 0);
                         pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION]
                             .Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), PLAYER_SKILL_MASTERY_NONE, 0, 0, 0);
                         InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
@@ -456,6 +456,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     // v730 = spell_targeted_at >> 3;
                     // HIDWORD(spellduration) =
                     // (int)&pActors[PID_ID(spell_targeted_at)];
+                    Vec3i spell_velocity = Vec3i(0, 0, 0);
                     InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pActors[PID_ID(spell_targeted_at)].vPosition;
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -876,6 +877,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         Vec3i dist = (pActors[monster_id].vPosition - pParty->vPosition).Abs();
                         int count = int_get_vector_length(dist.x, dist.y, dist.z);
                         if ((double)count <= 307.2) {
+                            Vec3i spell_velocity = Vec3i(0, 0, 0);
                             InitSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                             pSpellSprite.uSectorID = 0;
                             pSpellSprite.field_60_distance_related_prolly_lod = 0;
@@ -1048,6 +1050,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     pSpellSprite.field_60_distance_related_prolly_lod = 0;
                     pSpellSprite.uFacing = 0;
                     for (uint i = 0; i < mon_num; i++) {
+                        Vec3i spell_velocity = Vec3i(0, 0, 0);
                         Actor *target_actor = &pActors[_50BF30_actors_in_viewport_ids[i]];
                         unsigned int height_offset = (unsigned int)(int64_t)((double)target_actor->uActorHeight * -0.8);
                         pSpellSprite.vPosition = target_actor->vPosition - Vec3i(0, 0, height_offset);
@@ -2420,6 +2423,7 @@ void CastSpellInfoHelpers::CastSpell() {
 
                 case SPELL_LIGHT_DISPEL_MAGIC:
                 {
+                    Vec3i spell_velocity = Vec3i(0, 0, 0);
                     sRecoveryTime -= spell_level;
                     spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.VibrantGreen.C32(), 192);
                     int mon_num = render->GetActorsInViewport(4096);
@@ -2526,6 +2530,7 @@ void CastSpellInfoHelpers::CastSpell() {
                         SpellFailed(pCastSpell, LSTR_CANT_PRISMATIC_OUTDOORS);
                         continue;
                     }
+                    Vec3i spell_velocity = Vec3i(0, 0, 0);
                     int mon_num = render->GetActorsInViewport(4096);
                     // ++pSpellSprite.uType;
                     pSpellSprite.uType = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
@@ -2901,6 +2906,7 @@ void CastSpellInfoHelpers::CastSpell() {
                     pSpellSprite.uFacing = 0;
                     int drained_halth = 0;
                     if (mon_num > 0) {
+                        Vec3i spell_velocity = Vec3i(0, 0, 0);
                         drained_halth = (mon_num * (7 * spell_level + 25));
                         for (int monster_id = 0; monster_id < mon_num; monster_id++) {
                             Actor *target_actor = &pActors[_50BF30_actors_in_viewport_ids[monster_id]];

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -216,7 +216,7 @@ void CastSpellInfoHelpers::castSpell() {
             sRecoveryTime = pPlayer->GetAttackRecoveryTime(true);
             initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
             if (pPlayer->WearsItem(ITEM_ARTIFACT_ULLYSES, ITEM_SLOT_BOW)) {
-                pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(0xBD6u);
+                pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(SPRITE_SPELL_WATER_ICE_BOLT);
             }
             pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, (signed int)pParty->uPartyHeight / 3);
             pSpellSprite.spell_target_pid = spell_targeted_at;
@@ -290,7 +290,7 @@ void CastSpellInfoHelpers::castSpell() {
                 _506348_current_lloyd_playerid = pCastSpell->uPlayerID;
                 ::uRequiredMana = uRequiredMana;
                 ::sRecoveryTime = sRecoveryTime;
-                LloydsBeaconSpellLevel = (int)(604800 * spell_level);
+                LloydsBeaconSpellDuration = GameTime::FromDays(7 * spell_level).GetSeconds();
                 LloydsBeaconSpellId = pCastSpell->uSpellID;
                 pCastSpell->uFlags |= ON_CAST_NoRecoverySpell;
                 pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2357,7 +2357,7 @@ int LloydsBeaconSpellId;
 signed int sRecoveryTime;    // idb
 unsigned int uRequiredMana;  // idb
 int _506348_current_lloyd_playerid;
-int LloydsBeaconSpellLevel;  // 604800 * spell level
+int LloydsBeaconSpellDuration;  // 604800 * spell level
 int MapBookOpen;
 int books_page_number;
 int books_primary_item_per_page;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -121,7 +121,7 @@ extern int LloydsBeaconSpellId;
 extern signed int sRecoveryTime;    // idb
 extern unsigned int uRequiredMana;  // idb
 extern int _506348_current_lloyd_playerid;
-extern int LloydsBeaconSpellLevel;
+extern int LloydsBeaconSpellDuration;
 extern int MapBookOpen;
 // extern Texture_MM7 *dword_50640C[];
 extern int

--- a/src/Utility/Geometry/Vec.h
+++ b/src/Utility/Geometry/Vec.h
@@ -93,10 +93,6 @@ struct Vec3 {
         z *= denom;
     }
 
-    Vec3<T> Abs() const requires std::is_integral_v<T> {
-        return Vec3<T>(abs(x), abs(y), abs(z));
-    }
-
     Vec3<short> ToShort() const requires std::is_floating_point_v<T> {
         return Vec3<short>(std::round(x), std::round(y), std::round(z));
     }

--- a/src/Utility/Geometry/Vec.h
+++ b/src/Utility/Geometry/Vec.h
@@ -93,6 +93,10 @@ struct Vec3 {
         z *= denom;
     }
 
+    Vec3<T> Abs() const requires std::is_integral_v<T> {
+        return Vec3<T>(abs(x), abs(y), abs(z));
+    }
+
     Vec3<short> ToShort() const requires std::is_floating_point_v<T> {
         return Vec3<short>(std::round(x), std::round(y), std::round(z));
     }


### PR DESCRIPTION
Mainly style changes with moving code aroung.

Notable things:
- Get rid of universal variable 'amount' and use variable with more precise meaning in each of spells processing code.
- Move other variables declaration from the start of the function CastSpell into spell processing code where these variables are defined and used.
- Remove some magic numbers.

P.S.
Change error string for Fly spell failure I wrongly changed in one of the previous commits.