### PR TITLE
Fix #491

### DIFF
--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -289,7 +289,6 @@ void CastSpellInfoHelpers::castSpell() {
                 LloydsBeaconSpellDuration = GameTime::FromDays(7 * spell_level).GetSeconds();
                 LloydsBeaconSpellId = pCastSpell->uSpellID;
                 pCastSpell->uFlags |= ON_CAST_NoRecoverySpell;
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
             } else {
                 pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
                 pCastSpell->uSpellID = SPELL_NONE;

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -382,3 +382,8 @@ GAME_TEST(Issue, Issue490) {
     test->playTraceFromTestData("issue_490.mm7", "issue_490.json", []() { EXPECT_EQ(pParty->pPlayers[0].uExperience, 279); });
     EXPECT_EQ(pParty->pPlayers[0].uExperience, 285);
 }
+
+GAME_TEST(Issue, Issue491) {
+    // Check that opening and closing Lloyd book does not cause Segmentation Fault
+    test->playTraceFromTestData("issue_491.mm7", "issue_491.json");
+}


### PR DESCRIPTION
Fix #491.
Duplicated event message UIMSG_OnCastLloydsBeacon in cast spell processing caused the SIGSEGV.