### PR TITLE
Fix Water Walk and Fly mana draining

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -157,6 +157,10 @@ namespace Application {
                                     "Treat clubs as maces. "
                                     "In vanilla clubs are using a separate hidden skill and can be equipped without learning the mace skill."};
 
+            Bool FixWaterWalkManaDrain = {this, "fix_water_walk_mana_drain", true,
+                                          "Fix water walk mana drain interval. "
+                                          "In vanilla water walk drains mana every 5 minutes but spell description says that mana drains every 20 minutes."};
+
          private:
             static int ValidateMaxFlightHeight(int max_flight_height) {
                 if (max_flight_height <= 0 || max_flight_height > 16192)

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -158,8 +158,8 @@ namespace Application {
                                     "In vanilla clubs are using a separate hidden skill and can be equipped without learning the mace skill."};
 
             Bool FixWaterWalkManaDrain = {this, "fix_water_walk_mana_drain", true,
-                                          "Fix water walk mana drain interval. "
-                                          "In vanilla water walk drains mana every 5 minutes but spell description says that mana drains every 20 minutes."};
+                                          "Change water walk mana drain interval to 20 minutes. "
+                                          "Spell description says that mana is drained every 20 minutes, but in vanilla, it was every 5 minutes."};
 
          private:
             static int ValidateMaxFlightHeight(int max_flight_height) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1738,9 +1738,7 @@ void RegeneratePartyHealthMana() {
         return;
     }
 
-    bool is_5min_boundary = (cur_minutes % 5) == 0;
-
-    if (is_5min_boundary) {
+    if ((cur_minutes % 5) == 0) {
         //int times_triggered = (current_time - last_reg_time) / 5;
 
         // TODO: actually this looks like it never triggers.

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -235,7 +235,7 @@ void SetDecorationSprite(uint16_t uCog, bool bHide,
 void _494035_timed_effects__water_walking_damage__etc();
 
 /**
- * Modify party health of mana based on party or players conditions/buffs.
+ * Modify party health or mana based on party or players conditions/buffs.
  *
  * @offset 0x00493938.
  */

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -235,6 +235,8 @@ void SetDecorationSprite(uint16_t uCog, bool bHide,
 void _494035_timed_effects__water_walking_damage__etc();
 
 /**
+ * Modify party health of mana based on party or players conditions/buffs.
+ *
  * @offset 0x00493938.
  */
 void RegeneratePartyHealthMana();

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1929,7 +1929,7 @@ void ODM_ProcessPartyActions() {
         bWaterWalk = true;
         *(short *)&stru_5E4C90_MapPersistVars._decor_events
              [20 * pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uOverlayID + 119] |= 1;
-        if (!(pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags & 1) &&
+        if (!pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGMBuff &&
             pParty->pPlayers[pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uCaster - 1].sMana <= 0)
             bWaterWalk = false;
     }
@@ -2032,7 +2032,7 @@ void ODM_ProcessPartyActions() {
 
                 pParty->bFlying = false;
                 if (engine->IsUnderwater() ||
-                    pParty->pPartyBuffs[PARTY_BUFF_FLY].uFlags & 1 ||
+                    pParty->pPartyBuffs[PARTY_BUFF_FLY].isGMBuff ||
                     (pParty->pPlayers[pParty->pPartyBuffs[PARTY_BUFF_FLY].uCaster - 1].sMana > 0 ||
                     engine->config->debug.AllMagic.Get())) {
                     if (pParty->vPosition.z < engine->config->gameplay.MaxFlightHeight.Get() || hovering) {
@@ -2070,7 +2070,7 @@ void ODM_ProcessPartyActions() {
                 if (pParty->FlyActive() || engine->IsUnderwater()) {
                     pParty->bFlying = false;
                     if (engine->IsUnderwater() ||
-                        pParty->pPartyBuffs[PARTY_BUFF_FLY].uFlags & 1 ||
+                        pParty->pPartyBuffs[PARTY_BUFF_FLY].isGMBuff ||
                         (pParty->pPlayers[pParty->pPartyBuffs[PARTY_BUFF_FLY].uCaster - 1].sMana > 0 ||
                         engine->config->debug.AllMagic.Get())) {
                         // *(int *)&pParty->pArtifactsFound[6972 *

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -1262,20 +1262,19 @@ int UseNPCSkill(NPCProf profession) {
                 pAudioPlayer->PlaySound(SOUND_fizzle, 0, 0, -1, 0, 0);
             } else {
                 int v19 = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
-                pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
-                    GameTime(pParty->GetPlayingTime() + GameTime::FromHours(2)), PLAYER_SKILL_MASTERY_MASTER, 1,
-                    v19, 0);
-                pParty->pPartyBuffs[PARTY_BUFF_FLY].uFlags |= 1;
+                // Spell power was changed to 0 because it does not have meaning for this buff
+                pParty->pPartyBuffs[PARTY_BUFF_FLY]
+                    .Apply(pParty->GetPlayingTime() + GameTime::FromHours(2), PLAYER_SKILL_MASTERY_MASTER, 0, v19, 0);
+                pParty->pPartyBuffs[PARTY_BUFF_FLY].isGMBuff = true;
                 pAudioPlayer->PlaySound(SOUND_21fly03, 0, 0, -1, 0, 0);
             }
         } break;
 
         case WaterMaster: {
             int v20 = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
-            pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].Apply(
-                GameTime(pParty->GetPlayingTime() + GameTime::FromHours(3)), PLAYER_SKILL_MASTERY_MASTER, 0, v20,
-                0);
-            pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags |= 1;
+            pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK]
+                .Apply(pParty->GetPlayingTime() + GameTime::FromHours(3), PLAYER_SKILL_MASTERY_MASTER, 0, v20, 0);
+            pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGMBuff = true;
             pAudioPlayer->PlaySound(SOUND_WaterWalk, 0, 0, -1, 0, 0);
         } break;
 

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -1265,6 +1265,7 @@ int UseNPCSkill(NPCProf profession) {
                 // Spell power was changed to 0 because it does not have meaning for this buff
                 pParty->pPartyBuffs[PARTY_BUFF_FLY]
                     .Apply(pParty->GetPlayingTime() + GameTime::FromHours(2), PLAYER_SKILL_MASTERY_MASTER, 0, v19, 0);
+                // Mark buff as GM because NPC buff does not drain mana
                 pParty->pPartyBuffs[PARTY_BUFF_FLY].isGMBuff = true;
                 pAudioPlayer->PlaySound(SOUND_21fly03, 0, 0, -1, 0, 0);
             }
@@ -1274,6 +1275,7 @@ int UseNPCSkill(NPCProf profession) {
             int v20 = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
             pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK]
                 .Apply(pParty->GetPlayingTime() + GameTime::FromHours(3), PLAYER_SKILL_MASTERY_MASTER, 0, v20, 0);
+            // Mark buff as GM because NPC buff does not drain mana
             pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGMBuff = true;
             pAudioPlayer->PlaySound(SOUND_WaterWalk, 0, 0, -1, 0, 0);
         } break;

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -7954,7 +7954,7 @@ Player::Player() {
         pPlayerBuffs[i].uPower = 0;
         pPlayerBuffs[i].expire_time.Reset();
         pPlayerBuffs[i].uCaster = 0;
-        pPlayerBuffs[i].uFlags = 0;
+        pPlayerBuffs[i].isGMBuff = 0;
     }
 
     pName[0] = 0;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -293,7 +293,7 @@ struct Party {
     int jump_strength; // jump strength, higher value => higher jumps, default 5.
     int field_28_set0_unused;
     GameTime playing_time;  // uint64_t uTimePlayed;
-    GameTime last_regenerated;
+    GameTime last_regenerated; // Timestamp when HP/MP regeneration was checked last time (using 5 minutes granularity)
     PartyTimeStruct PartyTimes;
     Vec3i vPosition;
     int sRotationZ;

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -199,7 +199,7 @@ void Serialize(const SpellBuff &src, SpellBuff_MM7 *dst) {
     dst->uSkillMastery = std::to_underlying(src.uSkillMastery);
     dst->uOverlayID = src.uOverlayID;
     dst->uCaster = src.uCaster;
-    dst->uFlags = src.uFlags;
+    dst->uFlags = src.isGMBuff;
 }
 
 void Deserialize(const SpellBuff_MM7 &src, SpellBuff *dst) {
@@ -208,7 +208,7 @@ void Deserialize(const SpellBuff_MM7 &src, SpellBuff *dst) {
     dst->uSkillMastery = PLAYER_SKILL_MASTERY(src.uSkillMastery);
     dst->uOverlayID = src.uOverlayID;
     dst->uCaster = src.uCaster;
-    dst->uFlags = src.uFlags;
+    dst->isGMBuff = src.uFlags;
 }
 
 void Serialize(const ItemGen &src, ItemGen_MM7 *dst) {

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1148,15 +1148,15 @@ void CastSpellInfoHelpers::castSpell() {
                         spellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         continue;
                     }
-                    int mana_drain = (spell_mastery < PLAYER_SKILL_MASTERY_GRANDMASTER) ? 1 : 0;
                     for (size_t i = 0; i < pParty->pPlayers.size(); i++) {
                         pOtherOverlayList->_4418B1(2090, i + 100, 0, 65536);
                     }
                     int spell_overlay_id = pOtherOverlayList->_4418B1(10008, 203, 0, 65536);
                     pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
                             pParty->GetPlayingTime() + GameTime::FromHours(spell_level),
-                            spell_mastery, mana_drain, spell_overlay_id,
+                            spell_mastery, 0, spell_overlay_id,
                             pCastSpell->uPlayerID + 1);
+                    pParty->pPartyBuffs[PARTY_BUFF_FLY].isGMBuff = (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER);
                     break;
                 }
 
@@ -1332,14 +1332,11 @@ void CastSpellInfoHelpers::castSpell() {
                             assert(false);
                     }
 
-                    int mana_drain = (spell_mastery < PLAYER_SKILL_MASTERY::PLAYER_SKILL_MASTERY_GRANDMASTER) ? 1 : 0;
                     int spell_overlay_id = pOtherOverlayList->_4418B1(10005, 201, 0, 65536);
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, mana_drain, spell_overlay_id, pCastSpell->uPlayerID + 1);
-                    if (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) {
-                        pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].uFlags = 1;
-                    }
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, spell_overlay_id, pCastSpell->uPlayerID + 1);
+                    pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGMBuff = (spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER);
                     break;
                 }
 

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -391,7 +391,7 @@ void SpellBuff::Reset() {
     uPower = 0;
     expire_time.Reset();
     uCaster = 0;
-    uFlags = 0;
+    isGMBuff = false;
     if (uOverlayID) {
         pOtherOverlayList->pOverlays[uOverlayID - 1].Reset();
         uOverlayID = 0;

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -238,7 +238,7 @@ struct SpellBuff {
     PLAYER_SKILL_MASTERY uSkillMastery = PLAYER_SKILL_MASTERY_NONE; // 1-4, normal to grandmaster.
     uint16_t uOverlayID = 0;
     uint8_t uCaster = 0;
-    uint8_t uFlags = 0; // 0x1 => cast at grandmaster.
+    bool isGMBuff = false; // Buff was casted at grandmaster mastery
 };
 #pragma pack(pop)
 

--- a/src/Engine/Time.h
+++ b/src/Engine/Time.h
@@ -36,8 +36,8 @@ struct GameTime {
     int GetYears() const { return this->GetMonths() / 12; }
 
     int GetSecondsFraction() const { return this->GetSeconds() % 60; }
-    int GetMinutesFraction() const { return (this->GetSeconds() / 60) % 60; }
-    int GetHoursOfDay() const { return (this->GetSeconds() / 3600) % 24; }
+    int GetMinutesFraction() const { return this->GetMinutes() % 60; }
+    int GetHoursOfDay() const { return this->GetHours() % 24; }
     int GetDaysOfWeek() const { return this->GetDays() % 7; }
     int GetDaysOfMonth() const { return this->GetDays() % 28; }
     int GetWeeksOfMonth() const { return this->GetWeeks() % 4; }
@@ -71,6 +71,10 @@ struct GameTime {
     }
     GameTime &operator+=(GameTime &rhs) {
         this->value += rhs.value;
+        return *this;
+    }
+    GameTime &operator-=(GameTime &rhs) {
+        this->value -= rhs.value;
         return *this;
     }
 

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2294,7 +2294,6 @@ std::array<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL_L
 }};
 std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX = {{489, 559}};
 std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY = {{152, 152}};
-//std::array<int, 2> Party_Spec_Motion_status_ids = {{7, 18}};  // dword_4EE07C
 std::array<short, 28> word_4EE150 = {{1,  2,  3,  4,  5,  7,  32, 33, 36, 37,
                                       38, 40, 41, 42, 43, 45, 46, 47, 48, 49,
                                       50, 51, 52, 53, 54, 55, 56, 60}};

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2294,7 +2294,7 @@ std::array<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL_L
 }};
 std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX = {{489, 559}};
 std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY = {{152, 152}};
-std::array<int, 2> Party_Spec_Motion_status_ids = {{7, 18}};  // dword_4EE07C
+//std::array<int, 2> Party_Spec_Motion_status_ids = {{7, 18}};  // dword_4EE07C
 std::array<short, 28> word_4EE150 = {{1,  2,  3,  4,  5,  7,  32, 33, 36, 37,
                                       38, 40, 41, 42, 43, 45, 46, 47, 48, 49,
                                       50, 51, 52, 53, 54, 55, 56, 60}};

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -94,7 +94,6 @@ extern std::array<IndexedArray<CLASS_SKILL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAS
 extern std::array<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST>, 36> byte_4ED970_skill_learn_ability_by_class_table;
 extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX;
 extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY;
-//extern std::array<int, 2> Party_Spec_Motion_status_ids;  // dword_4EE07C
 extern std::array<short, 28> word_4EE150;
 extern int16_t word_4F0576[];
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -94,7 +94,7 @@ extern std::array<IndexedArray<CLASS_SKILL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAS
 extern std::array<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST>, 36> byte_4ED970_skill_learn_ability_by_class_table;
 extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX;
 extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY;
-extern std::array<int, 2> Party_Spec_Motion_status_ids;  // dword_4EE07C
+//extern std::array<int, 2> Party_Spec_Motion_status_ids;  // dword_4EE07C
 extern std::array<short, 28> word_4EE150;
 extern int16_t word_4F0576[];
 


### PR DESCRIPTION
Fix #441.
This fix retains vailla behaviour where all HP/MP changes over time happen on 5-minute boundary of game time.
Also integrate fix of vanilla bug where mana for Water Walk was draining with the same speed as Fly (1 MP every 5 minutes). Spell description says that draining speed is 1 MP every 20 minutes.
This fix is configurable with "fix_water_walk_mana_drain" entry.