### PR TITLE
Fix #689 and #691

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -823,8 +823,7 @@ void Game::processQueuedMessages() {
                                         DialogueEnding();
                                         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
                                         continue;
-                                    case CURRENT_SCREEN::SCREEN_CHANGE_LOCATION:  // click
-                                                                  // escape
+                                    case CURRENT_SCREEN::SCREEN_CHANGE_LOCATION: // escape
                                         if (pParty->vPosition.x < -22528)
                                             pParty->vPosition.x = -22528;
                                         if (pParty->vPosition.x > 22528)
@@ -833,9 +832,9 @@ void Game::processQueuedMessages() {
                                             pParty->vPosition.y = -22528;
                                         if (pParty->vPosition.y > 22528)
                                             pParty->vPosition.y = 22528;
-                                        ReleaseBranchlessDialogue();
+                                        pMediaPlayer->Unload();
                                         DialogueEnding();
-                                        current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
+                                        onEscape();
                                         continue;
                                     case CURRENT_SCREEN::SCREEN_VIDEO:
                                         pMediaPlayer->Unload();

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -403,7 +403,10 @@ void MainMenuLoad_EventLoop() {
         case UIMSG_SaveLoadScroll: {
             // pskelton add for scroll click
             int pSaveFiles{ static_cast<int>(uNumSavegameFiles) };
-            if (!pSaveFiles) break;
+            if (pSaveFiles < 7) {
+                // Too few saves to scroll yet
+                break;
+            }
             int mx{}, my{};
             mouse->GetClickPos(&mx, &my);
             // 276 is offset down from top (216 + 60 frame)

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 61568c08768f2998d376ed3c370451aeeaf9090e
+            GIT_TAG 8d66ca4006209fbae58796bf30a8705ec87683bd
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -641,3 +641,9 @@ GAME_TEST(Issues, Issue662) {
     EXPECT_EQ(pParty->pPlayers[3].GetItemsBonus(CHARACTER_ATTRIBUTE_SKILL_AIR),
               2);
 }
+
+GAME_TEST(Issues, Issue691) {
+    // Test that hitting escape when in transition window does not crash
+    test->playTraceFromTestData("issue_691.mm7", "issue_691.json");
+    EXPECT_EQ(current_screen_type, CURRENT_SCREEN::SCREEN_GAME);
+}


### PR DESCRIPTION
Fix #689 - ignore scroll click if too few saves, not just zero saves.
Fix #691 - make escape processing for transition window same as cancel button processing.