### PR TITLE
Implement functionality to retain OpenAL buffers

### DIFF
--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -293,6 +293,8 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
             logger->warning("AudioPlayer: failed to create sound data source {} ({})", eSoundID, si.sName);
             return;
         }
+
+        si.dataSource = PlatformDataSourceInitialize(si.dataSource);
     }
 
     PAudioSample sample = CreateAudioSample(si.dataSource);

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -681,6 +681,8 @@ PAudioTrack CreateAudioTrack(const std::string &file_path) {
     return std::dynamic_pointer_cast<IAudioTrack, AudioTrackS16>(track);
 }
 
+// TODO(Nik-RE-dev): this middleware class is temporary because Media API is not fully
+// ready to properly support current use cases
 class OpenALAudioDataSource : public IAudioDataSource {
  public:
     explicit OpenALAudioDataSource(PAudioDataSource baseDataSource):_baseDataSource(baseDataSource) {}

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -683,7 +683,7 @@ PAudioTrack CreateAudioTrack(const std::string &file_path) {
 
 class OpenALAudioDataSource : public IAudioDataSource {
  public:
-    OpenALAudioDataSource(PAudioDataSource baseDataSource):_baseDataSource(baseDataSource) {}
+    explicit OpenALAudioDataSource(PAudioDataSource baseDataSource):_baseDataSource(baseDataSource) {}
     virtual ~OpenALAudioDataSource();
 
     virtual bool Open();

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -684,14 +684,14 @@ PAudioTrack CreateAudioTrack(const std::string &file_path) {
 class OpenALAudioDataSource : public IAudioDataSource {
  public:
     explicit OpenALAudioDataSource(PAudioDataSource baseDataSource):_baseDataSource(baseDataSource) {}
-    virtual ~OpenALAudioDataSource();
+    virtual ~OpenALAudioDataSource() override;
 
-    virtual bool Open();
-    virtual void Close();
+    virtual bool Open() override;
+    virtual void Close() override;
 
-    virtual size_t GetSampleRate() { return _baseDataSource->GetSampleRate(); }
-    virtual size_t GetChannelCount() { return _baseDataSource->GetChannelCount(); }
-    virtual std::shared_ptr<Blob> GetNextBuffer() { return _baseDataSource->GetNextBuffer(); }
+    virtual size_t GetSampleRate() override { return _baseDataSource->GetSampleRate(); }
+    virtual size_t GetChannelCount() override { return _baseDataSource->GetChannelCount(); }
+    virtual std::shared_ptr<Blob> GetNextBuffer() override { return _baseDataSource->GetNextBuffer(); }
 
     bool linkSource(ALuint al_source);
 
@@ -786,26 +786,24 @@ bool OpenALAudioDataSource::linkSource(ALuint al_source) {
 }
 
 PAudioDataSource PlatformDataSourceInitialize(PAudioDataSource baseDataSource) {
-    std::shared_ptr<OpenALAudioDataSource> source = std::make_shared<OpenALAudioDataSource>(baseDataSource);
-
-    return std::dynamic_pointer_cast<IAudioDataSource, OpenALAudioDataSource>(source);
+    return std::make_shared<OpenALAudioDataSource>(baseDataSource);
 }
 
 class AudioSample16 : public IAudioSample {
  public:
-    AudioSample16();
-    virtual ~AudioSample16();
+    AudioSample16():al_source(-1) {}
+    virtual ~AudioSample16() override;
 
-    virtual bool Open(PAudioDataSource data_source);
-    virtual bool IsValid();
-    virtual bool IsStopped();
+    virtual bool Open(PAudioDataSource data_source) override;
+    virtual bool IsValid() override;
+    virtual bool IsStopped() override;
 
-    virtual bool Play(bool loop = false, bool positioned = false);
-    virtual bool Stop();
-    virtual bool Pause();
-    virtual bool Resume();
-    virtual bool SetVolume(float volume);
-    virtual bool SetPosition(float x, float y, float z, float max_dist);
+    virtual bool Play(bool loop = false, bool positioned = false) override;
+    virtual bool Stop() override;
+    virtual bool Pause() override;
+    virtual bool Resume() override;
+    virtual bool SetVolume(float volume) override;
+    virtual bool SetPosition(float x, float y, float z, float max_dist) override;
 
  protected:
     void Close();
@@ -813,10 +811,6 @@ class AudioSample16 : public IAudioSample {
     PAudioDataSource pDataSource;
     ALuint al_source;
 };
-
-AudioSample16::AudioSample16() {
-    al_source = -1;
-}
 
 AudioSample16::~AudioSample16() { Close(); }
 
@@ -991,5 +985,5 @@ PAudioSample CreateAudioSample(PAudioDataSource dataSource) {
         sample = nullptr;
     }
 
-    return std::dynamic_pointer_cast<IAudioSample, AudioSample16>(sample);
+    return sample;
 }

--- a/src/Media/Media.h
+++ b/src/Media/Media.h
@@ -22,6 +22,7 @@ typedef std::shared_ptr<IAudioDataSource> PAudioDataSource;
 
 PAudioDataSource CreateAudioFileDataSource(const std::string &file_name);
 PAudioDataSource CreateAudioBufferDataSource(Blob buffer);
+PAudioDataSource PlatformDataSourceInitialize(PAudioDataSource baseDataSource);
 
 class IAudioTrack {
  public:


### PR DESCRIPTION
Create middleware class that retains created OpenAL buffers.
On sample initialization these buffers are queued into OpenAL source. When source is destroyed burres are just unqueued and can be used again.