### PR TITLE
Refactor sound pausing

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -322,7 +322,6 @@ bool Game::loop() {
             continue;
         }
         if (uGameState == GAME_STATE_GAME_QUITTING_TO_MAIN_MENU) {  // from the loaded game
-            pAudioPlayer->PauseSounds(-1);
             uGameState = GAME_STATE_PLAYING;
             break;
         }
@@ -1323,7 +1322,7 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_OnGameOverWindowClose:
-                    pAudioPlayer->PauseSounds(-1);
+                    pAudioPlayer->stopSounds();
                     SaveGame(1, 0);
 
                     pParty->vPosition.x = -17331;  // respawn point in Harmondale
@@ -2402,7 +2401,7 @@ void Game::gameLoop() {
 
 
             if (uGameState == GAME_STATE_CHANGE_LOCATION) {  // смена локации
-                pAudioPlayer->PauseSounds(-1);
+                pAudioPlayer->stopSounds();
                 PrepareWorld(0);
                 uGameState = GAME_STATE_PLAYING;
                 continue;
@@ -2429,7 +2428,7 @@ void Game::gameLoop() {
                 continue;
             }
             if (uGameState == GAME_STATE_PARTY_DIED) {
-                pAudioPlayer->PauseSounds(-1);
+                pAudioPlayer->stopSounds();
                 pParty->pHirelings[0] = NPCData();
                 pParty->pHirelings[1] = NPCData();
                 for (int i = 0; i < (signed int)pNPCStats->uNumNewNPCs; ++i) {

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -55,6 +55,7 @@ void Game_QuitGameWhilePlaying(bool force_quit) {
         pCurrentFrameMessageQueue->Flush();
         // pGUIWindow_CurrentMenu->Release();
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
+        pAudioPlayer->stopSounds();
         pAudioPlayer->playUISound(SOUND_WoodDoorClosing);
         uGameState = GAME_STATE_GAME_QUITTING_TO_MAIN_MENU;
     } else {
@@ -426,7 +427,6 @@ void Menu::EventLoop() {
 
 void Menu::MenuLoop() {
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     current_screen_type = CURRENT_SCREEN::SCREEN_MENU;
 
     pGUIWindow_CurrentMenu = new GUIWindow_GameMenu();
@@ -465,6 +465,4 @@ void Menu::MenuLoop() {
         gamma_preview_image->Release();
         gamma_preview_image = nullptr;
     }
-
-    pAudioPlayer->ResumeSounds();
 }

--- a/src/Application/GameOver.cpp
+++ b/src/Application/GameOver.cpp
@@ -31,7 +31,7 @@
 void GameOver_Loop(int v15) {
     dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_4000;
     bGameoverLoop = true;
-    pAudioPlayer->PauseSounds(-1);
+    pAudioPlayer->stopSounds();
 
     CreateWinnerCertificate();
 

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -373,7 +373,7 @@ void GameWindowHandler::OnActivated() {
             }
         }
 
-        pAudioPlayer->ResumeSounds();
+        pAudioPlayer->resumeSounds();
         if (!bGameoverLoop && !pMovie_Track) {  // continue an audio track
             pAudioPlayer->MusicResume();
         }
@@ -400,7 +400,7 @@ void GameWindowHandler::OnDeactivated() {
         }
 
         if (pAudioPlayer != nullptr) {
-            pAudioPlayer->PauseSounds(2);
+            pAudioPlayer->pauseAllSounds();
             pAudioPlayer->MusicPause();
         }
     }

--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -1233,7 +1233,6 @@ char PlayerTurn(int player_num) {
         switch (get_message.am_input_type) {
             case ARCO_MSG_FORCEQUIT:
                 if (get_message.field_4 == 129 && get_message.am_input_key == 1) {
-                    pAudioPlayer->PauseSounds(-1);
                     num_actions_left = 0;
                     break_loop = true;
                     pArcomageGame->force_am_exit = 1;
@@ -1243,7 +1242,6 @@ char PlayerTurn(int player_num) {
                 break;
             case ARCO_MSG_ESCAPE:
                 if (pArcomageGame->check_exit == 1) {
-                    pAudioPlayer->PauseSounds(-1);
                     pArcomageGame->GameOver = 1;
                     pArcomageGame->uGameWinner = 2;
                     pArcomageGame->Victory_type = -2;
@@ -2892,7 +2890,6 @@ void GameResultsApply() {
 
 void ArcomageGame::PrepareArcomage() {
     // stop all audio and set player names
-    pAudioPlayer->PauseSounds(-1);
     pArcomageGame->pPlayer1Name = Player1Name;
     pArcomageGame->pPlayer2Name = Player2Name;
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1179,7 +1179,7 @@ void Engine::ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows() {
     else if (uCurrentlyLoadedLevelType == LEVEL_Outdoor)
         pOutdoor->Release();
 
-    pAudioPlayer->PauseSounds(-1);
+    pAudioPlayer->stopSounds();
     uCurrentlyLoadedLevelType = LEVEL_null;
     pSpriteFrameTable->ResetLoadedFlags();
     pParty->armageddon_timer = 0;
@@ -2161,7 +2161,7 @@ bool _44100D_should_alter_right_panel() {
 
 void Transition_StopSound_Autosave(const char *pMapName,
                                    MapStartPoint start_point) {
-    pAudioPlayer->PauseSounds(-1);
+    pAudioPlayer->stopSounds();
 
     // pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_None);
 

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -455,7 +455,6 @@ LABEL_47:
                             window_SpeakInHouse->Release();
                             pParty->uFlags &= ~PARTY_FLAGS_1_ForceRedraw;
                             if (EnterHouse(HOUSE_DARK_GUILD_PIT)) {
-                                pAudioPlayer->PauseSounds(-1);
                                 window_SpeakInHouse = new GUIWindow_House({0, 0}, render->GetRenderDimensions(), HOUSE_DARK_GUILD_PIT, "");
                                 window_SpeakInHouse->CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1, "");
                                 window_SpeakInHouse->CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2, "");
@@ -900,7 +899,6 @@ LABEL_47:
                         v133 = 1;
                         if (current_screen_type == CURRENT_SCREEN::SCREEN_HOUSE) {
                             if (uGameState == GAME_STATE_CHANGE_LOCATION) {
-                                pAudioPlayer->PauseSounds(-1);
                                 dialog_menu_id = DIALOGUE_NULL;
                                 while (HouseDialogPressCloseBtn()) {}
                                 pMediaPlayer->Unload();

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1818,7 +1818,6 @@ void ODM_UpdateUserInputAndOther() {
             if (pParty->vPosition.y < -22528) pParty->vPosition.y = -22528;
             if (pParty->vPosition.y > 22528) pParty->vPosition.y = 22528;
         } else {
-            pAudioPlayer->PauseSounds(-1);
             pDialogueWindow = new GUIWindow_Travel();  // TravelUI_Load();
         }
     }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -151,7 +151,6 @@ bool Chest::Open(int uChestID) {
         chest->uFlags &= ~CHEST_TRAPPED;
         flag_shout = true;
     }
-    pAudioPlayer->PauseSounds(-1);
     pAudioPlayer->playUISound(SOUND_openchest0101);
     if (flag_shout == true) {
         if (!OpenedTelekinesis) {

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -120,7 +120,6 @@ void stru262_TurnBased::Start() {
 
     pTurnEngine->flags &= ~TE_HAVE_PENDING_ACTIONS;
     pEventTimer->TrackGameTime();
-    pAudioPlayer->PauseSounds(-1);
     pAudioPlayer->playUISound(SOUND_batllest);
     // pPlayer = pParty->pPlayers.data();
     dword_50C998_turnbased_icon_1A =
@@ -247,7 +246,6 @@ void stru262_TurnBased::End(bool bPlaySound) {
                 (uint16_t)((double)pQueue[i].actor_initiative *
                                    flt_debugrecmod3);
     }
-    pAudioPlayer->PauseSounds(-1);
     if (bPlaySound != 0)
         pAudioPlayer->playUISound(SOUND_batlleen);
     pTurnEngine->flags &= ~TE_HAVE_PENDING_ACTIONS;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -274,7 +274,6 @@ void GUIWindow::Release() {
         nuklear->Release(WINDOW_GameUI);
 
     log->info("Release window: {}", toString(eWindowType));
-    pAudioPlayer->ResumeSounds();
 }
 
 void GUIWindow::DeleteButtons() {

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -26,7 +26,6 @@ GUIWindow_AutonotesBook::GUIWindow_AutonotesBook() : GUIWindow_Book() {
     // --------------------------------
     // 004304E7 Game_EventLoop --- part
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     pChildBooksOverlay = new GUIWindow_BooksButtonOverlay({527, 353}, {0, 0}, pBtn_Autonotes);
     bFlashAutonotesBook = 0;
 

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -32,7 +32,6 @@ GUIWindow_CalendarBook::GUIWindow_CalendarBook() : GUIWindow_Book() {
     // --------------------------------
     // 004304E7 Game_EventLoop --- part
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     pChildBooksOverlay = new GUIWindow_BooksButtonOverlay({570, 354}, {0, 0}, pBtn_Calendar);
 
     // ----------------------------------------------

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -29,7 +29,6 @@ GUIWindow_JournalBook::GUIWindow_JournalBook() : GUIWindow_Book() {
     BasicBookInitialization();
 
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     pChildBooksOverlay = new GUIWindow_BooksButtonOverlay({600, 361}, {0, 0}, pBtn_History);
     bFlashHistoryBook = 0;
 

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -31,7 +31,6 @@ GUIWindow_LloydsBook::GUIWindow_LloydsBook() : GUIWindow_Book() {
     BasicBookInitialization();
 
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
 
     isLloydsBeaconBeingInstalled = false;
     if (!ui_book_lloyds_border) {

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -36,7 +36,6 @@ GUIWindow_MapBook::GUIWindow_MapBook() : GUIWindow_Book() {
     pEventTimer->Pause();
     viewparams->sViewCenterX = pParty->vPosition.x;
     viewparams->sViewCenterY = pParty->vPosition.y;
-    pAudioPlayer->PauseSounds(-1);
     pChildBooksOverlay = new GUIWindow_BooksButtonOverlay({546, 353}, {0, 0}, pBtn_Maps);
 
     MapBookOpen = 1;

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -25,7 +25,6 @@ GUIWindow_QuestBook::GUIWindow_QuestBook() : GUIWindow_Book() {
     // --------------------------------
     // 004304E7 Game_EventLoop --- part
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     pChildBooksOverlay = new GUIWindow_BooksButtonOverlay({493, 355}, {0, 0}, pBtn_Quests);
     bFlashQuestBook = 0;
 

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -38,7 +38,6 @@ GUIWindow_TownPortalBook::GUIWindow_TownPortalBook(int casterPid)  // const char
     BasicBookInitialization();
 
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     townPortalCasterPid = casterPid;
 
     // ----------------------------------------------

--- a/src/GUI/UI/Spellbook.cpp
+++ b/src/GUI/UI/Spellbook.cpp
@@ -307,7 +307,6 @@ static void BookUI_Spellbook_DrawCurrentSchoolBackground() {
 }
 
 void InitializeSpellBookTextures() {
-    pAudioPlayer->PauseSounds(-1);
     pAudioPlayer->playUISound(SOUND_openbook);
 
     ui_spellbook_btn_close = assets->GetImage_Solid("ib-m5-u");

--- a/src/GUI/UI/UIBooks.cpp
+++ b/src/GUI/UI/UIBooks.cpp
@@ -68,7 +68,6 @@ GUIWindow_Book::GUIWindow_Book()
     : GUIWindow(WINDOW_Book, {0, 0}, render->GetRenderDimensions(), 0) {}
 
 void GUIWindow_Book::BasicBookInitialization() {
-    pAudioPlayer->PauseSounds(-1);
     InitializeFonts();
     CreateButton({475, 445}, {158, 34}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_DIALOGUE_EXIT));
     current_screen_type = CURRENT_SCREEN::SCREEN_BOOKS;
@@ -80,7 +79,6 @@ void GUIWindow_Book::BasicBookInitialization() {
 
 //----- (00411AAA) --------------------------------------------------------
 void GUIWindow_Book::InitializeFonts() {
-    pAudioPlayer->PauseSounds(-1);
     pAudioPlayer->playUISound(SOUND_openbook);
 
     ui_book_map_frame = assets->GetImage_Alpha("mapbordr");

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -567,7 +567,6 @@ GUIWindow_CharacterRecord::GUIWindow_CharacterRecord(
     unsigned int uActiveCharacter, CURRENT_SCREEN screen)
     : GUIWindow(WINDOW_CharacterRecord, {0, 0}, render->GetRenderDimensions(), uActiveCharacter) {
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     bRingsShownInCharScreen = false;
     CharacterUI_LoadPaperdollTextures();
     current_screen_type = screen;
@@ -731,7 +730,6 @@ void GUIWindow_CharacterRecord::ToggleRingsOverlay() {
 
 GUIWindow *CastSpellInfo::GetCastSpellInInventoryWindow() {
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     bRingsShownInCharScreen = 0;
     CharacterUI_LoadPaperdollTextures();
     current_screen_type = CURRENT_SCREEN::SCREEN_CASTING;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -36,7 +36,6 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     pNPCStats->dword_AE336C_LastMispronouncedNameFirstLetter = -1;
     pEventTimer->Pause();
     pMiscTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     uDialogueType = DIALOGUE_NULL;
     sDialogue_SpeakingActorNPC_ID = actor->sNPC_ID;
     pDialogue_SpeakingActor = actor;
@@ -521,7 +520,6 @@ void StartBranchlessDialogue(int eventid, int entryline, int button) {
         if (pParty->uFlags & PARTY_FLAGS_1_ForceRedraw) {
             engine->Draw();
         }
-        pAudioPlayer->PauseSounds(-1);
         pMiscTimer->Pause();
         pEventTimer->Pause();
         dword_5C3418 = eventid;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -1,7 +1,6 @@
 #include "UIHouses.h"
 
 #include <cstdlib>
-#include <thread>
 
 #include "Application/GameOver.h"
 
@@ -48,8 +47,6 @@
 #include "Utility/String.h"
 #include "Library/Random/Random.h"
 #include "Utility/Math/TrigLut.h"
-
-using namespace std::chrono_literals; // NOLINT
 
 using Io::TextInputType;
 
@@ -855,7 +852,6 @@ bool EnterHouse(HOUSE_ID uHouseID) {
                 return 0;
             }
         }
-        // pAudioPlayer->PauseSounds(-1);
 
         uCurrentHouse_Animation = p2DEvents[uHouseID - HOUSE_SMITH_EMERALD_ISLE].uAnimationID;
         in_current_building_type = pAnimatedRooms[uCurrentHouse_Animation].uBuildingType;
@@ -1336,7 +1332,6 @@ void TravelByTransport() {
             } else {
                 travel_window.DrawTitleText(pFontArrus, 0, (174 - pFontArrus->CalcTextHeight(localization->GetString(LSTR_COME_BACK_ANOTHER_DAY), travel_window.uFrameWidth, 0)) / 2 + 138,
                                             colorTable.White.c16(), localization->GetString(LSTR_COME_BACK_ANOTHER_DAY), 3);
-                pAudioPlayer->PauseSounds(-1);
             }
         }
     } else {  //после нажатия топика - travel option selected
@@ -1385,21 +1380,15 @@ void TravelByTransport() {
                 int traveltimedays = GetTravelTimeTransportDays(transport_routes[route_id][choice_id]);
 
                 PlayerSpeech pSpeech;
-                int speechlength = 0;
                 if (route_id >= HOUSE_BOATS_EMERALD_ISLE - HOUSE_STABLES_HARMONDALE) {
                     pSpeech = SPEECH_TravelBoat;
-                    speechlength = 2500;
                 } else {
                     pSpeech = SPEECH_TravelHorse;
-                    speechlength = 1500;
                 }
 
                 RestAndHeal(24 * 60 * traveltimedays);
                 pPlayers[pParty->getActiveCharacter()]->playReaction(pSpeech);
-                auto timeLimit = std::chrono::system_clock::now() + std::chrono::milliseconds(speechlength);
-                while (std::chrono::system_clock::now() < timeLimit) {
-                    std::this_thread::sleep_for(1ms);
-                }
+                pAudioPlayer->soundDrain();
                 while (HouseDialogPressCloseBtn()) {}
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
             } else {
@@ -3349,7 +3338,6 @@ void GenerateStandartShopItems() {
 GUIWindow_House::GUIWindow_House(Pointi position, Sizei dimensions, HOUSE_ID houseId, const std::string &hint) :
     GUIWindow(WINDOW_HouseInterior, position, dimensions, houseId, hint) {
     pEventTimer->Pause();  // pause timer so not attacked
-    // pAudioPlayer->PauseSounds(-1);
 
     current_screen_type = CURRENT_SCREEN::SCREEN_HOUSE;
     pBtn_ExitCancel = CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_EXIT_BUILDING),

--- a/src/GUI/UI/UIMainMenu.cpp
+++ b/src/GUI/UI/UIMainMenu.cpp
@@ -143,7 +143,7 @@ void GUIWindow_MainMenu::Loop() {
     Image *tex;
     nuklear->Create(WINDOW_MainMenu_Load);
 
-    pAudioPlayer->PauseSounds(-1);
+    pAudioPlayer->stopSounds();
     pAudioPlayer->MusicPlayTrack(MUSIC_MainMenu);
 
     if (first_initialization) {

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -937,6 +937,6 @@ bool PartyCreationUI_LoopInternal() {
         }
     }
 
-    // pAudioPlayer->PauseSounds(-1);
+    pAudioPlayer->stopSounds();
     return party_not_creation_flag;
 }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1446,7 +1446,6 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                     popup_window.uFrameHeight = 200;
                     popup_window.uFrameX = 38;
                     popup_window.uFrameY = 60;
-                    pAudioPlayer->PauseSounds(-1);
                     GameUI_CharacterQuickRecord_Draw(
                         &popup_window, &pParty->pPlayers[popup_window.wData.val]);
                 }
@@ -1458,18 +1457,15 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                         popup_window.uFrameHeight = 200;
                         popup_window.uFrameX = 38;
                         popup_window.uFrameY = 60;
-                        pAudioPlayer->PauseSounds(-1);
                         popup_window._41D73D_draw_buff_tooltip();
                     } else if ((int)pX < 485 || (int)pX > 548 ||
                                (int)pY < 156 ||
                                (int)pY > 229) {  // NPC zone
                         if (!((signed int)pX < 566 || (signed int)pX > 629 ||
                               (signed int)pY < 156 || (signed int)pY > 229)) {
-                            pAudioPlayer->PauseSounds(-1);
                             GameUI_DrawNPCPopup((void *)1);  // NPC 2
                         }
                     } else {
-                        pAudioPlayer->PauseSounds(-1);
                         GameUI_DrawNPCPopup(0);  // NPC 1
                     }
                 } else {  // minimap zone
@@ -1478,7 +1474,6 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                     popup_window.uFrameX = 130;
                     popup_window.uFrameY = 140;
                     popup_window.uFrameHeight = 64;
-                    pAudioPlayer->PauseSounds(-1);
                     popup_window.DrawMessageBox(0);
                 }
             } else {  // game zone
@@ -1520,7 +1515,6 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
             popup_window.uFrameX = pX + 5;
             popup_window.uFrameY = pY + 5;
             popup_window.uFrameHeight = 64;
-            pAudioPlayer->PauseSounds(-1);
             popup_window.DrawMessageBox(0);
             break;
         }

--- a/src/GUI/UI/UIQuickReference.cpp
+++ b/src/GUI/UI/UIQuickReference.cpp
@@ -24,7 +24,6 @@ GUIWindow_QuickReference::GUIWindow_QuickReference()
     : GUIWindow(WINDOW_QuickReference, {0, 0}, render->GetRenderDimensions(), 5) {
     // 004304E7 Game_EventLoop --- part
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     current_screen_type = CURRENT_SCREEN::SCREEN_QUICK_REFERENCE;
 
     // paperdoll_dbrds[2] = assets->GetImage_16BitAlpha(L"BUTTEXI1");

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -51,9 +51,6 @@ void GUIWindow_RestWindow::Update() {
 #endif
 
 static void prepareToLoadRestUI() {
-    if (currentRestType == REST_NONE) {
-        pAudioPlayer->PauseSounds(-1);
-    }
     if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) {
         if (pGUIWindow_CurrentMenu) {
             pGUIWindow_CurrentMenu->Release();

--- a/src/GUI/UI/UISpell.cpp
+++ b/src/GUI/UI/UISpell.cpp
@@ -11,7 +11,6 @@
 TargetedSpellUI::TargetedSpellUI(Pointi position, Sizei dimensions, WindowData data, const std::string &hint)
     : GUIWindow(WINDOW_CastSpell, position, dimensions, data, hint) {
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     mouse->SetCursorImage("MICON2");
     GameUI_SetStatusBar(LSTR_CHOOSE_TARGET);
 }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -79,7 +79,6 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
     Party_Teleport_Map_Name = (char *)pLocationName;
     uCurrentHouse_Animation = anim_id;
     pEventTimer->Pause();
-    pAudioPlayer->PauseSounds(-1);
     current_screen_type = CURRENT_SCREEN::SCREEN_CHANGE_LOCATION;
 
     mapid = pMapStats->GetMapInfo(pCurrentMapName);

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -17,8 +17,6 @@
 
 #include "Media/Audio/OpenALSoundProvider.h"
 
-using namespace std::chrono_literals;
-
 int sLastTrackLengthMS;
 AudioPlayer *pAudioPlayer;
 SoundList *pSoundList;
@@ -444,11 +442,11 @@ void AudioPlayer::pauseLooping() {
 
 void AudioPlayer::soundDrain() {
     while (_voiceSoundPool.hasPlaying()) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         _voiceSoundPool.update();
     }
     while (_regularSoundPool.hasPlaying()) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         _regularSoundPool.update();
     }
 }

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <filesystem>
 #include <utility>
+#include <thread>
 
 #include "Media/Audio/AudioPlayer.h"
 
@@ -16,6 +17,7 @@
 
 #include "Media/Audio/OpenALSoundProvider.h"
 
+using namespace std::chrono_literals;
 
 int sLastTrackLengthMS;
 AudioPlayer *pAudioPlayer;
@@ -206,8 +208,8 @@ void AudioPlayer::SetMasterVolume(int level) {
     level = std::min(9, level);
     uMasterVolume = (maxVolumeGain * pSoundVolumeLevels[level]);
 
-    _exclusiveSoundPool.setVolume(uMasterVolume);
-    _nonExclusiveSoundPool.setVolume(uMasterVolume);
+    _regularSoundPool.setVolume(uMasterVolume);
+    _loopingSoundPool.setVolume(uMasterVolume);
     if (_currentWalkingSample) {
         _currentWalkingSample->SetVolume(uMasterVolume);
     }
@@ -227,8 +229,8 @@ void AudioPlayer::stopSounds() {
     }
 
     _voiceSoundPool.stop();
-    _exclusiveSoundPool.stop();
-    _nonExclusiveSoundPool.stop();
+    _regularSoundPool.stop();
+    _loopingSoundPool.stop();
     if (_currentWalkingSample) {
         _currentWalkingSample->Stop();
         _currentWalkingSample = nullptr;
@@ -246,10 +248,10 @@ void AudioPlayer::stopWalkingSounds() {
     }
 }
 
-void AudioPlayer::ResumeSounds() {
+void AudioPlayer::resumeSounds() {
     _voiceSoundPool.resume();
-    _exclusiveSoundPool.resume();
-    _nonExclusiveSoundPool.resume();
+    _regularSoundPool.resume();
+    _loopingSoundPool.resume();
     if (_currentWalkingSample) {
         _currentWalkingSample->Resume();
     }
@@ -305,16 +307,16 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
     sample->SetVolume(uMasterVolume);
 
     if (pid == 0) {  // generic sound like from UI
-        _nonExclusiveSoundPool.playNew(sample);
+        _regularSoundPool.playNew(sample);
     } else if (pid == PID_INVALID) { // exclusive sounds - can override
-        _exclusiveSoundPool.stopSoundId(eSoundID);
-        _exclusiveSoundPool.playUniqueSoundId(sample, eSoundID);
+        _regularSoundPool.stopSoundId(eSoundID);
+        _regularSoundPool.playUniqueSoundId(sample, eSoundID);
     } else if (pid == -1) { // all instances must be changed to PID_INVALID
         assert(false && "AudioPlayer::playSound - pid == -1 is encountered.");
-        _exclusiveSoundPool.stopSoundId(eSoundID);
-        _exclusiveSoundPool.playUniqueSoundId(sample, eSoundID);
+        _regularSoundPool.stopSoundId(eSoundID);
+        _regularSoundPool.playUniqueSoundId(sample, eSoundID);
     } else if (pid == SOUND_PID_NON_RESETABLE) {  // exclusive sounds - no override (close chest)
-        _exclusiveSoundPool.playUniqueSoundId(sample, eSoundID);
+        _regularSoundPool.playUniqueSoundId(sample, eSoundID);
     } else if (pid == SOUND_PID_WALKING) {
         if (_currentWalkingSample) {
             _currentWalkingSample->Stop();
@@ -323,8 +325,8 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
         _currentWalkingSample->Play();
     } else if (pid == SOUND_PID_MUSIC_VOLUME) {
         sample->SetVolume(pSoundVolumeLevels[engine->config->settings.MusicLevel.value()] * maxVolumeGain);
-        _exclusiveSoundPool.stopSoundId(eSoundID);
-        _exclusiveSoundPool.playUniqueSoundId(sample, eSoundID);
+        _regularSoundPool.stopSoundId(eSoundID);
+        _regularSoundPool.playUniqueSoundId(sample, eSoundID);
     } else {
         ObjectType object_type = PID_TYPE(pid);
         unsigned int object_id = PID_ID(pid);
@@ -339,7 +341,7 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
 
                 // Door sounds are "looped" for the duration of moving animation by calling sound play each frame
                 // so need to actually start new playing after previous sound finished playing.
-                _nonExclusiveSoundPool.playUniquePid(sample, pid, false, true);
+                _regularSoundPool.playUniquePid(sample, pid, true);
 
                 break;
             }
@@ -359,7 +361,7 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
                                     pActors[object_id].vPosition.y / positionScaling,
                                     pActors[object_id].vPosition.z / positionScaling, 500.f);
 
-                _nonExclusiveSoundPool.playNew(sample, false, true);
+                _regularSoundPool.playNew(sample, true);
 
                 break;
             }
@@ -372,7 +374,7 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
                                     (float)pLevelDecorations[object_id].vPosition.y / positionScaling,
                                     (float)pLevelDecorations[object_id].vPosition.z / positionScaling, 2000.f);
 
-                _nonExclusiveSoundPool.playNew(sample, true, true);
+                _loopingSoundPool.playNew(sample, true);
 
                 break;
             }
@@ -384,19 +386,19 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
                                     pSpriteObjects[object_id].vPosition.y / positionScaling,
                                     pSpriteObjects[object_id].vPosition.z / positionScaling, 500.f);
 
-                _nonExclusiveSoundPool.playNew(sample, false, true);
+                _regularSoundPool.playNew(sample, true);
                 break;
             }
 
             case OBJECT_Face: {
-                _nonExclusiveSoundPool.playNew(sample);
+                _regularSoundPool.playNew(sample);
 
                 break;
             }
 
             default: {
                 // TODO(pskelton): temp fix to reduce instances of sounds not playing
-                _nonExclusiveSoundPool.playNew(sample);
+                _regularSoundPool.playNew(sample);
                 logger->verbose("Unexpected object type from PID in playSound");
                 break;
             }
@@ -420,50 +422,62 @@ void AudioPlayer::UpdateSounds() {
                                   pParty->vPosition.z / positionScaling);
 
     _voiceSoundPool.update();
-    _exclusiveSoundPool.update();
-    _nonExclusiveSoundPool.update();
+    _regularSoundPool.update();
+    _loopingSoundPool.update();
     if (_currentWalkingSample && _currentWalkingSample->IsStopped()) {
         _currentWalkingSample = nullptr;
     }
 }
 
-void AudioPlayer::PauseSounds(int uType) {
-    // pause everything
-    if (uType == 2) {
-        _exclusiveSoundPool.pause();
-    }
+void AudioPlayer::pauseAllSounds() {
     _voiceSoundPool.pause();
-    _nonExclusiveSoundPool.pause();
+    _regularSoundPool.pause();
+    _loopingSoundPool.pause();
     if (_currentWalkingSample) {
         _currentWalkingSample->Pause();
     }
 }
 
-void AudioSamplePool::playNew(PAudioSample sample, bool loop, bool positional) {
+void AudioPlayer::pauseLooping() {
+    _loopingSoundPool.pause();
+}
+
+void AudioPlayer::soundDrain() {
+    while (_voiceSoundPool.hasPlaying()) {
+        std::this_thread::sleep_for(1ms);
+        _voiceSoundPool.update();
+    }
+    while (_regularSoundPool.hasPlaying()) {
+        std::this_thread::sleep_for(1ms);
+        _regularSoundPool.update();
+    }
+}
+
+void AudioSamplePool::playNew(PAudioSample sample, bool positional) {
     update();
-    sample->Play(loop, positional);
+    sample->Play(_looping, positional);
     _samplePool.push_back(AudioSamplePoolEntry(sample, SOUND_Invalid, PID_INVALID));
 }
 
-void AudioSamplePool::playUniqueSoundId(PAudioSample sample, SoundID id, bool loop, bool positional) {
+void AudioSamplePool::playUniqueSoundId(PAudioSample sample, SoundID id, bool positional) {
     update();
     for (AudioSamplePoolEntry &entry : _samplePool) {
         if (entry.id == id) {
             return;
         }
     }
-    sample->Play(loop, positional);
+    sample->Play(_looping, positional);
     _samplePool.push_back(AudioSamplePoolEntry(sample, id, PID_INVALID));
 }
 
-void AudioSamplePool::playUniquePid(PAudioSample sample, int pid, bool loop, bool positional) {
+void AudioSamplePool::playUniquePid(PAudioSample sample, int pid, bool positional) {
     update();
     for (AudioSamplePoolEntry &entry : _samplePool) {
         if (entry.pid == pid) {
             return;
         }
     }
-    sample->Play(loop, positional);
+    sample->Play(_looping, positional);
     _samplePool.push_back(AudioSamplePoolEntry(sample, SOUND_Invalid, pid));
 }
 
@@ -518,13 +532,22 @@ void AudioSamplePool::stopPid(int pid) {
 
 void AudioSamplePool::update() {
     auto it = _samplePool.begin();
-    std::erase_if(_samplePool, [](const AudioSamplePoolEntry& entry){ return entry.samplePtr->IsStopped(); });
+    std::erase_if(_samplePool, [](const AudioSamplePoolEntry& entry) { return entry.samplePtr->IsStopped(); });
 }
 
 void AudioSamplePool::setVolume(float value) {
     for (AudioSamplePoolEntry &entry : _samplePool) {
         entry.samplePtr->SetVolume(value);
     }
+}
+
+bool AudioSamplePool::hasPlaying() {
+    for (AudioSamplePoolEntry &entry : _samplePool) {
+        if (!entry.samplePtr->IsStopped()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 #pragma pack(push, 1)

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -781,6 +781,7 @@ void MPlayer::OpenHouseMovie(const std::string &pMovieName, bool bLoop) {
     }
 
     pEventTimer->Pause();
+    pAudioPlayer->pauseLooping();
     pAudioPlayer->MusicPause();
     size_t size = 0;
     size_t offset = 0;
@@ -865,6 +866,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
     pMovie_Track = std::dynamic_pointer_cast<IMovie>(pMovie);
 
     pEventTimer->Pause();
+    pAudioPlayer->pauseLooping();
     pAudioPlayer->MusicPause();
     platform->setCursorShown(false);
     current_screen_type = CURRENT_SCREEN::SCREEN_VIDEO;
@@ -975,6 +977,7 @@ void MPlayer::Unload() {
     pMovie_Track = nullptr;
     if (!bGameoverLoop) {
         pAudioPlayer->MusicResume();
+        pAudioPlayer->resumeSounds();
     }
     pEventTimer->Resume();
 }


### PR DESCRIPTION
Remove sound pausing from most of places in code. Now sounds are not paused on different interface windows opening and will be finished playing.
Exception is decoration sounds which are played indifinitely while on outdoor map - these are paused in the same place where background music is being paused.
Places that are related to game state change (like quitting to main menu or traveling to different map) are changed from pausing to outright dropping all current sounds.

Side changes:
- Drop exclusive and non-exclusive sound pools as these separation is useless now. But add separate pool for looping sounds.
- Add function to wait for sounds completion and use it instead of artifical waiting for stable/ship speech.