### PR TITLE
Make corrections for walking sounds

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -231,6 +231,10 @@ void Engine::DrawGUI() {
         uCurrentlyLoadedLevelType == LEVEL_Outdoor)
         pWeather->Draw();  // Ritor1: my include
 
+    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) {
+        pAudioPlayer->stopWalkingSounds();
+    }
+
                            // while(GetTickCount() - last_frame_time < 33 );//FPS control
     uint frame_dt = platform->tickCount() - last_frame_time;
     last_frame_time = platform->tickCount();

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -232,6 +232,7 @@ void Engine::DrawGUI() {
         pWeather->Draw();  // Ritor1: my include
 
     if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) {
+        // TODO(Nik-RE-dev): this really doesn't belong to Engine::DrawGUI
         pAudioPlayer->stopWalkingSounds();
     }
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -2240,7 +2240,6 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
 
             if (walkDelta < 2) {
                 // mute the walking sound when stopping
-                pParty->currentWalkingSound = SOUND_Invalid;
                 pAudioPlayer->stopWalkingSounds();
             } else {
                 // Delta limits for running/walking has been changed. Previously:
@@ -2274,7 +2273,6 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                     }
 
                     if (sound != pParty->currentWalkingSound) {
-                        pParty->currentWalkingSound = SOUND_Invalid;
                         pAudioPlayer->stopWalkingSounds();
                         canStartNewSound = true;
                     }
@@ -2283,7 +2281,6 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                         pAudioPlayer->playWalkSound(sound);
                     }
                 } else {
-                    pParty->currentWalkingSound = SOUND_Invalid;
                     pAudioPlayer->stopWalkingSounds();
                 }
             }

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -2231,22 +2231,22 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
 
     // walking / running sounds ------------------------
     if (engine->config->settings.WalkSound.value()) {
-        pParty->walk_sound_timer -= pEventTimer->uTimeElapsed;
-
-        if (pParty->walk_sound_timer <= 0) {
-            pAudioPlayer->stopWalkingSounds();
-        }
+        bool canStartNewSound = !pAudioPlayer->isWalkingSoundPlays();
 
         // Start sound processing only when actual movement is performed to avoid stopping sounds on high FPS
         if (pEventTimer->uTimeElapsed) {
             // TODO(Nik-RE-dev): use calculated velocity of party and walk/run flags instead of delta
             int walkDelta = integer_sqrt((pParty->vPosition - Vec3i(new_party_x, new_party_y, new_party_z)).lengthSqr());
 
-            // Delta limits for running/walking has been changed. Previously:
-            // - for run limit was >= 16
-            // - for walk limit was >= 8
-            // - stop sound if delta < 8
-            if (pParty->walk_sound_timer <= 0) {
+            if (walkDelta < 2) {
+                // mute the walking sound when stopping
+                pParty->currentWalkingSound = SOUND_Invalid;
+                pAudioPlayer->stopWalkingSounds();
+            } else {
+                // Delta limits for running/walking has been changed. Previously:
+                // - for run limit was >= 16
+                // - for walk limit was >= 8
+                // - stop sound if delta < 8
                 if (!hovering || not_high_fall) {
                     SoundID sound = SOUND_Invalid;
                     if (party_running_flag) {
@@ -2259,7 +2259,6 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                                 // TODO(Nik-RE-dev): need to probe surface
                                 sound = SOUND_RunWood;
                             }
-                            pParty->walk_sound_timer = 96;  // 64
                         }
                     } else if (party_walking_flag) {
                         if (walkDelta >= 2) {
@@ -2271,19 +2270,22 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                                 // TODO(Nik-RE-dev): need to probe surface
                                 sound = SOUND_WalkWood;
                             }
-                            pParty->walk_sound_timer = 144;  // 64
                         }
                     }
 
-                    if (sound != SOUND_Invalid) {
+                    if (sound != pParty->currentWalkingSound) {
+                        pParty->currentWalkingSound = SOUND_Invalid;
+                        pAudioPlayer->stopWalkingSounds();
+                        canStartNewSound = true;
+                    }
+                    if (sound != SOUND_Invalid && canStartNewSound) {
+                        pParty->currentWalkingSound = sound;
                         pAudioPlayer->playWalkSound(sound);
                     }
+                } else {
+                    pParty->currentWalkingSound = SOUND_Invalid;
+                    pAudioPlayer->stopWalkingSounds();
                 }
-            }
-
-            // mute the walking sound when stopping
-            if (walkDelta < 2) {
-                pAudioPlayer->stopWalkingSounds();
             }
         }
     }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2530,7 +2530,6 @@ void ODM_ProcessPartyActions() {
 
             if (walkDelta < 2) {
                 // mute the walking sound when stopping
-                pParty->currentWalkingSound = SOUND_Invalid;
                 pAudioPlayer->stopWalkingSounds();
             } else {
                 // Delta limits for running/walking has been changed. Previously:
@@ -2562,7 +2561,6 @@ void ODM_ProcessPartyActions() {
                     }
 
                     if (sound != pParty->currentWalkingSound) {
-                        pParty->currentWalkingSound = SOUND_Invalid;
                         pAudioPlayer->stopWalkingSounds();
                         canStartNewSound = true;
                     }
@@ -2571,7 +2569,6 @@ void ODM_ProcessPartyActions() {
                         pAudioPlayer->playWalkSound(sound);
                     }
                 } else {
-                    pParty->currentWalkingSound = SOUND_Invalid;
                     pAudioPlayer->stopWalkingSounds();
                 }
             }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2530,7 +2530,7 @@ void ODM_ProcessPartyActions() {
 
             if (walkDelta < 2) {
                 // mute the walking sound when stopping
-                pParty->walk_sound_timer = 0;
+                pParty->currentWalkingSound = SOUND_Invalid;
                 pAudioPlayer->stopWalkingSounds();
             } else {
                 // Delta limits for running/walking has been changed. Previously:
@@ -2561,17 +2561,17 @@ void ODM_ProcessPartyActions() {
                         }
                     }
 
-                    if (sound != pParty->walk_sound_timer) {
-                        pParty->walk_sound_timer = 0;
+                    if (sound != pParty->currentWalkingSound) {
+                        pParty->currentWalkingSound = SOUND_Invalid;
                         pAudioPlayer->stopWalkingSounds();
                         canStartNewSound = true;
                     }
                     if (sound != SOUND_Invalid && canStartNewSound) {
-                        pParty->walk_sound_timer = (int)sound;
+                        pParty->currentWalkingSound = sound;
                         pAudioPlayer->playWalkSound(sound);
                     }
                 } else {
-                    pParty->walk_sound_timer = 0;
+                    pParty->currentWalkingSound = SOUND_Invalid;
                     pAudioPlayer->stopWalkingSounds();
                 }
             }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2388,69 +2388,12 @@ void ODM_ProcessPartyActions() {
         partyInputZSpeed = fixpoint_mul(58500, partyInputZSpeed);
     }
 
-    // walking / running sounds ------------------------
-    if (engine->config->settings.WalkSound.value()) {
-        pParty->walk_sound_timer -= pEventTimer->uTimeElapsed;
-
-        if (pParty->walk_sound_timer <= 0) {
-            pAudioPlayer->stopWalkingSounds();
-        }
-
-        // Start sound processing only when actual movement is performed to avoid stopping sounds on high FPS
-        if (pEventTimer->uTimeElapsed) {
-            // TODO(Nik-RE-dev): use calculated velocity of party and walk/run flags instead of delta
-            int walkDelta = integer_sqrt((pParty->vPosition - Vec3i(partyNewX, partyNewY, partyNewZ)).lengthSqr());
-
-            // Delta limits for running/walking has been changed. Previously:
-            // - for run limit was >= 16
-            // - for walk limit was >= 8
-            // - stop sound if delta < 8
-            if (pParty->walk_sound_timer <= 0) {
-                if (!partyNotTouchingFloor || partyCloseToGround) {
-                    int modelId = pParty->floor_face_pid >> 9;
-                    int faceId = (pParty->floor_face_pid >> 3) & 0x3F;
-                    bool isModelWalk = !partyNotOnModel && pOutdoor->pBModels[modelId].pFaces[faceId].Visible();
-                    SoundID sound = SOUND_Invalid;
-                    if (partyIsRunning) {
-                        if (walkDelta >= 4 ) {
-                            if (isModelWalk) {
-                                sound = SOUND_RunWood;
-                            } else {
-                                // Old comment: 56 is ground run
-                                sound = pOutdoor->getSoundIdByGrid(WorldPosToGridCellX(pParty->vPosition.x), WorldPosToGridCellY(pParty->vPosition.y), true);
-                            }
-                            pParty->walk_sound_timer = 96;  // 64
-                        }
-                    } else if (partyIsWalking) {
-                        if (walkDelta >= 2) {
-                            if (isModelWalk) {
-                                sound = SOUND_RunWood;
-                            } else {
-                                sound = pOutdoor->getSoundIdByGrid(WorldPosToGridCellX(pParty->vPosition.x), WorldPosToGridCellY(pParty->vPosition.y), false);
-                            }
-                            pParty->walk_sound_timer = 114;  // 64
-                        }
-                    }
-
-                    if (sound != SOUND_Invalid) {
-                        pAudioPlayer->playWalkSound(sound);
-                    }
-                }
-            }
-
-            // mute the walking sound when stopping
-            if (walkDelta < 2) {
-                pAudioPlayer->stopWalkingSounds();
-            }
-        }
-    }
-    //------------------------------------------------------------------------
-
     if (!partyNotTouchingFloor || partyCloseToGround)
         pParty->setAirborne(false);
     else
         pParty->setAirborne(true);
 
+    Vec3i partyOldPosition = pParty->vPosition;
     int partyCurrentXGrid = WorldPosToGridCellX(pParty->vPosition.x);
     int partyCurrentYGrid = WorldPosToGridCellY(pParty->vPosition.y);
     int partyNewXGrid = WorldPosToGridCellX(partyNewX);
@@ -2520,9 +2463,6 @@ void ODM_ProcessPartyActions() {
                     }
                 }
             }
-        } else if (engine->config->settings.WalkSound.value() && pParty->walk_sound_timer <= 0) {
-            pAudioPlayer->stopWalkingSounds();
-            pParty->walk_sound_timer = 64;
         }
 
         pParty->vPosition.z = partyNewZ;
@@ -2547,9 +2487,8 @@ void ODM_ProcessPartyActions() {
     }
 
     // new ground level
-
     int newFloorLevel = ODM_GetFloorLevel(Vec3i(partyNewX, partyNewY, partyNewZ), pParty->uPartyHeight,
-        &partyIsOnWater, &modelStandingOnPID, waterWalkActive);
+            &partyIsOnWater, &modelStandingOnPID, waterWalkActive);
     int newGroundLevel = newFloorLevel + 1;
 
     // Falling damage
@@ -2579,6 +2518,65 @@ void ODM_ProcessPartyActions() {
 
     if (partySlopeMod)
         pParty->uFallStartZ = partyNewZ;
+
+    // walking / running sounds ------------------------
+    if (engine->config->settings.WalkSound.value()) {
+        bool canStartNewSound = !pAudioPlayer->isWalkingSoundPlays();
+
+        // Start sound processing only when actual movement is performed to avoid stopping sounds on high FPS
+        if (pEventTimer->uTimeElapsed) {
+            // TODO(Nik-RE-dev): use calculated velocity of party and walk/run flags instead of delta
+            int walkDelta = integer_sqrt((partyOldPosition - pParty->vPosition).lengthSqr());
+
+            if (walkDelta < 2) {
+                // mute the walking sound when stopping
+                pParty->walk_sound_timer = 0;
+                pAudioPlayer->stopWalkingSounds();
+            } else {
+                // Delta limits for running/walking has been changed. Previously:
+                // - for run limit was >= 16
+                // - for walk limit was >= 8
+                // - stop sound if delta < 8
+                if (!partyNotTouchingFloor || partyCloseToGround) {
+                    int modelId = pParty->floor_face_pid >> 9;
+                    int faceId = (pParty->floor_face_pid >> 3) & 0x3F;
+                    bool isModelWalk = !partyNotOnModel && pOutdoor->pBModels[modelId].pFaces[faceId].Visible();
+                    SoundID sound = SOUND_Invalid;
+                    if (partyIsRunning) {
+                        if (walkDelta >= 4 ) {
+                            if (isModelWalk) {
+                                sound = SOUND_RunWood;
+                            } else {
+                                // Old comment: 56 is ground run
+                                sound = pOutdoor->getSoundIdByGrid(WorldPosToGridCellX(partyOldPosition.x), WorldPosToGridCellY(partyOldPosition.y), true);
+                            }
+                        }
+                    } else if (partyIsWalking) {
+                        if (walkDelta >= 2) {
+                            if (isModelWalk) {
+                                sound = SOUND_RunWood;
+                            } else {
+                                sound = pOutdoor->getSoundIdByGrid(WorldPosToGridCellX(partyOldPosition.x), WorldPosToGridCellY(partyOldPosition.y), false);
+                            }
+                        }
+                    }
+
+                    if (sound != pParty->walk_sound_timer) {
+                        pParty->walk_sound_timer = 0;
+                        pAudioPlayer->stopWalkingSounds();
+                        canStartNewSound = true;
+                    }
+                    if (sound != SOUND_Invalid && canStartNewSound) {
+                        pParty->walk_sound_timer = (int)sound;
+                        pAudioPlayer->playWalkSound(sound);
+                    }
+                } else {
+                    pParty->walk_sound_timer = 0;
+                    pAudioPlayer->stopWalkingSounds();
+                }
+            }
+        }
+    }
 }
 
 int GetCeilingHeight(int Party_X, signed int Party_Y, int Party_ZHeight, int *pFaceID) {

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -102,7 +102,7 @@ void Party::Zero() {
     field_6EC_set0_unused = 0;
     sPartySavedFlightZ = 0;
     floor_face_pid = 0;
-    walk_sound_timer = 0;
+    currentWalkingSound = SOUND_Invalid;
     _6FC_water_lava_timer = 0;
     uFallStartZ = 0;
     bFlying = 0;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -12,6 +12,7 @@
 #include "Engine/Time.h"
 #include "GUI/UI/UIHouseEnums.h"
 #include "Library/Random/Random.h"
+#include "Media/Audio/AudioPlayer.h"
 
 #define PARTY_AUTONOTES_BIT__EMERALD_FIRE_FOUNTAIN 2
 
@@ -397,7 +398,7 @@ struct Party {
     int field_6EC_set0_unused;
     int sPartySavedFlightZ;  // this saves the Z position when flying without bob mods
     int floor_face_pid;  // face we are standing at
-    int walk_sound_timer;
+    SoundID currentWalkingSound; // previously was 'walk_sound_timer'
     int _6FC_water_lava_timer;
     int uFallStartZ;
     unsigned int bFlying;

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -343,7 +343,7 @@ void Serialize(const Party &src, Party_MM7 *dst) {
     dst->field_6EC = src.field_6EC_set0_unused;
     dst->field_6F0 = src.sPartySavedFlightZ;
     dst->floor_face_pid = src.floor_face_pid;
-    dst->walk_sound_timer = src.walk_sound_timer;
+    dst->walk_sound_timer = 0; // zero walking sound timer, in OE it was removed and it is little meaning saving it
     dst->_6FC_water_lava_timer = src._6FC_water_lava_timer;
     dst->uFallStartZ = src.uFallStartZ;
     dst->bFlying = src.bFlying;
@@ -464,7 +464,8 @@ void Deserialize(const Party_MM7 &src, Party *dst) {
     dst->field_6EC_set0_unused = src.field_6EC;
     dst->sPartySavedFlightZ = src.field_6F0;
     dst->floor_face_pid = src.floor_face_pid;
-    dst->walk_sound_timer = src.walk_sound_timer;
+    // Walking sound timer was removed from OE
+    //dst->walk_sound_timer = src.walk_sound_timer;
     dst->_6FC_water_lava_timer = src._6FC_water_lava_timer;
     dst->uFallStartZ = src.uFallStartZ;
     dst->bFlying = src.bFlying;

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -458,6 +458,13 @@ void AudioPlayer::soundDrain() {
     }
 }
 
+bool AudioPlayer::isWalkingSoundPlays() {
+    if (_currentWalkingSample) {
+        return !_currentWalkingSample->IsStopped();
+    }
+    return false;
+}
+
 bool AudioSamplePool::playNew(PAudioSample sample, PAudioDataSource source, bool positional) {
     update();
     if (!sample->Open(source)) {

--- a/src/Media/Audio/AudioPlayer.h
+++ b/src/Media/Audio/AudioPlayer.h
@@ -216,6 +216,7 @@ class AudioPlayer {
     void stopVoiceSounds();
     void stopWalkingSounds();
     void soundDrain();
+    bool isWalkingSoundPlays();
 
     /**
      * Play sound.


### PR DESCRIPTION
Fix #702.
Remove walking timer altogether and rely on actual walk sound duration or walking status changes for starting new walk sound instance.
Zero walk timer for game saves (it actually have little meaning in saved game).
Move walking sound processing outdoor after water tiles probing to avoid playing walking sounds when party movement is limited by water.