### PR TITLE
Rename and enable actually swapping event queues

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2503,6 +2503,7 @@ void Game::EventLoop() {
     }
 
     std::swap(pCurrentFrameMessageQueue, pNextFrameMessageQueue);
+    assert(pNextFrameMessageQueue->Empty());
 
     if (GateMasterEventId != UIMSG_0) {
         pCurrentFrameMessageQueue->AddGUIMessage(GateMasterEventId, (int64_t)GateMasterNPCData, 0);

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -375,7 +375,7 @@ Image *gamma_preview_image = nullptr;  // 506E40
 
 void Game_StartDialogue(unsigned int actor_id) {
     if (uActiveCharacter) {
-        pMessageQueue_50CBD0->Flush();
+        pCurrentFrameMessageQueue->Flush();
 
         dword_5B65D0_dialogue_actor_npc_id = pActors[actor_id].sNPC_ID;
         GameUI_InitializeDialogue(&pActors[actor_id], true);
@@ -385,7 +385,7 @@ void Game_StartDialogue(unsigned int actor_id) {
 void Game_StartHirelingDialogue(unsigned int hireling_id) {
     if (bNoNPCHiring || current_screen_type != CURRENT_SCREEN::SCREEN_GAME) return;
 
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
 
     FlatHirelings buf;
     buf.Prepare();
@@ -545,14 +545,14 @@ void Game::EventLoop() {
         GameUI_InitializeDialogue(&actor, false);
         bDialogueUI_InitializeActor_NPC_ID = 0;
     }
-    if (!pMessageQueue_50CBD0->Empty()) {
+    if (!pCurrentFrameMessageQueue->Empty()) {
         // v1 = "";
         while (2) {
-            if (pMessageQueue_50CBD0->Empty()) {
+            if (pCurrentFrameMessageQueue->Empty()) {
                 break;
             }
 
-            pMessageQueue_50CBD0->PopMessage(&uMessage, &uMessageParam,
+            pCurrentFrameMessageQueue->PopMessage(&uMessage, &uMessageParam,
                                              (int *)&v199);
             switch (uMessage) {
                 case UIMSG_ChangeGameState:
@@ -604,10 +604,10 @@ void Game::EventLoop() {
                     new OnCancel({350, 302}, {106, 42}, pBtnCancel);
                     continue;
                 case UIMSG_OpenQuestBook:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_QuestBook) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -623,10 +623,10 @@ void Game::EventLoop() {
                     pGUIWindow_CurrentMenu = new GUIWindow_QuestBook();
                     continue;
                 case UIMSG_OpenAutonotes:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_AutonotesBook) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -642,10 +642,10 @@ void Game::EventLoop() {
                     pGUIWindow_CurrentMenu = new GUIWindow_AutonotesBook();
                     continue;
                 case UIMSG_OpenMapBook:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_MapsBook) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -661,10 +661,10 @@ void Game::EventLoop() {
                     pGUIWindow_CurrentMenu = new GUIWindow_MapBook();
                     continue;
                 case UIMSG_OpenCalendar:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_CalendarBook) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -680,10 +680,10 @@ void Game::EventLoop() {
                     pGUIWindow_CurrentMenu = new GUIWindow_CalendarBook();
                     continue;
                 case UIMSG_OpenHistoryBook:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_JournalBook) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -699,7 +699,7 @@ void Game::EventLoop() {
                     pGUIWindow_CurrentMenu = new GUIWindow_JournalBook();
                     continue;
                 case UIMSG_OpenDebugMenu:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_DEBUG) {
                         back_to_game();
                         OnEscape();
@@ -713,7 +713,7 @@ void Game::EventLoop() {
                     continue;
                 case UIMSG_Escape:  // нажатие Escape and return to game
                     back_to_game();
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     switch (current_screen_type) {
                         case CURRENT_SCREEN::SCREEN_E:
                             __debugbreak();
@@ -753,7 +753,7 @@ void Game::EventLoop() {
                             dword_6BE138 = -1;
                             new OnButtonClick2({602, 450}, {0, 0}, pBtn_GameSettings, std::string(), false);
 
-                            pMessageQueue_50CBD0->Flush();
+                            pCurrentFrameMessageQueue->Flush();
                             menu->MenuLoop();
                         } else {
                             pGUIWindow_CastTargetedSpell->Release();
@@ -988,7 +988,7 @@ void Game::EventLoop() {
                     continue;
 
                 case UIMSG_TransitionUI_Confirm:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     dword_50CDC8 = 1;
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, PID_INVALID, 0, -1, 0, 0);
 
@@ -1059,7 +1059,7 @@ void Game::EventLoop() {
                     uActiveCharacter = CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled());
                     continue;
                 case UIMSG_OnTravelByFoot:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     dword_50CDC8 = 1;
 
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
@@ -1242,7 +1242,7 @@ void Game::EventLoop() {
                                                                  // upgrade)
                 case UIMSG_CastSpell_Character_Small_Improvement:  // Fate, cure
                 case UIMSG_HiredNPC_CastSpell:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     if (IsEnchantingInProgress) {
                         uActiveCharacter = uMessageParam;
                     } else {
@@ -1300,7 +1300,7 @@ void Game::EventLoop() {
                             v55 | Party_Teleport_Y_Pos | v56 | v57;
                     }
                     HouseDialogPressCloseBtn();
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                     continue;
 
                 case UIMSG_OnCastTownPortal:
@@ -1354,7 +1354,7 @@ void Game::EventLoop() {
                 }
                 case UIMSG_CloseAfterInstallBeacon:
                     dword_50CDC8 = 1;
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                     continue;
                 case UIMSG_InstallBeacon:
                     pPlayer9 = pPlayers[CurrentLloydPlayerID + 1];
@@ -1396,7 +1396,7 @@ void Game::EventLoop() {
                             pParty->sRotationZ = pPlayer9->vBeacons[uMessageParam].PartyRot_X;
                             pParty->sRotationY = pPlayer9->vBeacons[uMessageParam].PartyRot_Y;
                         }
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                         pGUIWindow_CurrentMenu->Release();
                         pGUIWindow_CurrentMenu = 0;
                     } else {
@@ -1460,7 +1460,7 @@ void Game::EventLoop() {
                     }
 
                     pParty->pPlayers[(uint8_t)TownPortalCasterId].SpendMana(0x14u);
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                     continue;
                 case UIMSG_HintTownPortal: {
                     std::string v69;
@@ -1739,10 +1739,10 @@ void Game::EventLoop() {
                     pParty->pPlayers[0].SetAsleep(GameTime(1));
                     continue;
                 case UIMSG_RestWindow:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     //if (current_screen_type == CURRENT_SCREEN::SCREEN_REST) {
-                    //    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                    //    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                     //    continue;
                     //}
                     if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) continue;
@@ -1794,7 +1794,7 @@ void Game::EventLoop() {
                     pPlayers[uActiveCharacter]->PlaySound(SPEECH_CantRestHere, 0);
                     continue;
                 case UIMSG_Rest8Hour:
-                    pMessageQueue_50CBD0->Clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
+                    pCurrentFrameMessageQueue->Clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
                     if (_506F14_resting_stage != 0) {
                         GameUI_SetStatusBar(LSTR_ALREADY_RESTING);
                         pAudioPlayer->PlaySound(SOUND_error, 0, 0, -1, 0, 0);
@@ -1834,7 +1834,7 @@ void Game::EventLoop() {
                                 _506F18_num_minutes_to_sleep = 0;
                                 _506F14_resting_stage = 0;
 
-                                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                                 GameUI_SetStatusBar(LSTR_ENCOUNTER);
                                 pAudioPlayer->PlaySound(SOUND_encounter, 0, 0, -1, 0, 0);
                                 continue;
@@ -1988,10 +1988,10 @@ void Game::EventLoop() {
                             dword_50C9E8 + 2] = uActiveCharacter - 1;
                             ++dword_50C9E8;
                             }*/
-                            pMessageQueue_50C9E8->AddGUIMessage(
-                                UIMSG_CastSpellFromBook, v103,
-                                uActiveCharacter - 1);
-                            //  pMessageQueue_50CBD0->AddGUIMessage(UIMSG_CastSpellFromBook,
+                            // Processing must happen on next frame because need to close spell book and update
+                            // drawing object list which is used to count actors for some spells
+                            pNextFrameMessageQueue->AddGUIMessage( UIMSG_CastSpellFromBook, v103, uActiveCharacter - 1);
+                            //  pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastSpellFromBook,
                             //  v103, uActiveCharacter - 1);
                         } else {
                             byte_506550 = 1;
@@ -2019,11 +2019,11 @@ void Game::EventLoop() {
                         GameUI_SetStatusBar(LSTR_CANT_DO_UNDERWATER);
                         pAudioPlayer->PlaySound(SOUND_error, 0, 0, -1, 0, 0);
                     } else {
-                        pMessageQueue_50CBD0->Flush();
+                        pCurrentFrameMessageQueue->Flush();
                         if (uActiveCharacter && !pPlayers[uActiveCharacter]->uTimeToRecovery) {
                             // toggle
                             if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) {
-                                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                                 continue;
                             }
                             // cant open screen - talking or in shop or map transition
@@ -2043,10 +2043,10 @@ void Game::EventLoop() {
                     }
                     continue;
                 case UIMSG_QuickReference:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // toggle
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_QUICK_REFERENCE) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                         continue;
                     }
                     // cant open screen - talking or in shop or map transition
@@ -2078,17 +2078,17 @@ void Game::EventLoop() {
 
                     new OnButtonClick({602, 450}, {0, 0}, pBtn_GameSettings);
                     // LABEL_453:
-                    /*if ( (signed int)pMessageQueue_50CBD0->uNumMessages >= 40
+                    /*if ( (signed int)pCurrentFrameMessageQueue->uNumMessages >= 40
                     ) continue;
-                    pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].eType
+                    pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].eType
                     = UIMSG_Escape;
                     //goto LABEL_770;
-                    pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].param
+                    pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].param
                     = 0;
-                    *(&pMessageQueue_50CBD0->uNumMessages + 3 *
-                    pMessageQueue_50CBD0->uNumMessages + 3) = 0;
-                    ++pMessageQueue_50CBD0->uNumMessages;*/
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                    *(&pCurrentFrameMessageQueue->uNumMessages + 3 *
+                    pCurrentFrameMessageQueue->uNumMessages + 3) = 0;
+                    ++pCurrentFrameMessageQueue->uNumMessages;*/
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
                     continue;
                 case UIMSG_ClickAwardScrollBar: {
                     books_page_number = 1;
@@ -2196,7 +2196,7 @@ void Game::EventLoop() {
                     new OnButtonClick({pButton->uX, pButton->uY}, {0, 0}, pButton, std::string(), false);
                     continue;
                 case UIMSG_SelectCharacter:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     GameUI_OnPlayerPortraitLeftClick(uMessageParam);
                     continue;
                 case UIMSG_ShowStatus_Funds: {
@@ -2270,14 +2270,14 @@ void Game::EventLoop() {
                     pPlayers[uActiveCharacter]->OnInventoryLeftClick();
                     continue;
                 case UIMSG_MouseLeftClickInGame:
-                    pMessageQueue_50CBD0->Flush();
-                    pMessageQueue_50CBD0->AddGUIMessage(
+                    pCurrentFrameMessageQueue->Flush();
+                    pCurrentFrameMessageQueue->AddGUIMessage(
                         UIMSG_MouseLeftClickInScreen, 0, 0);
                     continue;
                 case UIMSG_MouseLeftClickInScreen:  // срабатывает при нажатии на
                                                     // правую кнопку мыши после
                                                     // UIMSG_MouseLeftClickInGame
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     engine->OnGameViewportClick();
                     continue;
                 case UIMSG_F:  // what event?
@@ -2291,7 +2291,7 @@ void Game::EventLoop() {
                     __debugbreak();  // GUIWindow::Create(0, 0, 0, 0, WINDOW_22, (int)pButton2, 0);
                     continue;
                 case UIMSG_Game_Action:
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
                     // if currently in a chest
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
                         Chest::GrabItem(keyboardInputHandler->IsTakeAllToggled());
@@ -2502,17 +2502,16 @@ void Game::EventLoop() {
         }
     }
 
-    pMessageQueue_50CBD0 = pMessageQueue_50C9E8;
-    pMessageQueue_50C9E8->Clear();
+    std::swap(pCurrentFrameMessageQueue, pNextFrameMessageQueue);
 
     if (GateMasterEventId != UIMSG_0) {
-        pMessageQueue_50CBD0->AddGUIMessage(GateMasterEventId, (int64_t)GateMasterNPCData, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(GateMasterEventId, (int64_t)GateMasterNPCData, 0);
         GateMasterEventId = UIMSG_0;
     } else {
         if (AfterEnchClickEventId != UIMSG_0) {
             AfterEnchClickEventTimeout -= pEventTimer->uTimeElapsed;
             if (AfterEnchClickEventTimeout <= 0) {
-                pMessageQueue_50CBD0->AddGUIMessage(AfterEnchClickEventId, AfterEnchClickEventSecondParam, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(AfterEnchClickEventId, AfterEnchClickEventSecondParam, 0);
                 AfterEnchClickEventId = UIMSG_0;
                 AfterEnchClickEventSecondParam = 0;
                 AfterEnchClickEventTimeout = 0;
@@ -2558,7 +2557,7 @@ void Game::GameLoop() {
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
 
     while (2) {
-        pMessageQueue_50CBD0->Flush();
+        pCurrentFrameMessageQueue->Flush();
 
         pPartyActionQueue->uNumActions = 0;
 

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -43,7 +43,7 @@ std::map<InputAction, PlatformKey> curr_key_map;
 
 void Game_StartNewGameWhilePlaying(bool force_start) {
     if (dword_6BE138 == 124 || force_start) {
-        pMessageQueue_50CBD0->Flush();
+        pCurrentFrameMessageQueue->Flush();
         // pGUIWindow_CurrentMenu->Release();
         uGameState = GAME_STATE_NEWGAME_OUT_GAMEMENU;
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
@@ -56,7 +56,7 @@ void Game_StartNewGameWhilePlaying(bool force_start) {
 
 void Game_QuitGameWhilePlaying(bool force_quit) {
     if (dword_6BE138 == 132 || force_quit) {
-        pMessageQueue_50CBD0->Flush();
+        pCurrentFrameMessageQueue->Flush();
         // pGUIWindow_CurrentMenu->Release();
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
         pAudioPlayer->PlaySound(SOUND_WoodDoorClosing, 0, 0, -1, 0, 0);
@@ -69,7 +69,7 @@ void Game_QuitGameWhilePlaying(bool force_quit) {
 }
 
 void Game_OpenLoadGameDialog() {
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
     pGUIWindow_CurrentMenu->Release();
     pGUIWindow_CurrentMenu = nullptr;
     game_ui_status_bar_event_string_time_left = 0;
@@ -79,10 +79,10 @@ void Game_OpenLoadGameDialog() {
 }
 
 void Menu::EventLoop() {
-    while (!pMessageQueue_50CBD0->Empty()) {
+    while (!pCurrentFrameMessageQueue->Empty()) {
         UIMessageType msg;
         int param, param2;
-        pMessageQueue_50CBD0->PopMessage(&msg, &param, &param2);
+        pCurrentFrameMessageQueue->PopMessage(&msg, &param, &param2);
 
         switch (msg) {
             case UIMSG_StartNewGame:
@@ -122,8 +122,8 @@ void Menu::EventLoop() {
                 if (current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME ||
                     uLoadGameUI_SelectedSlot != v10) {
                     if (dword_6BE138 == pSaveListPosition + param) {
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_LoadGame, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
                     }
                     uLoadGameUI_SelectedSlot = v10;
                     dword_6BE138 = v10;
@@ -173,7 +173,7 @@ void Menu::EventLoop() {
             }
             case UIMSG_Game_OpenOptionsDialog:  // Open
             {
-                pMessageQueue_50CBD0->Flush();
+                pCurrentFrameMessageQueue->Flush();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameOptions();  // GameMenuUI_Options_Load();
@@ -185,7 +185,7 @@ void Menu::EventLoop() {
 
             case UIMSG_OpenKeyMappingOptions:  // Open
             {
-                pMessageQueue_50CBD0->Flush();
+                pCurrentFrameMessageQueue->Flush();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameKeyBindings();  // GameMenuUI_OptionsKeymapping_Load();
@@ -228,7 +228,7 @@ void Menu::EventLoop() {
                 continue;
 
             case UIMSG_OpenVideoOptions: {
-                pMessageQueue_50CBD0->Flush();
+                pCurrentFrameMessageQueue->Flush();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameVideoOptions();

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -313,13 +313,13 @@ void GameWindowHandler::OnKey(PlatformKey key) {
             if (!viewparams->field_4C)
                 UI_OnKeyDown(key);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::Escape, key)) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, window_SpeakInHouse != 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, window_SpeakInHouse != 0, 0);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::ToggleFullscreen, key) && !pMovie_Track) {
             OnToggleFullscreen();
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::Console, key)) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OpenDebugMenu, window_SpeakInHouse != 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_OpenDebugMenu, window_SpeakInHouse != 0, 0);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::ReloadShaders, key) && current_screen_type == CURRENT_SCREEN::SCREEN_GAME) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_DebugReloadShader, window_SpeakInHouse != 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_DebugReloadShader, window_SpeakInHouse != 0, 0);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::DialogLeft, key) || keyboardActionMapping->IsKeyMatchAction(InputAction::DialogRight, key)
             || keyboardActionMapping->IsKeyMatchAction(InputAction::DialogUp, key) || keyboardActionMapping->IsKeyMatchAction(InputAction::DialogDown, key)
             || keyboardActionMapping->IsKeyMatchAction(InputAction::DialogSelect, key)) {

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -941,7 +941,7 @@ LABEL_47:
                                 pMediaPlayer->Unload();
                                 window_SpeakInHouse->Release();
                                 window_SpeakInHouse = 0;
-                                pMessageQueue_50CBD0->Flush();
+                                pCurrentFrameMessageQueue->Flush();
                                 current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
                                 pDialogueNPCCount = 0;
                                 if (pDialogueWindow) {

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -252,7 +252,7 @@ void InteractWithActor(unsigned int id) {
 
     Actor::AI_FaceObject(id, 4, 0, 0);
     if (pActors[id].sNPC_ID) {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_StartNPCDialogue, id, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_StartNPCDialogue, id, 0);
     } else {
         if (pNPCStats->pGroups_copy[pActors[id].uGroup]) {
             if (pNPCStats->pCatchPhrases
@@ -362,13 +362,13 @@ void Engine::OnGameViewportClick() {
                 if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
                     pTurnEngine->flags |= TE_FLAG_8_finished;
                 } else {
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Attack, 0, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Attack, 0, 0);
                 }
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->SetAirborne(true);
         } else if (uActiveCharacter != 0 && IsSpellQuickCastableOnShiftClick(pPlayers[uActiveCharacter]->uQuickSpell)) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
         }
     } else if (PID_TYPE(pid) == OBJECT_Decoration) {
         int id = PID_ID(pid);

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -1281,7 +1281,7 @@ int UseNPCSkill(NPCProf profession) {
         } break;
 
         case GateMaster: {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             GateMasterEventId = UIMSG_OnCastTownPortal;
             GateMasterNPCData = GetNPCData(sDialogue_SpeakingActorNPC_ID);
         } break;

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -3778,7 +3778,7 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
 
         if (pGUIWindow_CurrentMenu &&
             pGUIWindow_CurrentMenu->eWindowType != WINDOW_null) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
         }
         if (v73) {
             if (pParty->bTurnBasedModeOn) {
@@ -4202,7 +4202,7 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
             //           pMouse->RemoveHoldingItem();
             //           return;
             //         }
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
         }
         if (v73) {
             if (pParty->bTurnBasedModeOn) {
@@ -4245,10 +4245,12 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
             pushScrollSpell(scroll_id, player_num - 1);
         } else {
             mouse->RemoveHoldingItem();
-            pMessageQueue_50C9E8->AddGUIMessage(UIMSG_SpellScrollUse, scroll_id, player_num - 1);
-            if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME && pGUIWindow_CurrentMenu &&
+            // Process spell on next frame after game exits inventory window.
+            pNextFrameMessageQueue->AddGUIMessage(UIMSG_SpellScrollUse, scroll_id, player_num - 1);
+            if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME &&
+                pGUIWindow_CurrentMenu &&
                 (pGUIWindow_CurrentMenu->eWindowType != WINDOW_null)) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             }
         }
         return;
@@ -4321,7 +4323,7 @@ void Player::UseItem_DrinkPotion_etc(signed int player_num, int a3) {
                 mouse->RemoveHoldingItem();
                 return;
             }
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
         }
         //       if ( v73 )                                                v73
         //       is always 0 at this point
@@ -7213,7 +7215,7 @@ void Player::OnInventoryLeftClick() {
                     ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
                     IsEnchantingInProgress = false;
 
-                    pMessageQueue_50CBD0->Flush();
+                    pCurrentFrameMessageQueue->Flush();
 
                     mouse->SetCursorImage("MICON1");
                     AfterEnchClickEventId = UIMSG_Escape;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -1020,7 +1020,7 @@ void Party::Sleep8Hours() {
             OutdoorLocation::LoadActualSkyFrame();
         }
         if (_506F14_resting_stage == 2) {
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
         }
     } else {
         Rest(6u);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -268,7 +268,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                 }
                 TownPortalCasterId = pCastSpell->uPlayerID;
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastTownPortal, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_OnCastTownPortal, 0, 0);
                 spell_sound_flag = true;
             } else {
                 pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
@@ -282,7 +282,7 @@ void CastSpellInfoHelpers::castSpell() {
             }
             if (pPlayer->CanCastSpell(uRequiredMana)) {
                 pEventTimer->Pause();
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_OnCastLloydsBeacon, 0, 0);
                 CurrentLloydPlayerID = pCastSpell->uPlayerID;
                 ::uRequiredMana = uRequiredMana;
                 ::sRecoveryTime = sRecoveryTime;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -87,8 +87,8 @@ MENU_STATE sCurrentMenuID;
 enum CURRENT_SCREEN current_screen_type = CURRENT_SCREEN::SCREEN_VIDEO;
 enum CURRENT_SCREEN prev_screen_type;
 
-struct GUIMessageQueue *pMessageQueue_50CBD0 = new GUIMessageQueue;  // main message queue
-struct GUIMessageQueue *pMessageQueue_50C9E8 = new GUIMessageQueue;  // swap message queue - for handling message after main queue ??
+struct GUIMessageQueue *pCurrentFrameMessageQueue = new GUIMessageQueue;
+struct GUIMessageQueue *pNextFrameMessageQueue = new GUIMessageQueue;
 
 Image *ui_exit_cancel_button_background = nullptr;
 Image *game_ui_right_panel_frame = nullptr;
@@ -177,7 +177,7 @@ GUIButton *GUI_HandleHotkey(PlatformKey hotkey) {
     for (GUIWindow *pWindow : lWindowList) {
         for (GUIButton *result : pWindow->vButtons) {
             if (result->action != InputAction::Invalid && keyboardActionMapping->IsKeyMatchAction(result->action, hotkey)) {
-                pMessageQueue_50CBD0->AddGUIMessage(result->msg, result->msg_param, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(result->msg, result->msg_param, 0);
                 return result;
             }
         }
@@ -865,9 +865,9 @@ void OnSaveLoad::Update() {
     Release();
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SAVEGAME) {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_SaveGame, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveGame, 0, 0);
     } else {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_LoadGame, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
     }
 }
 
@@ -882,7 +882,7 @@ void OnCancel::Update() {
     }
     Release();
 
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
 }
 
 void OnCancel2::Update() {
@@ -896,7 +896,7 @@ void OnCancel2::Update() {
     }
     Release();
 
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
 }
 
 void OnCancel3::Update() {
@@ -911,7 +911,7 @@ void OnCancel3::Update() {
     }
     Release();
 
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
 }
 
 void GUI_UpdateWindows() {
@@ -1410,7 +1410,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
                         pPlayers[uActiveCharacter]->SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
                         pPlayers[uActiveCharacter]->PlaySound(SPEECH_SkillMasteryInc, 0);
                     }
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 }
             } else {
                 if (topic == DIALOGUE_82_join_guild && guild_membership_approved) {
@@ -1453,7 +1453,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
                     default:
                         break;
                     }
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                     if (uActiveCharacter) {
                         pPlayers[uActiveCharacter]->PlaySound(SPEECH_JoinedGuild, 0);
                         BackToHouseMenu();
@@ -1511,7 +1511,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     PrepareHouse(static_cast<HOUSE_ID>(window_SpeakInHouse->wData.val));
     dialog_menu_id = DIALOGUE_MAIN;
 
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
     if (uActiveCharacter)
         pPlayers[uActiveCharacter]->PlaySound(SPEECH_HireNPC, 0);
 
@@ -2285,8 +2285,8 @@ void WindowManager::DeleteAllVisibleWindows() {
     pGUIWindow2 = nullptr; // branchless dialougue
 
     current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
-    pMessageQueue_50C9E8->Clear();
-    pMessageQueue_50CBD0->Clear();
+    pNextFrameMessageQueue->Clear();
+    pCurrentFrameMessageQueue->Clear();
     pMediaPlayer->Unload();
 }
 

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -279,9 +279,18 @@ struct GUIMessageQueue {
     std::queue<GUIMessage> qMessages;
 };
 
-extern struct GUIMessageQueue *pMessageQueue_50CBD0;  // idb
+/**
+ * Message queue for current frame.
+ *
+ * @offset 0x50CBD0
+ */
+extern struct GUIMessageQueue *pCurrentFrameMessageQueue;
 
-extern struct GUIMessageQueue *pMessageQueue_50C9E8;  // idb
+/**
+ * Message queue that will be processed on next frame.
+ * @offset 0x50C9E8
+ */
+extern struct GUIMessageQueue *pNextFrameMessageQueue;
 
 extern enum WindowType current_character_screen_window;
 extern std::list<GUIWindow*> lWindowList;

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -161,6 +161,6 @@ void GUIWindow_LloydsBook::Update() {
     }
 
     if (_506360_installing_beacon) {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_CloseAfterInstallBeacon, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CloseAfterInstallBeacon, 0, 0);
     }
 }

--- a/src/GUI/UI/UIArena.cpp
+++ b/src/GUI/UI/UIArena.cpp
@@ -141,17 +141,17 @@ void ArenaFight() {
     pParty->sRotationZ = 512;
     pParty->sRotationY = 0;
     pParty->uFallSpeed = 0;
-    /*if ( (signed int)pMessageQueue_50CBD0->uNumMessages < 40 )
+    /*if ( (signed int)pCurrentFrameMessageQueue->uNumMessages < 40 )
     {
-    pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].eType =
+    pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].eType =
     UIMSG_Escape;
-    pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].param =
+    pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].param =
     1;
-    *(&pMessageQueue_50CBD0->uNumMessages + 3 *
-    pMessageQueue_50CBD0->uNumMessages + 3) = 0;
-    ++pMessageQueue_50CBD0->uNumMessages;
+    *(&pCurrentFrameMessageQueue->uNumMessages + 3 *
+    pCurrentFrameMessageQueue->uNumMessages + 3) = 0;
+    ++pCurrentFrameMessageQueue->uNumMessages;
     }*/
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
     // v2 = pParty->pPlayers.data();
     for (uint i = 0; i < 4; i++) {
         v3 = pParty->pPlayers[i].GetActualLevel();

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -2512,7 +2512,7 @@ void OnPaperdollLeftClick() {
 
             ptr_50C9A4_ItemToEnchant = pitem;
             IsEnchantingInProgress = false;
-            pMessageQueue_50CBD0->Flush();
+            pCurrentFrameMessageQueue->Flush();
             mouse->SetCursorImage("MICON1");
             AfterEnchClickEventId = UIMSG_Escape;
             AfterEnchClickEventSecondParam = 0;
@@ -2587,7 +2587,7 @@ void OnPaperdollLeftClick() {
                 ptr_50C9A4_ItemToEnchant =
                     &pPlayers[uActiveCharacter]->pInventoryItemList[v34 - 1];
                 IsEnchantingInProgress = false;
-                pMessageQueue_50CBD0->Flush();
+                pCurrentFrameMessageQueue->Flush();
                 mouse->SetCursorImage("MICON1");
                 AfterEnchClickEventId = UIMSG_Escape;
                 AfterEnchClickEventSecondParam = 0;

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -68,11 +68,11 @@ void GUICredits::Update() {
 }
 
 void GUICredits::EventLoop() {
-    while (!pMessageQueue_50CBD0->Empty()) {
+    while (!pCurrentFrameMessageQueue->Empty()) {
         UIMessageType pUIMessageType;
         int pParam;
         int param2;
-        pMessageQueue_50CBD0->PopMessage(&pUIMessageType, &pParam, &param2);
+        pCurrentFrameMessageQueue->PopMessage(&pUIMessageType, &pParam, &param2);
 
         switch (pUIMessageType) {  // For buttons of window MainMenu
             case UIMSG_Escape:
@@ -85,7 +85,7 @@ void GUICredits::EventLoop() {
 }
 
 void GUICredits::ExecuteCredits() {
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
 
     pAudioPlayer->MusicPlayTrack(MUSIC_Credits);
 

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -590,7 +590,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
                 pParty->pHirelings[1] = NPCData();
             pParty->hirelingScrollPosition = 0;
             pParty->CountHirelings();
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             dword_7241C8 = 0;
             return;
         }
@@ -621,7 +621,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             }
             pParty->hirelingScrollPosition = 0;
             pParty->CountHirelings();
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             if (sDialogue_SpeakingActorNPC_ID >= 0)
                 pDialogue_SpeakingActor->uAIState = Removed;
             if (uActiveCharacter)
@@ -635,7 +635,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             if (speakingNPC->profession != GateMaster) {
                 speakingNPC->bHasUsedTheAbility = 1;
             }
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         } else {
             GameUI_SetStatusBar(LSTR_RATIONS_FULL);
         }
@@ -655,7 +655,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
                 pParty->pHirelings[1] = NPCData();
             pParty->hirelingScrollPosition = 0;
             pParty->CountHirelings();
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             dword_7241C8 = 0;
             return;
         }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1170,7 +1170,7 @@ void GameUI_WritePointedObjectStatusString() {
                                 pMessageType1 =
                                     (UIMessageType)pButton->uData;
                                 if (pMessageType1)
-                                    pMessageQueue_50CBD0->AddGUIMessage(
+                                    pCurrentFrameMessageQueue->AddGUIMessage(
                                         pMessageType1, pButton->msg_param, 0);
                                 GameUI_StatusBar_Set(pButton->sLabel);
                                 uLastPointedObjectID = 1;
@@ -1193,7 +1193,7 @@ void GameUI_WritePointedObjectStatusString() {
                                     pMessageType2 =
                                         (UIMessageType)pButton->uData;
                                     if (pMessageType2 != 0)
-                                        pMessageQueue_50CBD0->AddGUIMessage(
+                                        pCurrentFrameMessageQueue->AddGUIMessage(
                                             pMessageType2, pButton->msg_param,
                                             0);
                                     GameUI_StatusBar_Set(
@@ -1287,7 +1287,7 @@ void GameUI_WritePointedObjectStatusString() {
                             if (pMessageType3 == 0) {  // For books
                                 GameUI_StatusBar_Set(pButton->sLabel);
                             } else {
-                                pMessageQueue_50CBD0->AddGUIMessage(
+                                pCurrentFrameMessageQueue->AddGUIMessage(
                                     pMessageType3, pButton->msg_param, 0);
                             }
                             uLastPointedObjectID = 1;
@@ -1309,7 +1309,7 @@ void GameUI_WritePointedObjectStatusString() {
                                 pMessageType2 =
                                     (UIMessageType)pButton->uData;
                                 if (pMessageType2 != 0)
-                                    pMessageQueue_50CBD0->AddGUIMessage(
+                                    pCurrentFrameMessageQueue->AddGUIMessage(
                                         pMessageType2, pButton->msg_param, 0);
                                 GameUI_StatusBar_Set(
                                     pButton->sLabel);  // for character name

--- a/src/GUI/UI/UIGameOver.cpp
+++ b/src/GUI/UI/UIGameOver.cpp
@@ -45,7 +45,7 @@ void GUIWindow_GameOver::Update() {
 }
 
 void GUIWindow_GameOver::Release() {
-    pMessageQueue_50CBD0->AddGUIMessage(static_cast<UIMessageType>(wData.val), 0, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(static_cast<UIMessageType>(wData.val), 0, 0);
 
     current_screen_type = prev_screen_type;
     bGameoverLoop = false;

--- a/src/GUI/UI/UIGuilds.cpp
+++ b/src/GUI/UI/UIGuilds.cpp
@@ -142,7 +142,7 @@ void GuildDialog() {
         return;
     }
 
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
 }
 
 //----- (004BC8D5) --------------------------------------------------------

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -807,13 +807,13 @@ bool HouseUI_CheckIfPlayerCanInteract() {
 bool EnterHouse(HOUSE_ID uHouseID) {
     GameUI_StatusBar_Clear();
     GameUI_SetStatusBar("");
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
     uDialogueType = DIALOGUE_NULL;
     keyboardInputHandler->SetWindowInputStatus(WindowInputStatus::WINDOW_INPUT_CANCELLED);
     keyboardInputHandler->ResetKeys();
 
     if (uHouseID == HOUSE_THRONEROOM_WIN_GOOD || uHouseID == HOUSE_THRONEROOM_WIN_EVIL) {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_ShowGameOverWindow, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_ShowGameOverWindow, 0, 0);
         return 0;
     }
 
@@ -1328,7 +1328,7 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
     }
     case DIALOGUE_TAVERN_ARCOMAGE_RESULT:
     {
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_PlayArcomage, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_PlayArcomage, 0, 0);
         dialog_menu_id = DIALOGUE_TAVERN_ARCOMAGE_RESULT;
         break;
     }
@@ -1556,7 +1556,7 @@ void TravelByTransport() {
             if (pParty->GetGold() < pPrice) {
                 GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                 PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_Greeting_2);
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
 
@@ -1612,7 +1612,7 @@ void TravelByTransport() {
                     std::this_thread::sleep_for(1ms);
                 }
                 while (HouseDialogPressCloseBtn()) {}
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             } else {
                 dialog_menu_id = DIALOGUE_MAIN;
                 pAudioPlayer->PlaySound(SOUND_error, 0, 0, -1, 0, 0);
@@ -1749,7 +1749,7 @@ void TownHallDialog() {
             }
         }
         window_SpeakInHouse->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
     default:
@@ -1796,7 +1796,7 @@ void BankDialog() {
         if (window_SpeakInHouse->keyboard_input_status == WindowInputStatus::WINDOW_INPUT_CONFIRMED) {
             int sum = atoi(keyboardInputHandler->GetTextInput().c_str());
             if (sum <= 0) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
 
@@ -1815,7 +1815,7 @@ void BankDialog() {
             }
         }
         window_SpeakInHouse->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
     case DIALOGUE_BANK_GET_GOLD:
@@ -1830,7 +1830,7 @@ void BankDialog() {
             window_SpeakInHouse->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
             int sum = atoi(keyboardInputHandler->GetTextInput().c_str());
             if (sum <= 0) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
 
@@ -1846,7 +1846,7 @@ void BankDialog() {
             }
         }
         window_SpeakInHouse->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
     default:
@@ -2055,14 +2055,14 @@ void TavernDialog() {
             GetHouseGoodbyeSpeech();
             pMediaPlayer->Unload();
 
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_RentRoom, window_SpeakInHouse->wData.val, 1);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_RentRoom, window_SpeakInHouse->wData.val, 1);
             window_SpeakInHouse->Release();
             window_SpeakInHouse = 0;
             return;
         }
         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
         PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_Goodbye);
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
 
@@ -2101,19 +2101,19 @@ void TavernDialog() {
             GameUI_SetStatusBar(LSTR_RATIONS_FULL);
             if (uActiveCharacter)
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_PacksFull, 0);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
         if (pParty->GetGold() >= pPriceFood) {
             pParty->TakeGold(pPriceFood);
             pParty->SetFood(p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
             PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_Greeting_2);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
         PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_Goodbye);
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
 
@@ -2253,7 +2253,7 @@ void TempleDialog() {
         if (pParty->GetGold() < pPrice) {
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
             PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_NotEnoughMoney);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
         pParty->TakeGold(pPrice);
@@ -2280,7 +2280,7 @@ void TempleDialog() {
             pAudioPlayer->PlaySound((SoundID)SOUND_heal, PID_INVALID, 0, -1, 0, 0);
             pPlayers[uActiveCharacter]->PlaySound(SPEECH_TempleHeal, 0);
             pOtherOverlayList->_4418B1(20, uActiveCharacter + 99, 0, 65536);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
         if (pPlayers[uActiveCharacter]->conditions.Has(Condition_Zombie)) {
@@ -2294,7 +2294,7 @@ void TempleDialog() {
                 pAudioPlayer->PlaySound((SoundID)SOUND_heal, PID_INVALID, 0, -1, 0, 0);
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_TempleHeal, 0);
                 pOtherOverlayList->_4418B1(20, uActiveCharacter + 99, 0, 65536);
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
             pPlayers[uActiveCharacter]->uPrevFace =
@@ -2318,7 +2318,7 @@ void TempleDialog() {
         pAudioPlayer->PlaySound((SoundID)SOUND_heal, PID_INVALID, 0, -1, 0, 0);
         pPlayers[uActiveCharacter]->PlaySound(SPEECH_TempleHeal, 0);
         pOtherOverlayList->_4418B1(20, uActiveCharacter + 99, 0, 65536);
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
     //---------------------------------------------------
@@ -2355,13 +2355,13 @@ void TempleDialog() {
             ++byte_F8B1EF[uActiveCharacter];
             pPlayers[uActiveCharacter]->PlaySound(SPEECH_TempleDonate, 0);
             GameUI_SetStatusBar(LSTR_THANK_YOU);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
         PlayHouseSound(window_SpeakInHouse->wData.val,
             HouseSound_NotEnoughMoney);
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
     //------------------------------------------------
@@ -2586,13 +2586,13 @@ void TrainingDialog(const char *s) {
                             pPlayers[uActiveCharacter]->uLevel / 10 + 5
                         );
 
-                        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                         return;
                     }
 
                     GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                     PlayHouseSound(window_SpeakInHouse->wData.val, (HouseSoundID)4);
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                     return;
                 }
                 label = localization->FormatString(
@@ -2613,7 +2613,7 @@ void TrainingDialog(const char *s) {
                 pFontArrus, 0, v36, colorTable.Jonquil.C16(), label, 3);
 
             PlayHouseSound(window_SpeakInHouse->wData.val, (HouseSoundID)3);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
     }
@@ -2738,7 +2738,7 @@ void MercenaryGuildDialog() {
     } else {
         v5 = 0;
     }
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 1, v5);
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, v5);
 }
 
 void SimpleHouseDialog() {
@@ -3182,7 +3182,7 @@ void InitializeBuildingResidents() {
 }
 
 int HouseDialogPressCloseBtn() {
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
     keyboardInputHandler->SetWindowInputStatus(WindowInputStatus::WINDOW_INPUT_CANCELLED);
     keyboardInputHandler->ResetKeys();
     activeLevelDecoration = nullptr;
@@ -3622,7 +3622,7 @@ void GUIWindow_House::Update() {
         return;
     }
     // dialog_menu_id = DIALOGUE_MAIN;
-    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);  // banned from shop so leaving
+    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);  // banned from shop so leaving
 }
 
 void GUIWindow_House::Release() {

--- a/src/GUI/UI/UIMainMenu.cpp
+++ b/src/GUI/UI/UIMainMenu.cpp
@@ -101,15 +101,15 @@ void GUIWindow_MainMenu::Update() {
 
 void GUIWindow_MainMenu::EventLoop() {
     if (nuklear->Mode(WINDOW_MainMenu) == nuklear->NUKLEAR_MODE_EXCLUSIVE) {
-        pMessageQueue_50CBD0->Clear();
+        pCurrentFrameMessageQueue->Clear();
         return;
     }
 
-    while (!pMessageQueue_50CBD0->Empty()) {
+    while (!pCurrentFrameMessageQueue->Empty()) {
         UIMessageType pUIMessageType;
         int pParam;
         int param2;
-        pMessageQueue_50CBD0->PopMessage(&pUIMessageType, &pParam, &param2);
+        pCurrentFrameMessageQueue->PopMessage(&pUIMessageType, &pParam, &param2);
 
         switch (pUIMessageType) {  // For buttons of window MainMenu
         case UIMSG_MainMenu_ShowPartyCreationWnd:

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -71,10 +71,10 @@ bool PlayerCreation_Choose4Skills() {
 
 void CreateParty_EventLoop() {
     auto pPlayer = pParty->pPlayers.data();
-    while (!pMessageQueue_50CBD0->Empty()) {
+    while (!pCurrentFrameMessageQueue->Empty()) {
         UIMessageType msg;
         int param, param2;
-        pMessageQueue_50CBD0->PopMessage(&msg, &param, &param2);
+        pCurrentFrameMessageQueue->PopMessage(&msg, &param, &param2);
 
         switch (msg) {
         case UIMSG_PlayerCreation_SelectAttribute:
@@ -237,7 +237,7 @@ void CreateParty_EventLoop() {
                 GetCurrentMenuID() == MENU_NAMEPANELESC) {
                 // if ( current_screen_type == SCREEN_VIDEO )
                 // pVideoPlayer->FastForwardToFrame(pVideoPlayer->pResetflag);
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_ChangeGameState,
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_ChangeGameState,
                     0, 0);
             }
             break;
@@ -604,7 +604,7 @@ void GUIWindow_PartyCreation::Update() {
 //----- (0049695A) --------------------------------------------------------
 GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     GUIWindow(WINDOW_CharacterCreation, {0, 0}, render->GetRenderDimensions(), 0) {
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
 
     main_menu_background = assets->GetImage_PCXFromIconsLOD("makeme.pcx");
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -2063,7 +2063,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             }
 
             pAudioPlayer->PlaySound(SOUND_fireBall, 0, 0, -1, 0, 0);
-            pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             v39.z = pParty->vPosition.z + pParty->sEyelevel;
             v39.x = pParty->vPosition.x;
             v39.y = pParty->vPosition.y;

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -285,7 +285,7 @@ static void UI_DrawSaveLoad(bool save) {
     if (pGUIWindow_CurrentMenu->keyboard_input_status == WindowInputStatus::WINDOW_INPUT_CONFIRMED) {
         pGUIWindow_CurrentMenu->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
         strcpy(pSavegameHeader[uLoadGameUI_SelectedSlot].pName, keyboardInputHandler->GetTextInput().c_str());
-        pMessageQueue_50CBD0->AddGUIMessage(UIMSG_SaveGame, 0, 0);
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveGame, 0, 0);
     } else {
         if (pGUIWindow_CurrentMenu->keyboard_input_status == WindowInputStatus::WINDOW_INPUT_CANCELLED)
             pGUIWindow_CurrentMenu->keyboard_input_status = WindowInputStatus::WINDOW_INPUT_NONE;
@@ -333,10 +333,10 @@ static void UI_DrawSaveLoad(bool save) {
 }
 
 void MainMenuLoad_EventLoop() {
-    while (!pMessageQueue_50CBD0->Empty()) {
+    while (!pCurrentFrameMessageQueue->Empty()) {
         UIMessageType msg;
         int param, param2;
-        pMessageQueue_50CBD0->PopMessage(&msg, &param, &param2);
+        pCurrentFrameMessageQueue->PopMessage(&msg, &param, &param2);
 
         switch (msg) {
         case UIMSG_LoadGame: {
@@ -353,9 +353,9 @@ void MainMenuLoad_EventLoop() {
                 // load clicked line
                 int v26 = param + pSaveListPosition;
                 if (dword_6BE138 == v26) {
-                    pMessageQueue_50CBD0->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
                     // Breaks UI interaction after save load
-                    // pMessageQueue_50CBD0->AddGUIMessage(UIMSG_LoadGame, 0, 0);
+                    // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
                 }
                 uLoadGameUI_SelectedSlot = v26;
                 dword_6BE138 = v26;

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -61,26 +61,26 @@ void KeyboardInputHandler::GeneratePausedActions() {
 
         if (action == InputAction::EventTrigger) {
             if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME || current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Game_Action, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Game_Action, 0, 0);
                 continue;
             }
             if (current_screen_type == CURRENT_SCREEN::SCREEN_NPC_DIALOGUE || current_screen_type == CURRENT_SCREEN::SCREEN_BRANCHLESS_NPC_DIALOG) {
-                /*v15 = pMessageQueue_50CBD0->uNumMessages;
-                if (pMessageQueue_50CBD0->uNumMessages) {
+                /*v15 = pCurrentFrameMessageQueue->uNumMessages;
+                if (pCurrentFrameMessageQueue->uNumMessages) {
                     v15 = 0;
-                    if (pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].field_8) {
+                    if (pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].field_8) {
                         v15 = 1;
-                        pMessageQueue_50CBD0->uNumMessages = 0;
-                        pMessageQueue_50CBD0->pMessages[v15].eType = UIMSG_Escape;
-                        pMessageQueue_50CBD0->pMessages[pMessageQueue_50CBD0->uNumMessages].param = 0;
-                        *(&pMessageQueue_50CBD0->uNumMessages + 3 * pMessageQueue_50CBD0->uNumMessages + 3) = 0;
-                        ++pMessageQueue_50CBD0->uNumMessages;
+                        pCurrentFrameMessageQueue->uNumMessages = 0;
+                        pCurrentFrameMessageQueue->pMessages[v15].eType = UIMSG_Escape;
+                        pCurrentFrameMessageQueue->pMessages[pCurrentFrameMessageQueue->uNumMessages].param = 0;
+                        *(&pCurrentFrameMessageQueue->uNumMessages + 3 * pCurrentFrameMessageQueue->uNumMessages + 3) = 0;
+                        ++pCurrentFrameMessageQueue->uNumMessages;
                         continue;
                     }
-                    pMessageQueue_50CBD0->uNumMessages = 0;
+                    pCurrentFrameMessageQueue->uNumMessages = 0;
 
                 }*/
-                // pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             }
         }
     }
@@ -238,9 +238,10 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             bool enoughMana = pPlayers[uActiveCharacter]->sMana >= uRequiredMana;
 
             if (quickSpellNumber == SPELL_NONE || engine->IsUnderwater() || !enoughMana) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Attack, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Attack, 0, 0);
             } else {
-                pMessageQueue_50C9E8->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
+                // TODO(Nik-RE-dev): why next frame?
+                pNextFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
             }
 
             break;
@@ -254,26 +255,27 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
                 pTurnEngine->flags |= TE_FLAG_8_finished;
             } else {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Attack, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Attack, 0, 0);
             }
 
             break;
 
         case InputAction::EventTrigger:
             if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME) {
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Game_Action, 0, 0);
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Game_Action, 0, 0);
                 break;
             }
 
             if (current_screen_type == CURRENT_SCREEN::SCREEN_NPC_DIALOGUE) {
-                pMessageQueue_50CBD0->Clear();
-                pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, 0, 0);
+                pCurrentFrameMessageQueue->Clear();
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             }
             break;
 
         case InputAction::CharCycle:
             if (current_screen_type != CURRENT_SCREEN::SCREEN_SPELL_BOOK) {
-                pMessageQueue_50C9E8->AddGUIMessage(UIMSG_CycleCharacters, 0, 0);
+                // TODO(Nik-RE-dev): why next frame?
+                pNextFrameMessageQueue->AddGUIMessage(UIMSG_CycleCharacters, 0, 0);
             }
             break;
 
@@ -308,11 +310,11 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             break;
 
         case InputAction::ZoomIn:
-            // pMessageQueue_50C9E8->AddGUIMessage(UIMSG_ClickZoomInBtn, 0, 0);
+            // pNextFrameMessageQueue->AddGUIMessage(UIMSG_ClickZoomInBtn, 0, 0);
             break;
 
         case InputAction::ZoomOut:
-            // pMessageQueue_50C9E8->AddGUIMessage(UIMSG_ClickZoomOutBtn, 0, 0);
+            // pNextFrameMessageQueue->AddGUIMessage(UIMSG_ClickZoomOutBtn, 0, 0);
             break;
 
         case InputAction::AlwaysRun:
@@ -320,7 +322,7 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             break;
 
         case InputAction::Escape:
-            // pMessageQueue_50CBD0->AddGUIMessage(UIMSG_Escape, window_SpeakInHouse != 0, 0);
+            // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, window_SpeakInHouse != 0, 0);
             break;
 
         default:

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -280,8 +280,8 @@ void Mouse::UI_OnMouseLeftClick() {
                     if (control->uButtonType == 1) {
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
-                            pMessageQueue_50CBD0->Flush();
-                            pMessageQueue_50CBD0->AddGUIMessage(
+                            pCurrentFrameMessageQueue->Flush();
+                            pCurrentFrameMessageQueue->AddGUIMessage(
                                 control->msg, control->msg_param, 0);
                             return;
                         }
@@ -292,8 +292,8 @@ void Mouse::UI_OnMouseLeftClick() {
                                 (double)((x - control->uX) * (x - control->uX) +
                                          (y - control->uY) * (y - control->uY))) < (double)control->uWidth) {
                             control->field_2C_is_pushed = true;
-                            pMessageQueue_50CBD0->Flush();
-                            pMessageQueue_50CBD0->AddGUIMessage(control->msg, control->msg_param, 0);
+                            pCurrentFrameMessageQueue->Flush();
+                            pCurrentFrameMessageQueue->AddGUIMessage(control->msg, control->msg_param, 0);
                             return;
                         }
                         continue;
@@ -301,8 +301,8 @@ void Mouse::UI_OnMouseLeftClick() {
                     if (control->uButtonType == 3) {  // clicking skills
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
-                            pMessageQueue_50CBD0->Flush();
-                            pMessageQueue_50CBD0->AddGUIMessage(control->msg, control->msg_param, 0);
+                            pCurrentFrameMessageQueue->Flush();
+                            pCurrentFrameMessageQueue->AddGUIMessage(control->msg, control->msg_param, 0);
                             return;
                         }
                         continue;
@@ -319,7 +319,7 @@ void Mouse::UI_OnMouseLeftClick() {
     if (type == OBJECT_Actor && uActiveCharacter && picked_object.depth < 0x200 &&
         pPlayers[uActiveCharacter]->CanAct() &&
         pPlayers[uActiveCharacter]->CanSteal()) {
-        pMessageQueue_50CBD0->AddGUIMessage(
+        pCurrentFrameMessageQueue->AddGUIMessage(
             UIMSG_STEALFROMACTOR,
             PID_ID(picked_object.object_pid),
             0
@@ -351,7 +351,7 @@ bool UI_OnKeyDown(PlatformKey key) {
                 break;
             }
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            pMessageQueue_50CBD0->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
             break;
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::DialogRight, key)) {
             int v7 = win->pCurrentPosActiveItem + win->field_34;
@@ -365,7 +365,7 @@ bool UI_OnKeyDown(PlatformKey key) {
                 break;
             }
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            pMessageQueue_50CBD0->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
             break;
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::DialogDown, key)) {
             int v17 = win->pStartingPosActiveItem;
@@ -376,7 +376,7 @@ bool UI_OnKeyDown(PlatformKey key) {
                 win->pCurrentPosActiveItem = v18 + 1;
             if (win->field_30 != 0) return true;
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            pMessageQueue_50CBD0->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
             return true;
         } else if (key == PlatformKey::Select) {
             int uClickX;
@@ -395,7 +395,7 @@ bool UI_OnKeyDown(PlatformKey key) {
                     ++v4;
                     if (v4 >= v28) {
                         // v1 = 0;
-                        // v2 = pMessageQueue_50CBD0->uNumMessages;
+                        // v2 = pCurrentFrameMessageQueue->uNumMessages;
                         // --i;
                         // if ( i < 0 )
                         return false;
@@ -416,11 +416,11 @@ bool UI_OnKeyDown(PlatformKey key) {
                 win->pCurrentPosActiveItem = v22 - 1;
             if (win->field_30 != 0) return true;
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            pMessageQueue_50CBD0->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
             return true;
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::DialogSelect, key)) {
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            pMessageQueue_50CBD0->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
+            pCurrentFrameMessageQueue->AddGUIMessage(pButton->msg, pButton->msg_param, 0);
         } else if (key == PlatformKey::PageDown) { // not button event from user, but a call from GUI_UpdateWindows to track mouse
             if (win->field_30 != 0) {
                 int uClickX;

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -910,7 +910,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
     pMovie_Track = nullptr;
 
     // prevent passing UIMSG_Escape event if video stopped by ESC key
-    pMessageQueue_50CBD0->Flush();
+    pCurrentFrameMessageQueue->Flush();
 
     platform->setCursorShown(true);
 }

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -18,7 +18,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG c7dfdac25bd1fb2c57869d04a9a7f3ce0310b713
+        GIT_TAG f8b8f675c2da2c038a629d51f91af2033f9dd556
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Tests/TestPartyCreationMenu.cpp
+++ b/test/Tests/TestPartyCreationMenu.cpp
@@ -387,3 +387,9 @@ GAME_TEST(Issue, Issue491) {
     // Check that opening and closing Lloyd book does not cause Segmentation Fault
     test->playTraceFromTestData("issue_491.mm7", "issue_491.json");
 }
+
+GAME_TEST(Issue, Issue492) {
+    // Check that spells that target all visible actors work
+    test->playTraceFromTestData("issue_492.mm7", "issue_492.json", []() { EXPECT_EQ(pParty->pPlayers[0].uExperience, 279); });
+    EXPECT_EQ(pParty->pPlayers[0].uExperience, 287);
+}


### PR DESCRIPTION
Rename event queues to properly mark if this is queue for current or next tick.
Correctly support swapping queues after current tick queue has been drained.
Comment each instance of adding message for next tick queue (if I understand why it's necessary).

This change fixes #492 because certain spells must be processed on next tick after spellbook has been actually closed.
Add test for #492.