### PR TITLE
Small refactor of ParticleEngine, fixes #453

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1533,8 +1533,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
 
     if (decoration->uFlags & DECORATION_DESC_EMITS_FIRE) {
         memset(&particle, 0, sizeof(Particle_sw));  // fire,  like at the Pit's tavern
-        particle.type =
-            ParticleType_Bitmap | ParticleType_Rotating | ParticleType_8;
+        particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
         particle.uDiffuse = colorTable.OrangeyRed.C32();
         particle.x = (double)pLevelDecorations[uDecorationID].vPosition.x;
         particle.y = (double)pLevelDecorations[uDecorationID].vPosition.y;

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -45,16 +45,10 @@ void TrailParticleGenerator::UpdateParticles() {
     }
 }
 
-/**
- * @offset 0x48AAC5
- */
 ParticleEngine::ParticleEngine() {
     ResetParticles();
 }
 
-/**
- * @offset 0x48AAF6
- */
 void ParticleEngine::ResetParticles() {
     pParticles.fill({});
     uStartParticle = PARTICLES_ARRAY_SIZE;
@@ -62,9 +56,6 @@ void ParticleEngine::ResetParticles() {
     uTimeElapsed = 0;
 }
 
-/**
- * @offset 0x48AB23
- */
 void ParticleEngine::AddParticle(Particle_sw *patricle) {
     if (!pMiscTimer->bPaused) {
         Particle *freeParticle = nullptr;
@@ -111,9 +102,6 @@ void ParticleEngine::AddParticle(Particle_sw *patricle) {
     }
 }
 
-/**
- * @offset 0x48ABF3
- */
 void ParticleEngine::Draw() {
     uTimeElapsed += pEventTimer->uTimeElapsed;
     pLines.uNumLines = 0;
@@ -124,9 +112,6 @@ void ParticleEngine::Draw() {
     }
 }
 
-/**
- * @offset 0x48AC65
- */
 void ParticleEngine::UpdateParticles() {
     unsigned uCurrentEnd = 0;
     unsigned uCurrentBegin = PARTICLES_ARRAY_SIZE;
@@ -206,11 +191,7 @@ void ParticleEngine::UpdateParticles() {
     uStartParticle = uCurrentBegin;
 }
 
-/**
- * @offset 0x48AE74
- */
-bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(
-    unsigned int uParticleID) {
+bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(unsigned int uParticleID) {
     Particle *pParticle;  // esi@1
     int y_int_;           // [sp+10h] [bp-40h]@2
     int x_int;            // [sp+20h] [bp-30h]@2
@@ -249,9 +230,6 @@ bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(
     return true;
 }
 
-/**
- * @offset 0x48BBA6
- */
 void ParticleEngine::DrawParticles_BLV() {
     SoftwareBillboard v15 {};  // [sp+Ch] [bp-58h]@1
 

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -45,161 +45,170 @@ void TrailParticleGenerator::UpdateParticles() {
     }
 }
 
-//----- (0048AAC5) --------------------------------------------------------
+/**
+ * @offset 0x48AAC5
+ */
 ParticleEngine::ParticleEngine() {
-    for (uint i = 0; i < 500; ++i)
-        memset(&pParticles[i], 0, sizeof(pParticles[i]));
-
     ResetParticles();
 }
 
-//----- (0048AAF6) --------------------------------------------------------
+/**
+ * @offset 0x48AAF6
+ */
 void ParticleEngine::ResetParticles() {
-    memset(pParticles, 0, 500 * sizeof(*pParticles));
-    uStartParticle = 500;
+    pParticles.fill({});
+    uStartParticle = PARTICLES_ARRAY_SIZE;
     uEndParticle = 0;
     uTimeElapsed = 0;
 }
 
-//----- (0048AB23) --------------------------------------------------------
-void ParticleEngine::AddParticle(Particle_sw *a2) {
-    signed int v2;  // eax@2
-    Particle *v3;   // edx@2
-    Particle *v4;   // esi@10
-    int v5;         // ecx@10
-    // char v6; // zf@10
-
+/**
+ * @offset 0x48AB23
+ */
+void ParticleEngine::AddParticle(Particle_sw *patricle) {
     if (!pMiscTimer->bPaused) {
-        v2 = 0;
-        v3 = this->pParticles;
-        do {
-            if (v3->type == ParticleType_Invalid) break;
-            ++v2;
-            ++v3;
-        } while (v2 < 500);
-        if (v2 < 500) {
-            if (v2 < this->uStartParticle) this->uStartParticle = v2;
-            if (v2 > this->uEndParticle) this->uEndParticle = v2;
-            v4 = &this->pParticles[v2];
-            v4->type = a2->type;
-            v4->x = a2->x;
-            v4->y = a2->y;
-            v4->z = a2->z;
-            v4->_x = a2->x;
-            v4->_y = a2->y;
-            v4->_z = a2->z;
-            v4->flt_10 = a2->r;
-            v4->flt_14 = a2->g;
-            v4->flt_18 = a2->b;
-            v5 = a2->uDiffuse;
-            v4->uParticleColor = v5;
-            v4->uLightColor_bgr = v5;
+        Particle *freeParticle = nullptr;
+
+        for (int i = 0; i < pParticles.size(); i++) {
+            if (pParticles[i].type == ParticleType_Invalid) {
+                if (i < this->uStartParticle) {
+                    this->uStartParticle = i;
+                }
+                if (i > this->uEndParticle) {
+                    this->uEndParticle = i;
+                }
+                freeParticle = &pParticles[i];
+                break;
+            }
+        }
+
+        if (freeParticle) {
+            freeParticle->type = patricle->type;
+            freeParticle->x = patricle->x;
+            freeParticle->y = patricle->y;
+            freeParticle->z = patricle->z;
+            freeParticle->_x = patricle->x;
+            freeParticle->_y = patricle->y;
+            freeParticle->_z = patricle->z;
+            freeParticle->shift_x = patricle->r; // TODO: seems Particle_sw struct fields are mixed up here
+            freeParticle->shift_y = patricle->g;
+            freeParticle->shift_z = patricle->b;
+            freeParticle->uParticleColor = patricle->uDiffuse;
+            freeParticle->uLightColor_bgr = patricle->uDiffuse;
             // v6 = (v4->uType & 4) == 0;
-            v4->timeToLive = a2->timeToLive;
-            v4->texture = a2->texture;
-            v4->paletteID = a2->paletteID;
-            v4->particle_size = a2->particle_size;
-            if (v4->type & ParticleType_Rotating) {
-                v4->rotation_speed = vrng->Random(256) - 128;
-                v4->angle = vrng->Random(TrigLUT.uIntegerDoublePi);
+            freeParticle->timeToLive = patricle->timeToLive;
+            freeParticle->texture = patricle->texture;
+            freeParticle->paletteID = patricle->paletteID;
+            freeParticle->particle_size = patricle->particle_size;
+            if (freeParticle->type & ParticleType_Rotating) {
+                freeParticle->rotation_speed = vrng->Random(256) - 128;
+                freeParticle->angle = vrng->Random(TrigLUT.uIntegerDoublePi);
             } else {
-                v4->rotation_speed = 0;
-                v4->angle = 0;
+                freeParticle->rotation_speed = 0;
+                freeParticle->angle = 0;
             }
         }
     }
 }
 
-//----- (0048ABF3) --------------------------------------------------------
+/**
+ * @offset 0x48ABF3
+ */
 void ParticleEngine::Draw() {
     uTimeElapsed += pEventTimer->uTimeElapsed;
     pLines.uNumLines = 0;
 
     DrawParticles_BLV();
-    // if (render->pRenderD3D)
-    {
-        if (pLines.uNumLines) {
-            render->DrawLines(pLines.pLineVertices, pLines.uNumLines);
-            /*render->pRenderD3D->pDevice->SetTexture(0, 0);
-            render->pRenderD3D->pDevice->DrawPrimitive(
-              D3DPT_LINELIST,
-              D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_SPECULAR | D3DFVF_TEX1,
-              pLines.pLineVertices,
-              pLines.uNumLines,
-              D3DDP_DONOTLIGHT);*/
-        }
+    if (pLines.uNumLines) {
+        render->DrawLines(pLines.pLineVertices, pLines.uNumLines);
     }
 }
 
-//----- (0048AC65) --------------------------------------------------------
+/**
+ * @offset 0x48AC65
+ */
 void ParticleEngine::UpdateParticles() {
-    unsigned int time;  // edi@1
-    // int v5; // eax@3
-    // char v6; // sf@4
-    float v7;   // ST4C_4@11
-    double v8;  // st7@12
-    // int v9; // eax@12
-    // double v10; // st7@14
-    signed int v19;      // [sp+38h] [bp-14h]@1
-    int v20;             // [sp+3Ch] [bp-10h]@1
-    unsigned int time_;  // [sp+40h] [bp-Ch]@1
-    int v22;             // [sp+44h] [bp-8h]@12
+    unsigned uCurrentEnd = 0;
+    unsigned uCurrentBegin = PARTICLES_ARRAY_SIZE;
+    int time = pMiscTimer->bPaused == 0 ? pEventTimer->uTimeElapsed : 0;
 
-    v20 = 0;
-    time = pMiscTimer->bPaused == 0 ? pEventTimer->uTimeElapsed : 0;
-    v19 = 500;
-    time_ = pMiscTimer->bPaused == 0 ? pEventTimer->uTimeElapsed : 0;
+    if (time == 0) {
+        return;
+    }
 
     for (uint i = uStartParticle; i <= uEndParticle; ++i) {
         Particle *p = &pParticles[i];
 
-        if (p->type == ParticleType_Invalid) continue;
+        if (p->type == ParticleType_Invalid) {
+            continue;
+        }
 
         if (p->timeToLive <= time) {
             p->timeToLive = 0;
             p->type = ParticleType_Invalid;
             continue;
         }
+
         p->timeToLive -= time;
 
+        // Line particle type appear unused
         if (p->type & ParticleType_Line) {
             p->_x = p->x;
             p->_y = p->y;
             p->_z = p->z;
         }
 
-        if (p->type & ParticleType_1)
-            p->flt_18 = p->flt_18 - (double)(signed int)time_ * 5.0;
-
-        if (p->type & ParticleType_8) {
-            v7 = (double)(signed int)time_;
-            *(float *)&p->x += (double)(vrng->Random(5) - 2) * v7 / 16.0f;
-            *(float *)&p->y += (double)(vrng->Random(5) - 2) * v7 / 16.0f;
-            *(float *)&p->z += (double)(vrng->Random(5) + 4) * v7 / 16.0f;
+        // Dropping particles drop downward with acceleration
+        if (p->type & ParticleType_Dropping) {
+            p->shift_z -= time * 5.0;
         }
-        v8 = (double)(signed int)time_ / 128.0f;
+
+        // Ascending particles slowly float upward
+        if (p->type & ParticleType_Ascending) {
+            int random_x = vrng->Random(5);
+            int random_y = vrng->Random(5);
+            int random_z = vrng->Random(5);
+            p->x += (random_x - 2) * time / 16.0;
+            p->y += (random_y - 2) * time / 16.0;
+            p->z += (random_z + 4) * time / 16.0;
+        }
+
         // v9 = (signed int)(time * p->rotation_speed) / 16;
 
-        p->x += v8 * p->flt_10;
-        p->y += v8 * p->flt_14;
-        p->z += v8 * p->flt_18;
+        // Particle shift with time
+        double shift = time / 128.0f;
+        p->x += shift * p->shift_x;
+        p->y += shift * p->shift_y;
+        p->z += shift * p->shift_z;
 
         p->angle += time * p->rotation_speed / 16;
-        v22 = 2 * p->timeToLive;
-        if (v22 >= 255) v22 = 255;
+
+        // With time particles become more transparent
+        int dissipate_value = 2 * p->timeToLive;
+        if (dissipate_value >= 255) {
+            dissipate_value = 255;
+        }
+        float dissipate_factor = dissipate_value / 255.0f;
         // v10 = (double)v22 * 0.0039215689;
-        p->uLightColor_bgr = ((uint)floorf(p->b * (v22 / 255.0f) + 0.5) << 16) |
-                             ((uint)floorf(p->g * (v22 / 255.0f) + 0.5) << 8) |
-                             ((uint)floorf(p->r * (v22 / 255.0f) + 0.5) << 0);
-        if (i < v19) v19 = i;
-        if (i > v20) v20 = i;
+        p->uLightColor_bgr = ((uint)floorf(p->b * dissipate_factor + 0.5) << 16) |
+                             ((uint)floorf(p->g * dissipate_factor + 0.5) << 8) |
+                             ((uint)floorf(p->r * dissipate_factor + 0.5) << 0);
+
+        if (i < uCurrentBegin) {
+           uCurrentBegin = i;
+        }
+        if (i > uCurrentEnd) {
+           uCurrentEnd = i;
+        }
     }
 
-    uEndParticle = v20;
-    uStartParticle = v19;
+    uEndParticle = uCurrentEnd;
+    uStartParticle = uCurrentBegin;
 }
 
-//----- (0048AE74) --------------------------------------------------------
+/**
+ * @offset 0x48AE74
+ */
 bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(
     unsigned int uParticleID) {
     Particle *pParticle;  // esi@1
@@ -240,9 +249,9 @@ bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(
     return true;
 }
 
-
-
-//----- (0048BBA6) --------------------------------------------------------
+/**
+ * @offset 0x48BBA6
+ */
 void ParticleEngine::DrawParticles_BLV() {
     SoftwareBillboard v15 {};  // [sp+Ch] [bp-58h]@1
 
@@ -256,7 +265,7 @@ void ParticleEngine::DrawParticles_BLV() {
         if (!ViewProject_TrueIfStillVisible_BLV(i)) continue;
 
         // TODO(pskelton): reinstate this guard check
-
+        // TODO(Nik-RE-dev): all types except for Line appear to behave identically
         if (true) {
             /*p->uScreenSpaceX >= pBLVRenderParams->uViewportX &&
             p->uScreenSpaceX < pBLVRenderParams->uViewportZ &&

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -56,7 +56,7 @@ void ParticleEngine::ResetParticles() {
     uTimeElapsed = 0;
 }
 
-void ParticleEngine::AddParticle(Particle_sw *patricle) {
+void ParticleEngine::AddParticle(Particle_sw *particle) {
     if (!pMiscTimer->bPaused) {
         Particle *freeParticle = nullptr;
 
@@ -74,23 +74,23 @@ void ParticleEngine::AddParticle(Particle_sw *patricle) {
         }
 
         if (freeParticle) {
-            freeParticle->type = patricle->type;
-            freeParticle->x = patricle->x;
-            freeParticle->y = patricle->y;
-            freeParticle->z = patricle->z;
-            freeParticle->_x = patricle->x;
-            freeParticle->_y = patricle->y;
-            freeParticle->_z = patricle->z;
-            freeParticle->shift_x = patricle->r; // TODO: seems Particle_sw struct fields are mixed up here
-            freeParticle->shift_y = patricle->g;
-            freeParticle->shift_z = patricle->b;
-            freeParticle->uParticleColor = patricle->uDiffuse;
-            freeParticle->uLightColor_bgr = patricle->uDiffuse;
+            freeParticle->type = particle->type;
+            freeParticle->x = particle->x;
+            freeParticle->y = particle->y;
+            freeParticle->z = particle->z;
+            freeParticle->_x = particle->x;
+            freeParticle->_y = particle->y;
+            freeParticle->_z = particle->z;
+            freeParticle->shift_x = particle->r; // TODO: seems Particle_sw struct fields are mixed up here
+            freeParticle->shift_y = particle->g;
+            freeParticle->shift_z = particle->b;
+            freeParticle->uParticleColor = particle->uDiffuse;
+            freeParticle->uLightColor_bgr = particle->uDiffuse;
             // v6 = (v4->uType & 4) == 0;
-            freeParticle->timeToLive = patricle->timeToLive;
-            freeParticle->texture = patricle->texture;
-            freeParticle->paletteID = patricle->paletteID;
-            freeParticle->particle_size = patricle->particle_size;
+            freeParticle->timeToLive = particle->timeToLive;
+            freeParticle->texture = particle->texture;
+            freeParticle->paletteID = particle->paletteID;
+            freeParticle->particle_size = particle->particle_size;
             if (freeParticle->type & ParticleType_Rotating) {
                 freeParticle->rotation_speed = vrng->Random(256) - 128;
                 freeParticle->angle = vrng->Random(TrigLUT.uIntegerDoublePi);
@@ -175,6 +175,7 @@ void ParticleEngine::UpdateParticles() {
         }
         float dissipate_factor = dissipate_value / 255.0f;
         // v10 = (double)v22 * 0.0039215689;
+        // TODO(Nik-RE-dev): check colour format use in particles
         p->uLightColor_bgr = ((uint)floorf(p->b * dissipate_factor + 0.5) << 16) |
                              ((uint)floorf(p->g * dissipate_factor + 0.5) << 8) |
                              ((uint)floorf(p->r * dissipate_factor + 0.5) << 0);

--- a/src/Engine/Graphics/ParticleEngine.h
+++ b/src/Engine/Graphics/ParticleEngine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Utility/Flags.h"
 
 #include "Engine/Graphics/IRender.h"
@@ -7,12 +9,12 @@
 
 enum class ParticleFlag : uint32_t {
     ParticleType_Invalid = 0,
-    ParticleType_1 = 0x0001,
-    ParticleType_Rotating = 0x0004,
-    ParticleType_8 = 0x0008,
-    ParticleType_Diffuse = 0x0100,  // colored plane
-    ParticleType_Line = 0x0200,     // line
-    ParticleType_Bitmap = 0x0400,   // textured planed
+    ParticleType_Dropping = 0x0001,  // particle drops with time
+    ParticleType_Rotating = 0x0004,  // particle rotates with time
+    ParticleType_Ascending = 0x0008, // particle ascends with time
+    ParticleType_Diffuse = 0x0100,   // colored plane
+    ParticleType_Line = 0x0200,      // line
+    ParticleType_Bitmap = 0x0400,    // textured planed
     ParticleType_Sprite = 0x0800
 };
 using enum ParticleFlag;
@@ -50,9 +52,9 @@ struct Particle {
     float x = 0;
     float y = 0;
     float z = 0;
-    float flt_10 = 0;
-    float flt_14 = 0;
-    float flt_18 = 0;
+    float shift_x = 0;
+    float shift_y = 0;
+    float shift_z = 0;
     union {
         struct {
             unsigned char r, g, b, a;
@@ -103,17 +105,19 @@ class ParticleEngine {
  public:
     ParticleEngine();
 
+    static const int PARTICLES_ARRAY_SIZE = 500;
+
     void ResetParticles();
-    void AddParticle(Particle_sw *a2);
+    void AddParticle(Particle_sw *patricle);
     void Draw();
     void UpdateParticles();
     bool ViewProject_TrueIfStillVisible_BLV(unsigned int uParticleID);
     void DrawParticles_BLV();
 
-    Particle pParticles[500];
+    std::array<Particle, PARTICLES_ARRAY_SIZE> pParticles;
     stru2_LineList pLines;
-    char field_D160[4800];
-    float field_E420;
+    char field_D160[4800]; // unused
+    float field_E420; // unused
     int uStartParticle;
     int uEndParticle;
     int uTimeElapsed;

--- a/src/Engine/Graphics/ParticleEngine.h
+++ b/src/Engine/Graphics/ParticleEngine.h
@@ -103,15 +103,52 @@ struct stru2_LineList {
 #pragma pack(push, 1)
 class ParticleEngine {
  public:
-    ParticleEngine();
-
     static const int PARTICLES_ARRAY_SIZE = 500;
 
+    /**
+     * Particle engine constructor.
+     *
+     * @offset 0x48AAC5
+     */
+    ParticleEngine();
+
+    /**
+     * Remove all active particles if any and initialize/reinitialize then particles engine.
+     *
+     * @offset 0x48AAF6
+     */
     void ResetParticles();
+
+    /**
+     * Add particle to engine.
+     *
+     * @offset 0x48AB23
+     */
     void AddParticle(Particle_sw *patricle);
+
+    /**
+     * Draw all active particles.
+     *
+     * @offset 0x48ABF3
+     */
     void Draw();
+
+    /**
+     * Update all active particles based on time elapsed since previous tick.
+     * Transform particles if needed and remove them if particle live time expired.
+     *
+     * @offset 0x48AC65
+     */
     void UpdateParticles();
+
+    /**
+     * @offset 0x48AE74
+     */
     bool ViewProject_TrueIfStillVisible_BLV(unsigned int uParticleID);
+
+    /**
+     * @offset 0x48BBA6
+     */
     void DrawParticles_BLV();
 
     std::array<Particle, PARTICLES_ARRAY_SIZE> pParticles;

--- a/src/Engine/Graphics/ParticleEngine.h
+++ b/src/Engine/Graphics/ParticleEngine.h
@@ -124,7 +124,7 @@ class ParticleEngine {
      *
      * @offset 0x48AB23
      */
-    void AddParticle(Particle_sw *patricle);
+    void AddParticle(Particle_sw *particle);
 
     /**
      * Draw all active particles.

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -383,8 +383,7 @@ void RenderBase::PrepareDecorationsRenderList_ODM() {
             } else {
                 // Emit fire particles.
                 memset(&local_0, 0, sizeof(Particle_sw));
-                local_0.type = ParticleType_Bitmap | ParticleType_Rotating |
-                    ParticleType_8;
+                local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                 local_0.uDiffuse = colorTable.OrangeyRed.C32();
                 local_0.x = static_cast<float>(pLevelDecorations[i].vPosition.x);
                 local_0.y = static_cast<float>(pLevelDecorations[i].vPosition.y);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -320,7 +320,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
 
             actorPtr->pActorBuffs[ACTOR_BUFF_HASTE].Apply((pParty->GetPlayingTime() + spell_length),
                 masteryLevel, 0, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, colorTable.OrangeyRed.C32());
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.OrangeyRed.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Haste,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -473,7 +473,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_STONESKIN].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints + 5, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0x5C310Eu);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.Cioccolato.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Stoneskin,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0, 0);
             return;
@@ -492,7 +492,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints + 5, 0, 0);
 
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0xC8C805u);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Bless,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -511,7 +511,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_FATE].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, v48, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0xC8C805u);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Fate,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -530,7 +530,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_HEROISM].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints + 5, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0xC8C805u);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_51heroism03,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -546,7 +546,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_PAIN_HAMMERHANDS].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0xA81376u);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.JazzberryJam.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_51heroism03,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -556,7 +556,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->sCurrentHP += 5 * realPoints + 10;
             if (actorPtr->sCurrentHP >= (signed int)actorPtr->pMonsterInfo.uHP)
                 actorPtr->sCurrentHP = (short)actorPtr->pMonsterInfo.uHP;
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, 0xA81376u);
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.JazzberryJam.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Fate,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -601,7 +601,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_DAY_OF_PROTECTION].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, colorTable.White.C32());
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.White.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_94dayofprotection03,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -620,7 +620,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_HOUR_OF_POWER].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, realPoints + 5, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, colorTable.White.C32());
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.White.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_9armageddon01,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);
@@ -690,7 +690,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->pActorBuffs[ACTOR_BUFF_PAIN_REFLECTION].Apply(
                 (pParty->GetPlayingTime() + spell_length),
                 masteryLevel, 0, 0, 0);
-            spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(actorPtr, colorTable.MediumGrey.C32());
+            spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.MediumGrey.C32());
             pAudioPlayer->PlaySound((SoundID)SOUND_Sacrifice2,
                                     PID(OBJECT_Actor, uActorID), 0, -1, 0,
                                     0);

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -217,8 +217,7 @@ void SpriteObject::UpdateObject_fn0_ODM(unsigned int uLayingItemID) {
             Dst.g = 0.0;
             Dst.b = 0.0;
             if (object->uFlags & OBJECT_DESC_TRIAL_FIRE) {
-                Dst.type = ParticleType_Bitmap | ParticleType_Rotating |
-                           ParticleType_8;
+                Dst.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                 Dst.uDiffuse = colorTable.OrangeyRed.C32();
                 Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                 Dst.texture = spell_fx_renderer->effpar01;
@@ -232,7 +231,7 @@ void SpriteObject::UpdateObject_fn0_ODM(unsigned int uLayingItemID) {
                 Dst.particle_size = 1.0f;
                 particle_engine->AddParticle(&Dst);
             } else if (object->uFlags & OBJECT_DESC_TRIAL_PARTICLE) {
-                Dst.type = ParticleType_Bitmap | ParticleType_8;
+                Dst.type = ParticleType_Bitmap | ParticleType_Ascending;
                 Dst.uDiffuse = vrng->Random(RAND_MAX);
                 Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                 Dst.texture = spell_fx_renderer->effpar03;
@@ -331,8 +330,7 @@ LABEL_13:
                 Dst.g = 0.0;
                 Dst.b = 0.0;
                 if (object->uFlags & OBJECT_DESC_TRIAL_FIRE) {
-                    Dst.type = ParticleType_Bitmap | ParticleType_Rotating |
-                               ParticleType_8;
+                    Dst.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                     Dst.uDiffuse = colorTable.OrangeyRed.C32();
                     Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                     Dst.texture = spell_fx_renderer->effpar01;
@@ -348,7 +346,7 @@ LABEL_13:
                     particle_engine->AddParticle(&Dst);
                     return;
                 } else if (object->uFlags & OBJECT_DESC_TRIAL_PARTICLE) {
-                    Dst.type = ParticleType_Bitmap | ParticleType_8;
+                    Dst.type = ParticleType_Bitmap | ParticleType_Ascending;
                     Dst.uDiffuse = vrng->Random(RAND_MAX);
                     Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                     Dst.texture = spell_fx_renderer->effpar03;
@@ -533,8 +531,7 @@ LABEL_25:
                 Dst.g = 0.0;
                 Dst.b = 0.0;
                 if (pObject->uFlags & OBJECT_DESC_TRIAL_FIRE) {
-                    Dst.type = ParticleType_Bitmap | ParticleType_Rotating |
-                               ParticleType_8;
+                    Dst.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                     Dst.uDiffuse = colorTable.OrangeyRed.C32();
                     Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                     Dst.texture = spell_fx_renderer->effpar01;
@@ -550,7 +547,7 @@ LABEL_25:
                     particle_engine->AddParticle(&Dst);
                     return;
                 } else if (pObject->uFlags & OBJECT_DESC_TRIAL_PARTICLE) {
-                    Dst.type = ParticleType_Bitmap | ParticleType_8;
+                    Dst.type = ParticleType_Bitmap | ParticleType_Ascending;
                     Dst.uDiffuse = vrng->Random(RAND_MAX);
                     Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
                     Dst.texture = spell_fx_renderer->effpar03;
@@ -720,8 +717,7 @@ LABEL_25:
             Dst.g = 0.0;
             Dst.b = 0.0;
             if (pObject->uFlags & OBJECT_DESC_TRIAL_FIRE) {
-                Dst.type = ParticleType_Bitmap | ParticleType_Rotating |
-                           ParticleType_8;
+                Dst.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                 Dst.uDiffuse = colorTable.OrangeyRed.C32();
                 Dst.particle_size = 1.0f;
                 Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80
@@ -737,7 +733,7 @@ LABEL_25:
                 particle_engine->AddParticle(&Dst);
                 return;
             } else if (pObject->uFlags & OBJECT_DESC_TRIAL_PARTICLE) {
-                Dst.type = ParticleType_Bitmap | ParticleType_8;
+                Dst.type = ParticleType_Bitmap | ParticleType_Ascending;
                 Dst.uDiffuse = vrng->Random(RAND_MAX);
                 Dst.particle_size = 1.0f;
                 Dst.timeToLive = vrng->Random(0x80) + 128; // was rand() & 0x80

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -556,7 +556,7 @@ void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
     }
 }
 
-void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse) {
+void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, uint32_t uDiffuse) {
     Particle_sw particle;
 
     memset(&particle, 0, sizeof(Particle_sw));
@@ -575,6 +575,7 @@ void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned in
         if (uDiffuse) {
             particle.uDiffuse = uDiffuse;
         } else {
+            // TODO(Nik-RE-dev): check colour format
             particle.uDiffuse = vrng->Random(0x10000) | (vrng->Random(0x10000) << 16);
         }
         particle_engine->AddParticle(&particle);

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -274,8 +274,7 @@ void SpellFxRenderer::
         x = ((float)a2->vPosition.x - v7->flt_0_x) * 0.5f + v7->flt_0_x;
         y = ((float)v5->vPosition.y - v7->flt_4_y) * 0.5f + v7->flt_4_y;
         z = ((float)v5->vPosition.z - v7->flt_8_z) * 0.5f + v7->flt_8_z;
-        local_0.type =
-            ParticleType_Bitmap | ParticleType_Rotating | ParticleType_8;
+        local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
         local_0.uDiffuse = uDiffuse;
         local_0.x = x + 4.0;
         local_0.y = y;
@@ -304,8 +303,7 @@ void SpellFxRenderer::
         thisspellfxrend->array_4[a2->field_54 & 0x1F].flt_4_y = (float)a2->vPosition.y;
         thisspellfxrend->array_4[a2->field_54 & 0x1F].flt_8_z = (float)a2->vPosition.z;
         v10 = (float)a2->vPosition.x;
-        local_0.type =
-            ParticleType_Bitmap | ParticleType_Rotating | ParticleType_8;
+        local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
         local_0.uDiffuse = uDiffuse;
         local_0.x = v10 + 4.0f;
         local_0.y = (float)a2->vPosition.y;
@@ -330,7 +328,7 @@ void SpellFxRenderer::_4A75CC_single_spell_collision_particle(
     Particle_sw local_0;  // [sp+8h] [bp-68h]@1
 
     memset(&local_0, 0, sizeof(Particle_sw));
-    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_1;
+    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.x = (float)a1->vPosition.x;
     local_0.y = (float)a1->vPosition.y;
     v4 = (float)a1->vPosition.z;
@@ -358,7 +356,7 @@ void SpellFxRenderer::_4A7688_fireball_collision_particle(SpriteObject *a2) {
         v4 = v3 * 1.333333333333333;
 
     Particle_sw local_0 = { 0 };
-    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_1;
+    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.uDiffuse = colorTable.OrangeyRed.C32();
     local_0.x = (float)a2->vPosition.x;
     local_0.y = (float)a2->vPosition.y;
@@ -401,7 +399,7 @@ void SpellFxRenderer::_4A77FD_implosion_particle_d3d(SpriteObject *a1) {
 //----- (004A7948) --------------------------------------------------------
 void SpellFxRenderer::_4A7948_mind_blast_after_effect(SpriteObject *a1) {
     Particle_sw Dst = { 0 };
-    Dst.type = ParticleType_Sprite | ParticleType_Rotating | ParticleType_1;
+    Dst.type = ParticleType_Sprite | ParticleType_Rotating | ParticleType_Dropping;
     Dst.uDiffuse = colorTable.MediumGrey.C32();
     Dst.x = (float)a1->vPosition.x;
     Dst.y = (float)a1->vPosition.y;
@@ -442,7 +440,7 @@ void SpellFxRenderer::
     float uTextureIDa;    // [sp+7Ch] [bp+10h]@1
 
     memset(&local_0, 0, sizeof(Particle_sw));
-    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_1;
+    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.x = (float)a1->vPosition.x;
     v5 = a1->vPosition.z;
     local_0.y = (float)a1->vPosition.y;
@@ -558,39 +556,32 @@ void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
     }
 }
 
-//----- (004A7E89) --------------------------------------------------------
-void SpellFxRenderer::_4A7E89_sparkles_on_actor_after_it_casts_buff(
-    Actor *pActor, unsigned int uDiffuse) {
-    Actor *v3;  // edi@1
-    int v4;     // ebx@3
-    // int result; // eax@5
-    Particle_sw Dst;     // [sp+Ch] [bp-6Ch]@1
-    int v7;              // [sp+74h] [bp-4h]@2
-    signed int pActora;  // [sp+80h] [bp+8h]@1
+/**
+ * @offet 0x4A7E89
+ */
+void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse) {
+    Particle_sw particle;
 
-    memset(&Dst, 0, sizeof(Particle_sw));
-    Dst.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_8;
-    Dst.timeToLive = vrng->Random(0x80) + 128;
-    v3 = pActor;
-    Dst.texture = this->effpar02;
-    pActora = 50;
-    Dst.particle_size = 1.0;
-    do {
-        v7 = vrng->Random(256) + v3->vPosition.x - 127;
-        Dst.x = (float)v7;
-        v7 = vrng->Random(256) + v3->vPosition.y - 127;
-        Dst.y = (float)v7;
-        v7 = v3->vPosition.z + vrng->Random(256);
-        Dst.z = (float)v7;
+    memset(&particle, 0, sizeof(Particle_sw));
+    particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
+    particle.timeToLive = vrng->Random(128) + 128;
+    particle.texture = this->effpar02;
+    particle.particle_size = 1.0;
+
+    for (int i = 0; i < 50; i++) {
+        int random_x = vrng->Random(256);
+        int random_y = vrng->Random(256);
+        int random_z = vrng->Random(256);
+        particle.x = random_x + pActor->vPosition.x - 127;
+        particle.y = random_y + pActor->vPosition.y - 127;
+        particle.z = random_z + pActor->vPosition.z;
         if (uDiffuse) {
-            Dst.uDiffuse = uDiffuse;
+            particle.uDiffuse = uDiffuse;
         } else {
-            v4 = vrng->Random(65536) << 16;
-            Dst.uDiffuse = vrng->Random(65536) | v4;
+            particle.uDiffuse = vrng->Random(0x10000) | (vrng->Random(0x10000) << 16);
         }
-        particle_engine->AddParticle(&Dst);
-        --pActora;
-    } while (pActora);
+        particle_engine->AddParticle(&particle);
+    }
 }
 
 //----- (004A7F74) --------------------------------------------------------
@@ -602,7 +593,7 @@ void SpellFxRenderer::_4A7F74(int x, int y, int z) {
     float z1;             // [sp+88h] [bp+8h]@2
 
     memset(&local_0, 0, sizeof(local_0));
-    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_1;
+    local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.uDiffuse = colorTable.MediumGrey.C32();
     local_0.particle_size = 1.0;
     v6 = 8;

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -556,9 +556,6 @@ void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
     }
 }
 
-/**
- * @offset 0x4A7E89
- */
 void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse) {
     Particle_sw particle;
 

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -557,7 +557,7 @@ void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
 }
 
 /**
- * @offet 0x4A7E89
+ * @offset 0x4A7E89
  */
 void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse) {
     Particle_sw particle;

--- a/src/Engine/SpellFxRenderer.h
+++ b/src/Engine/SpellFxRenderer.h
@@ -12,7 +12,9 @@ class ParticleEngine;
 /*  120 */
 #pragma pack(push, 1)
 struct SpellFX_Billboard {
-    //----- (004775B1) --------------------------------------------------------
+    /**
+     * @offset 0x4775B1
+     */
     inline SpellFX_Billboard() {
         uNumVertices = 0;
         uNumVec4sInArray1 = 0;
@@ -21,7 +23,9 @@ struct SpellFX_Billboard {
         pArray2 = nullptr;
     }
 
-    //----- (004775C4) --------------------------------------------------------
+    /**
+     * @offset 0x4775C4
+     */
     virtual ~SpellFX_Billboard();
 
     int SpellFXNearClipAdjust(float a2);
@@ -58,14 +62,13 @@ struct SpellFX_Billboard {
 /*  122 */
 #pragma pack(push, 1)
 struct PlayerBuffAnim {
-    inline PlayerBuffAnim()
-        : bRender(false), uSpellAnimTime(0), uSpellIconID(0) {}
+    inline PlayerBuffAnim() : bRender(false), field_2(0), uSpellAnimTimeElapsed(0), uSpellAnimTime(0), uSpellIconID(0) {}
 
-    int16_t bRender = 0;
-    int16_t field_2 = 0;
-    int uSpellAnimTimeElapsed = 0;
-    int uSpellAnimTime = 0;
-    int uSpellIconID = 0;
+    int16_t bRender;
+    int16_t field_2;
+    int uSpellAnimTimeElapsed;
+    int uSpellAnimTime;
+    int uSpellIconID;
 };
 #pragma pack(pop)
 
@@ -96,7 +99,9 @@ struct stru6_stru2 {
 /* stru6 121 */
 #pragma pack(push, 1)
 struct SpellFxRenderer {
-    //----- (004A7155) --------------------------------------------------------
+    /**
+     * @offset 0x4A7155
+     */
     explicit inline SpellFxRenderer(std::shared_ptr<ParticleEngine> particle_engine) {
         this->particle_engine = particle_engine;
 
@@ -109,7 +114,10 @@ struct SpellFxRenderer {
         pStru1 = new SpellFX_Billboard();
         pStru1->Initialize(colorTable.OrangeyRed.C32());
     }
-    //----- (004A71DC) --------------------------------------------------------
+
+    /**
+     * @offset 0x4A71DC
+     */
     ~SpellFxRenderer() {
         delete pStru1;
         pStru1 = nullptr;
@@ -133,8 +141,7 @@ struct SpellFxRenderer {
         SpriteObject *a1, unsigned int uDiffuse, Texture *texture, float a4);
     void _4A7C07_stun_spell_fx(struct SpriteObject *a2);
     void AddProjectile(struct SpriteObject *a2, int a3, Texture *);
-    void _4A7E89_sparkles_on_actor_after_it_casts_buff(Actor *pActor,
-                                                       unsigned int uDiffuse);
+    void sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse);
     void _4A7F74(int x, int y, int z);
     float _4A806F_get_mass_distortion_value(Actor *pActor);
     // void _4A80DC_implosion_particle_sw(struct SpriteObject *a2);

--- a/src/Engine/SpellFxRenderer.h
+++ b/src/Engine/SpellFxRenderer.h
@@ -142,7 +142,7 @@ struct SpellFxRenderer {
     /**
      * @offset 0x4A7E89
      */
-    void sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse);
+    void sparklesOnActorAfterItCastsBuff(Actor *pActor, uint32_t uDiffuse);
     void _4A7F74(int x, int y, int z);
     float _4A806F_get_mass_distortion_value(Actor *pActor);
     // void _4A80DC_implosion_particle_sw(struct SpriteObject *a2);

--- a/src/Engine/SpellFxRenderer.h
+++ b/src/Engine/SpellFxRenderer.h
@@ -62,13 +62,11 @@ struct SpellFX_Billboard {
 /*  122 */
 #pragma pack(push, 1)
 struct PlayerBuffAnim {
-    inline PlayerBuffAnim() : bRender(false), field_2(0), uSpellAnimTimeElapsed(0), uSpellAnimTime(0), uSpellIconID(0) {}
-
-    int16_t bRender;
-    int16_t field_2;
-    int uSpellAnimTimeElapsed;
-    int uSpellAnimTime;
-    int uSpellIconID;
+    int16_t bRender = false;
+    int16_t field_2 = 0;
+    int uSpellAnimTimeElapsed = 0;
+    int uSpellAnimTime = 0;
+    int uSpellIconID = 0;
 };
 #pragma pack(pop)
 
@@ -141,6 +139,9 @@ struct SpellFxRenderer {
         SpriteObject *a1, unsigned int uDiffuse, Texture *texture, float a4);
     void _4A7C07_stun_spell_fx(struct SpriteObject *a2);
     void AddProjectile(struct SpriteObject *a2, int a3, Texture *);
+    /**
+     * @offset 0x4A7E89
+     */
     void sparklesOnActorAfterItCastsBuff(Actor *pActor, unsigned int uDiffuse);
     void _4A7F74(int x, int y, int z);
     float _4A806F_get_mass_distortion_value(Actor *pActor);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -542,7 +542,7 @@ void CastSpellInfoHelpers::castSpell() {
                         pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
                         pActors[monster_id].vVelocity.x = 0;
                         pActors[monster_id].vVelocity.y = 0;
-                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                        spell_fx_renderer->sparklesOnActorAfterItCastsBuff(&pActors[monster_id], 0);
                     }
                     break;
                 }
@@ -577,7 +577,7 @@ void CastSpellInfoHelpers::castSpell() {
                     if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage(DMGT_EARTH)) {
                         pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
                         pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                        spell_fx_renderer->sparklesOnActorAfterItCastsBuff(&pActors[monster_id], 0);
                     }
                     break;
                 }
@@ -1695,7 +1695,7 @@ void CastSpellInfoHelpers::castSpell() {
                         pActors[monster_id].pActorBuffs[ACTOR_BUFF_FATE]
                             .Apply(pParty->GetPlayingTime() + GameTime::FromMinutes(5), spell_mastery, spell_power, 0, 0);
                         pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
-                        spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
+                        spell_fx_renderer->sparklesOnActorAfterItCastsBuff(&pActors[monster_id], 0);
                     }
                     break;
                 }

--- a/src/Utility/Color.h
+++ b/src/Utility/Color.h
@@ -87,7 +87,10 @@ class ColorTable {
     Color NeonGreen = Color(30, 255, 30);         // #1EFF1E
     Color Mahogany = Color(192, 64, 0);           // #C04000
     Color Tawny = Color(200, 100, 0);             // #C86400
-    Color TealMask = Color(0, 255, 255);          // #00FCF8;
+    Color TealMask = Color(0, 255, 255);          // #00FCF8
+    Color Cioccolato = Color(92, 49, 14);         // #5C310E
+    Color JazzberryJam = Color(168, 19, 118);     // #A81376
+    Color RioGrande = Color(200, 200, 5);         // #C8C805
 };
 
 extern ColorTable colorTable;


### PR DESCRIPTION
Partial refactor of ParticlesEngine functions as well as function SpellFxRenderer::_4A7E89_sparkles_on_actor_after_it_casts_buff.
This refactor fixed #453.
Main source of problem in that bug was vrng->Random function which returns type unsigned int. When this function directly used in math calculation with conversion to float, there may be case when it's result is substracted with something and result wraps around 32-bit and then converted to float also with unsigned semantics.