### PR TITLE
Changes around branchless dialogue

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -938,7 +938,7 @@ void Game::processQueuedMessages() {
                                 MapStartPoint_Party);
                         }
                     } else {
-                        EventProcessor(dword_5C3418, 0, 1, dword_5C341C);
+                        EventProcessor(savedEventID, 0, 1, savedEventStep);
                     }
                     if (iequals(s_SavedMapName.data(), "d05.blv"))
                         pParty->GetPlayingTime().AddDays(4);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -2139,15 +2139,6 @@ void Level_LoadEvtAndStr(const std::string &pLevelName) {
     if (uLevelStrFileSize) LoadLevel_InitializeLevelStr();
 }
 
-void ReleaseBranchlessDialogue() {
-    pGUIWindow2->Release();
-    pGUIWindow2 = 0;
-    activeLevelDecoration = _591094_decoration;
-    EventProcessor(dword_5C3418, 0, 1, dword_5C341C);
-    activeLevelDecoration = nullptr;
-    pEventTimer->Resume();
-}
-
 bool _44100D_should_alter_right_panel() {
     return current_screen_type == CURRENT_SCREEN::SCREEN_NPC_DIALOGUE ||
            current_screen_type == CURRENT_SCREEN::SCREEN_CHARACTERS ||

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -261,7 +261,6 @@ void LoadLevel_InitializeLevelStr();
 void OnMapLeave();
 void OnMapLoad();
 void Level_LoadEvtAndStr(const std::string &pLevelName);
-void ReleaseBranchlessDialogue();
 bool _44100D_should_alter_right_panel();
 void Transition_StopSound_Autosave(const char *pMapName,
                                    MapStartPoint point);  // sub_44987B idb

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -58,6 +58,9 @@ _2devent p2DEvents[525];
 
 MapEventVariables mapEventVariables;
 
+int savedEventID;
+int savedEventStep;
+
 unsigned int LoadEventsToBuffer(const std::string &pContainerName, char *pBuffer,
                                 unsigned int uBufferSize) {
     Blob blob = pEvents_LOD->LoadCompressedTexture(pContainerName);
@@ -852,8 +855,8 @@ LABEL_47:
                         pDialogueWindow = new GUIWindow_Transition(
                             _evt->v29, _evt->v30, trans_partyx, trans_partyy, trans_partyz, trans_directionyaw, trans_directionpitch,
                             trans_partyzspeed, (char *)&_evt->v31);
-                        dword_5C3418 = uEventID;
-                        dword_5C341C = curr_seq_num + 1;
+                        savedEventID = uEventID;
+                        savedEventStep = curr_seq_num + 1;
                         if (v133 == 1) OnMapLeave();
                         return;
                     }

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -60,6 +60,7 @@ MapEventVariables mapEventVariables;
 
 int savedEventID;
 int savedEventStep;
+struct LevelDecoration *savedDecoration;
 
 unsigned int LoadEventsToBuffer(const std::string &pContainerName, char *pBuffer,
                                 unsigned int uBufferSize) {
@@ -702,7 +703,7 @@ LABEL_47:
                     if (!entry_line) {
                         game_ui_status_bar_event_string =
                             &pLevelStr[pLevelStrOffsets[EVT_DWORD(_evt->v5)]];
-                        StartBranchlessDialogue(uEventID, curr_seq_num, 26);
+                        StartBranchlessDialogue(uEventID, curr_seq_num, (int)EVENT_InputString);
                         if (v133 == 1) OnMapLeave();
                         return;
                     }
@@ -958,7 +959,7 @@ LABEL_47:
                     ++curr_seq_num;
                     break;
                 case EVENT_PressAnyKey:
-                    StartBranchlessDialogue(uEventID, curr_seq_num + 1, 33);
+                    StartBranchlessDialogue(uEventID, curr_seq_num + 1, (int)EVENT_PressAnyKey);
                     if (v133 == 1) OnMapLeave();
                     return;
                 case EVENT_Exit:

--- a/src/Engine/Events.h
+++ b/src/Engine/Events.h
@@ -341,6 +341,7 @@ std::string GetEventHintString(unsigned int uEventID);  // idb
 
 extern int savedEventID;
 extern int savedEventStep;
+extern struct LevelDecoration *savedDecoration;
 
 /*  312 */
 #pragma pack(push, 1)

--- a/src/Engine/Events.h
+++ b/src/Engine/Events.h
@@ -339,6 +339,9 @@ void LoadLevel_InitializeLevelEvt();
 void EventProcessor(int uEventID, int a2, int a3, int entry_line = 0);
 std::string GetEventHintString(unsigned int uEventID);  // idb
 
+extern int savedEventID;
+extern int savedEventStep;
+
 /*  312 */
 #pragma pack(push, 1)
 struct ByteArray {

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2583,7 +2583,6 @@ GameTime _5773B8_event_timer;
 struct Actor *pDialogue_SpeakingActor;
 DIALOGUE_TYPE uDialogueType;
 int sDialogue_SpeakingActorNPC_ID;
-struct LevelDecoration *_591094_decoration; // level decoration store for branchless dialogue
 int uCurrentHouse_Animation;
 char *Party_Teleport_Map_Name;
 // int Party_Teleport_Z_Speed;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2609,8 +2609,6 @@ int dword_5B65C4_cancelEventProcessing;
 int MapsLongTimers_count;  // dword_5B65C8 счётчик таймеров для колодцев,
                            // фаерволов-ловушек
 int npcIdToDismissAfterDialogue;
-int dword_5C3418; //  eventid store for branchless dialogue
-int dword_5C341C; // entry line store for branchless dialogue
 // std::array<char, 777> byte_5C3427;
 
 // TODO(pskelton): GameStatusBar class

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -216,8 +216,6 @@ extern int Start_Party_Teleport_Flag;
 extern int dword_5B65C4_cancelEventProcessing;
 extern int MapsLongTimers_count;  // dword_5B65C8
 extern int npcIdToDismissAfterDialogue;
-extern int dword_5C3418;
-extern int dword_5C341C;
 // extern std::array<char, 777> byte_5C3427;
 extern std::string game_ui_status_bar_event_string;
 extern std::string game_ui_status_bar_string;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -184,7 +184,6 @@ extern GameTime _5773B8_event_timer;  // 5773B8
 extern Actor *pDialogue_SpeakingActor;
 extern DIALOGUE_TYPE uDialogueType;
 extern signed int sDialogue_SpeakingActorNPC_ID;
-extern struct LevelDecoration *_591094_decoration;
 extern int uCurrentHouse_Animation;
 
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -62,7 +62,7 @@ GUIWindow *ptr_507BC8;  // screen 19 - not used?
 GUIWindow *pGUIWindow_CastTargetedSpell;
 GUIWindow *pGameOverWindow; // UIMSG_ShowGameOverWindow
 bool bGameOverWindowCheckExit{ false }; // TODO(pskelton): contain
-GUIWindow *pGUIWindow2; // branchless dialougue
+GUIWindow *pGUIWindow_BranchlessDialogue; // branchless dialougue
 
 typedef struct _RGBColor {
     unsigned char R;
@@ -2147,7 +2147,7 @@ void WindowManager::DeleteAllVisibleWindows() {
     ptr_507BC8 = nullptr;  // screen 19 - not used?
     pGUIWindow_CastTargetedSpell = nullptr;
     pGameOverWindow = nullptr; // UIMSG_ShowGameOverWindow
-    pGUIWindow2 = nullptr; // branchless dialougue
+    pGUIWindow_BranchlessDialogue = nullptr; // branchless dialougue
 
     current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
     pNextFrameMessageQueue->Clear();

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -405,7 +405,7 @@ extern GUIWindow *pGUIWindow_CastTargetedSpell;
 extern GUIWindow *pGameOverWindow;
 extern bool bGameOverWindowCheckExit;
 //extern GUIWindow *pGUIWindow_EscMessageWindow;
-extern GUIWindow *pGUIWindow2;
+extern GUIWindow *pGUIWindow_BranchlessDialogue;
 
 extern unsigned int ui_mainmenu_copyright_color;
 extern unsigned int ui_character_tooltip_header_default_color;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -515,7 +515,7 @@ void GUIWindow_GenericDialogue::Update() {
     }
 }
 
-void StartBranchlessDialogue(int eventid, int entryline, int button) {
+void StartBranchlessDialogue(int eventid, int entryline, int event) {
     if (!pGUIWindow_BranchlessDialogue) {
         if (pParty->uFlags & PARTY_FLAGS_1_ForceRedraw) {
             engine->Draw();
@@ -524,8 +524,8 @@ void StartBranchlessDialogue(int eventid, int entryline, int button) {
         pEventTimer->Pause();
         savedEventID = eventid;
         savedEventStep = entryline;
-        _591094_decoration = activeLevelDecoration;
-        pGUIWindow_BranchlessDialogue = new GUIWindow_GenericDialogue({0, 0}, render->GetRenderDimensions(), button);
+        savedDecoration = activeLevelDecoration;
+        pGUIWindow_BranchlessDialogue = new GUIWindow_GenericDialogue({0, 0}, render->GetRenderDimensions(), event);
         pGUIWindow_BranchlessDialogue->CreateButton({61, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1);
         pGUIWindow_BranchlessDialogue->CreateButton({177, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2);
         pGUIWindow_BranchlessDialogue->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
@@ -536,8 +536,12 @@ void StartBranchlessDialogue(int eventid, int entryline, int button) {
 void ReleaseBranchlessDialogue() {
     pGUIWindow_BranchlessDialogue->Release();
     pGUIWindow_BranchlessDialogue = nullptr;
-    activeLevelDecoration = _591094_decoration;
-    EventProcessor(savedEventID, 0, 1, savedEventStep);
+    if (savedEventID) {
+        // Do not run event engine whith no event, it may happen when you close talk window
+        // with NPC that only say catch phrases
+        activeLevelDecoration = savedDecoration;
+        EventProcessor(savedEventID, 0, 1, savedEventStep);
+    }
     activeLevelDecoration = nullptr;
     pEventTimer->Resume();
 }

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -481,29 +481,29 @@ void GUIWindow_GenericDialogue::Update() {
                                     ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
                                 _591428_endcap);
-    pGUIWindow2->DrawText(pFont, {12, 354 - pTextHeight}, 0,
+    pGUIWindow_BranchlessDialogue->DrawText(pFont, {12, 354 - pTextHeight}, 0,
         pFont->FitTextInAWindow(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12),
         0, 0, 0);
     render->DrawTextureNew(0, 352 / 480.0f, game_ui_statusbar);
-    if (pGUIWindow2->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS) {
-        if (pGUIWindow2->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-            pGUIWindow2->keyboard_input_status = WINDOW_INPUT_NONE;
+    if (pGUIWindow_BranchlessDialogue->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS) {
+        if (pGUIWindow_BranchlessDialogue->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
+            pGUIWindow_BranchlessDialogue->keyboard_input_status = WINDOW_INPUT_NONE;
             GameUI_StatusBar_OnInput(keyboardInputHandler->GetTextInput().c_str());
             ReleaseBranchlessDialogue();
             return;
         }
-        if (pGUIWindow2->keyboard_input_status != WINDOW_INPUT_CANCELLED)
+        if (pGUIWindow_BranchlessDialogue->keyboard_input_status != WINDOW_INPUT_CANCELLED)
             return;
-        pGUIWindow2->keyboard_input_status = WINDOW_INPUT_NONE;
+        pGUIWindow_BranchlessDialogue->keyboard_input_status = WINDOW_INPUT_NONE;
         GameUI_StatusBar_ClearInputString();
         ReleaseBranchlessDialogue();
         return;
     }
 
-    if (pGUIWindow2->wData.val == 26) { // EVENT_InputString
+    if (pGUIWindow_BranchlessDialogue->wData.val == (int)EVENT_InputString) {
         auto str = fmt::format("{} {}", GameUI_StatusBar_GetInput(), keyboardInputHandler->GetTextInput());
-        pGUIWindow2->DrawText(pFontLucida, {13, 357}, 0, str, 0, 0, 0);
-        pGUIWindow2->DrawFlashingInputCursor(pFontLucida->GetLineWidth(str) + 13, 357, pFontLucida);
+        pGUIWindow_BranchlessDialogue->DrawText(pFontLucida, {13, 357}, 0, str, 0, 0, 0);
+        pGUIWindow_BranchlessDialogue->DrawFlashingInputCursor(pFontLucida->GetLineWidth(str) + 13, 357, pFontLucida);
         return;
     }
 
@@ -516,23 +516,31 @@ void GUIWindow_GenericDialogue::Update() {
 }
 
 void StartBranchlessDialogue(int eventid, int entryline, int button) {
-    if (!pGUIWindow2) {
+    if (!pGUIWindow_BranchlessDialogue) {
         if (pParty->uFlags & PARTY_FLAGS_1_ForceRedraw) {
             engine->Draw();
         }
         pMiscTimer->Pause();
         pEventTimer->Pause();
-        dword_5C3418 = eventid;
-        dword_5C341C = entryline;
+        savedEventID = eventid;
+        savedEventStep = entryline;
         _591094_decoration = activeLevelDecoration;
-        pGUIWindow2 = new GUIWindow_GenericDialogue({0, 0}, render->GetRenderDimensions(), button);
-        pGUIWindow2->CreateButton({61, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1);
-        pGUIWindow2->CreateButton({177, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2);
-        pGUIWindow2->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
-        pGUIWindow2->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4);
+        pGUIWindow_BranchlessDialogue = new GUIWindow_GenericDialogue({0, 0}, render->GetRenderDimensions(), button);
+        pGUIWindow_BranchlessDialogue->CreateButton({61, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1);
+        pGUIWindow_BranchlessDialogue->CreateButton({177, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2);
+        pGUIWindow_BranchlessDialogue->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
+        pGUIWindow_BranchlessDialogue->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4);
     }
 }
 
+void ReleaseBranchlessDialogue() {
+    pGUIWindow_BranchlessDialogue->Release();
+    pGUIWindow_BranchlessDialogue = nullptr;
+    activeLevelDecoration = _591094_decoration;
+    EventProcessor(savedEventID, 0, 1, savedEventStep);
+    activeLevelDecoration = nullptr;
+    pEventTimer->Resume();
+}
 
 void BuildHireableNpcDialogue() {
     NPCData *v0 = GetNPCData(sDialogue_SpeakingActorNPC_ID);

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -26,6 +26,7 @@ class GUIWindow_GenericDialogue : public GUIWindow {
 };
 
 void StartBranchlessDialogue(int eventid, int entryline, int button);
+void ReleaseBranchlessDialogue();
 
 void OnSelectNPCDialogueOption(DIALOGUE_TYPE option);
 

--- a/src/GUI/UI/UIMainMenu.cpp
+++ b/src/GUI/UI/UIMainMenu.cpp
@@ -176,7 +176,7 @@ void GUIWindow_MainMenu::Loop() {
 
     current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
 
-    pGUIWindow2 = nullptr;
+    pGUIWindow_BranchlessDialogue = nullptr;
 
     pWindow_MainMenu = new GUIWindow_MainMenu();
 

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -15,6 +15,7 @@
 
 #include "GUI/GUIButton.h"
 #include "GUI/GUIWindow.h"
+#include "GUI/UI/UIDialogue.h"
 
 #include "Media/Audio/AudioPlayer.h"
 
@@ -259,7 +260,7 @@ void Mouse::UI_OnMouseLeftClick() {
         sub_4637E0_is_there_popup_onscreen())
         return;
 
-    if (pGUIWindow2 && pGUIWindow2->wData.val == 33) {  // EVENT_PressAnyKey
+    if (pGUIWindow_BranchlessDialogue && pGUIWindow_BranchlessDialogue->wData.val == (int)EVENT_PressAnyKey) {
         ReleaseBranchlessDialogue();
         return;
     }


### PR DESCRIPTION
Rename and move global variables related to branchless dialogue that may start in the middle of event processing.
Also do not run event engine when closing such dialogue. Running it when closing dialogue for one-line NPCs (town guardians for example) result in status message "Nothing here" to appear.