### PR TITLE
Fix #490

### DIFF
--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1268,30 +1268,22 @@ void CastSpellInfoHelpers::castSpell() {
                         default:
                             assert(false);
                     }
+                    initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
+                    pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
+                    pSpellSprite.spell_target_pid = spell_targeted_at;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
+                    if (pParty->bTurnBasedModeOn) {
+                        pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
+                    }
                     int spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
                     if (shots_num == 1) {
-                        initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                         pSpellSprite.uFacing = target_direction.uYawAngle;
-                        if (pParty->bTurnBasedModeOn) {
-                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                        }
                         if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, spell_speed, pCastSpell->uPlayerID + 1) != -1 &&
                                 pParty->bTurnBasedModeOn) {
                             ++pTurnEngine->pending_actions;
                         }
                     } else {
-                        initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                        pSpellSprite.vPosition = pParty->vPosition + Vec3i(0, 0, pParty->uPartyHeight / 3);
-                        pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
-                        pSpellSprite.spell_target_pid = spell_targeted_at;
-                        pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
-                        if (pParty->bTurnBasedModeOn) {
-                            pSpellSprite.uAttributes |= SPRITE_HALT_TURN_BASED;
-                        }
                         int spell_spray_angle_start = ONE_THIRD_PI / -2;
                         int spell_spray_angle_end = ONE_THIRD_PI / 2;
                         if (spell_spray_angle_start <= spell_spray_angle_end) {

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -18,7 +18,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG ccb524195783b3c73b68436daf073d2f76a4169d
+        GIT_TAG c7dfdac25bd1fb2c57869d04a9a7f3ce0310b713
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -376,3 +376,9 @@ GAME_TEST(Issue, Issue395) {
     test->playTraceFromTestData("issue_395.mm7", "issue_395.json", []() { check395exp({ {0, 100}, {1, 100}, {2, 100}, {3, 100} }); });
     check395exp({ {0, 214}, {1, 228}, {2, 237}, {3, 258} });
 }
+
+GAME_TEST(Issue, Issue490) {
+    // Check that Poison Spray sprites are moving and doing damage
+    test->playTraceFromTestData("issue_490.mm7", "issue_490.json", []() { EXPECT_EQ(pParty->pPlayers[0].uExperience, 279); });
+    EXPECT_EQ(pParty->pPlayers[0].uExperience, 285);
+}


### PR DESCRIPTION
In the process of refactoring the statement of getting spell speed for sprite creation was placed before spell sprite initialization and setting uObjectDescID which is used for getting spell speed.