### PR TITLE
fix empty file assert

### DIFF
--- a/src/Engine/LOD.cpp
+++ b/src/Engine/LOD.cpp
@@ -914,6 +914,10 @@ Blob LOD::File::LoadRaw(const std::string &pContainer) {
         Error("Unable to load %s", pContainer.c_str());
         return Blob();
     }
+    if (!size) {
+        logger->Info("Empty file {}", pContainer.c_str());
+        return Blob();
+    }
 
     return Blob::Read(File, size);
 }


### PR DESCRIPTION
#526 causing assert on files with read size 0. Return empty blob instead.