### PR TITLE
Style changes from events

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -359,7 +359,6 @@ void Game_StartDialogue(unsigned int actor_id) {
     if (pParty->hasActiveCharacter()) {
         pCurrentFrameMessageQueue->Flush();
 
-        dword_5B65D0_dialogue_actor_npc_id = pActors[actor_id].sNPC_ID;
         GameUI_InitializeDialogue(&pActors[actor_id], true);
     }
 }
@@ -458,7 +457,6 @@ void Game::processQueuedMessages() {
     if (bDialogueUI_InitializeActor_NPC_ID) {
         // Actor::Actor(&actor);
         Actor actor = Actor();
-        dword_5B65D0_dialogue_actor_npc_id = bDialogueUI_InitializeActor_NPC_ID;
         actor.sNPC_ID = bDialogueUI_InitializeActor_NPC_ID;
         GameUI_InitializeDialogue(&actor, false);
         bDialogueUI_InitializeActor_NPC_ID = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1353,8 +1353,7 @@ void sub_44861E_set_texture_outdoor(unsigned int uFaceCog,
     }
 }
 
-//----- (0044861E) --------------------------------------------------------
-void sub_44861E_set_texture(unsigned int uFaceCog, const char *pFilename) {
+void setTexture(unsigned int uFaceCog, const char *pFilename) {
     if (uFaceCog) {
         // unsigned int texture = pBitmaps_LOD->LoadTexture(pFilename);
         // if (texture != -1)
@@ -1373,8 +1372,7 @@ void sub_44861E_set_texture(unsigned int uFaceCog, const char *pFilename) {
     }
 }
 
-//----- (0044892E) --------------------------------------------------------
-void sub_44892E_set_faces_bit(int sCogNumber, FaceAttribute bit, int on) {
+void setFacesBit(int sCogNumber, FaceAttribute bit, int on) {
     if (sCogNumber) {
         if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
             for (uint i = 1; i < (unsigned int)pIndoor->pFaceExtras.size(); ++i) {
@@ -1405,8 +1403,7 @@ void sub_44892E_set_faces_bit(int sCogNumber, FaceAttribute bit, int on) {
     }
 }
 
-//----- (0044882F) --------------------------------------------------------
-void SetDecorationSprite(uint16_t uCog, bool bHide, const char *pFileName) {
+void setDecorationSprite(uint16_t uCog, bool bHide, const char *pFileName) {
     for (size_t i = 0; i < pLevelDecorations.size(); i++) {
         if (pLevelDecorations[i].uCog == uCog) {
             if (pFileName && strcmp(pFileName, "0")) {

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -230,10 +230,20 @@ void InitializeTurnBasedAnimations(void *);
 unsigned int GetGravityStrength();
 void GameUI_StatusBar_Update(bool force_hide = false);
 
-void sub_44861E_set_texture(unsigned int uFaceCog, const char *pFilename);
-void sub_44892E_set_faces_bit(int sCogNumber, FaceAttribute bit, int on);
-void SetDecorationSprite(uint16_t uCog, bool bHide,
-                         const char *pFileName);  // idb
+/**
+ * @offset 0x44861E
+ */
+void setTexture(unsigned int uFaceCog, const char *pFilename);
+
+/**
+ * @offset 0x44892E
+ */
+void setFacesBit(int sCogNumber, FaceAttribute bit, int on);
+
+/**
+ * @offset 0x44882F
+ */
+void setDecorationSprite(uint16_t uCog, bool bHide, const char *pFileName);  // idb
 void _494035_timed_effects__water_walking_damage__etc();
 
 /**

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -411,8 +411,7 @@ LABEL_47:
                     if (canShowMessages) {
                         // Actor::Actor(&Dst);
                         Dst = Actor();
-                        dword_5B65D0_dialogue_actor_npc_id = EVT_DWORD(_evt->v5);
-                        Dst.sNPC_ID = dword_5B65D0_dialogue_actor_npc_id;
+                        Dst.sNPC_ID = EVT_DWORD(_evt->v5);
                         GameUI_InitializeDialogue(&Dst, false);
                     } else {
                         bDialogueUI_InitializeActor_NPC_ID = EVT_DWORD(_evt->v5);
@@ -454,7 +453,7 @@ LABEL_47:
                             HouseDialogPressCloseBtn();
                             window_SpeakInHouse->Release();
                             pParty->uFlags &= ~PARTY_FLAGS_1_ForceRedraw;
-                            if (EnterHouse(HOUSE_DARK_GUILD_PIT)) {
+                            if (enterHouse(HOUSE_DARK_GUILD_PIT)) {
                                 window_SpeakInHouse = new GUIWindow_House({0, 0}, render->GetRenderDimensions(), HOUSE_DARK_GUILD_PIT, "");
                                 window_SpeakInHouse->CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1, "");
                                 window_SpeakInHouse->CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2, "");
@@ -519,7 +518,7 @@ LABEL_47:
                             window_SpeakInHouse->Release();
                             pParty->uFlags &= ~PARTY_FLAGS_1_ForceRedraw;
                             activeLevelDecoration = (LevelDecoration *)1;
-                            if (EnterHouse(HOUSE_BODY_GUILD_ERATHIA)) {
+                            if (enterHouse(HOUSE_BODY_GUILD_ERATHIA)) {
                                 pAudioPlayer->playUISound(SOUND_Invalid);
                                 window_SpeakInHouse = new GUIWindow_House({0, 0}, render->GetRenderDimensions(), HOUSE_BODY_GUILD_ERATHIA, "");
                                 window_SpeakInHouse->DeleteButtons();
@@ -744,27 +743,24 @@ LABEL_47:
                     ++curr_seq_num;
                     break;
                 case EVENT_ToggleIndoorLight:
-                    pIndoor->ToggleLight(EVT_DWORD(_evt->v5), _evt->v9);
+                    pIndoor->toggleLight(EVT_DWORD(_evt->v5), _evt->v9);
                     ++curr_seq_num;
                     break;
                 case EVENT_SetFacesBit:
-                    sub_44892E_set_faces_bit(EVT_DWORD(_evt->v5),
-                                             static_cast<FaceAttribute>(EVT_DWORD(_evt->v9)), _evt->v13);
+                    setFacesBit(EVT_DWORD(_evt->v5), static_cast<FaceAttribute>(EVT_DWORD(_evt->v9)), _evt->v13);
                     ++curr_seq_num;
                     break;
                 case EVENT_ToggleChestFlag:
-                    Chest::ToggleFlag(EVT_DWORD(_evt->v5), CHEST_FLAG(EVT_DWORD(_evt->v9)),
-                                      _evt->v13);
+                    Chest::toggleFlag(EVT_DWORD(_evt->v5), CHEST_FLAG(EVT_DWORD(_evt->v9)), _evt->v13);
                     ++curr_seq_num;
                     break;
                 case EVENT_ToggleActorFlag:
-                    Actor::ToggleFlag(EVT_DWORD(_evt->v5), ActorAttribute(EVT_DWORD(_evt->v9)),
+                    Actor::toggleFlag(EVT_DWORD(_evt->v5), ActorAttribute(EVT_DWORD(_evt->v9)),
                                       _evt->v13);
                     ++curr_seq_num;
                     break;
                 case EVENT_ToggleActorGroupFlag:
-                    ToggleActorGroupFlag(EVT_DWORD(_evt->v5),
-                                         ActorAttribute(EVT_DWORD(_evt->v9)), _evt->v13);
+                    toggleActorGroupFlag(EVT_DWORD(_evt->v5), ActorAttribute(EVT_DWORD(_evt->v9)), _evt->v13);
                     ++curr_seq_num;
                     break;
                 case EVENT_SetSnow:
@@ -798,20 +794,18 @@ LABEL_47:
                     ++curr_seq_num;
                     break;
                 case EVENT_CastSpell:
-                    EventCastSpell(static_cast<SPELL_TYPE>(_evt->v5), static_cast<PLAYER_SKILL_MASTERY>(_evt->v6 + 1), _evt->v7,
+                    eventCastSpell(static_cast<SPELL_TYPE>(_evt->v5), static_cast<PLAYER_SKILL_MASTERY>(_evt->v6 + 1), _evt->v7,
                                    EVT_DWORD(_evt->v8), EVT_DWORD(_evt->v12),
                                    EVT_DWORD(_evt->v16), EVT_DWORD(_evt->v20),
                                    EVT_DWORD(_evt->v24), EVT_DWORD(_evt->v28));
                     ++curr_seq_num;
                     break;
                 case EVENT_SetTexture:
-                    sub_44861E_set_texture(EVT_DWORD(_evt->v5),
-                                           (char *)&_evt->v9);
+                    setTexture(EVT_DWORD(_evt->v5), (char *)&_evt->v9);
                     ++curr_seq_num;
                     break;
                 case EVENT_SetSprite:
-                    SetDecorationSprite(EVT_DWORD(_evt->v5), _evt->v9,
-                                        (char *)&_evt->v10);
+                    setDecorationSprite(EVT_DWORD(_evt->v5), _evt->v9, (char *)&_evt->v10);
                     ++curr_seq_num;
                     break;
                 case EVENT_SummonMonsters:
@@ -827,11 +821,11 @@ LABEL_47:
                     ++curr_seq_num;
                     break;
                 case EVENT_ChangeDoorState:
-                    Door_switch_animation(_evt->v5, _evt->v6);
+                    switchDoorAnimation(_evt->v5, _evt->v6);
                     ++curr_seq_num;
                     break;
                 case EVENT_OpenChest:
-                    if (!Chest::Open(_evt->v5)) {
+                    if (!Chest::open(_evt->v5)) {
                         if (v133 == 1) OnMapLeave();
                         return;
                     }
@@ -938,7 +932,7 @@ LABEL_47:
                     break;
                 }
                 case EVENT_SpeakInHouse:
-                    if (EnterHouse((enum HOUSE_ID)EVT_DWORD(_evt->v5))) {
+                    if (enterHouse((enum HOUSE_ID)EVT_DWORD(_evt->v5))) {
                         //pAudioPlayer->playSound(SOUND_Invalid);
                         // PID 814 was used which is PID(OBJECT_Face, 101)
                         pAudioPlayer->playUISound(SOUND_enter);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -224,8 +224,7 @@ unsigned int IndoorLocation::GetLocationIndex(const char *Str1) {
     return 0;
 }
 
-//----- (004488F7) --------------------------------------------------------
-void IndoorLocation::ToggleLight(signed int sLightID, unsigned int bToggle) {
+void IndoorLocation::toggleLight(signed int sLightID, unsigned int bToggle) {
     if (uCurrentlyLoadedLevelType == LEVEL_Indoor &&
         (sLightID <= pIndoor->pLights.size() - 1) && (sLightID >= 0)) {
         if (bToggle)
@@ -2307,8 +2306,7 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
         EventProcessor(uFaceEvent, 0, 1);
 }
 
-//----- (00449A49) --------------------------------------------------------
-void Door_switch_animation(unsigned int uDoorID, int a2) {
+void switchDoorAnimation(unsigned int uDoorID, int a2) {
     BLVDoor::State old_state;       // eax@1
     signed int door_id;  // esi@2
 

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -355,7 +355,11 @@ struct IndoorLocation {
     bool Load(const std::string &filename, int num_days_played,
               int respawn_interval_days, char *pDest);
     void Draw();
-    void ToggleLight(signed int uLightID, unsigned int bToggle);
+
+    /**
+     * @offset 0x4488F7
+     */
+    void toggleLight(signed int uLightID, unsigned int bToggle);
 
     static unsigned int GetLocationIndex(const char *Str1);
     void DrawIndoorFaces(bool bD3D);
@@ -441,7 +445,11 @@ int BLV_GetFloorLevel(const Vec3i &pos, unsigned int uSectorID, unsigned int *pF
 void BLV_UpdateDoors();
 void UpdateActors_BLV();
 void BLV_ProcessPartyActions();
-void Door_switch_animation(unsigned int uDoorID, int a2);  // idb: sub_449A49
+
+/**
+ * @offset 0x449A49
+ */
+void switchDoorAnimation(unsigned int uDoorID, int a2);
 int CalcDistPointToLine(int a1, int a2, int a3, int a4, int a5, int a6);
 void PrepareDrawLists_BLV();
 void PrepareToLoadBLV(bool bLoading);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -116,8 +116,7 @@ void Actor::DrawHealthBar(Actor *actor, GUIWindow *window) {
                                 game_ui_monster_hp_border_right);
 }
 
-//----- (00448A40) --------------------------------------------------------
-void Actor::ToggleFlag(signed int uActorID, ActorAttribute uFlag, bool bValue) {
+void Actor::toggleFlag(signed int uActorID, ActorAttribute uFlag, bool bValue) {
     if (uActorID >= 0 && uActorID <= (signed int)(pActors.size() - 1)) {
         if (bValue) {
             pActors[uActorID].uAttributes |= uFlag;
@@ -4123,7 +4122,7 @@ bool Actor::DoesDmgTypeDoDamage(DAMAGE_TYPE uType) {
 }
 
 //----- (00448A98) --------------------------------------------------------
-void ToggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag,
+void toggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag,
                           bool bValue) {
     if (uGroupID) {
         if (bValue) {

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -156,7 +156,11 @@ class Actor {
     static void StealFrom(unsigned int uActorID);
     static void GiveItem(signed int uActorID, ITEM_TYPE uItemID,
                          unsigned int bGive);
-    static void ToggleFlag(signed int uActorID, ActorAttribute uFlag, bool bToggle);
+
+    /**
+     * @offset 0x448A40
+     */
+    static void toggleFlag(signed int uActorID, ActorAttribute uFlag, bool bToggle);
     static void ApplyFineForKillingPeasant(unsigned int uActorID);
     static void DrawHealthBar(Actor *actor, GUIWindow *window);
     int _43B3E0_CalcDamage(ABILITY_INDEX dmgSource);
@@ -237,8 +241,11 @@ bool CheckActors_proximity();
 int IsActorAlive(unsigned int uType, unsigned int uParam,
                  unsigned int uNumAlive);  // idb
 void sub_448518_npc_set_item(int npc, ITEM_TYPE item, int a3);
-void ToggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag,
-                          bool bValue);
+
+/**
+ * @offset 0x448A98
+ */
+void toggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag, bool bValue);
 bool Detect_Between_Objects(unsigned int uObjID, unsigned int uObj2ID);
 bool SpawnActor(unsigned int uMonsterID);
 void Spawn_Light_Elemental(int spell_power, PLAYER_SKILL_MASTERY caster_skill_mastery, int duration_game_seconds);

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -29,7 +29,7 @@
 ChestList *pChestList;
 std::vector<Chest> vChests;
 
-bool Chest::Open(int uChestID) {
+bool Chest::open(int uChestID) {
     ODMFace *pODMFace;                // eax@19
     BLVFace *pBLVFace;                // eax@20
     int pObjectX = 0;                     // ebx@21
@@ -421,7 +421,7 @@ void Chest::PlaceItems(int uChestID) {  // only sued for setup
     vChests[uChestID].SetInitialized(true);
 }
 
-void Chest::ToggleFlag(int uChestID, CHEST_FLAG uFlag, bool bValue) {
+void Chest::toggleFlag(int uChestID, CHEST_FLAG uFlag, bool bValue) {
     if (uChestID >= 0 && uChestID <= 19) {
         if (bValue)
             vChests[uChestID].uFlags |= uFlag;

--- a/src/Engine/Objects/Chest.h
+++ b/src/Engine/Objects/Chest.h
@@ -55,8 +55,8 @@ struct Chest {  // 0x14cc
     static int PutItemInChest(int a1, struct ItemGen *a2, int uChestID);
     static void PlaceItemAt(unsigned int put_cell_pos, unsigned int uItemIdx, int uChestID);
     static void PlaceItems(int uChestID);
-    static bool Open(int uChestID);
-    static void ToggleFlag(int uChestID, CHEST_FLAG uFlag, bool bValue);
+    static bool open(int uChestID);
+    static void toggleFlag(int uChestID, CHEST_FLAG uFlag, bool bValue);
     static bool ChestUI_WritePointedObjectStatusString();
     static void OnChestLeftClick();
     static void GrabItem(bool all = false);

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -778,11 +778,11 @@ void SpellStats::Initialize() {
     }
 }
 
-void EventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAYER_SKILL_LEVEL skillLevel, int fromx,
+void eventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAYER_SKILL_LEVEL skillLevel, int fromx,
                     int fromy, int fromz, int tox, int toy, int toz) {
     // For bug catching
     Assert(skillMastery >= PLAYER_SKILL_MASTERY_NOVICE && skillMastery <= PLAYER_SKILL_MASTERY_GRANDMASTER,
-          "EventCastSpell - Invalid mastery level");
+          "eventCastSpell - Invalid mastery level");
 
     Vec3i from(fromx, fromy, fromz);
     Vec3i to(tox, toy, toz);

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -153,7 +153,7 @@ bool IsSpellQuickCastableOnShiftClick(SPELL_TYPE uSpellID);
 /**
  * Function for processing spells cast from game scripts.
  */
-void EventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAYER_SKILL_LEVEL skillLevel, int fromx,
+void eventCastSpell(SPELL_TYPE uSpellID, PLAYER_SKILL_MASTERY skillMastery, PLAYER_SKILL_LEVEL skillLevel, int fromx,
                     int fromy, int fromz, int tox, int toy, int toz);  // sub_448DF8
 
 void armageddonProgress();

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2611,7 +2611,6 @@ int dword_5B65C4_cancelEventProcessing;
 int MapsLongTimers_count;  // dword_5B65C8 счётчик таймеров для колодцев,
                            // фаерволов-ловушек
 int npcIdToDismissAfterDialogue;
-signed int dword_5B65D0_dialogue_actor_npc_id;
 int dword_5C3418; //  eventid store for branchless dialogue
 int dword_5C341C; // entry line store for branchless dialogue
 // std::array<char, 777> byte_5C3427;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -216,7 +216,6 @@ extern int Start_Party_Teleport_Flag;
 extern int dword_5B65C4_cancelEventProcessing;
 extern int MapsLongTimers_count;  // dword_5B65C8
 extern int npcIdToDismissAfterDialogue;
-extern int dword_5B65D0_dialogue_actor_npc_id;
 extern int dword_5C3418;
 extern int dword_5C341C;
 // extern std::array<char, 777> byte_5C3427;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -801,8 +801,7 @@ bool HouseUI_CheckIfPlayerCanInteract() {
     }
 }
 
-//----- (0044622E) --------------------------------------------------------
-bool EnterHouse(HOUSE_ID uHouseID) {
+bool enterHouse(HOUSE_ID uHouseID) {
     GameUI_StatusBar_Clear();
     GameUI_SetStatusBar("");
     pCurrentFrameMessageQueue->Flush();
@@ -2339,11 +2338,8 @@ void TrainingDialog(const char *s) {
                         }
                         ++player_levels[pParty->getActiveCharacter() - 1];
                         if (player_levels[pParty->getActiveCharacter() - 1] >
-                            max_level_in_party) {  // if we reach new maximum
-                                                   // party level feature is
-                                                   // broken thou, since this
-                                                   // array is always zeroed in
-                                                   // EnterHouse
+                            max_level_in_party) {  // if we reach new maximum party level feature is broken thou,
+                                                   // since this array is always zeroed in enterHouse
                             v42 = 60 * (_494820_training_time(pParty->uCurrentHour) + 4) - pParty->uCurrentMinute;
                             if (window_SpeakInHouse->wData.val == HOUSE_TRAINING_HALL_PIT || window_SpeakInHouse->wData.val == HOUSE_TRAINING_HALL_NIGHON)
                                 v42 += 12 * 60;
@@ -3024,7 +3020,7 @@ void BackToHouseMenu() {
         HouseDialogPressCloseBtn();
         window_SpeakInHouse->Release();
         pParty->uFlags &= 0xFFFFFFFD;
-        if (EnterHouse(HOUSE_BODY_GUILD_ERATHIA)) {
+        if (enterHouse(HOUSE_BODY_GUILD_ERATHIA)) {
             pAudioPlayer->playUISound(SOUND_Invalid);
             window_SpeakInHouse = new GUIWindow_House({0, 0}, render->GetRenderDimensions(), HOUSE_BODY_GUILD_ERATHIA, "");
             window_SpeakInHouse->CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1);

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -37,7 +37,11 @@ void ArmorShopDialog();
 void SimpleHouseDialog();
 void OnSelectShopDialogueOption(DIALOGUE_TYPE option);
 void PrepareHouse(HOUSE_ID house);  // idb
-bool EnterHouse(HOUSE_ID uHouseID);
+
+/**
+ * @offset 0x44622E
+ */
+bool enterHouse(HOUSE_ID uHouseID);
 void BackToHouseMenu();
 
 void InitializaDialogueOptions_Tavern(BuildingType type);  // idb


### PR DESCRIPTION
Some styling changes I did while porting events to new engine.
One thing that stands out: dropping of `dword_5B65D0_dialogue_actor_npc_id` as it seems that this global is not read anywhere.