### PR TITLE
Indoor actor collisions work the same as outdoor actor collisions

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -496,18 +496,9 @@ void ProcessActorCollisionsBLV(Actor &actor, bool isAboveGround, bool isFlying) 
             CollideIndoorWithDecorations();
             CollideWithParty(false);
             _46ED8A_collide_against_sprite_objects(PID(OBJECT_Actor, actor.id));
-            for (uint j = 0; j < ai_arrays_size; j++) {
-                int actor2_id = ai_near_actors_ids[j];
-                if (actor2_id == actor.id)
-                    continue;
-
-                // TODO(captainurist): why we're checking that distance is greater that r1+r2? Shouldn't we check that it's less?
-                // Investigate, white a comment here.
-                Actor &actor2 = pActors[actor2_id];
-                if ((actor2.vPosition - actor.vPosition).length() >= actor.uActorRadius + actor2.uActorRadius &&
-                    CollideWithActor(actor2_id, 40))
-                    ++actorCollisions;
-            }
+            for (int j = 0; j < ai_arrays_size; j++)
+                if (ai_near_actors_ids[j] != actor.id && CollideWithActor(ai_near_actors_ids[j], 40))
+                    actorCollisions++;
             if (CollideIndoorWithPortals())
                 break;
         }

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -485,19 +485,17 @@ void ProcessActorCollisionsBLV(Actor &actor, bool isAboveGround, bool isFlying) 
         collision_state.position_lo = actor.vPosition.toFloat() + Vec3f(0, 0, actor.uActorRadius + 1);
         collision_state.position_hi = actor.vPosition.toFloat() + Vec3f(0, 0, actor.uActorHeight - actor.uActorRadius - 1);
         collision_state.position_hi.z = std::max(collision_state.position_hi.z, collision_state.position_lo.z);
-
         collision_state.velocity = actor.vVelocity.toFloat();
         collision_state.uSectorID = actor.uSectorID;
         if (collision_state.PrepareAndCheckIfStationary(0))
             break;
 
-        int collisionsWithOtherActors = 0;
-        unsigned int pid = PID(OBJECT_Actor, actor.id);
+        int actorCollisions = 0;
         for (int i = 0; i < 100; ++i) {
             CollideIndoorWithGeometry(true);
             CollideIndoorWithDecorations();
             CollideWithParty(false);
-            _46ED8A_collide_against_sprite_objects(pid);
+            _46ED8A_collide_against_sprite_objects(PID(OBJECT_Actor, actor.id));
             for (uint j = 0; j < ai_arrays_size; j++) {
                 int actor2_id = ai_near_actors_ids[j];
                 if (actor2_id == actor.id)
@@ -508,12 +506,12 @@ void ProcessActorCollisionsBLV(Actor &actor, bool isAboveGround, bool isFlying) 
                 Actor &actor2 = pActors[actor2_id];
                 if ((actor2.vPosition - actor.vPosition).length() >= actor.uActorRadius + actor2.uActorRadius &&
                     CollideWithActor(actor2_id, 40))
-                    ++collisionsWithOtherActors;
+                    ++actorCollisions;
             }
             if (CollideIndoorWithPortals())
                 break;
         }
-        bool isInCrowd = collisionsWithOtherActors > 1;
+        bool isInCrowd = actorCollisions > 1;
 
         Vec3f newPos = actor.vPosition.toFloat() + collision_state.adjusted_move_distance * collision_state.direction;
         unsigned int newFaceID;
@@ -678,12 +676,11 @@ void ProcessActorCollisionsODM(Actor &actor, bool isFlying) {
     collision_state.radius_lo = actorRadius;
 
     for (int attempt = 0; attempt < 100; ++attempt) {
-        collision_state.position_hi = actor.vPosition.toFloat() + Vec3f(0, 0, actor.uActorHeight - actorRadius - 1);
         collision_state.position_lo = actor.vPosition.toFloat() + Vec3f(0, 0, actorRadius + 1);
+        collision_state.position_hi = actor.vPosition.toFloat() + Vec3f(0, 0, actor.uActorHeight - actorRadius - 1);
         collision_state.position_hi.z = std::max(collision_state.position_hi.z, collision_state.position_lo.z);
         collision_state.velocity = actor.vVelocity.toFloat();
         collision_state.uSectorID = 0;
-
         if (collision_state.PrepareAndCheckIfStationary(0))
             break;
 

--- a/src/Library/Trace/EventTrace.h
+++ b/src/Library/Trace/EventTrace.h
@@ -18,6 +18,7 @@ struct EventTraceHeader {
     std::vector<EventTraceConfigLine> config;
 
     // TODO(captainurist): std::string saveFileChecksum;
+    // TODO(captainurist): now that we can easily retrace everything, it would make sense to add starting/ending pos & map here.
 };
 
 struct EventTrace {

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG e7d4b2b6ea0124c657f590d578b32e0c534f9ba1
+            GIT_TAG 3bc2dcb428ccadb4c8293293c32728c2bdb3926f
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -390,6 +390,7 @@ GAME_TEST(Issues, Issue408) {
 
 GAME_TEST(Issues, Issue417) {
     // testing that portal nodes looping doesnt assert
+    // TODO(captainurist): 417b needs to be retraced, party is getting stuck on a monster.
     test->playTraceFromTestData("issue_417a.mm7", "issue_417a.json");
     test->playTraceFromTestData("issue_417b.mm7", "issue_417b.json");
 }


### PR DESCRIPTION
Basically, indoor actor-actor collisions weren't working for actors with R>40, and now they do.

This might be a change that deviates from vanilla (needs testing, help is very welcome), and thus affects gameplay. I believe this is still the right thing to do, and we don't need a config setting for this. 

If we decide we liked the old behavior, we can move the radius that's used for collisions to config. E.g. using 20 there instead of 40 would give us _almost_ vanilla behavior (party can still be ganged up on by a group of behemoths) while retaining some kind of sanity.