### PR TITLE
Fix experience gain when learning skill is not present

### DIFF
--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -996,9 +996,10 @@ int Player::GetDisarmTrap() {
 
 char Player::GetLearningPercent() {
     PLAYER_SKILL_LEVEL skill = GetActualSkillLevel(PLAYER_SKILL_LEARNING);
-    int multiplier = GetMultiplierForSkillLevel(PLAYER_SKILL_LEARNING, 1, 2, 3, 5);
 
     if (skill) {
+        int multiplier = GetMultiplierForSkillLevel(PLAYER_SKILL_LEARNING, 1, 2, 3, 5);
+
         return multiplier * skill + 9;
     } else {
         return 0;

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -994,13 +994,15 @@ int Player::GetDisarmTrap() {
     return multiplier * skill;
 }
 
-//----- (00491317) --------------------------------------------------------
 char Player::GetLearningPercent() {
     PLAYER_SKILL_LEVEL skill = GetActualSkillLevel(PLAYER_SKILL_LEARNING);
-    int multiplier =
-        GetMultiplierForSkillLevel(PLAYER_SKILL_LEARNING, 1, 2, 3, 5);
+    int multiplier = GetMultiplierForSkillLevel(PLAYER_SKILL_LEARNING, 1, 2, 3, 5);
 
-    return multiplier * skill + 9;
+    if (skill) {
+        return multiplier * skill + 9;
+    } else {
+        return 0;
+    }
 }
 
 //----- (0048C855) --------------------------------------------------------

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -264,6 +264,12 @@ struct Player {
     int GetMerchant();
     int GetPerception();
     int GetDisarmTrap();
+
+    /**
+     * Get percentage bonus for character EXP received.
+     *
+     * @offset 0x491317
+     */
     char GetLearningPercent();
     bool CanFitItem(unsigned int uSlot, ITEM_TYPE uItemID);
     int FindFreeInventoryListSlot();

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -1068,10 +1068,7 @@ void Party::GivePartyExp(unsigned int pEXPNum) {
         if (pActivePlayerCount) {
             pEXPNum = pEXPNum / pActivePlayerCount;
             for (uint i = 0; i < 4; ++i) {
-                if (!pParty->pPlayers[i].conditions.Has(Condition_Unconscious) &&
-                    !pParty->pPlayers[i].conditions.Has(Condition_Dead) &&
-                    !pParty->pPlayers[i].conditions.Has(Condition_Petrified) &&
-                    !pParty->pPlayers[i].conditions.Has(Condition_Eradicated)) {
+                if (pParty->pPlayers[i].conditions.HasNone({Condition_Unconscious, Condition_Dead, Condition_Petrified, Condition_Eradicated})) {
                     pLearningPercent = pParty->pPlayers[i].GetLearningPercent();
                     playermodexp = pEXPNum + pEXPNum * pLearningPercent / 100;
                     pParty->pPlayers[i].uExperience += playermodexp;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -18,7 +18,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG c848b554e39d6cf51c9e5cabd4e3407c32ffa4f6
+        GIT_TAG 5e8d109842994797a331cdac5140cd54494e3b0d
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -337,7 +337,7 @@ GAME_TEST(Issue, Issue331) {
     test->playTraceFromTestData("issue_331.mm7", "issue_331.json");
 }
 
-static void check395res( std::initializer_list<std::pair<int, int>> playerexppairs) {
+static void check395exp( std::initializer_list<std::pair<int, int>> playerexppairs) {
     for (auto pair : playerexppairs) {
         EXPECT_EQ(pParty->pPlayers[pair.first].uExperience, pair.second);
     }
@@ -345,6 +345,6 @@ static void check395res( std::initializer_list<std::pair<int, int>> playerexppai
 
 GAME_TEST(Issue, Issue395) {
     // Check that learning skill works as intended
-    test->playTraceFromTestData("issue_395.mm7", "issue_395.json");
-    check395res({ {0, 214}, {1, 228}, {2, 237}, {3, 258} });
+    test->playTraceFromTestData("issue_395.mm7", "issue_395.json", []() { check395exp({ {0, 100}, {1, 100}, {2, 100}, {3, 100} }); });
+    check395exp({ {0, 214}, {1, 228}, {2, 237}, {3, 258} });
 }

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -336,3 +336,15 @@ GAME_TEST(Issue, Issue331) {
     // Assert when traveling by horse caused by out of bound access to pObjectList->pObjects
     test->playTraceFromTestData("issue_331.mm7", "issue_331.json");
 }
+
+static void check395res( std::initializer_list<std::pair<int, int>> playerexppairs) {
+    for (auto pair : playerexppairs) {
+        EXPECT_EQ(pParty->pPlayers[pair.first].uExperience, pair.second);
+    }
+}
+
+GAME_TEST(Issue, Issue395) {
+    // Check that learning skill works as intended
+    test->playTraceFromTestData("issue_395.mm7", "issue_395.json");
+    check395res({ {0, 214}, {1, 228}, {2, 237}, {3, 258} });
+}


### PR DESCRIPTION
Fix #395.
When character have no learning skill exp bonus must be 0.