### PR TITLE
Refactored command line options, handling verbose logging properly

### DIFF
--- a/src/Application/Game.h
+++ b/src/Application/Game.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "GameConfig.h"
 #include "GameMenu.h"
@@ -56,6 +57,6 @@ class Game {
     std::shared_ptr<Nuklear> nuklear = nullptr;
 };
 
-void AutoInitDataPath(Platform *platform);
+void initDataPath(const std::string &dataPath);
 
 extern class Image *gamma_preview_image;  // 506E40

--- a/src/Application/GameConfig.cpp
+++ b/src/Application/GameConfig.cpp
@@ -7,8 +7,6 @@
 #include "Library/Logger/Logger.h"
 #include "Library/Serialization/EnumSerialization.h"
 
-#include "Utility/DataPath.h"
-
 MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(RendererType, CASE_INSENSITIVE, {
     {RendererType::OpenGL, "OpenGL"},
     {RendererType::OpenGLES, "OpenGLES"}
@@ -29,26 +27,22 @@ MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(PlatformWindowMode, CASE_INSENSITIVE, {
 })
 
 void GameConfig::LoadConfiguration() {
-    std::string path = MakeDataPath(config_file);
-
-    if (std::filesystem::exists(path)) {
-        Config::load(path);
-        logger->info("Configuration file '{}' loaded!", path);
+    if (std::filesystem::exists(_path)) {
+        Config::load(_path);
+        _logger->info("Configuration file '{}' loaded!", _path);
     } else {
         Config::reset();
-        logger->warning("Cound not read configuration file '{}'! Loaded default configuration instead!", path);
+        _logger->warning("Could not read configuration file '{}'! Loaded default configuration instead!", _path);
     }
 }
 
 void GameConfig::SaveConfiguration() {
-    std::string path = MakeDataPath(config_file);
-
-    Config::save(path);
-    logger->info("Configuration file '{}' saved!", path);
+    Config::save(_path);
+    _logger->info("Configuration file '{}' saved!", _path);
 }
 
-GameConfig::GameConfig() {
-    this->logger = EngineIocContainer::ResolveLogger();
+GameConfig::GameConfig(const std::string &path) : _path(path) {
+    _logger = EngineIocContainer::ResolveLogger();
 }
 
 GameConfig::~GameConfig() {}

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -23,7 +23,7 @@ MM_DECLARE_SERIALIZATION_FUNCTIONS(PlatformWindowMode)
 
 class GameConfig : public Config {
  public:
-    GameConfig();
+    explicit GameConfig(const std::string &path);
     ~GameConfig();
 
     void LoadConfiguration();
@@ -577,7 +577,7 @@ class GameConfig : public Config {
     Window window{ this };
 
  private:
-    const std::string config_file = "openenroth.ini";
-    Logger *logger = nullptr;
+    std::string _path;
+    Logger *_logger = nullptr;
 };
 

--- a/src/Application/GameOptions.cpp
+++ b/src/Application/GameOptions.cpp
@@ -1,107 +1,50 @@
 #include "GameOptions.h"
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include <CLI/CLI.hpp>
 
-#include "Application/GameConfig.h"
 #include "Utility/Format.h"
 
-template<class T>
-bool lexical_cast(const std::string &input, ConfigEntry<T> &configValue) {
-    T value;
-    if (!CLI::detail::lexical_cast(input, value))
-        return false;
+#include "GamePathResolver.h"
+#include "GameConfig.h"
 
-    configValue.setValue(value);
-    return true;
-}
-
-// TODO(captainurist): we shouldn't need to overload lexical_assign, this begs a PR to CLI11
-template<class A, class B, class T>
-bool lexical_assign(const std::string &input, ConfigEntry<T> &configValue) {
-    return lexical_cast(input, configValue);
-}
-
-bool ParseGameOptions(int argc, char **argv, GameConfig *config) {
+GameOptions GameOptions::Parse(int argc, char **argv) {
+    GameOptions result;
     std::unique_ptr<CLI::App> app = std::make_unique<CLI::App>();
 
-    auto enableDebug = [&] {
-        config->debug.ShowFPS.setValue(true);
-        config->debug.ShowPickedFace.setValue(true);
-        config->debug.TownPortal.setValue(true);
-        config->debug.InfiniteFood.setValue(true);
-        config->debug.InfiniteGold.setValue(true);
-    };
-
-    auto unset = [] (ConfigEntry<bool>& value) {
-        return [&] {
-            value.setValue(false);
-        };
-    };
-
-    auto setOption = [&] (const std::string& string) {
-        size_t dotPos = string.find_first_of('.');
-        size_t equalsPos = string.find_first_of('=', dotPos + 1);
-        if (dotPos == std::string::npos || equalsPos == std::string::npos)
-            throw CLI::ParseError(fmt::format("Expected a value in 'SECTION.NAME=VALUE' format, got '{}'"_cf, string), CLI::ExitCodes::BaseClass);
-
-        std::string sectionName = string.substr(0, dotPos);
-        std::string valueName = string.substr(dotPos + 1, equalsPos - dotPos - 1);
-        std::string valueString = string.substr(equalsPos + 1);
-
-        ConfigSection *section = config->section(sectionName);
-        if (!section)
-            throw CLI::ParseError(fmt::format("Section '{}' doesn't exist"_cf, sectionName), CLI::ExitCodes::BaseClass);
-
-        AnyConfigEntry *value = section->entry(valueName);
-        if (!value)
-            throw CLI::ParseError(fmt::format("Value '{}' doesn't exist in section '{}'"_cf, valueName, sectionName), CLI::ExitCodes::BaseClass);
-
-        try {
-            value->setString(valueString);
-        } catch (const std::exception &e) {
-            throw CLI::ParseError(e.what(), CLI::ExitCodes::BaseClass);
-        }
-    };
-
-    std::string generalOptions = "General Options";
-    std::string gameOptions = "Game Options";
-    std::string windowOptions = "Window Options";
-
-    std::vector<std::string> setArgs;
-
-    app->set_help_flag("-h,--help", "Print help and exit")->group(generalOptions);
-    app->add_flag("-v,--verbose", config->debug.VerboseLogging, "Enable verbose logging")->group(generalOptions);
-    app->add_option("-s,--set", setArgs, "Set config option")->type_name("SECTION.NAME=VALUE")->group(generalOptions)->expected(1, 1000)->each(setOption);
-
-    // TODO(captainurist): redo the rest of this file, use Config directly.
-
-    app->add_flag("--nointro", config->debug.NoIntro, "Skip intro movie")->group(gameOptions);
-    app->add_flag("--nologo", config->debug.NoLogo, "Skip 3DO & NWC logos")->group(gameOptions);
-    app->add_flag("--nosound", config->debug.NoSound, "Disable sound")->group(gameOptions);
-    app->add_flag("--novideo", config->debug.NoVideo, "Disable all videos, including house backgrounds")->group(gameOptions);
-    app->add_flag("--nomarg", config->debug.NoMargaret, "Disable Margaret the guide")->group(gameOptions);
-    app->add_flag_callback("--nowalksound", unset(config->settings.WalkSound), "Disable walking sound")->group(gameOptions);
-    app->add_flag_callback("--nograb", unset(config->window.MouseGrab), "Don't restrict mouse movement to the game window")->group(gameOptions);
-    app->add_flag_callback("--debug", enableDebug, "Minimal debug mode")->group(gameOptions);
-
-    app->add_option("--display", config->window.Display, "Display number to place the game window at (0 is your main display)")->type_name("NUMBER")->group(windowOptions);
-    app->add_option("--window-width", config->window.Width, "Game window width")->type_name("WIDTH")->group(windowOptions);
-    app->add_option("--window-height", config->window.Height, "Game window height")->type_name("HEIGHT")->group(windowOptions);
-    app->add_option("--window-x", config->window.PositionX, "Game window x position in display coordinates")->type_name("X")->group(windowOptions);
-    app->add_option("--window-y", config->window.PositionY, "Game window y position in display coordinates")->type_name("Y")->group(windowOptions);
-    app->add_option("--window-mode", config->window.Mode,
-                    "Game window mode, one of 'windowed', 'borderless', 'fullscreen' or 'fullscreen_borderless'")->type_name("MODE")->group(windowOptions);
+    app->add_option("--data-path", result.dataPath,
+                    fmt::format("Path to MM7 data folder, default is taken from '{}' environment variable. "
+                                "If neither this argument is supplied nor the environment variable is set, "
+                                "then on Windows OpenEnroth will also try to read the path from registry. "
+                                "If this also fails, then OpenEnroth will look for game data in the current folder.", mm7PathOverrideKey))->check(CLI::ExistingDirectory)->option_text("PATH");
+    app->add_option("--config", result.configPath,
+                    "Path to OpenEnroth config file, default is 'openenroth.ini' in data folder.")->option_text("PATH");
+    app->add_flag("-v,--verbose", result.verbose,
+                  "Enable verbose logging.");
+    app->set_help_flag("-h,--help", "Print help and exit.");
 
     try {
         app->parse(argc, argv);
     } catch (const CLI::ParseError &e) {
-        app->exit(e);
-        return false;
+        if (app->get_help_ptr()->as<bool>()) {
+            app->exit(e);
+            result.helpPrinted = true;
+        } else {
+            throw; // Genuine parse error => propagate.
+        }
     }
 
-    return true;
+    return result;
+}
+
+void GameOptions::ResolveDefaults(Platform *platform) {
+    if (dataPath.empty())
+        dataPath = resolveMm7Path(platform);
+
+    if (configPath.empty()) {
+        configPath = "openenroth.ini";
+        if (!dataPath.empty())
+            configPath = dataPath + "/" + configPath;
+    }
 }

--- a/src/Application/GameOptions.h
+++ b/src/Application/GameOptions.h
@@ -1,5 +1,29 @@
 #pragma once
 
-class GameConfig;
+#include <string>
 
-bool ParseGameOptions(int argc, char **argv, GameConfig *config);
+class GameConfig;
+class Platform;
+
+struct GameOptions {
+    std::string configPath;
+    std::string dataPath;
+    bool verbose = false;
+    bool helpPrinted = false; // True means that help message was already printed.
+
+    /**
+     * Parses OpenEnroth command line options.
+     *
+     * @param argc                      argc as passed to main.
+     * @param argv                      argv as passed to main.
+     * @throw std::exception            On errors.
+     */
+    static GameOptions Parse(int argc, char **argv);
+
+    /**
+     * Resolves default values after `Platform` was constructed.
+     *
+     * @param platform                  Platform object.
+     */
+    void ResolveDefaults(Platform *platform);
+};

--- a/src/Application/GamePathResolver.cpp
+++ b/src/Application/GamePathResolver.cpp
@@ -54,12 +54,16 @@ static std::string _resolvePath(
 #ifdef __ANDROID__
     // TODO: find a better way to deal with paths and remove this android specific block.
     std::string result = platform->StoragePath(ANDROID_STORAGE_EXTERNAL);
-    if (result.empty()) {
+    if (result.empty())
         result = platform->StoragePath(ANDROID_STORAGE_INTERNAL);
-    }
-
+    if (result.empty())
+        platform->ShowMessageBox("Device currently unsupported", "Your device doesn't have any storage so it is unsupported!");
     return result;
 #else
+    // TODO (captainurist): we should consider reading Unicode (utf8) strings from win32 registry, as it might contain paths
+    // curretnly we convert all strings out of registry into CP_ACP (default windows ansi)
+    // it is later on passed to std::filesystem that should be ascii on windows as well
+    // this means we will can't handle win32 unicode paths at the time
     const char *envPathStr = std::getenv(envVarOverride);
 
     std::string envPath{};

--- a/src/Application/main.cpp
+++ b/src/Application/main.cpp
@@ -2,6 +2,8 @@
 #include <string>
 #include <exception>
 
+#include <CLI/Error.hpp>
+
 #include "Application/Game.h"
 #include "Application/GameConfig.h"
 #include "Application/GameFactory.h"
@@ -15,27 +17,36 @@
 
 int MM_Main(int argc, char **argv) {
     try {
+        GameOptions options = GameOptions::Parse(argc, argv);
+        if (options.helpPrinted)
+            return 1;
+
         std::unique_ptr<PlatformLogger> logger = PlatformLogger::createStandardLogger(WIN_ENSURE_CONSOLE_OPTION);
-        logger->setLogLevel(APPLICATION_LOG, LOG_INFO);
-        logger->setLogLevel(PLATFORM_LOG, LOG_ERROR);
+        logger->setLogLevel(APPLICATION_LOG, options.verbose ? LOG_VERBOSE : LOG_INFO);
+        logger->setLogLevel(PLATFORM_LOG, options.verbose ? LOG_VERBOSE : LOG_ERROR);
         EngineIocContainer::ResolveLogger()->setBaseLogger(logger.get());
         MM_AT_SCOPE_EXIT(EngineIocContainer::ResolveLogger()->setBaseLogger(nullptr));
         Engine::LogEngineBuildInfo();
 
         std::unique_ptr<PlatformApplication> app = std::make_unique<PlatformApplication>(logger.get());
+        options.ResolveDefaults(app->platform());
 
-        AutoInitDataPath(app->platform());
+        initDataPath(options.dataPath);
 
-        std::shared_ptr<GameConfig> gameConfig = std::make_shared<GameConfig>();
+        std::shared_ptr<GameConfig> gameConfig = std::make_shared<GameConfig>(options.configPath);
         gameConfig->LoadConfiguration();
-        if (!ParseGameOptions(argc, argv, &*gameConfig))
-            return 1;
+
+        // TODO(captainurist): move into ConfigValue::subscribe.
+        if (gameConfig->debug.VerboseLogging.value()) {
+            logger->setLogLevel(APPLICATION_LOG, LOG_VERBOSE);
+            logger->setLogLevel(PLATFORM_LOG, LOG_VERBOSE);
+        }
 
         std::shared_ptr<Game> game = GameFactory().CreateGame(app.get(), gameConfig);
 
         return game->Run();
     } catch (const std::exception &e) {
-        fprintf(stderr, "%s\n", e.what());
+        fmt::print(stderr, "{}\n", e.what());
         return 1;
     }
 }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -352,8 +352,7 @@ void Engine::StackPartyTorchLight() {
             pParty->flt_TorchlightColorG = 96;
             pParty->flt_TorchlightColorB = 96;
 
-            if (engine->config->debug.VerboseLogging.value())
-                logger->warning("Torchlight doesn't have color");
+            logger->verbose("Torchlight doesn't have color");
         }
 
         // TODO: either add conversion functions, or keep only glm / only Vec3_* classes.

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -317,8 +317,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
     v133 = 0;
     EvtTargetObj = targetObj;
     dword_5B65C4_cancelEventProcessing = 0;
-    if (engine->config->debug.VerboseLogging.value())
-        logger->info("Processing EventID: {}", uEventID);
+    logger->verbose("Processing EventID: {}", uEventID);
 
     if (!uEventID) {
         if (!game_ui_status_bar_event_string_time_left)

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1486,8 +1486,7 @@ int BLV_GetFloorLevel(const Vec3i &pos, unsigned int uSectorID, unsigned int *pF
 
     // no face found - probably wrong sector supplied
     if (!FacesFound) {
-        if (engine->config->debug.VerboseLogging.value())
-            logger->warning("Floorlvl fail: {} {} {}", pos.x, pos.y, pos.z);
+        logger->verbose("Floorlvl fail: {} {} {}", pos.x, pos.y, pos.z);
 
         *pFaceID = -1;
         return -30000;

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -282,8 +282,8 @@ linesverts lineshaderstore[2000] = {};
 int linevertscnt = 0;
 
 void RenderOpenGL::BeginLines2D() {
-    if (linevertscnt && engine->config->debug.VerboseLogging.value())
-        logger->warning("BeginLines with points still stored in buffer");
+    if (linevertscnt)
+        logger->verbose("BeginLines with points still stored in buffer");
 
     DrawTwodVerts();
 
@@ -711,8 +711,7 @@ void RenderOpenGL::DrawTextureOffset(int pX, int pY, int move_X, int move_Y,
 
 void RenderOpenGL::DrawImage(Image *img, const Recti &rect, uint paletteid, uint32_t uColor32) {
     if (!img) {
-        if (engine->config->debug.VerboseLogging.value())
-            logger->warning("Null img passed to DrawImage");
+        logger->verbose("Null img passed to DrawImage");
         return;
     }
 
@@ -1422,8 +1421,7 @@ void RenderOpenGL::DrawFromSpriteSheet(Recti *pSrcRect, Pointi *pTargetPoint, in
     TextureOpenGL *texture = (TextureOpenGL*)pArcomageGame->pSprites;
 
     if (!texture) {
-        if (engine->config->debug.VerboseLogging.value())
-            logger->warning("Missing Arcomage Sprite Sheet");
+        logger->verbose("Missing Arcomage Sprite Sheet");
         return;
     }
 
@@ -1632,8 +1630,7 @@ bool RenderOpenGL::MoveTextureToDevice(Texture *texture) {
         pixels = (uint8_t *)t->GetPixels(IMAGE_FORMAT_A8B8G8R8);
         gl_format = GL_RGBA;
     } else {
-        if (engine->config->debug.VerboseLogging.value())
-            log->warning("Image {} not loaded!", *t->GetName());
+        log->verbose("Image {} not loaded!", *t->GetName());
     }
 
     if (pixels) {
@@ -2733,8 +2730,8 @@ void RenderOpenGL::DoRenderBillboards_D3D() {
     _set_ortho_projection(1);
     _set_ortho_modelview();
 
-    if (billbstorecnt && engine->config->debug.VerboseLogging.value())
-        logger->warning("Billboard shader store isnt empty!");
+    if (billbstorecnt)
+        logger->verbose("Billboard shader store isnt empty!");
 
     // track loaded tex
     float gltexid{ 0 };
@@ -3083,8 +3080,7 @@ void RenderOpenGL::BeginScene2D() {
 void RenderOpenGL::DrawTextureNew(float u, float v, Image *tex, uint32_t colourmask) {
     TextureOpenGL *texture = dynamic_cast<TextureOpenGL *>(tex);
     if (!texture) {
-        if (engine->config->debug.VerboseLogging.value())
-            logger->info("Null texture passed to DrawTextureNew");
+        logger->verbose("Null texture passed to DrawTextureNew");
         return;
     }
 
@@ -3212,8 +3208,7 @@ void RenderOpenGL::DrawTextureNew(float u, float v, Image *tex, uint32_t colourm
 void RenderOpenGL::DrawTextureCustomHeight(float u, float v, class Image *img, int custom_height) {
     TextureOpenGL* texture = dynamic_cast<TextureOpenGL*>(img);
     if (!texture) {
-        if (engine->config->debug.VerboseLogging.value())
-            logger->info("Null texture passed to DrawTextureCustomHeight");
+        logger->verbose("Null texture passed to DrawTextureCustomHeight");
         return;
     }
 

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -148,8 +148,7 @@ void RenderBase::DrawSpriteObjects() {
                 (object->uType < SPRITE_TRAP_FIRE || object->uType > SPRITE_TRAP_BODY))) {
             SpriteFrame *frame = object->GetSpriteFrame();
             if (frame->icon_name == "null" || frame->texture_name == "null") {
-                if (engine->config->debug.VerboseLogging.value())
-                    logger->warning("Trying to draw sprite with null frame");
+                logger->verbose("Trying to draw sprite with null frame");
                 continue;
             }
 
@@ -160,8 +159,7 @@ void RenderBase::DrawSpriteObjects() {
             pBillboardRenderList[::uNumBillboardsToDraw].hwsprite = frame->hw_sprites[octant];
             // error catching
             if (frame->hw_sprites[octant]->texture->GetHeight() == 0 || frame->hw_sprites[octant]->texture->GetWidth() == 0) {
-                if (engine->config->debug.VerboseLogging.value())
-                    logger->warning("Trying to draw sprite with empty octant texture");
+                logger->verbose("Trying to draw sprite with empty octant texture");
                 continue;
             }
 
@@ -423,8 +421,7 @@ void RenderBase::TransformBillboardsAndSetPalettesODM() {
 
             TransformBillboard(&billboard, p);
         } else {
-            if (engine->config->debug.VerboseLogging.value())
-                logger->warning("Billboard with no sprite!");
+            logger->verbose("Billboard with no sprite!");
         }
     }
 }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -414,8 +414,8 @@ void Chest::PlaceItems(int uChestID) {  // only sued for setup
                 if (vChests[uChestID].uFlags & CHEST_OPENED) {
                     vChests[uChestID].igChestItems[items_counter].SetIdentified();
                 }
-            } else if (engine->config->debug.VerboseLogging.value()) {
-                logger->warning("Cannot place item with id {} in the chest!", std::to_underlying(chest_item_id));
+            } else {
+                logger->verbose("Cannot place item with id {} in the chest!", std::to_underlying(chest_item_id));
             }
         }
     }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -994,7 +994,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         pWindow->DrawTitleText(pFontSmallnum, 0, pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, 0, str, 3);
     }
 
-    // ps - test to track ai states
+    // TODO(captainurist): this isn't about verbose logging and should depend on some other parameter
     if (engine->config->debug.VerboseLogging.value()) {
         std::string str = fmt::format("AI State: {}", std::to_underlying(pActors[uActorID].uAIState));
         pFontSmallnum->GetLineWidth(str);

--- a/src/Library/Logger/Logger.h
+++ b/src/Library/Logger/Logger.h
@@ -13,9 +13,14 @@ class Logger {
     PlatformLogger *baseLogger() const;
     void setBaseLogger(PlatformLogger *baseLogger);
 
+    bool shouldLog(PlatformLogLevel logLevel) const {
+        return _baseLogger == nullptr || _baseLogger->logLevel(APPLICATION_LOG) <= logLevel;
+    }
+
     template<class... Args>
     void log(PlatformLogLevel logLevel, fmt::format_string<Args...> fmt, Args&&... args) {
-        logV(logLevel, fmt, fmt::make_format_args(std::forward<Args>(args)...));
+        if (shouldLog(logLevel))
+            logV(logLevel, fmt, fmt::make_format_args(std::forward<Args>(args)...));
     }
 
     template<class... Args>

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -226,8 +226,8 @@ void AudioPlayer::stopSounds() {
 
     for (auto &[_, si] : mapSounds) {
         if (si.sample) {
-            if (si.sample->Stop() && engine->config->debug.VerboseLogging.value()) {
-                logger->info("sound stopped: {}", si.sName);
+            if (si.sample->Stop()) {
+                logger->verbose("sound stopped: {}", si.sName);
             }
         }
     }
@@ -372,8 +372,7 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
             default: {
                 // TODO(pskelton): temp fix to reduce instances of sounds not playing
                 si.sample->Play();
-                if (engine->config->debug.VerboseLogging.value())
-                    logger->warning("Unexpected object type from PID in playSound");
+                logger->verbose("Unexpected object type from PID in playSound");
                 break;
             }
         }
@@ -381,21 +380,17 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
 
     si.last_pid = pid;
 
-    if (engine->config->debug.VerboseLogging.value()) {
-        if (si.sName == "")
-            logger->info("AudioPlayer: playing sound {}", eSoundID);
-        else
-            logger->info("AudioPlayer: playing sound {} with name '{}'", eSoundID, si.sName);
-    }
-
-    return;
+    if (si.sName.empty())
+        logger->verbose("AudioPlayer: playing sound {}", eSoundID);
+    else
+        logger->verbose("AudioPlayer: playing sound {} with name '{}'", eSoundID, si.sName);
 }
 
 void AudioPlayer::ResumeSounds() {
     for (auto &[_, si] : mapSounds) {
         if (si.sample) {
-            if (si.sample->Resume() && engine->config->debug.VerboseLogging.value())
-                logger->info("sound resumed: {}", si.sName);
+            if (si.sample->Resume())
+                logger->verbose("sound resumed: {}", si.sName);
         }
     }
 }
@@ -414,8 +409,8 @@ void AudioPlayer::PauseSounds(int uType) {
     if (uType == 2) {
         for (auto &[_, si] : mapSounds) {
             if (si.sample) {
-                if (si.sample->Pause() && engine->config->debug.VerboseLogging.value())
-                    logger->info("sound paused: {}", si.sName);
+                if (si.sample->Pause())
+                    logger->verbose("sound paused: {}", si.sName);
             }
         }
     } else {
@@ -424,8 +419,8 @@ void AudioPlayer::PauseSounds(int uType) {
             if (si.sample) {
                 if (si.last_pid != PID_INVALID &&
                         si.last_pid != SOUND_PID_NON_RESETABLE) {
-                    if (si.sample->Pause() && engine->config->debug.VerboseLogging.value())
-                        logger->info("sound paused: {}", si.sName);
+                    if (si.sample->Pause())
+                        logger->verbose("sound paused: {}", si.sName);
                 }
             }
         }

--- a/src/Media/MediaLogger.cpp
+++ b/src/Media/MediaLogger.cpp
@@ -25,7 +25,7 @@ MediaLogger::MediaLogger(Logger *logger): logger_(logger) {
 }
 
 void MediaLogger::Log(void *ptr, int logLevel, const char *format, va_list args) {
-    if (!engine->config->debug.VerboseLogging.value()) // TODO(captainurist): just handle log levels & log categories properly
+    if (!logger->shouldLog(LOG_VERBOSE))
         return;
 
     LogState& state = stateByThreadId_[std::this_thread::get_id()];
@@ -33,11 +33,11 @@ void MediaLogger::Log(void *ptr, int logLevel, const char *format, va_list args)
     char buffer[2048];
     int status = av_log_format_line2(ptr, logLevel, format, args, buffer, sizeof(buffer), &state.prefixFlag);
     if (status < 0) {
-        logger_->info("av_log_format_line2 failed with error code {}", status);
+        logger_->verbose("av_log_format_line2 failed with error code {}", status);
     } else {
         state.message += buffer;
         if (state.message.ends_with('\n')) {
-            logger_->info("{}", state.message.c_str());
+            logger_->verbose("{}", state.message.c_str());
             state.message.clear();
         }
     }

--- a/src/Platform/PlatformLogger.h
+++ b/src/Platform/PlatformLogger.h
@@ -29,8 +29,8 @@ class PlatformLogger {
      * for the provided category. It is advised to also do the log level check at the call site to avoid message
      * formatting overhead:
      * \code
-     * if (logger->logLevel(ApplicationLog) <= LogDebug)
-     *     logger->log(ApplicationLog, LogDebug, FormatMessage("blablabla %s %s", s1, s2).c_str());
+     * if (logger->logLevel(APPLICATION_LOG) <= LOG_DEBUG)
+     *     logger->log(APPLICATION_LOG, LOG_DEBUG, fmt::format("blablabla {}", s1).c_str());
      * \endcode
      *
      * This function is thread-safe.

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -29,7 +29,7 @@ if(ENABLE_TESTS)
 
     # GameTest
     add_custom_target(GameTest
-            OpenEnroth_GameTest --test-data ${CMAKE_CURRENT_BINARY_DIR}/test_data/data
+            OpenEnroth_GameTest --test-path ${CMAKE_CURRENT_BINARY_DIR}/test_data/data
             DEPENDS OpenEnroth_GameTest OpenEnroth_TestData
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/test/Bin/GameTest/GameTestMain.cpp
+++ b/test/Bin/GameTest/GameTestMain.cpp
@@ -17,22 +17,19 @@
 
 class GameThread {
  public:
-    explicit GameThread(const GameTestOptions& options) {
+    explicit GameThread(GameTestOptions& options) {
         _logger = PlatformLogger::createStandardLogger(WIN_ENSURE_CONSOLE_OPTION);
-        _logger->setLogLevel(APPLICATION_LOG, LOG_INFO);
-        _logger->setLogLevel(PLATFORM_LOG, LOG_ERROR);
+        _logger->setLogLevel(APPLICATION_LOG, LOG_VERBOSE);
+        _logger->setLogLevel(PLATFORM_LOG, LOG_VERBOSE);
         EngineIocContainer::ResolveLogger()->setBaseLogger(_logger.get());
         Engine::LogEngineBuildInfo();
 
         _application = std::make_unique<PlatformApplication>(_logger.get());
+        options.ResolveDefaults(_application->platform());
 
-        if (options.gameDataDir.empty()) {
-            AutoInitDataPath(_application->platform());
-        } else {
-            setDataPath(options.gameDataDir);
-        }
+        initDataPath(options.dataPath);
 
-        _config = std::make_shared<GameConfig>();
+        _config = std::make_shared<GameConfig>("openenroth.ini");
         ResetTestConfig(_config.get());
         _game = GameFactory().CreateGame(_application.get(), _config);
     }
@@ -63,41 +60,37 @@ void printGoogleTestHelp(char *app) {
     testing::InitGoogleTest(&argc, argv);
 }
 
-int parseOptions(int argc, char **argv, GameTestOptions *opts) {
-    int exitCode = opts->Parse(argc, argv) ? 0 : 1;
-
-    if (opts->helpRequested) {
-        std::cout << std::endl;
-        printGoogleTestHelp(argv[0]);
-    } else {
-        testing::InitGoogleTest(&argc, argv);
-    }
-
-    return exitCode;
-}
-
 int platformMain(int argc, char **argv) {
-    GameTestOptions opts;
-    int exitCode = parseOptions(argc, argv, &opts);
-    if (exitCode != 0)
+    try {
+        GameTestOptions opts = GameTestOptions::Parse(argc, argv);
+        if (opts.helpPrinted) {
+            fmt::print(stdout, "\n");
+            printGoogleTestHelp(argv[0]);
+            return 1;
+        }
+
+        testing::InitGoogleTest(&argc, argv);
+
+        GameThread gameThread(opts);
+
+        int exitCode = 0;
+        gameThread.app()->get<EngineControlComponent>()->runControlRoutine([&] (EngineController *game) {
+            TestController test(game, opts.testPath);
+
+            GameTest::init(game, &test);
+            gameThread.app()->get<EngineDeterministicComponent>()->enterDeterministicMode(); // And never leave it.
+            game->tick(10); // Let the game thread initialize everything.
+
+            exitCode = RUN_ALL_TESTS();
+
+            game->goToMainMenu();
+            game->pressGuiButton("MainMenu_ExitGame");
+        });
+        gameThread.run();
+
         return exitCode;
-
-    GameThread gameThread(opts);
-
-    gameThread.app()->get<EngineControlComponent>()->runControlRoutine([&] (EngineController *game) {
-        TestController test(game, opts.testDataDir);
-
-        GameTest::init(game, &test);
-        gameThread.app()->get<EngineDeterministicComponent>()->enterDeterministicMode(); // And never leave it.
-        game->tick(10); // Let the game thread initialize everything.
-
-        exitCode = RUN_ALL_TESTS();
-
-        game->goToMainMenu();
-        game->pressGuiButton("MainMenu_ExitGame");
-    });
-
-    gameThread.run();
-
-    return exitCode;
+    } catch (const std::exception &e) {
+        fmt::print(stderr, "{}\n", e.what());
+        return 1;
+    }
 }

--- a/test/Bin/GameTest/GameTestOptions.cpp
+++ b/test/Bin/GameTest/GameTestOptions.cpp
@@ -4,24 +4,38 @@
 
 #include <CLI/CLI.hpp>
 
-bool GameTestOptions::Parse(int argc, char **argv) {
+#include "Application/GamePathResolver.h"
+
+
+GameTestOptions GameTestOptions::Parse(int argc, char **argv) {
+    GameTestOptions result;
     std::unique_ptr<CLI::App> app = std::make_unique<CLI::App>();
 
     std::string requiredOptions = "Required Options";
     std::string otherOptions = "Other Options";
 
-    app->add_option("--test-data", testDataDir, "Path to test data dir")->check(CLI::ExistingDirectory)->option_text("PATH")->required()->group(requiredOptions);
-    app->add_option("--game-data", gameDataDir, "Path to game data dir")->check(CLI::ExistingDirectory)->option_text("PATH")->group(otherOptions);
-    app->set_help_flag("-h,--help", "Print help and exit")->group(otherOptions);
+    app->add_option("--test-path", result.testPath,
+                    "Path to test data dir")->check(CLI::ExistingDirectory)->option_text("PATH")->required()->group(requiredOptions);
+    app->add_option("--data-path", result.dataPath,
+                    "Path to game data dir")->check(CLI::ExistingDirectory)->option_text("PATH")->group(otherOptions);
+    app->set_help_flag("-h,--help", "Print help and exit.")->group(otherOptions);
     app->allow_extras();
 
     try {
         app->parse(argc, argv);
     } catch (const CLI::ParseError &e) {
-        app->exit(e);
-        helpRequested = app->get_help_ptr()->as<bool>();
-        return false;
+        if (app->get_help_ptr()->as<bool>()) {
+            app->exit(e);
+            result.helpPrinted = true;
+        } else {
+            throw; // Genuine parse error => propagate.
+        }
     }
 
-    return true;
+    return result;
+}
+
+void GameTestOptions::ResolveDefaults(Platform *platform) {
+    if (dataPath.empty())
+        dataPath = resolveMm7Path(platform);
 }

--- a/test/Bin/GameTest/GameTestOptions.h
+++ b/test/Bin/GameTest/GameTestOptions.h
@@ -2,10 +2,14 @@
 
 #include <string>
 
-struct GameTestOptions {
-    std::string testDataDir;
-    std::string gameDataDir;
-    bool helpRequested = false;
+class Platform;
 
-    bool Parse(int argc, char **argv);
+struct GameTestOptions {
+    std::string testPath;
+    std::string dataPath;
+    bool helpPrinted = false;
+
+    static GameTestOptions Parse(int argc, char **argv);
+
+    void ResolveDefaults(Platform *platform);
 };


### PR DESCRIPTION
* Command line options don't write to config anymore.
* Dropped most of the command line options. They were created before we had the config file, and aren't really needed anymore.
* Data & config paths can now be passed from the command line.
* Using `logger->verbose` where appropriate.