### PR TITLE
Audio minor corrections

### DIFF
--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -287,7 +287,7 @@ void Menu::EventLoop() {
 
                 engine->config->settings.MusicLevel.setValue(new_level);
                 pAudioPlayer->SetMusicVolume(engine->config->settings.MusicLevel.value());
-                pAudioPlayer->playMusicSound(SOUND_hurp);
+                pAudioPlayer->playSound(SOUND_hurp, AudioPlayer::SOUND_PID_MUSIC_VOLUME);
                 continue;
             }
 
@@ -338,7 +338,7 @@ void Menu::EventLoop() {
                 engine->config->settings.VoiceLevel.setValue(new_level);
                 pAudioPlayer->SetVoiceVolume(engine->config->settings.VoiceLevel.value());
                 if (engine->config->settings.VoiceLevel.value() > 0) {
-                    pAudioPlayer->playSound(SOUND_hf445a, AudioPlayer::SOUND_PID_PLAYER_RESETABLE);
+                    pAudioPlayer->playSound(SOUND_hf445a, AudioPlayer::SOUND_PID_VOICE_VOLUME);
                 }
                 continue;
             }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -101,6 +101,7 @@ void CreateParty_EventLoop() {
 
             new OnButtonClick({pButton->uX, pButton->uY}, {0, 0}, pButton, std::string(), false);
             pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
+            pAudioPlayer->stopVoiceSounds();
             pParty->pPlayers[param].playReaction(SPEECH_PickMe);
             break;
         }
@@ -114,6 +115,7 @@ void CreateParty_EventLoop() {
             auto pButton = pCreationUI_BtnPressRight2[param];
             new OnButtonClick({pButton->uX, pButton->uY}, {0, 0}, pButton, std::string(), false);
             pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
+            pAudioPlayer->stopVoiceSounds();
             pParty->pPlayers[param].playReaction(SPEECH_PickMe);
             break;
         }
@@ -137,6 +139,7 @@ void CreateParty_EventLoop() {
             new OnButtonClick({pCreationUI_BtnPressLeft[param]->uX, pCreationUI_BtnPressLeft[param]->uY}, {0, 0},
                 pCreationUI_BtnPressLeft[param], std::string(), false);
             pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
+            pAudioPlayer->stopVoiceSounds();
             pParty->pPlayers[param].playReaction(SPEECH_PickMe);
             break;
         case UIMSG_PlayerCreation_FaceNext:
@@ -158,6 +161,7 @@ void CreateParty_EventLoop() {
             new OnButtonClick({pCreationUI_BtnPressRight[param]->uX, pCreationUI_BtnPressRight[param]->uY}, {0, 0},
                 pCreationUI_BtnPressRight[param], std::string(), false);
             pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
+            pAudioPlayer->stopVoiceSounds();
             pParty->pPlayers[param].playReaction(SPEECH_PickMe);
             break;
         case UIMSG_PlayerCreationClickPlus:

--- a/src/Media/Audio/AudioPlayer.h
+++ b/src/Media/Audio/AudioPlayer.h
@@ -154,9 +154,9 @@ class AudioSamplePool {
  public:
     explicit AudioSamplePool(bool looping):_looping(looping) {}
 
-    bool playNew(PAudioSample sample, bool positional = false);
-    bool playUniqueSoundId(PAudioSample sample, SoundID id, bool positional = false);
-    bool playUniquePid(PAudioSample sample, int pid, bool positional = false);
+    bool playNew(PAudioSample sample, PAudioDataSource source, bool positional = false);
+    bool playUniqueSoundId(PAudioSample sample, PAudioDataSource source, SoundID id, bool positional = false);
+    bool playUniquePid(PAudioSample sample, PAudioDataSource source, int pid, bool positional = false);
     void pause();
     void resume();
     void stop();

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -793,7 +793,7 @@ PAudioDataSource PlatformDataSourceInitialize(PAudioDataSource baseDataSource) {
 
 class AudioSample16 : public IAudioSample {
  public:
-    AudioSample16():al_source(-1) {}
+    AudioSample16():al_source(-1),_position(0.0, 0.0, 0.0),_maxDistance(0.0),_volume(0.0) {}
     virtual ~AudioSample16() override;
 
     virtual bool Open(PAudioDataSource data_source) override;
@@ -812,6 +812,9 @@ class AudioSample16 : public IAudioSample {
 
     PAudioDataSource pDataSource;
     ALuint al_source;
+    Vec3f _position;
+    float _maxDistance;
+    float _volume;
 };
 
 AudioSample16::~AudioSample16() { Close(); }
@@ -865,14 +868,15 @@ bool AudioSample16::Open(PAudioDataSource data_source) {
 }
 
 bool AudioSample16::SetPosition(float x, float y, float z, float max_dist) {
-    if (!IsValid()) {
-        return false;
-    }
+    _position = Vec3f(x, y, z);
+    _maxDistance = max_dist;
 
-    alSource3f(al_source, AL_POSITION, x, y, z);
-    alSourcef(al_source, AL_MAX_DISTANCE, max_dist);
-    if (CheckError()) {
-        return false;
+    if (IsValid()) {
+        alSource3f(al_source, AL_POSITION, x, y, z);
+        alSourcef(al_source, AL_MAX_DISTANCE, max_dist);
+        if (CheckError()) {
+            return false;
+        }
     }
 
     return true;
@@ -897,9 +901,13 @@ bool AudioSample16::Play(bool loop, bool positioned) {
     alSourcei(al_source, AL_SOURCE_RELATIVE, positioned ? AL_FALSE : AL_TRUE);
     if (!positioned) {
         alSource3f(al_source, AL_POSITION, 0.f, 0.f, 0.f);
+        alSourcef(al_source, AL_MAX_DISTANCE, 2000.f);
+    } else {
+        alSource3f(al_source, AL_POSITION, _position.x, _position.y, _position.z);
+        alSourcef(al_source, AL_MAX_DISTANCE, _maxDistance);
     }
     alSource3f(al_source, AL_VELOCITY, 0.f, 0.f, 0.f);
-
+    alSourcef(al_source, AL_GAIN, _volume);
     alSourcei(al_source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
 
     ALint status;
@@ -968,24 +976,18 @@ bool AudioSample16::Resume() {
 }
 
 bool AudioSample16::SetVolume(float volume) {
-    if (!IsValid()) {
-        return false;
-    }
+    _volume = volume;
 
-    alSourcef(al_source, AL_GAIN, volume);
-    if (CheckError()) {
-        return false;
+    if (IsValid()) {
+        alSourcef(al_source, AL_GAIN, volume);
+        if (CheckError()) {
+            return false;
+        }
     }
 
     return true;
 }
 
-PAudioSample CreateAudioSample(PAudioDataSource dataSource) {
-    std::shared_ptr<AudioSample16> sample = std::make_shared<AudioSample16>();
-
-    if (!sample->Open(dataSource)) {
-        sample = nullptr;
-    }
-
-    return sample;
+PAudioSample CreateAudioSample() {
+    return std::make_shared<AudioSample16>();
 }

--- a/src/Media/Media.h
+++ b/src/Media/Media.h
@@ -61,7 +61,7 @@ class IAudioSample {
 };
 typedef std::shared_ptr<IAudioSample> PAudioSample;
 
-PAudioSample CreateAudioSample(PAudioDataSource dataSource);
+PAudioSample CreateAudioSample();
 
 class IVideoDataSource {
  public:


### PR DESCRIPTION
- Create separate field for music volume
- Create separate PID for config menu for sound scroll
- Play actors, players and items sounds on unique PID without restarting
- Optimize sample creation - open sample (i.e. generate OpenAL source) only when actual playing is performed. Playing may not start because of PID/SoundID filtering.