### PR TITLE
Fix repeated house sounds

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -778,8 +778,7 @@ void Game::processQueuedMessages() {
                                                 continue;
                                         }
                                         GetHouseGoodbyeSpeech();
-                                        // PID 814 was used which is PID(OBJECT_Face, 101)
-                                        pAudioPlayer->playUISound(SOUND_WoodDoorClosing);
+                                        pAudioPlayer->playHouseSound(SOUND_WoodDoorClosing, false);
                                         pMediaPlayer->Unload();
                                         pGUIWindow_CurrentMenu = window_SpeakInHouse;
 

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -941,8 +941,7 @@ LABEL_47:
                 case EVENT_SpeakInHouse:
                     if (enterHouse((enum HOUSE_ID)EVT_DWORD(_evt->v5))) {
                         //pAudioPlayer->playSound(SOUND_Invalid);
-                        // PID 814 was used which is PID(OBJECT_Face, 101)
-                        pAudioPlayer->playUISound(SOUND_enter);
+                        pAudioPlayer->playHouseSound(SOUND_enter, false);
                         HOUSE_ID houseId = HOUSE_JAIL;
                         if (uCurrentHouse_Animation != 167)
                             houseId = static_cast<HOUSE_ID>(EVT_DWORD(_evt->v5));

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -963,8 +963,7 @@ void PlayHouseSound(unsigned int uHouseID, HouseSoundID sound) {
     if (uHouseID > 0) {
         if (pAnimatedRooms[p2DEvents[uHouseID - HOUSE_SMITH_EMERALD_ISLE].uAnimationID].uRoomSoundId) {
             int roomSoundId = pAnimatedRooms[p2DEvents[uHouseID - HOUSE_SMITH_EMERALD_ISLE].uAnimationID].uRoomSoundId;
-            // PID 806 was used which is PID(OBJECT_Face, 100)
-            pAudioPlayer->playUISound((SoundID)(sound + 100 * (roomSoundId + 300)));
+            pAudioPlayer->playHouseSound((SoundID)(sound + 100 * (roomSoundId + 300)), true);
         }
     }
 }

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -327,6 +327,9 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
         sample->SetVolume(uVoiceVolume);
         _regularSoundPool.stopSoundId(eSoundID);
         result = _regularSoundPool.playUniqueSoundId(sample, si.dataSource, eSoundID);
+    } else if (pid == SOUND_PID_HOUSE_SPEECH || pid == SOUND_PID_HOUSE_DOOR) {
+        _regularSoundPool.stopPid(pid);
+        _regularSoundPool.playUniquePid(sample, si.dataSource, pid);
     } else {
         ObjectType object_type = PID_TYPE(pid);
         unsigned int object_id = PID_ID(pid);
@@ -388,7 +391,7 @@ void AudioPlayer::playSound(SoundID eSoundID, int pid, unsigned int uNumRepeats,
             }
 
             case OBJECT_Face: {
-                result = _regularSoundPool.playNew(sample, si.dataSource);
+                result = _regularSoundPool.playUniquePid(sample, si.dataSource, pid);
 
                 break;
             }

--- a/src/Media/Audio/AudioPlayer.h
+++ b/src/Media/Audio/AudioPlayer.h
@@ -190,6 +190,8 @@ class AudioPlayer {
     static const int SOUND_PID_WALKING = -3;
     static const int SOUND_PID_MUSIC_VOLUME = -4;
     static const int SOUND_PID_VOICE_VOLUME = -5;
+    static const int SOUND_PID_HOUSE_SPEECH = -6;
+    static const int SOUND_PID_HOUSE_DOOR = -7;
 
     void Initialize();
 
@@ -289,6 +291,20 @@ class AudioPlayer {
     void playWalkSound(SoundID id) {
         // All walk sounds originally used PID 804 which is PID(OBJECT_Player, 100)
         playSound(id, SOUND_PID_WALKING);
+    }
+
+    /**
+     * Play sound of houses.
+     * To avoid multiple sounds when entering/leaving repeatedly sounds needs to be stopped.
+     *
+     * @param id                        ID of sound.
+     * @param isSpeech                  true if this is house greet/goodbye speech.
+     *                                  false if this is entering/cloosing UI sound.
+     */
+    void playHouseSound(SoundID id, bool isSpeech) {
+        // Speech sounds originally used PID 806 which is PID(OBJECT_Face, 100)
+        // Opening/closing sounds originally used PID 814 which is PID(OBJECT_Face, 101)
+        playSound(id, isSpeech ? SOUND_PID_HOUSE_SPEECH : SOUND_PID_HOUSE_DOOR);
     }
 
  protected:


### PR DESCRIPTION
Fix #716.
Use special API for house sounds, speeches and door open/close - stop these sounds when new one is about to play.
Stop issued separately - if house have no goodbye speech when quickly entering end exiting will see that greet speech will be played in full but door entering sound will be stopped and overridden by door closing sound.