### PR TITLE
Fix trip on assert for accessing spell school with SPELL_NONE

### DIFF
--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -227,16 +227,17 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             }
 
             SPELL_TYPE quickSpellNumber = pPlayers[uActiveCharacter]->uQuickSpell;
-            PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
 
             int uRequiredMana = 0;
-            if (!engine->config->debug.AllMagic.Get()) {
+            if (quickSpellNumber != SPELL_NONE && !engine->config->debug.AllMagic.Get()) {
+                PLAYER_SKILL_MASTERY skill_mastery = pPlayers[uActiveCharacter]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
+
                 uRequiredMana = pSpellDatas[quickSpellNumber].mana_per_skill[std::to_underlying(skill_mastery) - 1];
             }
 
             bool enoughMana = pPlayers[uActiveCharacter]->sMana >= uRequiredMana;
 
-            if (pPlayers[uActiveCharacter]->uQuickSpell == 0 || engine->IsUnderwater() || !enoughMana) {
+            if (quickSpellNumber == SPELL_NONE || engine->IsUnderwater() || !enoughMana) {
                 pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Attack, 0, 0);
             } else {
                 pMessageQueue_50C9E8->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -242,3 +242,8 @@ GAME_TEST(Issue, Issue123) {
     // check party is still in the air
     EXPECT_GT(pParty->vPosition.z, 512);
 }
+
+GAME_TEST(Prs, Pr469) {
+    // Assert when using Quick Spell button when spell is not set
+    test->playTraceFromTestData("pr_469.mm7", "pr_469.json");
+}


### PR DESCRIPTION
Subj.
When spell is not set on Quick Cast button uQuickSpell will be SPELL_NONE.
It is then goes to getSkillTypeForSpell unconditionally.