### PR TITLE
pcx cleanup

### DIFF
--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -336,8 +336,7 @@ class IRender {
     virtual Image *TakeScreenshot(unsigned int width, unsigned int height) = 0;
     virtual void SaveScreenshot(const std::string &filename, unsigned int width,
                                 unsigned int height) = 0;
-    virtual void PackScreenshot(unsigned int width, unsigned int height,
-        uint8_t *&out_data, unsigned int &screenshot_size) = 0;
+    virtual Blob PackScreenshot(const unsigned int width, const unsigned int height) = 0;
     virtual void SavePCXScreenshot() = 0;
     virtual uint32_t *MakeScreenshot32(const int width, const int height) = 0;
 

--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -339,7 +339,7 @@ class IRender {
     virtual void PackScreenshot(unsigned int width, unsigned int height,
         uint8_t *&out_data, unsigned int &screenshot_size) = 0;
     virtual void SavePCXScreenshot() = 0;
-    virtual unsigned short* MakeScreenshot16(int width, int height) = 0;
+    virtual uint32_t *MakeScreenshot32(const int width, const int height) = 0;
 
     virtual std::vector<Actor*> getActorsInViewport(int pDepth) = 0;
 

--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -337,8 +337,7 @@ class IRender {
     virtual void SaveScreenshot(const std::string &filename, unsigned int width,
                                 unsigned int height) = 0;
     virtual void PackScreenshot(unsigned int width, unsigned int height,
-                                void *out_data, unsigned int data_size,
-                                unsigned int *screenshot_size) = 0;
+        uint8_t *&out_data, unsigned int &screenshot_size) = 0;
     virtual void SavePCXScreenshot() = 0;
     virtual unsigned short* MakeScreenshot16(int width, int height) = 0;
 

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1169,6 +1169,7 @@ bool RenderOpenGL::AreRenderSurfacesOk() {
     return true;
 }
 
+// TODO(pskelton): drop this one - use 32
 unsigned short *RenderOpenGL::MakeScreenshot16(int width, int height) {
     BeginScene3D();
 

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -130,7 +130,7 @@ class RenderOpenGL : public RenderBase {
 
     virtual bool AreRenderSurfacesOk() override;
 
-    virtual unsigned short *MakeScreenshot16(int width, int height) override;
+    virtual uint32_t *MakeScreenshot32(const int width, const int height) override;
 
     virtual std::vector<Actor*> getActorsInViewport(int pDepth) override;
 

--- a/src/Engine/Graphics/PCX.cpp
+++ b/src/Engine/Graphics/PCX.cpp
@@ -285,8 +285,8 @@ struct Format {
     ColorFormat b;
 };
 
-void Encode(Format f, const void *picture_data, unsigned int width,
-            unsigned int height, uint8_t *&pcx_data, unsigned int &packed_size) {
+void Encode(const Format f, const void *picture_data, const unsigned int width,
+            const unsigned int height, uint8_t *&pcx_data, unsigned int &packed_size) {
     // pcx lines are padded to next even byte boundary
     int pitch = width;
     if (width & 1) {
@@ -329,13 +329,7 @@ void Encode(Format f, const void *picture_data, unsigned int width,
     assert(packed_size <= worstCase);
 }
 
-void PCX::Encode16(const void *picture_data, unsigned int width, unsigned int height,
-    uint8_t *&pcx_data, unsigned int &packed_size) {
-    Format f(16, 0xF800, 0x07E0, 0x001F);
-    Encode(f, picture_data, width, height, pcx_data, packed_size);
-}
-
-void PCX::Encode32(const void *picture_data, unsigned int width, unsigned int height,
+void PCX::Encode32(const void *picture_data, const unsigned int width, const unsigned int height,
     uint8_t *&pcx_data, unsigned int &packed_size) {
     Format f(32, 0x000000FF, 0x0000FF00, 0x00FF0000);
     Encode(f, picture_data, width, height, pcx_data, packed_size);

--- a/src/Engine/Graphics/PCX.h
+++ b/src/Engine/Graphics/PCX.h
@@ -7,8 +7,6 @@
 namespace PCX {
 uint8_t *Decode(const void *pcx_data, size_t filesize, unsigned int *width,
     unsigned int *height, IMAGE_FORMAT *format, IMAGE_FORMAT requested_format);
-void Encode16(const void *picture_data, unsigned int width, unsigned int height,
-    uint8_t *&pcx_data, unsigned int &packed_size);
-void Encode32(const void *picture_data, unsigned int width, unsigned int height,
+void Encode32(const void *picture_data, const unsigned int width, const unsigned int height,
     uint8_t *&pcx_data, unsigned int &packed_size);
 }  // namespace PCX

--- a/src/Engine/Graphics/PCX.h
+++ b/src/Engine/Graphics/PCX.h
@@ -8,7 +8,7 @@ namespace PCX {
 uint8_t *Decode(const void *pcx_data, size_t filesize, unsigned int *width,
     unsigned int *height, IMAGE_FORMAT *format, IMAGE_FORMAT requested_format);
 void Encode16(const void *picture_data, unsigned int width, unsigned int height,
-              void *pcx_data, int max_buff_size, unsigned int *packed_size);
+    uint8_t *&pcx_data, unsigned int &packed_size);
 void Encode32(const void *picture_data, unsigned int width, unsigned int height,
-              void *pcx_data, int max_buff_size, unsigned int *packed_size);
+    uint8_t *&pcx_data, unsigned int &packed_size);
 }  // namespace PCX

--- a/src/Engine/Graphics/PCX.h
+++ b/src/Engine/Graphics/PCX.h
@@ -7,6 +7,15 @@
 namespace PCX {
 uint8_t *Decode(const void *pcx_data, size_t filesize, unsigned int *width,
     unsigned int *height, IMAGE_FORMAT *format, IMAGE_FORMAT requested_format);
+/**
+ * @param picture_data                  Pointer to the image data to encode.
+ * @param width                         Size of image width to store.
+ * @param height                        Size of image height to store.
+ * @param[in,out] pcx_data              Reference to pointer - must be nullptr before call.
+ *                                      Buffer is created in function and packed pcx file stored within.
+ *                                      Must be freed by delete[] after use.
+ * @param[out] packed_size              Size of the packed PCX image - must be 0 before call.
+ */
 void Encode32(const void *picture_data, const unsigned int width, const unsigned int height,
     uint8_t *&pcx_data, unsigned int &packed_size);
 }  // namespace PCX

--- a/src/Engine/Graphics/PCX.h
+++ b/src/Engine/Graphics/PCX.h
@@ -9,13 +9,9 @@ uint8_t *Decode(const void *pcx_data, size_t filesize, unsigned int *width,
     unsigned int *height, IMAGE_FORMAT *format, IMAGE_FORMAT requested_format);
 /**
  * @param picture_data                  Pointer to the image data to encode.
- * @param width                         Size of image width to store.
- * @param height                        Size of image height to store.
- * @param[in,out] pcx_data              Reference to pointer - must be nullptr before call.
- *                                      Buffer is created in function and packed pcx file stored within.
- *                                      Must be freed by delete[] after use.
- * @param[out] packed_size              Size of the packed PCX image - must be 0 before call.
+ * @param width                         Final width of image to create.
+ * @param height                        Final height of image to create.
+ * @return                              Returns Blob containing packed pcx data and its size.
  */
-void Encode32(const void *picture_data, const unsigned int width, const unsigned int height,
-    uint8_t *&pcx_data, unsigned int &packed_size);
+Blob Encode(const void *picture_data, const unsigned int width, const unsigned int height);
 }  // namespace PCX

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -644,10 +644,9 @@ void RenderBase::SavePCXImage16(const std::string& filename, uint16_t* picture_d
         return;
     }
 
-    unsigned int pcx_data_size = width * height * 5;
-    uint8_t* pcx_data = new uint8_t[pcx_data_size];
+    uint8_t *pcx_data = nullptr;
     unsigned int pcx_data_real_size = 0;
-    PCX::Encode16(picture_data, width, height, pcx_data, pcx_data_size, &pcx_data_real_size);
+    PCX::Encode16(picture_data, width, height, pcx_data, pcx_data_real_size);
     fwrite(pcx_data, pcx_data_real_size, 1, result);
     delete[] pcx_data;
     fclose(result);
@@ -660,10 +659,9 @@ void RenderBase::SaveScreenshot(const std::string& filename, unsigned int width,
 }
 
 void RenderBase::PackScreenshot(unsigned int width, unsigned int height,
-    void* out_data, unsigned int data_size,
-    unsigned int* screenshot_size) {
+    uint8_t *&out_data, unsigned int &screenshot_size) {
     auto pixels = render->MakeScreenshot16(width, height);
-    PCX::Encode16(pixels, 150, 112, out_data, data_size, screenshot_size);
+    PCX::Encode16(pixels, 150, 112, out_data, screenshot_size);
     free(pixels);
 }
 

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -636,7 +636,7 @@ void RenderBase::SavePCXScreenshot() {
     SaveWinnersCertificate(file_name.c_str());
 }
 
-void RenderBase::SavePCXImage16(const std::string& filename, uint16_t* picture_data, int width, int height) {
+void RenderBase::SavePCXImage32(const std::string& filename, const uint32_t* picture_data, const int width, const int height) {
     // TODO(pskelton): add "Screenshots" folder?
     std::string thispath = MakeDataPath(filename);
     FILE* result = fopen(thispath.c_str(), "wb");
@@ -646,28 +646,28 @@ void RenderBase::SavePCXImage16(const std::string& filename, uint16_t* picture_d
 
     uint8_t *pcx_data = nullptr;
     unsigned int pcx_data_real_size = 0;
-    PCX::Encode16(picture_data, width, height, pcx_data, pcx_data_real_size);
+    PCX::Encode32(picture_data, width, height, pcx_data, pcx_data_real_size);
     fwrite(pcx_data, pcx_data_real_size, 1, result);
     delete[] pcx_data;
     fclose(result);
 }
 
-void RenderBase::SaveScreenshot(const std::string& filename, unsigned int width, unsigned int height) {
-    auto pixels = render->MakeScreenshot16(width, height);
-    SavePCXImage16(filename, pixels, width, height);
+void RenderBase::SaveScreenshot(const std::string& filename, const unsigned int width, const unsigned int height) {
+    auto pixels = render->MakeScreenshot32(width, height);
+    SavePCXImage32(filename, pixels, width, height);
     free(pixels);
 }
 
-void RenderBase::PackScreenshot(unsigned int width, unsigned int height,
+void RenderBase::PackScreenshot(const unsigned int width, const unsigned int height,
     uint8_t *&out_data, unsigned int &screenshot_size) {
-    auto pixels = render->MakeScreenshot16(width, height);
-    PCX::Encode16(pixels, 150, 112, out_data, screenshot_size);
+    auto pixels = render->MakeScreenshot32(width, height);
+    PCX::Encode32(pixels, width, height, out_data, screenshot_size);
     free(pixels);
 }
 
-Image* RenderBase::TakeScreenshot(unsigned int width, unsigned int height) {
-    auto pixels = MakeScreenshot16(width, height);
-    Image* image = Image::Create(width, height, IMAGE_FORMAT_R5G6B5, pixels);
+Image* RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {
+    auto pixels = MakeScreenshot32(width, height);
+    Image* image = Image::Create(width, height, IMAGE_FORMAT_A8B8G8R8, pixels);
     free(pixels);
     return image;
 }

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -644,11 +644,8 @@ void RenderBase::SavePCXImage32(const std::string& filename, const uint32_t* pic
         return;
     }
 
-    uint8_t *pcx_data = nullptr;
-    unsigned int pcx_data_real_size = 0;
-    PCX::Encode32(picture_data, width, height, pcx_data, pcx_data_real_size);
-    fwrite(pcx_data, pcx_data_real_size, 1, result);
-    delete[] pcx_data;
+    Blob packedPCX{ PCX::Encode(picture_data, width, height) };
+    fwrite(packedPCX.data(), packedPCX.size(), 1, result);
     fclose(result);
 }
 
@@ -658,11 +655,11 @@ void RenderBase::SaveScreenshot(const std::string& filename, const unsigned int 
     free(pixels);
 }
 
-void RenderBase::PackScreenshot(const unsigned int width, const unsigned int height,
-    uint8_t *&out_data, unsigned int &screenshot_size) {
+Blob RenderBase::PackScreenshot(const unsigned int width, const unsigned int height) {
     auto pixels = render->MakeScreenshot32(width, height);
-    PCX::Encode32(pixels, width, height, out_data, screenshot_size);
+    Blob packedPCX{ PCX::Encode(pixels, width, height) };
     free(pixels);
+    return packedPCX;
 }
 
 Image* RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -36,7 +36,7 @@ class RenderBase : public IRender {
     virtual void SavePCXImage16(const std::string& filename, uint16_t* picture_data, int width, int height);
     virtual void SaveScreenshot(const std::string& filename, unsigned int width, unsigned int height) override;
     virtual void PackScreenshot(unsigned int width, unsigned int height,
-        void* out_data, unsigned int data_size, unsigned int* screenshot_size) override;
+        uint8_t *&out_data, unsigned int &screenshot_size) override;
     virtual Image* TakeScreenshot(unsigned int width, unsigned int height) override;
 
     virtual void DrawMasked(float u, float v, class Image* img,

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -33,7 +33,7 @@ class RenderBase : public IRender {
     virtual HWLTexture *LoadHwlSprite(const std::string &name) override;
 
     virtual void SavePCXScreenshot() override;
-    virtual void SavePCXImage16(const std::string& filename, uint16_t* picture_data, int width, int height);
+    virtual void SavePCXImage32(const std::string& filename, const uint32_t* picture_data, const int width, const int height);
     virtual void SaveScreenshot(const std::string& filename, unsigned int width, unsigned int height) override;
     virtual void PackScreenshot(unsigned int width, unsigned int height,
         uint8_t *&out_data, unsigned int &screenshot_size) override;

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -36,14 +36,11 @@ class RenderBase : public IRender {
     virtual void SavePCXImage32(const std::string& filename, const uint32_t* picture_data, const int width, const int height);
     virtual void SaveScreenshot(const std::string& filename, unsigned int width, unsigned int height) override;
     /**
-    * @param width                         Size of image width to store.
-    * @param height                        Size of image height to store.
-    * @param[in,out] out_data              Reference to pointer - must be nullptr before call.
-    *                                      Buffer is created in function and packed pcx file stored within.
-    *                                      Must be freed by delete[] after use. 
-    * @param[out] screenshot_size          Size of the packed PCX image - must be 0 before call.
+    * @param width                         Final width of image to create.
+    * @param height                        Final height of image to create.
+    * @return                              Returns Blob containing packed pcx data and its size.
     */
-    virtual void PackScreenshot(const unsigned int width, const unsigned int height, uint8_t *&out_data, unsigned int &screenshot_size) override;
+    virtual Blob PackScreenshot(const unsigned int width, const unsigned int height) override;
     virtual Image* TakeScreenshot(unsigned int width, unsigned int height) override;
 
     virtual void DrawMasked(float u, float v, class Image* img,

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -35,8 +35,15 @@ class RenderBase : public IRender {
     virtual void SavePCXScreenshot() override;
     virtual void SavePCXImage32(const std::string& filename, const uint32_t* picture_data, const int width, const int height);
     virtual void SaveScreenshot(const std::string& filename, unsigned int width, unsigned int height) override;
-    virtual void PackScreenshot(unsigned int width, unsigned int height,
-        uint8_t *&out_data, unsigned int &screenshot_size) override;
+    /**
+    * @param width                         Size of image width to store.
+    * @param height                        Size of image height to store.
+    * @param[in,out] out_data              Reference to pointer - must be nullptr before call.
+    *                                      Buffer is created in function and packed pcx file stored within.
+    *                                      Must be freed by delete[] after use. 
+    * @param[out] screenshot_size          Size of the packed PCX image - must be 0 before call.
+    */
+    virtual void PackScreenshot(const unsigned int width, const unsigned int height, uint8_t *&out_data, unsigned int &screenshot_size) override;
     virtual Image* TakeScreenshot(unsigned int width, unsigned int height) override;
 
     virtual void DrawMasked(float u, float v, class Image* img,

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -259,14 +259,10 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
     //    render->Present();
     //}
 
-    uint8_t *screenshotBuffer = nullptr;
-    unsigned int screenshotBufferSize = 0;
-    render->PackScreenshot(150, 112, screenshotBuffer, screenshotBufferSize);  // создание скриншота
-
-    if (pNew_LOD->Write("image.pcx", screenshotBuffer, screenshotBufferSize, 0)) {
+    Blob packedScreenshot{ render->PackScreenshot(150, 112) };  // создание скриншота
+    if (pNew_LOD->Write("image.pcx", packedScreenshot.data(), packedScreenshot.size(), 0)) {
         logger->Warning("{}", localization->FormatString(LSTR_FMT_SAVEGAME_CORRUPTED, 200));
     }
-    delete[] screenshotBuffer;
 
     static_assert(sizeof(SavegameHeader) == 100, "Wrong type size");
     SavegameHeader save_header;
@@ -333,15 +329,12 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
                 const void *pixels = image->GetPixels(IMAGE_FORMAT_A8B8G8R8);
                 if (!pixels)
                     __debugbreak();
-                unsigned int pcx_data_size = 0;
-                uint8_t *pcx_data = nullptr;
-                PCX::Encode32(pixels, image->GetWidth(), image->GetHeight(),
-                              pcx_data, pcx_data_size);
+
+                Blob packedPCX{ PCX::Encode(pixels, image->GetWidth(), image->GetHeight()) };
                 std::string str = fmt::format("lloyd{}{}.pcx", i + 1, j + 1);
-                if (pNew_LOD->Write(str, pcx_data, pcx_data_size, 0)) {
+                if (pNew_LOD->Write(str, packedPCX.data(), packedPCX.size(), 0)) {
                     logger->Warning("{}", localization->FormatString(LSTR_FMT_SAVEGAME_CORRUPTED, 207));
                 }
-                delete [] pcx_data;
             }
         }
     }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -217,8 +217,6 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
         return;
     }
 
-    char *uncompressed_buff = (char *)malloc(1000000);
-
     int pPositionX = pParty->vPosition.x;
     int pPositionY = pParty->vPosition.y;
     int pPositionZ = pParty->vPosition.z;
@@ -236,9 +234,6 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
         pIndoor->stru1.last_visit = pParty->GetPlayingTime();
     else
         pOutdoor->loc_time.last_visit = pParty->GetPlayingTime();
-
-    unsigned int buf_size = 0;
-    render->PackScreenshot(150, 112, uncompressed_buff, 1000000, &buf_size);  // создание скриншота
 
     // saving - please wait
 
@@ -264,9 +259,14 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
     //    render->Present();
     //}
 
-    if (pNew_LOD->Write("image.pcx", uncompressed_buff, buf_size, 0)) {
+    uint8_t *screenshotBuffer = nullptr;
+    unsigned int screenshotBufferSize = 0;
+    render->PackScreenshot(150, 112, screenshotBuffer, screenshotBufferSize);  // создание скриншота
+
+    if (pNew_LOD->Write("image.pcx", screenshotBuffer, screenshotBufferSize, 0)) {
         logger->Warning("{}", localization->FormatString(LSTR_FMT_SAVEGAME_CORRUPTED, 200));
     }
+    delete[] screenshotBuffer;
 
     static_assert(sizeof(SavegameHeader) == 100, "Wrong type size");
     SavegameHeader save_header;
@@ -333,19 +333,20 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
                 const void *pixels = image->GetPixels(IMAGE_FORMAT_A8B8G8R8);
                 if (!pixels)
                     __debugbreak();
-                unsigned int pcx_data_size = 30000;
-                void *pcx_data = malloc(pcx_data_size);
+                unsigned int pcx_data_size = 0;
+                uint8_t *pcx_data = nullptr;
                 PCX::Encode32(pixels, image->GetWidth(), image->GetHeight(),
-                              pcx_data, pcx_data_size, &pcx_data_size);
+                              pcx_data, pcx_data_size);
                 std::string str = fmt::format("lloyd{}{}.pcx", i + 1, j + 1);
                 if (pNew_LOD->Write(str, pcx_data, pcx_data_size, 0)) {
                     logger->Warning("{}", localization->FormatString(LSTR_FMT_SAVEGAME_CORRUPTED, 207));
                 }
-                free(pcx_data);
+                delete [] pcx_data;
             }
         }
     }
 
+    char *uncompressed_buff = (char *)malloc(1000000);
     if (!NotSaveWorld) {  // autosave for change location
         CompactLayingItemsList();
 


### PR DESCRIPTION
fix #243
moves pcx buffer creation to encode - failsafe size so can never overrun
encode returns blob
drops pcx encoding from 16bit input