### PR TITLE
Hotfix when OpenAL failed to create audio sample

### DIFF
--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -297,6 +297,11 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
 
     PAudioSample sample = CreateAudioSample(si.dataSource);
 
+    if (!sample) {
+        logger->warning("AudioPlayer: failed to create audio sample {} ({})", eSoundID, si.sName);
+        return;
+    }
+
     sample->SetVolume(uMasterVolume);
 
     if (pid == 0) {  // generic sound like from UI

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -790,19 +790,19 @@ bool AudioSample16::Open(PAudioDataSource data_source) {
         alGenBuffers(1, &al_buffer);
         if (CheckError()) {
             Close();
-            break;
+            return false;
         }
 
         alBufferData(al_buffer, al_format, buffer->data(), buffer->size(), al_sample_rate);
         if (CheckError()) {
             Close();
-            break;
+            return false;
         }
 
         alSourceQueueBuffers(al_source, 1, &al_buffer);
         if (CheckError()) {
             Close();
-            break;
+            return false;
         }
     }
 


### PR DESCRIPTION
Must not use sample that was not properly created.