### PR TITLE
Move last sound plays without originator to new API

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -731,9 +731,8 @@ void Engine::OutlineSelection() {
 
 
 
-//----- (0042FC15) --------------------------------------------------------
 void PlayButtonClickSound() {
-    pAudioPlayer->PlaySound(SOUND_StartMainChoice02, -2, 0, -1, 0, 0);
+    pAudioPlayer->playNonResetableSound(SOUND_StartMainChoice02);
 }
 
 //----- (0046BDC0) --------------------------------------------------------

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -209,6 +209,9 @@ struct Engine {
 
 extern std::shared_ptr<Engine> engine;
 
+/**
+ * @offset 0x42FC15
+ */
 void PlayButtonClickSound();
 void back_to_game();
 

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -896,8 +896,7 @@ LABEL_47:
                             Party_Teleport_Z_Pos = 0;
                             Party_Teleport_Y_Pos = 0;
                             Party_Teleport_X_Pos = 0;
-                            v106 = 232;
-                            pAudioPlayer->PlaySound((SoundID)v106, 0, 0, -1, 0, 0);
+                            pAudioPlayer->playUISound(SOUND_teleport);
                         }
                     } else {
                         pGameLoadingUI_ProgressBar->Initialize((GUIProgressBar::Type)((activeLevelDecoration == NULL) + 1));

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -139,6 +139,7 @@ bool Chest::Open(int uChestID) {
             pSpellObject.spell_target_pid = 0;
             pSpellObject.uFacing = 0;
             pSpellObject.Create(0, 0, 0, 0);
+            // TODO(Nik-RE-dev): chest is originator in this case
             pAudioPlayer->PlaySound(SOUND_fireBall, 0, 0, -1, 0, 0);
             pSpellObject.ExplosionTraps();
             chest->uFlags &= ~CHEST_TRAPPED;
@@ -155,7 +156,7 @@ bool Chest::Open(int uChestID) {
         flag_shout = true;
     }
     pAudioPlayer->PauseSounds(-1);
-    pAudioPlayer->PlaySound(SOUND_openchest0101, 0, 0, -1, 0, 0);
+    pAudioPlayer->playUISound(SOUND_openchest0101);
     if (flag_shout == true) {
         if (!OpenedTelekinesis) {
             pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TrapDisarmed);

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -6588,16 +6588,16 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
             int randVal = vrng->Random(4);
             switch (randVal) {
                 case 0:
-                    soundToPlay = (SoundID)108;
+                    soundToPlay = SOUND_dull_armor_strike1;
                     break;
                 case 1:
-                    soundToPlay = (SoundID)109;
+                    soundToPlay = SOUND_dull_armor_strike2;
                     break;
                 case 2:
-                    soundToPlay = (SoundID)110;
+                    soundToPlay = SOUND_dull_armor_strike3;
                     break;
                 case 3:
-                    soundToPlay = (SoundID)44;
+                    soundToPlay = SOUND_dull_strike;
                     break;
                 default:
                     Error("Unexpected sound value");
@@ -6606,22 +6606,23 @@ void DamagePlayerFromMonster(unsigned int uObjID, ABILITY_INDEX dmgSource, Vec3i
             int randVal = vrng->Random(4);
             switch (randVal) {
                 case 0:
-                    soundToPlay = (SoundID)105;
+                    soundToPlay = SOUND_metal_armor_strike1;
                     break;
                 case 1:
-                    soundToPlay = (SoundID)106;
+                    soundToPlay = SOUND_metal_armor_strike2;
                     break;
                 case 2:
-                    soundToPlay = (SoundID)107;
+                    soundToPlay = SOUND_metal_armor_strike3;
                     break;
                 case 3:
-                    soundToPlay = (SoundID)45;
+                    soundToPlay = SOUND_metal_vs_metal01h;
                     break;
                 default:
                     Error("Unexpected sound value");
             }
         }
-        pAudioPlayer->PlaySound(soundToPlay, PID(OBJECT_Player, targetchar + 80), 0, -1, 0, 0);
+        // TODO(Nik-RE-dev): is it correct to use voice volume for strike sounds?
+        pAudioPlayer->PlaySound(soundToPlay, PID(OBJECT_Player, targetchar), 0, -1, 0, 0);
 
         // calc damage
         int dmgToReceive = actorPtr->_43B3E0_CalcDamage(dmgSource);
@@ -7475,7 +7476,7 @@ void Player::playReaction(PlayerSpeech speech, int a3) {
             int numberOfSubvariants = byte_4ECF08[pickedVariant - 1][uVoiceID];
             if (numberOfSubvariants > 0) {
                 pickedSoundID = vrng->Random(numberOfSubvariants) + 2 * (pickedVariant + 50 * uVoiceID) + 4998;
-                pAudioPlayer->PlaySound((SoundID)pickedSoundID, PID(OBJECT_Player, pParty->getActiveCharacter() + 39), 0, -1, 0, 0);
+                pAudioPlayer->PlaySound((SoundID)pickedSoundID, PID(OBJECT_Player, GetPlayerIndex()), 0, -1, 0, 0);
             }
         }
     }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -719,7 +719,7 @@ void SpriteObject::createSplashObject(Vec3i pos) {
     sprite.uSectorID = pIndoor->GetSector(pos);
     int objID = sprite.Create(0, 0, 0, 0);
     if (objID != -1) {
-        pAudioPlayer->PlaySound((SoundID)SOUND_splash, PID(OBJECT_Item, objID), 0, 0, 0, 0);
+        pAudioPlayer->PlaySound(SOUND_splash, PID(OBJECT_Item, objID), 0, 0, 0, 0);
     }
 }
 

--- a/src/GUI/UI/Spellbook.cpp
+++ b/src/GUI/UI/Spellbook.cpp
@@ -61,7 +61,8 @@ GUIWindow_Spellbook::GUIWindow_Spellbook()
     InitializeSpellBookTextures();
     OpenSpellbook();
 
-    pAudioPlayer->PlaySound(SOUND_48, 0, 0, -1, 0, 0);
+    // Sound 48 is absent in MM7
+    pAudioPlayer->playUISound(SOUND_48);
 }
 
 void GUIWindow_Spellbook::OpenSpellbookPage(int page) {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -968,7 +968,8 @@ void PlayHouseSound(unsigned int uHouseID, HouseSoundID sound) {
     if (uHouseID > 0) {
         if (pAnimatedRooms[p2DEvents[uHouseID - HOUSE_SMITH_EMERALD_ISLE].uAnimationID].uRoomSoundId) {
             int roomSoundId = pAnimatedRooms[p2DEvents[uHouseID - HOUSE_SMITH_EMERALD_ISLE].uAnimationID].uRoomSoundId;
-            pAudioPlayer->PlaySound((SoundID)(sound + 100 * (roomSoundId + 300)), 806, 0, -1, 0, 0);
+            // PID 806 was used which is PID(OBJECT_Face, 100)
+            pAudioPlayer->playUISound((SoundID)(sound + 100 * (roomSoundId + 300)));
         }
     }
 }
@@ -2075,7 +2076,7 @@ void TempleDialog() {
             // LODWORD(pPlayers[pParty->getActiveCharacter()]->pConditions[Condition_Zombie]);
         } else {
             if (pPlayers[pParty->getActiveCharacter()]->conditions.HasNone({Condition_Eradicated, Condition_Petrified, Condition_Dead})) {
-                pAudioPlayer->playExclusiveSound(SOUND_heal);;
+                pAudioPlayer->playExclusiveSound(SOUND_heal);
                 pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TempleHeal);
                 pOtherOverlayList->_4418B1(20, pParty->getActiveCharacter() + 99, 0, 65536);
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);

--- a/src/Media/Audio/AudioPlayer.h
+++ b/src/Media/Audio/AudioPlayer.h
@@ -22,8 +22,10 @@ enum SoundID {
     SOUND_ClickPlus = 23,
     SOUND_ClickSkill = 24,
     SOUND_error = 27,
+    SOUND_dull_strike = 44,
+    SOUND_metal_vs_metal01h = 45,
     SOUND_metal_vs_metal03h = 47,
-    SOUND_48 = 0x30,
+    SOUND_48 = 48,
     SOUND_RunBadlands = 49,
     SOUND_RunCarpet = 50,
     SOUND_RunCooledLava = 51,
@@ -58,19 +60,25 @@ enum SoundID {
     SOUND_WalkWater = 101,
     SOUND_WalkWaterIndoor = 102,
     SOUND_WalkWood = 103,
+    SOUND_metal_armor_strike1 = 105,
+    SOUND_metal_armor_strike2 = 106,
+    SOUND_metal_armor_strike3 = 107,
+    SOUND_dull_armor_strike1 = 108,
+    SOUND_dull_armor_strike2 = 109,
+    SOUND_dull_armor_strike3 = 110,
     SOUND_bricks_down = 120,
     SOUND_bricks_up = 121,
-    SOUND_damage = 0x7A,
-    SOUND_deal = 0x7B,
-    SOUND_defeat = 0x7C,
-    SOUND_querry_up = 0x7D,
-    SOUND_querry_down = 0x7E,
-    SOUND_shuffle = 0x7F,
-    SOUND_title = 0x80,
-    SOUND_tower_up = 0x81,
-    SOUND_typing = 0x82,
-    SOUND_victory = 0x83,
-    SOUND_wall_up = 0x84,
+    SOUND_damage = 122,
+    SOUND_deal = 123,
+    SOUND_defeat = 124,
+    SOUND_querry_up = 125,
+    SOUND_querry_down = 126,
+    SOUND_shuffle = 127,
+    SOUND_title = 128,
+    SOUND_tower_up = 129,
+    SOUND_typing = 130,
+    SOUND_victory = 131,
+    SOUND_wall_up = 132,
     SOUND_luteguitar = 133,
     SOUND_panflute = 134,
     SOUND_trumpet = 135,
@@ -82,22 +90,23 @@ enum SoundID {
     SOUND_batlleen = 206,
     SOUND_batllest = 207,
     SOUND_openchest0101 = 208,
-    SOUND_spellfail0201 = 0xD1,
-    SOUND_drink = 0xD2,
+    SOUND_spellfail0201 = 209,
+    SOUND_drink = 210,
     SOUND_eat = 211,
-    SOUND_gong = 0xD7,
-    SOUND_hurp = 0xD9,
+    SOUND_gong = 215,
+    SOUND_hurp = 217,
     SOUND_church = 218,
-    SOUND_chimes = 0xDB,
+    SOUND_chimes = 219,
     SOUND_splash = 220,
-    SOUND_star1 = 0xDD,
-    SOUND_star2 = 0xDE,
-    SOUND_star4 = 0xE0,
-    SOUND_eradicate = 0xE1,
-    SOUND_eleccircle = 0xE2,
-    SOUND_encounter = 0xE3,
+    SOUND_star1 = 221,
+    SOUND_star2 = 222,
+    SOUND_star4 = 224,
+    SOUND_eradicate = 225,
+    SOUND_eleccircle = 226,
+    SOUND_encounter = 227,
     SOUND_openbook = 230,
     SOUND_closebook = 231,
+    SOUND_teleport = 232,
     SOUND_hf445a = 5788,
     SOUND_Haste = 10040,
     SOUND_21fly03 = 11090,
@@ -145,11 +154,11 @@ class AudioPlayer {
      * Play sound.
      *
      * @param eSoundID                  ID of sound.
-     * @param pid                       PID of sound originator or, 0 for generic ui sound, -1(PID_INVALID)
-     *                                  for resetable (playing this sound again whilst its playing will stop
-     *                                  it and start from beginning) exclusive (sound should not be stopped
-     *                                  by system on ui events) sound and other < 0 for non resetable sounds
-     *                                  (will not restart if played again whilst already playing).
+     * @param pid                       PID of sound originator or:
+     *                                  * 0 for generic ui sound
+     *                                  * -1(PID_INVALID) for resetable (playing this sound again whilst its playing will stop
+     *                                    it and start from beginning) exclusive (sound should not be stopped by system on ui events) sound
+     *                                  * other < 0 for non resetable sounds (will not restart if played again whilst already playing)
      *                                  NB: system use of exclusive sounds is inconsistent.
      * @param uNumRepeats               unused but presumably must be number of repeats before stopping
      * @param x                         ???, unused
@@ -178,7 +187,7 @@ class AudioPlayer {
     /**
      * Play generic UI sound.
      * Generic sounds are played in non-exclusive mode - it meand that each call to this function
-     * will play sound even if sound with the same ID has not funished playing.
+     * will play sound even if sound with the same ID has not finished playing.
      *
      * @param id                        ID of sound.
      */
@@ -195,6 +204,17 @@ class AudioPlayer {
      */
     void playExclusiveSound(SoundID id) {
         PlaySound(id, PID_INVALID, 0, -1, 0, 0);
+    }
+
+    /**
+     * Play sound in non-resetable mode.
+     * It means that if sound with the same ID has not finished playing, this call is effectively ignored.
+     * New playing of such sound can only start when previous one has finished playing.
+     *
+     * @param id                        ID of sound.
+     */
+    void playNonResetableSound(SoundID id) {
+        PlaySound(id, -2, 0, -1, 0, 0);
     }
 
     /**


### PR DESCRIPTION
Old API now uses only call to play sound with originator (positive PID), sound from events (PID 0 used, but with additional params) and pair of places with 0 PID.
P.S. I added changes proposed in #584, which seems to fix the issue.