### PR TITLE
Renames in Party struct

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -356,7 +356,7 @@ void ShowMM7IntroVideo_and_LoadingScreen() {
 Image *gamma_preview_image = nullptr;  // 506E40
 
 void Game_StartDialogue(unsigned int actor_id) {
-    if (pParty->hasActivePlayer()) {
+    if (pParty->hasActiveCharacter()) {
         pCurrentFrameMessageQueue->Flush();
 
         GameUI_InitializeDialogue(&pActors[actor_id], true);
@@ -396,7 +396,7 @@ void Game::closeTargetedSpellWindow() {
 void Game::onEscape() {
     closeTargetedSpellWindow();
 
-    // if ((signed int)pParty->activePlayerIndex() < 1 || (signed int)pParty->activePlayerIndex() > 4)
+    // if ((signed int)pParty->activeCharacterIndex() < 1 || (signed int)pParty->activeCharacterIndex() > 4)
 
     pParty->switchToNextActiveCharacter();  // always check this - could leave
                                            // shops with characters who couldnt
@@ -700,7 +700,7 @@ void Game::processQueuedMessages() {
                                 switch (current_screen_type) {
                                     case CURRENT_SCREEN::SCREEN_CASTING:
                                         if (enchantingActiveCharacter) {
-                                            pParty->setActivePlayerByIndex(enchantingActiveCharacter);
+                                            pParty->setActiveCharacterIndex(enchantingActiveCharacter);
                                             pParty->switchToNextActiveCharacter();
                                             enchantingActiveCharacter = 0;
                                             if (pParty->bTurnBasedModeOn) {
@@ -955,7 +955,7 @@ void Game::processQueuedMessages() {
                     onEscape();
                     continue;
                 case UIMSG_CycleCharacters:
-                    pParty->setActivePlayerByIndex(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
+                    pParty->setActiveCharacterIndex(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
                     continue;
                 case UIMSG_OnTravelByFoot:
                     pCurrentFrameMessageQueue->Flush();
@@ -1084,7 +1084,7 @@ void Game::processQueuedMessages() {
                     if (IsEnchantingInProgress) {
                         // Change character while enchanting is active
                         // TODO(Nik-RE-dev): need separate message type
-                        pParty->setActivePlayerByIndex(uMessageParam);
+                        pParty->setActiveCharacterIndex(uMessageParam);
                     } else {
                         spellTargetPicked(PID_INVALID, uMessageParam);
                         closeTargetedSpellWindow();
@@ -1405,12 +1405,12 @@ void Game::processQueuedMessages() {
                         pAudioPlayer->playUISound(SOUND_error);
                         continue;
                     }
-                    if (!pParty->activePlayerIndex() ||
-                        (pPlayer2 = pPlayers[pParty->activePlayerIndex()],
+                    if (!pParty->activeCharacterIndex() ||
+                        (pPlayer2 = pPlayers[pParty->activeCharacterIndex()],
                          pPlayer2->uTimeToRecovery))
                         continue;
-                    pushSpellOrRangedAttack(pPlayer2->uQuickSpell, pParty->activePlayerIndex() - 1,
-                                            0, 0, pParty->activePlayerIndex());
+                    pushSpellOrRangedAttack(pPlayer2->uQuickSpell, pParty->activeCharacterIndex() - 1,
+                                            0, 0, pParty->activeCharacterIndex());
                     continue;
                 }
 
@@ -1426,7 +1426,7 @@ void Game::processQueuedMessages() {
                 }
                 case UIMSG_1C:
                     __debugbreak();
-                    if (!pParty->activePlayerIndex() || current_screen_type != CURRENT_SCREEN::SCREEN_GAME)
+                    if (!pParty->activeCharacterIndex() || current_screen_type != CURRENT_SCREEN::SCREEN_GAME)
                         continue;
                     __debugbreak();  // ptr_507BC8 = GUIWindow::Create(0, 0,
                                      // window->GetWidth(), window->GetHeight(),
@@ -1435,7 +1435,7 @@ void Game::processQueuedMessages() {
                     pEventTimer->Pause();
                     continue;
                 case UIMSG_STEALFROMACTOR:
-                    if (!pParty->activePlayerIndex()) continue;
+                    if (!pParty->activeCharacterIndex()) continue;
                     if (!pParty->bTurnBasedModeOn) {
                         if (pActors[uMessageParam].uAIState == AIState::Dead)
                             pActors[uMessageParam].LootActor();
@@ -1455,7 +1455,7 @@ void Game::processQueuedMessages() {
                     continue;
 
                 case UIMSG_Attack:
-                    if (!pParty->hasActivePlayer()) continue;
+                    if (!pParty->hasActiveCharacter()) continue;
                     if (!pParty->bTurnBasedModeOn) {
                         Player::_42ECB5_PlayerAttacksActor();
                         continue;
@@ -1526,8 +1526,8 @@ void Game::processQueuedMessages() {
                         else
                             GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
 
-                        if (!pParty->activePlayerIndex()) continue;
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantRestHere);
+                        if (!pParty->activeCharacterIndex()) continue;
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantRestHere);
                         continue;
                     }
                     if (pParty->bTurnBasedModeOn) {
@@ -1555,8 +1555,8 @@ void Game::processQueuedMessages() {
                     else
                         GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
 
-                    if (!pParty->activePlayerIndex()) continue;
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantRestHere);
+                    if (!pParty->activeCharacterIndex()) continue;
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantRestHere);
                     continue;
                 case UIMSG_Rest8Hour:
                     pCurrentFrameMessageQueue->Clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
@@ -1567,8 +1567,8 @@ void Game::processQueuedMessages() {
                     }
                     if (pParty->GetFood() < foodRequiredToRest) {
                         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_FOOD);
-                        if (pParty->hasActivePlayer() && pPlayers[pParty->activePlayerIndex()]->CanAct()) {
-                            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughFood);
+                        if (pParty->hasActiveCharacter() && pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
+                            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NotEnoughFood);
                         }
                     } else {
                         for (Player &player : pParty->pPlayers) {
@@ -1632,9 +1632,9 @@ void Game::processQueuedMessages() {
                         GameUI_StatusBar_Set(localization->FormatString(
                             LSTR_FMT_SET_S_AS_READY_SPELL,
                             pSpellStats->pInfos[static_cast<SPELL_TYPE>(quick_spell_at_page +
-                                         11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage)].pName));
+                                         11 * pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage)].pName));
                     } else {
-                        if (pPlayers[pParty->activePlayerIndex()]->uQuickSpell != SPELL_NONE)
+                        if (pPlayers[pParty->activeCharacterIndex()]->uQuickSpell != SPELL_NONE)
                             GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_REMOVE_QUICKSPELL));
                         else
                             GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_SET_QUICKSPELL));
@@ -1643,8 +1643,8 @@ void Game::processQueuedMessages() {
                 }
 
                 case UIMSG_SPellbook_ShowHightlightedSpellInfo: {
-                    if (!pParty->activePlayerIndex())  // || (uNumSeconds = (unsigned
-                                            // int)pPlayers[pParty->activePlayerIndex()],!*(char
+                    if (!pParty->activeCharacterIndex())  // || (uNumSeconds = (unsigned
+                                            // int)pPlayers[pParty->activeCharacterIndex()],!*(char
                                             // *)(uNumSeconds + 11 * *(char
                                             // *)(uNumSeconds + 6734) +
                                             // uMessageParam + 402)))
@@ -1653,7 +1653,7 @@ void Game::processQueuedMessages() {
 
                     if (sub_4637E0_is_there_popup_onscreen())
                         dword_507B00_spell_info_to_draw_in_popup = uMessageParam + 1;
-                    int lastOpened = pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage;
+                    int lastOpened = pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage;
                     if (quick_spell_at_page - 1 == uMessageParam) {
                         GameUI_StatusBar_Set(localization->FormatString(LSTR_CAST_S,
                                     pSpellStats->pInfos[static_cast<SPELL_TYPE>(uMessageParam + 11 * lastOpened + 1)].pName));
@@ -1666,8 +1666,8 @@ void Game::processQueuedMessages() {
 
                 case UIMSG_ClickInstallRemoveQuickSpellBtn: {
                     new OnButtonClick2({pBtn_InstallRemoveSpell->uX, pBtn_InstallRemoveSpell->uY}, {0, 0}, pBtn_InstallRemoveSpell);
-                    if (!pParty->activePlayerIndex()) continue;
-                    Player *player = pPlayers[pParty->activePlayerIndex()];
+                    if (!pParty->activeCharacterIndex()) continue;
+                    Player *player = pPlayers[pParty->activeCharacterIndex()];
                     if (!byte_506550 || !quick_spell_at_page) {
                         player->uQuickSpell = SPELL_NONE;
                         quick_spell_at_page = 0;
@@ -1675,9 +1675,9 @@ void Game::processQueuedMessages() {
                         continue;
                     }
                     // TODO(captainurist): encapsulate the arithmetic below
-                    pPlayers[pParty->activePlayerIndex()]->uQuickSpell = static_cast<SPELL_TYPE>(
-                        quick_spell_at_page + 11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage);
-                    if (pParty->hasActivePlayer()) {
+                    pPlayers[pParty->activeCharacterIndex()]->uQuickSpell = static_cast<SPELL_TYPE>(
+                        quick_spell_at_page + 11 * pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage);
+                    if (pParty->hasActiveCharacter()) {
                         player->playReaction(SPEECH_SetQuickSpell);
                     }
                     byte_506550 = 0;
@@ -1687,13 +1687,13 @@ void Game::processQueuedMessages() {
                 case UIMSG_SpellBook_PressTab:  //перелистывание страниц
                                                 //клавишей Tab
                 {
-                    if (!pParty->activePlayerIndex()) continue;
+                    if (!pParty->activeCharacterIndex()) continue;
                     int skill_count = 0;
                     int uAction = 0;
                     int page = 0;
                     for (PLAYER_SKILL_TYPE i : MagicSkills()) {
-                        if (pPlayers[pParty->activePlayerIndex()]->pActiveSkills[i] || _engine->config->debug.AllMagic.value()) {
-                            if (pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage == page)
+                        if (pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[i] || _engine->config->debug.AllMagic.value()) {
+                            if (pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage == page)
                                 uAction = skill_count;
                             spellbookPages[skill_count++] = page;
                         }
@@ -1718,8 +1718,8 @@ void Game::processQueuedMessages() {
                 }
                 case UIMSG_OpenSpellbookPage:
                     if (pTurnEngine->turn_stage == TE_MOVEMENT ||
-                        !pParty->activePlayerIndex() ||
-                        uMessageParam == pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage) {
+                        !pParty->activeCharacterIndex() ||
+                        uMessageParam == pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage) {
                         continue;
                     }
                     ((GUIWindow_Spellbook *)pGUIWindow_CurrentMenu)->OpenSpellbookPage(uMessageParam);
@@ -1728,12 +1728,12 @@ void Game::processQueuedMessages() {
                     if (pTurnEngine->turn_stage == TE_MOVEMENT) {
                         continue;
                     }
-                    if (!pParty->activePlayerIndex()) {
+                    if (!pParty->activeCharacterIndex()) {
                         continue;
                     }
 
-                    //  uNumSeconds = (unsigned int)pPlayers[pParty->activePlayerIndex()];
-                    Player *player = pPlayers[pParty->activePlayerIndex()];
+                    //  uNumSeconds = (unsigned int)pPlayers[pParty->activeCharacterIndex()];
+                    Player *player = pPlayers[pParty->activeCharacterIndex()];
                     if (player->spellbook.pChapters[player->lastOpenedSpellbookPage].bIsSpellAvailable[uMessageParam]
                         || _engine->config->debug.AllMagic.value()) {
                         if (quick_spell_at_page - 1 == uMessageParam) {
@@ -1746,14 +1746,14 @@ void Game::processQueuedMessages() {
                             dword_50C9EC[3 * dword_50C9E8] =
                             UIMSG_CastSpellFromBook; dword_50C9EC[3 *
                             dword_50C9E8 + 1] = v103; dword_50C9EC[3 *
-                            dword_50C9E8 + 2] = pParty->activePlayerIndex() - 1;
+                            dword_50C9E8 + 2] = pParty->activeCharacterIndex() - 1;
                             ++dword_50C9E8;
                             }*/
                             // Processing must happen on next frame because need to close spell book and update
                             // drawing object list which is used to count actors for some spells
-                            pNextFrameMessageQueue->AddGUIMessage( UIMSG_CastSpellFromBook, v103, pParty->activePlayerIndex() - 1);
+                            pNextFrameMessageQueue->AddGUIMessage( UIMSG_CastSpellFromBook, v103, pParty->activeCharacterIndex() - 1);
                             //  pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastSpellFromBook,
-                            //  v103, pParty->activePlayerIndex() - 1);
+                            //  v103, pParty->activeCharacterIndex() - 1);
                         } else {
                             byte_506550 = 1;
                             quick_spell_at_page = uMessageParam + 1;
@@ -1783,8 +1783,8 @@ void Game::processQueuedMessages() {
                         pAudioPlayer->playUISound(SOUND_error);
                     } else {
                         pCurrentFrameMessageQueue->Flush();
-                        if (pParty->hasActivePlayer()) {
-                            if (!pPlayers[pParty->activePlayerIndex()]->uTimeToRecovery) {
+                        if (pParty->hasActiveCharacter()) {
+                            if (!pPlayers[pParty->activeCharacterIndex()]->uTimeToRecovery) {
                                 // toggle
                                 if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) {
                                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
@@ -1878,7 +1878,7 @@ void Game::processQueuedMessages() {
                 case UIMSG_SkillUp:
                 {
                     PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(uMessageParam);
-                    Player *player = pPlayers[pParty->activePlayerIndex()];
+                    Player *player = pPlayers[pParty->activeCharacterIndex()];
                     PLAYER_SKILL_LEVEL skill_level = player->GetSkillLevel(skill);
                     const char *statusString;
                     if (player->uSkillPoints < skill_level + 1) {
@@ -2029,13 +2029,13 @@ void Game::processQueuedMessages() {
 
                 case UIMSG_CHEST_ClickItem:
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-                        pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
+                        pPlayers[pParty->activeCharacterIndex()]->OnInventoryLeftClick();
                         continue;
                     }
                     Chest::OnChestLeftClick();
                     continue;
                 case UIMSG_InventoryLeftClick:
-                    pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
+                    pPlayers[pParty->activeCharacterIndex()]->OnInventoryLeftClick();
                     continue;
                 case UIMSG_MouseLeftClickInGame:
                     pCurrentFrameMessageQueue->Flush();
@@ -2112,13 +2112,13 @@ void Game::processQueuedMessages() {
 
                     break;
                 case UIMSG_DebugSpecialItem: {
-                    if (!pParty->hasActivePlayer())
+                    if (!pParty->hasActiveCharacter())
                         continue;
 
                     for(size_t attempt = 0; attempt < 500; attempt++) {
                         ITEM_TYPE pItemID = grng->randomSample(SpawnableItems());
                         if (pItemTable->pItems[pItemID].uItemID_Rep_St > 6) {
-                            if (!pPlayers[pParty->activePlayerIndex()]->AddItem(-1, pItemID)) {
+                            if (!pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, pItemID)) {
                                 pAudioPlayer->playUISound(SOUND_error);
                             }
                             break;
@@ -2129,14 +2129,14 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_DebugGenItem: {
-                    if (!pParty->hasActivePlayer())
+                    if (!pParty->hasActiveCharacter())
                         continue;
 
                     for (size_t attempt = 0; attempt < 500; attempt++) {
                         ITEM_TYPE pItemID = grng->randomSample(SpawnableItems());
                         // if (pItemTable->pItems[pItemID].uItemID_Rep_St ==
                         //   (item_id - 40015 + 1)) {
-                        if (!pPlayers[pParty->activePlayerIndex()]->AddItem(-1, pItemID)) {
+                        if (!pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, pItemID)) {
                             pAudioPlayer->playUISound(SOUND_error);
                         }
                         break;
@@ -2147,23 +2147,23 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_DebugKillChar:
-                    if (!pParty->hasActivePlayer())
+                    if (!pParty->hasActiveCharacter())
                         continue;
-                    pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Dead, 0);
+                    pPlayers[pParty->activeCharacterIndex()]->SetCondition(Condition_Dead, 0);
                     continue;
                 case UIMSG_DebugEradicate:
-                    if (!pParty->hasActivePlayer())
+                    if (!pParty->hasActiveCharacter())
                         continue;
-                    pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Eradicated, 0);
+                    pPlayers[pParty->activeCharacterIndex()]->SetCondition(Condition_Eradicated, 0);
                     continue;
                 case UIMSG_DebugFullHeal:
-                    if (!pParty->hasActivePlayer())
+                    if (!pParty->hasActiveCharacter())
                         continue;
-                    pPlayers[pParty->activePlayerIndex()]->conditions.ResetAll();
-                    pPlayers[pParty->activePlayerIndex()]->sHealth =
-                        pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
-                    pPlayers[pParty->activePlayerIndex()]->sMana =
-                        pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
+                    pPlayers[pParty->activeCharacterIndex()]->conditions.ResetAll();
+                    pPlayers[pParty->activeCharacterIndex()]->sHealth =
+                        pPlayers[pParty->activeCharacterIndex()]->GetMaxHealth();
+                    pPlayers[pParty->activeCharacterIndex()]->sMana =
+                        pPlayers[pParty->activeCharacterIndex()]->GetMaxMana();
                     pAudioPlayer->playUISound(SOUND_heal);
                     continue;
                 case UIMSG_DebugCycleAlign:
@@ -2197,11 +2197,11 @@ void Game::processQueuedMessages() {
                     for (Player &player : pParty->pPlayers) {
                         player.uSkillPoints += 50;
                     }
-                    pPlayers[std::max(pParty->activePlayerIndex(), 1u)]->PlayAwardSound_Anim();
+                    pPlayers[std::max(pParty->activeCharacterIndex(), 1u)]->PlayAwardSound_Anim();
                     continue;
                 case UIMSG_DebugGiveEXP:
                     pParty->GivePartyExp(20000);
-                    pPlayers[std::max(pParty->activePlayerIndex(), 1u)]->PlayAwardSound_Anim();
+                    pPlayers[std::max(pParty->activeCharacterIndex(), 1u)]->PlayAwardSound_Anim();
                     continue;
                 case UIMSG_DebugGiveGold:
                     pParty->AddGold(10000);
@@ -2300,7 +2300,7 @@ void Game::onPressSpace() {
     uint16_t pid = _vis->get_picked_object_zbuf_val().object_pid;
     if (pid != PID_INVALID) {
         // wasn't there, but we decided to deny interactions where there are no active character
-        if (!pParty->hasActivePlayer()) {
+        if (!pParty->hasActiveCharacter()) {
             GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
             return;
         }
@@ -2459,7 +2459,7 @@ void Game::gameLoop() {
                                        // 0, 0x180u);//(pPlayerBuffs[0], 0, 384)
                     player.sHealth = 1;
                 }
-                pParty->setActivePlayerByIndex(1);
+                pParty->setActiveCharacterIndex(1);
 
                 if (_449B57_test_bit(pParty->_quest_bits, QBIT_ESCAPED_EMERALD_ISLE)) {
                     pParty->vPosition.x = -17331;  // respawn in harmondale

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -356,7 +356,7 @@ void ShowMM7IntroVideo_and_LoadingScreen() {
 Image *gamma_preview_image = nullptr;  // 506E40
 
 void Game_StartDialogue(unsigned int actor_id) {
-    if (pParty->hasActiveCharacter()) {
+    if (pParty->hasActivePlayer()) {
         pCurrentFrameMessageQueue->Flush();
 
         GameUI_InitializeDialogue(&pActors[actor_id], true);
@@ -396,7 +396,7 @@ void Game::closeTargetedSpellWindow() {
 void Game::onEscape() {
     closeTargetedSpellWindow();
 
-    // if ((signed int)pParty->getActiveCharacter() < 1 || (signed int)pParty->getActiveCharacter() > 4)
+    // if ((signed int)pParty->activePlayerIndex() < 1 || (signed int)pParty->activePlayerIndex() > 4)
 
     pParty->switchToNextActiveCharacter();  // always check this - could leave
                                            // shops with characters who couldnt
@@ -700,7 +700,7 @@ void Game::processQueuedMessages() {
                                 switch (current_screen_type) {
                                     case CURRENT_SCREEN::SCREEN_CASTING:
                                         if (enchantingActiveCharacter) {
-                                            pParty->setActiveCharacter(enchantingActiveCharacter);
+                                            pParty->setActivePlayerIndex(enchantingActiveCharacter);
                                             pParty->switchToNextActiveCharacter();
                                             enchantingActiveCharacter = 0;
                                             if (pParty->bTurnBasedModeOn) {
@@ -955,7 +955,7 @@ void Game::processQueuedMessages() {
                     onEscape();
                     continue;
                 case UIMSG_CycleCharacters:
-                    pParty->setActiveCharacter(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
+                    pParty->setActivePlayerIndex(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
                     continue;
                 case UIMSG_OnTravelByFoot:
                     pCurrentFrameMessageQueue->Flush();
@@ -1084,7 +1084,7 @@ void Game::processQueuedMessages() {
                     if (IsEnchantingInProgress) {
                         // Change character while enchanting is active
                         // TODO(Nik-RE-dev): need separate message type
-                        pParty->setActiveCharacter(uMessageParam);
+                        pParty->setActivePlayerIndex(uMessageParam);
                     } else {
                         spellTargetPicked(PID_INVALID, uMessageParam);
                         closeTargetedSpellWindow();
@@ -1405,12 +1405,12 @@ void Game::processQueuedMessages() {
                         pAudioPlayer->playUISound(SOUND_error);
                         continue;
                     }
-                    if (!pParty->getActiveCharacter() ||
-                        (pPlayer2 = pPlayers[pParty->getActiveCharacter()],
+                    if (!pParty->activePlayerIndex() ||
+                        (pPlayer2 = pPlayers[pParty->activePlayerIndex()],
                          pPlayer2->uTimeToRecovery))
                         continue;
-                    pushSpellOrRangedAttack(pPlayer2->uQuickSpell, pParty->getActiveCharacter() - 1,
-                                            0, 0, pParty->getActiveCharacter());
+                    pushSpellOrRangedAttack(pPlayer2->uQuickSpell, pParty->activePlayerIndex() - 1,
+                                            0, 0, pParty->activePlayerIndex());
                     continue;
                 }
 
@@ -1426,7 +1426,7 @@ void Game::processQueuedMessages() {
                 }
                 case UIMSG_1C:
                     __debugbreak();
-                    if (!pParty->getActiveCharacter() || current_screen_type != CURRENT_SCREEN::SCREEN_GAME)
+                    if (!pParty->activePlayerIndex() || current_screen_type != CURRENT_SCREEN::SCREEN_GAME)
                         continue;
                     __debugbreak();  // ptr_507BC8 = GUIWindow::Create(0, 0,
                                      // window->GetWidth(), window->GetHeight(),
@@ -1435,7 +1435,7 @@ void Game::processQueuedMessages() {
                     pEventTimer->Pause();
                     continue;
                 case UIMSG_STEALFROMACTOR:
-                    if (!pParty->getActiveCharacter()) continue;
+                    if (!pParty->activePlayerIndex()) continue;
                     if (!pParty->bTurnBasedModeOn) {
                         if (pActors[uMessageParam].uAIState == AIState::Dead)
                             pActors[uMessageParam].LootActor();
@@ -1455,7 +1455,7 @@ void Game::processQueuedMessages() {
                     continue;
 
                 case UIMSG_Attack:
-                    if (!pParty->hasActiveCharacter()) continue;
+                    if (!pParty->hasActivePlayer()) continue;
                     if (!pParty->bTurnBasedModeOn) {
                         Player::_42ECB5_PlayerAttacksActor();
                         continue;
@@ -1526,8 +1526,8 @@ void Game::processQueuedMessages() {
                         else
                             GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
 
-                        if (!pParty->getActiveCharacter()) continue;
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantRestHere);
+                        if (!pParty->activePlayerIndex()) continue;
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantRestHere);
                         continue;
                     }
                     if (pParty->bTurnBasedModeOn) {
@@ -1555,8 +1555,8 @@ void Game::processQueuedMessages() {
                     else
                         GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
 
-                    if (!pParty->getActiveCharacter()) continue;
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantRestHere);
+                    if (!pParty->activePlayerIndex()) continue;
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantRestHere);
                     continue;
                 case UIMSG_Rest8Hour:
                     pCurrentFrameMessageQueue->Clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
@@ -1567,8 +1567,8 @@ void Game::processQueuedMessages() {
                     }
                     if (pParty->GetFood() < foodRequiredToRest) {
                         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_FOOD);
-                        if (pParty->hasActiveCharacter() && pPlayers[pParty->getActiveCharacter()]->CanAct()) {
-                            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NotEnoughFood);
+                        if (pParty->hasActivePlayer() && pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+                            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughFood);
                         }
                     } else {
                         for (Player &player : pParty->pPlayers) {
@@ -1632,9 +1632,9 @@ void Game::processQueuedMessages() {
                         GameUI_StatusBar_Set(localization->FormatString(
                             LSTR_FMT_SET_S_AS_READY_SPELL,
                             pSpellStats->pInfos[static_cast<SPELL_TYPE>(quick_spell_at_page +
-                                         11 * pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage)].pName));
+                                         11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage)].pName));
                     } else {
-                        if (pPlayers[pParty->getActiveCharacter()]->uQuickSpell != SPELL_NONE)
+                        if (pPlayers[pParty->activePlayerIndex()]->uQuickSpell != SPELL_NONE)
                             GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_REMOVE_QUICKSPELL));
                         else
                             GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_SET_QUICKSPELL));
@@ -1643,8 +1643,8 @@ void Game::processQueuedMessages() {
                 }
 
                 case UIMSG_SPellbook_ShowHightlightedSpellInfo: {
-                    if (!pParty->getActiveCharacter())  // || (uNumSeconds = (unsigned
-                                            // int)pPlayers[pParty->getActiveCharacter()],!*(char
+                    if (!pParty->activePlayerIndex())  // || (uNumSeconds = (unsigned
+                                            // int)pPlayers[pParty->activePlayerIndex()],!*(char
                                             // *)(uNumSeconds + 11 * *(char
                                             // *)(uNumSeconds + 6734) +
                                             // uMessageParam + 402)))
@@ -1653,7 +1653,7 @@ void Game::processQueuedMessages() {
 
                     if (sub_4637E0_is_there_popup_onscreen())
                         dword_507B00_spell_info_to_draw_in_popup = uMessageParam + 1;
-                    int lastOpened = pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage;
+                    int lastOpened = pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage;
                     if (quick_spell_at_page - 1 == uMessageParam) {
                         GameUI_StatusBar_Set(localization->FormatString(LSTR_CAST_S,
                                     pSpellStats->pInfos[static_cast<SPELL_TYPE>(uMessageParam + 11 * lastOpened + 1)].pName));
@@ -1666,8 +1666,8 @@ void Game::processQueuedMessages() {
 
                 case UIMSG_ClickInstallRemoveQuickSpellBtn: {
                     new OnButtonClick2({pBtn_InstallRemoveSpell->uX, pBtn_InstallRemoveSpell->uY}, {0, 0}, pBtn_InstallRemoveSpell);
-                    if (!pParty->getActiveCharacter()) continue;
-                    Player *player = pPlayers[pParty->getActiveCharacter()];
+                    if (!pParty->activePlayerIndex()) continue;
+                    Player *player = pPlayers[pParty->activePlayerIndex()];
                     if (!byte_506550 || !quick_spell_at_page) {
                         player->uQuickSpell = SPELL_NONE;
                         quick_spell_at_page = 0;
@@ -1675,9 +1675,9 @@ void Game::processQueuedMessages() {
                         continue;
                     }
                     // TODO(captainurist): encapsulate the arithmetic below
-                    pPlayers[pParty->getActiveCharacter()]->uQuickSpell = static_cast<SPELL_TYPE>(
-                        quick_spell_at_page + 11 * pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage);
-                    if (pParty->hasActiveCharacter()) {
+                    pPlayers[pParty->activePlayerIndex()]->uQuickSpell = static_cast<SPELL_TYPE>(
+                        quick_spell_at_page + 11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage);
+                    if (pParty->hasActivePlayer()) {
                         player->playReaction(SPEECH_SetQuickSpell);
                     }
                     byte_506550 = 0;
@@ -1687,13 +1687,13 @@ void Game::processQueuedMessages() {
                 case UIMSG_SpellBook_PressTab:  //перелистывание страниц
                                                 //клавишей Tab
                 {
-                    if (!pParty->getActiveCharacter()) continue;
+                    if (!pParty->activePlayerIndex()) continue;
                     int skill_count = 0;
                     int uAction = 0;
                     int page = 0;
                     for (PLAYER_SKILL_TYPE i : MagicSkills()) {
-                        if (pPlayers[pParty->getActiveCharacter()]->pActiveSkills[i] || _engine->config->debug.AllMagic.value()) {
-                            if (pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage == page)
+                        if (pPlayers[pParty->activePlayerIndex()]->pActiveSkills[i] || _engine->config->debug.AllMagic.value()) {
+                            if (pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage == page)
                                 uAction = skill_count;
                             spellbookPages[skill_count++] = page;
                         }
@@ -1718,8 +1718,8 @@ void Game::processQueuedMessages() {
                 }
                 case UIMSG_OpenSpellbookPage:
                     if (pTurnEngine->turn_stage == TE_MOVEMENT ||
-                        !pParty->getActiveCharacter() ||
-                        uMessageParam == pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage) {
+                        !pParty->activePlayerIndex() ||
+                        uMessageParam == pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage) {
                         continue;
                     }
                     ((GUIWindow_Spellbook *)pGUIWindow_CurrentMenu)->OpenSpellbookPage(uMessageParam);
@@ -1728,12 +1728,12 @@ void Game::processQueuedMessages() {
                     if (pTurnEngine->turn_stage == TE_MOVEMENT) {
                         continue;
                     }
-                    if (!pParty->getActiveCharacter()) {
+                    if (!pParty->activePlayerIndex()) {
                         continue;
                     }
 
-                    //  uNumSeconds = (unsigned int)pPlayers[pParty->getActiveCharacter()];
-                    Player *player = pPlayers[pParty->getActiveCharacter()];
+                    //  uNumSeconds = (unsigned int)pPlayers[pParty->activePlayerIndex()];
+                    Player *player = pPlayers[pParty->activePlayerIndex()];
                     if (player->spellbook.pChapters[player->lastOpenedSpellbookPage].bIsSpellAvailable[uMessageParam]
                         || _engine->config->debug.AllMagic.value()) {
                         if (quick_spell_at_page - 1 == uMessageParam) {
@@ -1746,14 +1746,14 @@ void Game::processQueuedMessages() {
                             dword_50C9EC[3 * dword_50C9E8] =
                             UIMSG_CastSpellFromBook; dword_50C9EC[3 *
                             dword_50C9E8 + 1] = v103; dword_50C9EC[3 *
-                            dword_50C9E8 + 2] = pParty->getActiveCharacter() - 1;
+                            dword_50C9E8 + 2] = pParty->activePlayerIndex() - 1;
                             ++dword_50C9E8;
                             }*/
                             // Processing must happen on next frame because need to close spell book and update
                             // drawing object list which is used to count actors for some spells
-                            pNextFrameMessageQueue->AddGUIMessage( UIMSG_CastSpellFromBook, v103, pParty->getActiveCharacter() - 1);
+                            pNextFrameMessageQueue->AddGUIMessage( UIMSG_CastSpellFromBook, v103, pParty->activePlayerIndex() - 1);
                             //  pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastSpellFromBook,
-                            //  v103, pParty->getActiveCharacter() - 1);
+                            //  v103, pParty->activePlayerIndex() - 1);
                         } else {
                             byte_506550 = 1;
                             quick_spell_at_page = uMessageParam + 1;
@@ -1783,8 +1783,8 @@ void Game::processQueuedMessages() {
                         pAudioPlayer->playUISound(SOUND_error);
                     } else {
                         pCurrentFrameMessageQueue->Flush();
-                        if (pParty->hasActiveCharacter()) {
-                            if (!pPlayers[pParty->getActiveCharacter()]->uTimeToRecovery) {
+                        if (pParty->hasActivePlayer()) {
+                            if (!pPlayers[pParty->activePlayerIndex()]->uTimeToRecovery) {
                                 // toggle
                                 if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) {
                                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
@@ -1878,7 +1878,7 @@ void Game::processQueuedMessages() {
                 case UIMSG_SkillUp:
                 {
                     PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(uMessageParam);
-                    Player *player = pPlayers[pParty->getActiveCharacter()];
+                    Player *player = pPlayers[pParty->activePlayerIndex()];
                     PLAYER_SKILL_LEVEL skill_level = player->GetSkillLevel(skill);
                     const char *statusString;
                     if (player->uSkillPoints < skill_level + 1) {
@@ -2029,13 +2029,13 @@ void Game::processQueuedMessages() {
 
                 case UIMSG_CHEST_ClickItem:
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-                        pPlayers[pParty->getActiveCharacter()]->OnInventoryLeftClick();
+                        pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
                         continue;
                     }
                     Chest::OnChestLeftClick();
                     continue;
                 case UIMSG_InventoryLeftClick:
-                    pPlayers[pParty->getActiveCharacter()]->OnInventoryLeftClick();
+                    pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
                     continue;
                 case UIMSG_MouseLeftClickInGame:
                     pCurrentFrameMessageQueue->Flush();
@@ -2112,13 +2112,13 @@ void Game::processQueuedMessages() {
 
                     break;
                 case UIMSG_DebugSpecialItem: {
-                    if (!pParty->hasActiveCharacter())
+                    if (!pParty->hasActivePlayer())
                         continue;
 
                     for(size_t attempt = 0; attempt < 500; attempt++) {
                         ITEM_TYPE pItemID = grng->randomSample(SpawnableItems());
                         if (pItemTable->pItems[pItemID].uItemID_Rep_St > 6) {
-                            if (!pPlayers[pParty->getActiveCharacter()]->AddItem(-1, pItemID)) {
+                            if (!pPlayers[pParty->activePlayerIndex()]->AddItem(-1, pItemID)) {
                                 pAudioPlayer->playUISound(SOUND_error);
                             }
                             break;
@@ -2129,14 +2129,14 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_DebugGenItem: {
-                    if (!pParty->hasActiveCharacter())
+                    if (!pParty->hasActivePlayer())
                         continue;
 
                     for (size_t attempt = 0; attempt < 500; attempt++) {
                         ITEM_TYPE pItemID = grng->randomSample(SpawnableItems());
                         // if (pItemTable->pItems[pItemID].uItemID_Rep_St ==
                         //   (item_id - 40015 + 1)) {
-                        if (!pPlayers[pParty->getActiveCharacter()]->AddItem(-1, pItemID)) {
+                        if (!pPlayers[pParty->activePlayerIndex()]->AddItem(-1, pItemID)) {
                             pAudioPlayer->playUISound(SOUND_error);
                         }
                         break;
@@ -2147,23 +2147,23 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_DebugKillChar:
-                    if (!pParty->hasActiveCharacter())
+                    if (!pParty->hasActivePlayer())
                         continue;
-                    pPlayers[pParty->getActiveCharacter()]->SetCondition(Condition_Dead, 0);
+                    pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Dead, 0);
                     continue;
                 case UIMSG_DebugEradicate:
-                    if (!pParty->hasActiveCharacter())
+                    if (!pParty->hasActivePlayer())
                         continue;
-                    pPlayers[pParty->getActiveCharacter()]->SetCondition(Condition_Eradicated, 0);
+                    pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Eradicated, 0);
                     continue;
                 case UIMSG_DebugFullHeal:
-                    if (!pParty->hasActiveCharacter())
+                    if (!pParty->hasActivePlayer())
                         continue;
-                    pPlayers[pParty->getActiveCharacter()]->conditions.ResetAll();
-                    pPlayers[pParty->getActiveCharacter()]->sHealth =
-                        pPlayers[pParty->getActiveCharacter()]->GetMaxHealth();
-                    pPlayers[pParty->getActiveCharacter()]->sMana =
-                        pPlayers[pParty->getActiveCharacter()]->GetMaxMana();
+                    pPlayers[pParty->activePlayerIndex()]->conditions.ResetAll();
+                    pPlayers[pParty->activePlayerIndex()]->sHealth =
+                        pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
+                    pPlayers[pParty->activePlayerIndex()]->sMana =
+                        pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
                     pAudioPlayer->playUISound(SOUND_heal);
                     continue;
                 case UIMSG_DebugCycleAlign:
@@ -2197,11 +2197,11 @@ void Game::processQueuedMessages() {
                     for (Player &player : pParty->pPlayers) {
                         player.uSkillPoints += 50;
                     }
-                    pPlayers[std::max(pParty->getActiveCharacter(), 1u)]->PlayAwardSound_Anim();
+                    pPlayers[std::max(pParty->activePlayerIndex(), 1u)]->PlayAwardSound_Anim();
                     continue;
                 case UIMSG_DebugGiveEXP:
                     pParty->GivePartyExp(20000);
-                    pPlayers[std::max(pParty->getActiveCharacter(), 1u)]->PlayAwardSound_Anim();
+                    pPlayers[std::max(pParty->activePlayerIndex(), 1u)]->PlayAwardSound_Anim();
                     continue;
                 case UIMSG_DebugGiveGold:
                     pParty->AddGold(10000);
@@ -2300,7 +2300,7 @@ void Game::onPressSpace() {
     uint16_t pid = _vis->get_picked_object_zbuf_val().object_pid;
     if (pid != PID_INVALID) {
         // wasn't there, but we decided to deny interactions where there are no active character
-        if (!pParty->hasActiveCharacter()) {
+        if (!pParty->hasActivePlayer()) {
             GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
             return;
         }
@@ -2459,7 +2459,7 @@ void Game::gameLoop() {
                                        // 0, 0x180u);//(pPlayerBuffs[0], 0, 384)
                     player.sHealth = 1;
                 }
-                pParty->setActiveCharacter(1);
+                pParty->setActivePlayerIndex(1);
 
                 if (_449B57_test_bit(pParty->_quest_bits, QBIT_ESCAPED_EMERALD_ISLE)) {
                     pParty->vPosition.x = -17331;  // respawn in harmondale

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -700,7 +700,7 @@ void Game::processQueuedMessages() {
                                 switch (current_screen_type) {
                                     case CURRENT_SCREEN::SCREEN_CASTING:
                                         if (enchantingActiveCharacter) {
-                                            pParty->setActivePlayerIndex(enchantingActiveCharacter);
+                                            pParty->setActivePlayerByIndex(enchantingActiveCharacter);
                                             pParty->switchToNextActiveCharacter();
                                             enchantingActiveCharacter = 0;
                                             if (pParty->bTurnBasedModeOn) {
@@ -955,7 +955,7 @@ void Game::processQueuedMessages() {
                     onEscape();
                     continue;
                 case UIMSG_CycleCharacters:
-                    pParty->setActivePlayerIndex(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
+                    pParty->setActivePlayerByIndex(CycleCharacter(keyboardInputHandler->IsAdventurerBackcycleToggled()));
                     continue;
                 case UIMSG_OnTravelByFoot:
                     pCurrentFrameMessageQueue->Flush();
@@ -1084,7 +1084,7 @@ void Game::processQueuedMessages() {
                     if (IsEnchantingInProgress) {
                         // Change character while enchanting is active
                         // TODO(Nik-RE-dev): need separate message type
-                        pParty->setActivePlayerIndex(uMessageParam);
+                        pParty->setActivePlayerByIndex(uMessageParam);
                     } else {
                         spellTargetPicked(PID_INVALID, uMessageParam);
                         closeTargetedSpellWindow();
@@ -2459,7 +2459,7 @@ void Game::gameLoop() {
                                        // 0, 0x180u);//(pPlayerBuffs[0], 0, 384)
                     player.sHealth = 1;
                 }
-                pParty->setActivePlayerIndex(1);
+                pParty->setActivePlayerByIndex(1);
 
                 if (_449B57_test_bit(pParty->_quest_bits, QBIT_ESCAPED_EMERALD_ISLE)) {
                     pParty->vPosition.x = -17331;  // respawn in harmondale

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1695,9 +1695,9 @@ void _494035_timed_effects__water_walking_damage__etc() {
         }
     }
 
-    if (pParty->hasActivePlayer()) {
+    if (pParty->hasActiveCharacter()) {
         if (current_screen_type != CURRENT_SCREEN::SCREEN_REST) {
-            if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+            if (!pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
                 pParty->switchToNextActiveCharacter();
             }
         }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1695,9 +1695,9 @@ void _494035_timed_effects__water_walking_damage__etc() {
         }
     }
 
-    if (pParty->hasActiveCharacter()) {
+    if (pParty->hasActivePlayer()) {
         if (current_screen_type != CURRENT_SCREEN::SCREEN_REST) {
-            if (!pPlayers[pParty->getActiveCharacter()]->CanAct()) {
+            if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
                 pParty->switchToNextActiveCharacter();
             }
         }

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -331,7 +331,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
             GameUI_SetStatusBar(LSTR_NOTHING_HERE);
         return;
     }
-    player_choose = (!pParty->hasActiveCharacter())
+    player_choose = (!pParty->hasActivePlayer())
                         ? 6
                         : 4;  // 4 - active or  6 - random player if active =0
     curr_seq_num = entry_line;
@@ -377,7 +377,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
                         v24 = pParty->pPlayers[player_choose].pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
                     } else {
                         if (player_choose == 4) {
-                            v24 = pPlayers[pParty->getActiveCharacter()]->pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
+                            v24 = pPlayers[pParty->activePlayerIndex()]->pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
                         } else {
                             if (player_choose == 5) {
                                 v20 = 0;
@@ -551,7 +551,7 @@ LABEL_47:
                     if (_evt->v5 <= 3u) {  // someone
                         pParty->pPlayers[_evt->v5].playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
                     } else if (_evt->v5 == 4) {  // active
-                        pPlayers[pParty->getActiveCharacter()]->playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
+                        pPlayers[pParty->activePlayerIndex()]->playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
                     } else if (_evt->v5 == 5) {  // all players
                         for (Player &player : pParty->pPlayers) {
                             player.playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
@@ -565,7 +565,7 @@ LABEL_47:
                     if (_evt->v5 <= 3) {  // someone
                         pParty->pPlayers[_evt->v5].playReaction((PlayerSpeech)_evt->v6);
                     } else if (_evt->v5 == 4) {  // active
-                        pPlayers[pParty->getActiveCharacter()]->playReaction((PlayerSpeech)_evt->v6);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction((PlayerSpeech)_evt->v6);
                     } else if (_evt->v5 == 5) {  // all
                         for (Player &player : pParty->pPlayers) {
                             player.playReaction((PlayerSpeech)_evt->v6);
@@ -593,8 +593,8 @@ LABEL_47:
                             curr_seq_num = _evt->v11 - 1;
                         }
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActiveCharacter()) {
-                            if (pPlayers[pParty->getActiveCharacter()]->CompareVariable((enum VariableType)EVT_WORD(_evt->v5), pValue)) {
+                        if (pParty->hasActivePlayer()) {
+                            if (pPlayers[pParty->activePlayerIndex()]->CompareVariable((enum VariableType)EVT_WORD(_evt->v5), pValue)) {
                                 // v124 = -1;
                                 curr_seq_num = _evt->v11 - 1;
                             }
@@ -632,8 +632,8 @@ LABEL_47:
                     if (player_choose <= 3) {
                         pParty->pPlayers[player_choose].SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActiveCharacter()) {
-                            pPlayers[pParty->getActiveCharacter()]->SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActivePlayer()) {
+                            pPlayers[pParty->activePlayerIndex()]->SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         if (EVT_WORD(_evt->v5) == VAR_PlayerItemInHands) {
@@ -658,8 +658,8 @@ LABEL_47:
                     if (player_choose <= 3) {
                         pParty->pPlayers[player_choose].SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActiveCharacter()) {
-                            pPlayers[pParty->getActiveCharacter()]->SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActivePlayer()) {
+                            pPlayers[pParty->activePlayerIndex()]->SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         // recheck v130
@@ -677,8 +677,8 @@ LABEL_47:
                         pPlayer = &pParty->pPlayers[player_choose];
                         pPlayer->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActiveCharacter()) {
-                            pPlayers[pParty->getActiveCharacter()]->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActivePlayer()) {
+                            pPlayers[pParty->activePlayerIndex()]->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         for (Player &player : pParty->pPlayers) {
@@ -731,11 +731,11 @@ LABEL_47:
                         break;
                     }
                     if (_evt->v5 == 4) {
-                        if (!pParty->hasActiveCharacter()) {
+                        if (!pParty->hasActivePlayer()) {
                             ++curr_seq_num;
                             break;
                         }
-                        pPlayers[pParty->getActiveCharacter()]->receiveDamage(EVT_DWORD(_evt->v7), (DAMAGE_TYPE)_evt->v6);
+                        pPlayers[pParty->activePlayerIndex()]->receiveDamage(EVT_DWORD(_evt->v7), (DAMAGE_TYPE)_evt->v6);
                         ++curr_seq_num;
                         break;
                     }

--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -331,7 +331,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
             GameUI_SetStatusBar(LSTR_NOTHING_HERE);
         return;
     }
-    player_choose = (!pParty->hasActivePlayer())
+    player_choose = (!pParty->hasActiveCharacter())
                         ? 6
                         : 4;  // 4 - active or  6 - random player if active =0
     curr_seq_num = entry_line;
@@ -377,7 +377,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
                         v24 = pParty->pPlayers[player_choose].pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
                     } else {
                         if (player_choose == 4) {
-                            v24 = pPlayers[pParty->activePlayerIndex()]->pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
+                            v24 = pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[static_cast<PLAYER_SKILL_TYPE>(_evt->v5)];
                         } else {
                             if (player_choose == 5) {
                                 v20 = 0;
@@ -551,7 +551,7 @@ LABEL_47:
                     if (_evt->v5 <= 3u) {  // someone
                         pParty->pPlayers[_evt->v5].playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
                     } else if (_evt->v5 == 4) {  // active
-                        pPlayers[pParty->activePlayerIndex()]->playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
+                        pPlayers[pParty->activeCharacterIndex()]->playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
                     } else if (_evt->v5 == 5) {  // all players
                         for (Player &player : pParty->pPlayers) {
                             player.playEmotion((CHARACTER_EXPRESSION_ID)_evt->v6, 0);
@@ -565,7 +565,7 @@ LABEL_47:
                     if (_evt->v5 <= 3) {  // someone
                         pParty->pPlayers[_evt->v5].playReaction((PlayerSpeech)_evt->v6);
                     } else if (_evt->v5 == 4) {  // active
-                        pPlayers[pParty->activePlayerIndex()]->playReaction((PlayerSpeech)_evt->v6);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction((PlayerSpeech)_evt->v6);
                     } else if (_evt->v5 == 5) {  // all
                         for (Player &player : pParty->pPlayers) {
                             player.playReaction((PlayerSpeech)_evt->v6);
@@ -593,8 +593,8 @@ LABEL_47:
                             curr_seq_num = _evt->v11 - 1;
                         }
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActivePlayer()) {
-                            if (pPlayers[pParty->activePlayerIndex()]->CompareVariable((enum VariableType)EVT_WORD(_evt->v5), pValue)) {
+                        if (pParty->hasActiveCharacter()) {
+                            if (pPlayers[pParty->activeCharacterIndex()]->CompareVariable((enum VariableType)EVT_WORD(_evt->v5), pValue)) {
                                 // v124 = -1;
                                 curr_seq_num = _evt->v11 - 1;
                             }
@@ -632,8 +632,8 @@ LABEL_47:
                     if (player_choose <= 3) {
                         pParty->pPlayers[player_choose].SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActivePlayer()) {
-                            pPlayers[pParty->activePlayerIndex()]->SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActiveCharacter()) {
+                            pPlayers[pParty->activeCharacterIndex()]->SubtractVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         if (EVT_WORD(_evt->v5) == VAR_PlayerItemInHands) {
@@ -658,8 +658,8 @@ LABEL_47:
                     if (player_choose <= 3) {
                         pParty->pPlayers[player_choose].SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActivePlayer()) {
-                            pPlayers[pParty->activePlayerIndex()]->SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActiveCharacter()) {
+                            pPlayers[pParty->activeCharacterIndex()]->SetVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         // recheck v130
@@ -677,8 +677,8 @@ LABEL_47:
                         pPlayer = &pParty->pPlayers[player_choose];
                         pPlayer->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                     } else if (player_choose == 4) {  // active
-                        if (pParty->hasActivePlayer()) {
-                            pPlayers[pParty->activePlayerIndex()]->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
+                        if (pParty->hasActiveCharacter()) {
+                            pPlayers[pParty->activeCharacterIndex()]->AddVariable((enum VariableType)EVT_WORD(_evt->v5), pValue);
                         }
                     } else if (player_choose == 5) {  // all
                         for (Player &player : pParty->pPlayers) {
@@ -731,11 +731,11 @@ LABEL_47:
                         break;
                     }
                     if (_evt->v5 == 4) {
-                        if (!pParty->hasActivePlayer()) {
+                        if (!pParty->hasActiveCharacter()) {
                             ++curr_seq_num;
                             break;
                         }
-                        pPlayers[pParty->activePlayerIndex()]->receiveDamage(EVT_DWORD(_evt->v7), (DAMAGE_TYPE)_evt->v6);
+                        pPlayers[pParty->activeCharacterIndex()]->receiveDamage(EVT_DWORD(_evt->v7), (DAMAGE_TYPE)_evt->v6);
                         ++curr_seq_num;
                         break;
                     }

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -2032,16 +2032,16 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 vertical_angle += engine->config->settings.VerticalTurnSpeed.value();
                 if (vertical_angle > 128)
                     vertical_angle = 128;
-                if (pParty->hasActiveCharacter())
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LookUp);
+                if (pParty->hasActivePlayer())
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookUp);
                 break;
 
             case PARTY_LookDown:
                 vertical_angle -= engine->config->settings.VerticalTurnSpeed.value();
                 if (vertical_angle < -128)
                     vertical_angle = -128;
-                if (pParty->hasActiveCharacter())
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LookDown);
+                if (pParty->hasActivePlayer())
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookDown);
                 break;
 
             case PARTY_CenterView:

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -2032,16 +2032,16 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 vertical_angle += engine->config->settings.VerticalTurnSpeed.value();
                 if (vertical_angle > 128)
                     vertical_angle = 128;
-                if (pParty->hasActivePlayer())
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookUp);
+                if (pParty->hasActiveCharacter())
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LookUp);
                 break;
 
             case PARTY_LookDown:
                 vertical_angle -= engine->config->settings.VerticalTurnSpeed.value();
                 if (vertical_angle < -128)
                     vertical_angle = -128;
-                if (pParty->hasActivePlayer())
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookDown);
+                if (pParty->hasActiveCharacter())
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LookDown);
                 break;
 
             case PARTY_CenterView:

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2074,16 +2074,16 @@ void ODM_ProcessPartyActions() {
             case PARTY_LookUp:
                 partyViewNewPitch += engine->config->settings.VerticalTurnSpeed.value();
                 if (partyViewNewPitch > 128) partyViewNewPitch = 128;
-                if (pParty->hasActiveCharacter()) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LookUp);
+                if (pParty->hasActivePlayer()) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookUp);
                 }
                 break;
 
             case PARTY_LookDown:
                 partyViewNewPitch -= engine->config->settings.VerticalTurnSpeed.value();
                 if (partyViewNewPitch < -128) partyViewNewPitch = -128;
-                if (pParty->hasActiveCharacter()) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LookDown);
+                if (pParty->hasActivePlayer()) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookDown);
                 }
                 break;
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2074,16 +2074,16 @@ void ODM_ProcessPartyActions() {
             case PARTY_LookUp:
                 partyViewNewPitch += engine->config->settings.VerticalTurnSpeed.value();
                 if (partyViewNewPitch > 128) partyViewNewPitch = 128;
-                if (pParty->hasActivePlayer()) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookUp);
+                if (pParty->hasActiveCharacter()) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LookUp);
                 }
                 break;
 
             case PARTY_LookDown:
                 partyViewNewPitch -= engine->config->settings.VerticalTurnSpeed.value();
                 if (partyViewNewPitch < -128) partyViewNewPitch = -128;
-                if (pParty->hasActivePlayer()) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LookDown);
+                if (pParty->hasActiveCharacter()) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LookDown);
                 }
                 break;
 

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -312,7 +312,7 @@ void Engine::OnGameViewportClick() {
         return;
 
     // wasn't there, but we decided to deny interactions where there are no active character
-    if (!pParty->hasActiveCharacter()) {
+    if (!pParty->hasActivePlayer()) {
         GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
         return;
     }
@@ -359,7 +359,7 @@ void Engine::OnGameViewportClick() {
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->setAirborne(true);
-        } else if (pParty->hasActiveCharacter() && IsSpellQuickCastableOnShiftClick(pPlayers[pParty->getActiveCharacter()]->uQuickSpell)) {
+        } else if (pParty->hasActivePlayer() && IsSpellQuickCastableOnShiftClick(pPlayers[pParty->activePlayerIndex()]->uQuickSpell)) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
         }
     } else if (PID_TYPE(pid) == OBJECT_Decoration) {

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -312,7 +312,7 @@ void Engine::OnGameViewportClick() {
         return;
 
     // wasn't there, but we decided to deny interactions where there are no active character
-    if (!pParty->hasActivePlayer()) {
+    if (!pParty->hasActiveCharacter()) {
         GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
         return;
     }
@@ -359,7 +359,7 @@ void Engine::OnGameViewportClick() {
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->setAirborne(true);
-        } else if (pParty->hasActivePlayer() && IsSpellQuickCastableOnShiftClick(pPlayers[pParty->activePlayerIndex()]->uQuickSpell)) {
+        } else if (pParty->hasActiveCharacter() && IsSpellQuickCastableOnShiftClick(pPlayers[pParty->activeCharacterIndex()]->uQuickSpell)) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
         }
     } else if (PID_TYPE(pid) == OBJECT_Decoration) {

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1367,7 +1367,7 @@ void Actor::StealFrom(unsigned int uActorID) {
     DDM_DLV_Header *v6;  // esi@4
     int v8;              // [sp+8h] [bp-4h]@6
 
-    pPlayer = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
+    pPlayer = &pParty->pPlayers[pParty->activeCharacterIndex() - 1];
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
         v4 = 0;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1367,7 +1367,7 @@ void Actor::StealFrom(unsigned int uActorID) {
     DDM_DLV_Header *v6;  // esi@4
     int v8;              // [sp+8h] [bp-4h]@6
 
-    pPlayer = &pParty->pPlayers[pParty->getActiveCharacter() - 1];
+    pPlayer = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
         v4 = 0;

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -55,11 +55,11 @@ bool Chest::open(int uChestID) {
     if (!chest->Initialized() || engine->config->gameplay.ChestTryPlaceItems.value() == 1)
         Chest::PlaceItems(uChestID);
 
-    if (!pParty->hasActiveCharacter()) return false;
+    if (!pParty->hasActivePlayer()) return false;
     flag_shout = false;
     unsigned int pMapID = pMapStats->GetMapInfo(pCurrentMapName);
     if (chest->Trapped() && pMapID) {
-        if (pPlayers[pParty->getActiveCharacter()]->GetDisarmTrap() <
+        if (pPlayers[pParty->activePlayerIndex()]->GetDisarmTrap() <
             2 * pMapStats->pInfos[pMapID].LockX5) {
             pSpriteID[0] = SPRITE_TRAP_FIRE;
             pSpriteID[1] = SPRITE_TRAP_LIGHTNING;
@@ -139,11 +139,11 @@ bool Chest::open(int uChestID) {
             pAudioPlayer->playSound(SOUND_fireBall, 0);
             pSpellObject.explosionTraps();
             chest->uFlags &= ~CHEST_TRAPPED;
-            if (pParty->getActiveCharacter() && !_A750D8_player_speech_timer &&
+            if (pParty->activePlayerIndex() && !_A750D8_player_speech_timer &&
                 !OpenedTelekinesis) {
                 _A750D8_player_speech_timer = 256;
                 PlayerSpeechID = SPEECH_TrapExploded;
-                uSpeakingCharacter = pParty->getActiveCharacter() - 1;
+                uSpeakingCharacter = pParty->activePlayerIndex() - 1;
             }
             OpenedTelekinesis = false;
             return false;
@@ -154,7 +154,7 @@ bool Chest::open(int uChestID) {
     pAudioPlayer->playUISound(SOUND_openchest0101);
     if (flag_shout == true) {
         if (!OpenedTelekinesis) {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TrapDisarmed);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TrapDisarmed);
         }
     }
     OpenedTelekinesis = false;
@@ -323,8 +323,8 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
         }
 
         if (test_pos == max_size) {  // limits check no room
-            if (pParty->hasActiveCharacter()) {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NoRoom);
+            if (pParty->hasActivePlayer()) {
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
             }
             return 0;
         }
@@ -559,7 +559,7 @@ void Chest::OnChestLeftClick() {
 }
 
 void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using spacebar
-    if (pParty->pPickedItem.uItemID != ITEM_NULL || !pParty->hasActiveCharacter()) {
+    if (pParty->pPickedItem.uItemID != ITEM_NULL || !pParty->hasActivePlayer()) {
         return;
     }
 
@@ -582,8 +582,8 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
             goldamount += chestitem.special_enchantment;
             goldcount++;
         } else {  // this should add item to invetory of active char - if that fails set as holding item and break
-            if (pParty->hasActiveCharacter() && (InventSlot = pPlayers[pParty->getActiveCharacter()]->AddItem(-1, chestitem.uItemID)) != 0) {  // can place
-                memcpy(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[InventSlot - 1], &chestitem, 0x24u);
+            if (pParty->hasActivePlayer() && (InventSlot = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, chestitem.uItemID)) != 0) {  // can place
+                memcpy(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[InventSlot - 1], &chestitem, 0x24u);
                 grabcount++;
                 GameUI_SetStatusBar(
                     LSTR_FMT_YOU_FOUND_ITEM,
@@ -592,7 +592,7 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
             } else {  // no room so set as holding item
                 pParty->setHoldingItem(&chestitem);
                 RemoveItemAtChestIndex(loop);
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NoRoom);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
                 break;
             }
         }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -55,11 +55,11 @@ bool Chest::open(int uChestID) {
     if (!chest->Initialized() || engine->config->gameplay.ChestTryPlaceItems.value() == 1)
         Chest::PlaceItems(uChestID);
 
-    if (!pParty->hasActivePlayer()) return false;
+    if (!pParty->hasActiveCharacter()) return false;
     flag_shout = false;
     unsigned int pMapID = pMapStats->GetMapInfo(pCurrentMapName);
     if (chest->Trapped() && pMapID) {
-        if (pPlayers[pParty->activePlayerIndex()]->GetDisarmTrap() <
+        if (pPlayers[pParty->activeCharacterIndex()]->GetDisarmTrap() <
             2 * pMapStats->pInfos[pMapID].LockX5) {
             pSpriteID[0] = SPRITE_TRAP_FIRE;
             pSpriteID[1] = SPRITE_TRAP_LIGHTNING;
@@ -139,11 +139,11 @@ bool Chest::open(int uChestID) {
             pAudioPlayer->playSound(SOUND_fireBall, 0);
             pSpellObject.explosionTraps();
             chest->uFlags &= ~CHEST_TRAPPED;
-            if (pParty->activePlayerIndex() && !_A750D8_player_speech_timer &&
+            if (pParty->activeCharacterIndex() && !_A750D8_player_speech_timer &&
                 !OpenedTelekinesis) {
                 _A750D8_player_speech_timer = 256;
                 PlayerSpeechID = SPEECH_TrapExploded;
-                uSpeakingCharacter = pParty->activePlayerIndex() - 1;
+                uSpeakingCharacter = pParty->activeCharacterIndex() - 1;
             }
             OpenedTelekinesis = false;
             return false;
@@ -154,7 +154,7 @@ bool Chest::open(int uChestID) {
     pAudioPlayer->playUISound(SOUND_openchest0101);
     if (flag_shout == true) {
         if (!OpenedTelekinesis) {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TrapDisarmed);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_TrapDisarmed);
         }
     }
     OpenedTelekinesis = false;
@@ -323,8 +323,8 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
         }
 
         if (test_pos == max_size) {  // limits check no room
-            if (pParty->hasActivePlayer()) {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
+            if (pParty->hasActiveCharacter()) {
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NoRoom);
             }
             return 0;
         }
@@ -559,7 +559,7 @@ void Chest::OnChestLeftClick() {
 }
 
 void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using spacebar
-    if (pParty->pPickedItem.uItemID != ITEM_NULL || !pParty->hasActivePlayer()) {
+    if (pParty->pPickedItem.uItemID != ITEM_NULL || !pParty->hasActiveCharacter()) {
         return;
     }
 
@@ -582,8 +582,8 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
             goldamount += chestitem.special_enchantment;
             goldcount++;
         } else {  // this should add item to invetory of active char - if that fails set as holding item and break
-            if (pParty->hasActivePlayer() && (InventSlot = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, chestitem.uItemID)) != 0) {  // can place
-                memcpy(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[InventSlot - 1], &chestitem, 0x24u);
+            if (pParty->hasActiveCharacter() && (InventSlot = pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, chestitem.uItemID)) != 0) {  // can place
+                memcpy(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[InventSlot - 1], &chestitem, 0x24u);
                 grabcount++;
                 GameUI_SetStatusBar(
                     LSTR_FMT_YOU_FOUND_ITEM,
@@ -592,7 +592,7 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
             } else {  // no room so set as holding item
                 pParty->setHoldingItem(&chestitem);
                 RemoveItemAtChestIndex(loop);
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NoRoom);
                 break;
             }
         }

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -611,8 +611,8 @@ int Player::CreateItemInInventory(unsigned int uSlot, ITEM_TYPE uItemID) {
     signed int freeSlot = findFreeInventoryListSlot();
 
     if (freeSlot == -1) {  // no room
-        if (pParty->hasActiveCharacter()) {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NoRoom);
+        if (pParty->hasActivePlayer()) {
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
         }
 
         return 0;
@@ -2352,7 +2352,7 @@ bool Player::Recover(GameTime dt) {
     } else {
         uTimeToRecovery = 0;  // recovered
 
-        if (!pParty->hasActiveCharacter())  // set recoverd char as active
+        if (!pParty->hasActivePlayer())  // set recoverd char as active
             pParty->switchToNextActiveCharacter();
 
         return false;
@@ -2366,7 +2366,7 @@ void Player::SetRecoveryTime(signed int rec) {
 
     if (rec > uTimeToRecovery) uTimeToRecovery = rec;
 
-    if (pParty->hasActiveCharacter() && pPlayers[pParty->getActiveCharacter()] == this &&
+    if (pParty->hasActivePlayer() && pPlayers[pParty->activePlayerIndex()] == this &&
         !enchantingActiveCharacter)
         pParty->switchToNextActiveCharacter();
 }
@@ -6232,21 +6232,21 @@ void Player::EquipBody(ITEM_EQUIP_TYPE uEquipType) {
 
     tempPickedItem.Reset();
     itemAnchor = pEquipTypeToBodyAnchor[uEquipType];
-    itemInvLocation = pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[itemAnchor];
+    itemInvLocation = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor];
     if (itemInvLocation) {  //переодеться в другую вещь
         tempPickedItem = pParty->pPickedItem;
-        pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[itemInvLocation - 1].uBodyAnchor = ITEM_SLOT_INVALID;
+        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1].uBodyAnchor = ITEM_SLOT_INVALID;
         pParty->pPickedItem.Reset();
-        pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[itemInvLocation - 1]);
+        pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1]);
         tempPickedItem.uBodyAnchor = itemAnchor;
-        pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[itemInvLocation - 1] = tempPickedItem;
-        pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[itemAnchor] = itemInvLocation;
+        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1] = tempPickedItem;
+        pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor] = itemInvLocation;
     } else {  // одеть вещь
-        freeSlot = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+        freeSlot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
         if (freeSlot >= 0) {
             pParty->pPickedItem.uBodyAnchor = itemAnchor;
-            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeSlot] = pParty->pPickedItem;
-            pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[itemAnchor] = freeSlot + 1;
+            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeSlot] = pParty->pPickedItem;
+            pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor] = freeSlot + 1;
             mouse->RemoveHoldingItem();
         }
     }
@@ -6260,12 +6260,12 @@ int CycleCharacter(bool backwards) {
 
     for (int i = 0; i < (PARTYSIZE - 1); i++) {
         int currCharId =
-            ((pParty->getActiveCharacter() + mult * i + valToAdd) % PARTYSIZE) + 1;
+            ((pParty->activePlayerIndex() + mult * i + valToAdd) % PARTYSIZE) + 1;
         if (pPlayers[currCharId]->uTimeToRecovery == 0) {
             return currCharId;
         }
     }
-    return pParty->getActiveCharacter();
+    return pParty->activePlayerIndex();
 }
 
 bool Player::hasUnderwaterSuitEquipped() {
@@ -6753,14 +6753,14 @@ void Player::OnInventoryLeftClick() {
                     /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
                      *0x7Fu;
                      *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                     *pParty->getActiveCharacter() - 1;
+                     *pParty->activePlayerIndex() - 1;
                      *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                      *enchantedItemPos - 1;
                      *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                      *invMatrixIndex;*/
                     pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
                     pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-                    pSpellInfo->uPlayerID_2 = pParty->getActiveCharacter() - 1;
+                    pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
                     pSpellInfo->spell_target_pid = enchantedItemPos - 1;
                     pSpellInfo->field_6 = this->GetItemMainInventoryIndex(invMatrixIndex);
                     ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
@@ -7076,8 +7076,8 @@ void Player::_42ECB5_PlayerAttacksActor() {
     //  unsigned int v12; // eax@47
     //  SoundID v24; // [sp-4h] [bp-40h]@58
 
-    // result = pParty->pPlayers[pParty->getActiveCharacter()-1].CanAct();
-    Player *player = &pParty->pPlayers[pParty->getActiveCharacter() - 1];
+    // result = pParty->pPlayers[pParty->activePlayerIndex()-1].CanAct();
+    Player *player = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
     if (!player->CanAct()) return;
 
     CastSpellInfoHelpers::cancelSpellCastInProgress();
@@ -7152,14 +7152,14 @@ void Player::_42ECB5_PlayerAttacksActor() {
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
         pushSpellOrRangedAttack(SPELL_LASER_PROJECTILE,
-                                pParty->getActiveCharacter() - 1, 0, 0,
-                                pParty->getActiveCharacter() + 8);
+                                pParty->activePlayerIndex() - 1, 0, 0,
+                                pParty->activePlayerIndex() + 8);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         int main_hand_idx = player->pEquipment.uMainHand;
         pushSpellOrRangedAttack(wandSpellIds[player->pInventoryItemList[main_hand_idx - 1].uItemID],
-                                pParty->getActiveCharacter() - 1, 8, 0, pParty->getActiveCharacter() + 8);
+                                pParty->activePlayerIndex() - 1, 8, 0, pParty->activePlayerIndex() + 8);
 
         if (!--player->pInventoryItemList[main_hand_idx - 1].uNumCharges)
             player->pEquipment.uMainHand = 0;
@@ -7169,17 +7169,17 @@ void Player::_42ECB5_PlayerAttacksActor() {
         Vec3i a3 = actor->vPosition - pParty->vPosition;
         normalize_to_fixpoint(&a3.x, &a3.y, &a3.z);
 
-        Actor::DamageMonsterFromParty(PID(OBJECT_Player, pParty->getActiveCharacter() - 1),
+        Actor::DamageMonsterFromParty(PID(OBJECT_Player, pParty->activePlayerIndex() - 1),
                                       target_id, &a3);
         if (player->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_MAIN_HAND) ||
             player->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_OFF_HAND))
             _42FA66_do_explosive_impact(
                 actor->vPosition.x, actor->vPosition.y,
                 actor->vPosition.z + actor->uActorHeight / 2, 0, 512,
-                pParty->getActiveCharacter());
+                pParty->activePlayerIndex());
     } else if (bow_idx) {
         shooting_bow = true;
-        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->getActiveCharacter() - 1, 0, 0, 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activePlayerIndex() - 1, 0, 0, 0);
     } else {
         melee_attack = true;
         // ; // actor out of range or no actor; no ranged weapon so melee

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -611,8 +611,8 @@ int Player::CreateItemInInventory(unsigned int uSlot, ITEM_TYPE uItemID) {
     signed int freeSlot = findFreeInventoryListSlot();
 
     if (freeSlot == -1) {  // no room
-        if (pParty->hasActivePlayer()) {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
+        if (pParty->hasActiveCharacter()) {
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NoRoom);
         }
 
         return 0;
@@ -2352,7 +2352,7 @@ bool Player::Recover(GameTime dt) {
     } else {
         uTimeToRecovery = 0;  // recovered
 
-        if (!pParty->hasActivePlayer())  // set recoverd char as active
+        if (!pParty->hasActiveCharacter())  // set recoverd char as active
             pParty->switchToNextActiveCharacter();
 
         return false;
@@ -2366,7 +2366,7 @@ void Player::SetRecoveryTime(signed int rec) {
 
     if (rec > uTimeToRecovery) uTimeToRecovery = rec;
 
-    if (pParty->hasActivePlayer() && pPlayers[pParty->activePlayerIndex()] == this &&
+    if (pParty->hasActiveCharacter() && pPlayers[pParty->activeCharacterIndex()] == this &&
         !enchantingActiveCharacter)
         pParty->switchToNextActiveCharacter();
 }
@@ -6232,21 +6232,21 @@ void Player::EquipBody(ITEM_EQUIP_TYPE uEquipType) {
 
     tempPickedItem.Reset();
     itemAnchor = pEquipTypeToBodyAnchor[uEquipType];
-    itemInvLocation = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor];
+    itemInvLocation = pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[itemAnchor];
     if (itemInvLocation) {  //переодеться в другую вещь
         tempPickedItem = pParty->pPickedItem;
-        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1].uBodyAnchor = ITEM_SLOT_INVALID;
+        pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[itemInvLocation - 1].uBodyAnchor = ITEM_SLOT_INVALID;
         pParty->pPickedItem.Reset();
-        pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1]);
+        pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[itemInvLocation - 1]);
         tempPickedItem.uBodyAnchor = itemAnchor;
-        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[itemInvLocation - 1] = tempPickedItem;
-        pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor] = itemInvLocation;
+        pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[itemInvLocation - 1] = tempPickedItem;
+        pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[itemAnchor] = itemInvLocation;
     } else {  // одеть вещь
-        freeSlot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+        freeSlot = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
         if (freeSlot >= 0) {
             pParty->pPickedItem.uBodyAnchor = itemAnchor;
-            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeSlot] = pParty->pPickedItem;
-            pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[itemAnchor] = freeSlot + 1;
+            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeSlot] = pParty->pPickedItem;
+            pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[itemAnchor] = freeSlot + 1;
             mouse->RemoveHoldingItem();
         }
     }
@@ -6260,12 +6260,12 @@ int CycleCharacter(bool backwards) {
 
     for (int i = 0; i < (PARTYSIZE - 1); i++) {
         int currCharId =
-            ((pParty->activePlayerIndex() + mult * i + valToAdd) % PARTYSIZE) + 1;
+            ((pParty->activeCharacterIndex() + mult * i + valToAdd) % PARTYSIZE) + 1;
         if (pPlayers[currCharId]->uTimeToRecovery == 0) {
             return currCharId;
         }
     }
-    return pParty->activePlayerIndex();
+    return pParty->activeCharacterIndex();
 }
 
 bool Player::hasUnderwaterSuitEquipped() {
@@ -6753,14 +6753,14 @@ void Player::OnInventoryLeftClick() {
                     /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
                      *0x7Fu;
                      *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                     *pParty->activePlayerIndex() - 1;
+                     *pParty->activeCharacterIndex() - 1;
                      *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                      *enchantedItemPos - 1;
                      *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                      *invMatrixIndex;*/
                     pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
                     pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-                    pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
+                    pSpellInfo->uPlayerID_2 = pParty->activeCharacterIndex() - 1;
                     pSpellInfo->spell_target_pid = enchantedItemPos - 1;
                     pSpellInfo->field_6 = this->GetItemMainInventoryIndex(invMatrixIndex);
                     ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
@@ -7076,8 +7076,8 @@ void Player::_42ECB5_PlayerAttacksActor() {
     //  unsigned int v12; // eax@47
     //  SoundID v24; // [sp-4h] [bp-40h]@58
 
-    // result = pParty->pPlayers[pParty->activePlayerIndex()-1].CanAct();
-    Player *player = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
+    // result = pParty->pPlayers[pParty->activeCharacterIndex()-1].CanAct();
+    Player *player = &pParty->pPlayers[pParty->activeCharacterIndex() - 1];
     if (!player->CanAct()) return;
 
     CastSpellInfoHelpers::cancelSpellCastInProgress();
@@ -7152,14 +7152,14 @@ void Player::_42ECB5_PlayerAttacksActor() {
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
         pushSpellOrRangedAttack(SPELL_LASER_PROJECTILE,
-                                pParty->activePlayerIndex() - 1, 0, 0,
-                                pParty->activePlayerIndex() + 8);
+                                pParty->activeCharacterIndex() - 1, 0, 0,
+                                pParty->activeCharacterIndex() + 8);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         int main_hand_idx = player->pEquipment.uMainHand;
         pushSpellOrRangedAttack(wandSpellIds[player->pInventoryItemList[main_hand_idx - 1].uItemID],
-                                pParty->activePlayerIndex() - 1, 8, 0, pParty->activePlayerIndex() + 8);
+                                pParty->activeCharacterIndex() - 1, 8, 0, pParty->activeCharacterIndex() + 8);
 
         if (!--player->pInventoryItemList[main_hand_idx - 1].uNumCharges)
             player->pEquipment.uMainHand = 0;
@@ -7169,17 +7169,17 @@ void Player::_42ECB5_PlayerAttacksActor() {
         Vec3i a3 = actor->vPosition - pParty->vPosition;
         normalize_to_fixpoint(&a3.x, &a3.y, &a3.z);
 
-        Actor::DamageMonsterFromParty(PID(OBJECT_Player, pParty->activePlayerIndex() - 1),
+        Actor::DamageMonsterFromParty(PID(OBJECT_Player, pParty->activeCharacterIndex() - 1),
                                       target_id, &a3);
         if (player->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_MAIN_HAND) ||
             player->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_OFF_HAND))
             _42FA66_do_explosive_impact(
                 actor->vPosition.x, actor->vPosition.y,
                 actor->vPosition.z + actor->uActorHeight / 2, 0, 512,
-                pParty->activePlayerIndex());
+                pParty->activeCharacterIndex());
     } else if (bow_idx) {
         shooting_bow = true;
-        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activePlayerIndex() - 1, 0, 0, 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, 0, 0, 0);
     } else {
         melee_attack = true;
         // ; // actor out of range or no actor; no ranged weapon so melee

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -156,6 +156,7 @@ class PlayerConditions {
     std::array<GameTime, 20> times_;
 };
 
+// TODO(eksekk): Rename to "Character" (incl. all methods and helper functions, and probably enums too)
 struct Player {
     static constexpr unsigned int INVENTORY_SLOTS_WIDTH = 14;
     static constexpr unsigned int INVENTORY_SLOTS_HEIGHT = 9;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -241,7 +241,7 @@ void Party::setHoldingItem(ItemGen *pItem) {
 void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems entering shops
     for (int i = 0; i < this->pPlayers.size(); ++i) {
         if (this->pPlayers[i].CanAct()) {
-            _activeCharacter = i + 1;
+            _activePlayer = i + 1;
             return;
         }
     }
@@ -252,15 +252,15 @@ void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems enteri
 //----- (0049370F) --------------------------------------------------------
 void Party::switchToNextActiveCharacter() {
     // avoid switching away from char that can act
-    if (hasActiveCharacter() && this->pPlayers[_activeCharacter - 1].CanAct() &&
-        this->pPlayers[_activeCharacter - 1].uTimeToRecovery < 1)
+    if (hasActivePlayer() && this->pPlayers[_activePlayer - 1].CanAct() &&
+        this->pPlayers[_activePlayer - 1].uTimeToRecovery < 1)
         return;
 
     if (pParty->bTurnBasedModeOn) {
         if (pTurnEngine->turn_stage != TE_ATTACK || PID_TYPE(pTurnEngine->pQueue[0].uPackedID) != OBJECT_Player) {
-            _activeCharacter = 0;
+            _activePlayer = 0;
         } else {
-            _activeCharacter = PID_ID(pTurnEngine->pQueue[0].uPackedID) + 1;
+            _activePlayer = PID_ID(pTurnEngine->pQueue[0].uPackedID) + 1;
         }
         return;
     }
@@ -277,7 +277,7 @@ void Party::switchToNextActiveCharacter() {
             playerAlreadyPicked[i] = true;
             if (i > 0) { // TODO(_) check if this condition really should be here. it is
                 // equal to the original source but still seems kind of weird
-                _activeCharacter = i + 1;
+                _activePlayer = i + 1;
                 return;
             }
             break;
@@ -295,7 +295,7 @@ void Party::switchToNextActiveCharacter() {
             }
         }
     }
-    _activeCharacter = v12;
+    _activePlayer = v12;
     return;
 }
 
@@ -640,7 +640,7 @@ void Party::Reset() {
 
     bTurnBasedModeOn = false;
 
-    pParty->_activeCharacter = 1;
+    pParty->_activePlayer = 1;
     for (int i = 0; i < pPlayers.size(); ++i) {
         ::pPlayers[i + 1] = &pPlayers[i];
     }
@@ -1083,9 +1083,9 @@ void Party::PickedItem_PlaceInInventory_or_Drop() {
     auto texture = assets->GetImage_ColorKey(pParty->pPickedItem.GetIconName());
 
     // check if active player has room in inventory
-    int inventIndex = ::pPlayers[pParty->_activeCharacter]->AddItem(-1, pParty->pPickedItem.uItemID);
-    if (pParty->_activeCharacter && inventIndex != 0) {
-        ::pPlayers[pParty->_activeCharacter]->pInventoryItemList[inventIndex - 1] = pParty->pPickedItem;
+    int inventIndex = ::pPlayers[pParty->_activePlayer]->AddItem(-1, pParty->pPickedItem.uItemID);
+    if (pParty->_activePlayer && inventIndex != 0) {
+        ::pPlayers[pParty->_activePlayer]->pInventoryItemList[inventIndex - 1] = pParty->pPickedItem;
         mouse->RemoveHoldingItem();
     } else {
         // see if any other char has room
@@ -1129,7 +1129,7 @@ void Party::PickedItem_PlaceInInventory_or_Drop() {
 bool Party::AddItemToParty(ItemGen *pItem) {
     int v10;        // eax@11
 
-    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->_activeCharacter = 0 and crash
+    assert(pParty->hasActivePlayer()); // code in this function couldn't handle pParty->_activePlayer = 0 and crash
 
     if (!pItemTable->pItems[pItem->uItemID].uItemID_Rep_St) {
         pItem->SetIdentified();
@@ -1138,7 +1138,7 @@ bool Party::AddItemToParty(ItemGen *pItem) {
     char *iconName = pItemTable->pItems[pItem->uItemID].pIconName;
     if (iconName) {
         auto texture = assets->GetImage_ColorKey(iconName);
-        int current_player = pParty->_activeCharacter - 1;
+        int current_player = pParty->_activePlayer - 1;
         for (int i = 0; i < pPlayers.size(); i++, current_player++) {
             if (current_player >= pPlayers.size()) {
                 current_player = 0;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -241,7 +241,7 @@ void Party::setHoldingItem(ItemGen *pItem) {
 void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems entering shops
     for (int i = 0; i < this->pPlayers.size(); ++i) {
         if (this->pPlayers[i].CanAct()) {
-            _activePlayer = i + 1;
+            _activeCharacter = i + 1;
             return;
         }
     }
@@ -252,15 +252,15 @@ void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems enteri
 //----- (0049370F) --------------------------------------------------------
 void Party::switchToNextActiveCharacter() {
     // avoid switching away from char that can act
-    if (hasActivePlayer() && this->pPlayers[_activePlayer - 1].CanAct() &&
-        this->pPlayers[_activePlayer - 1].uTimeToRecovery < 1)
+    if (hasActiveCharacter() && this->pPlayers[_activeCharacter - 1].CanAct() &&
+        this->pPlayers[_activeCharacter - 1].uTimeToRecovery < 1)
         return;
 
     if (pParty->bTurnBasedModeOn) {
         if (pTurnEngine->turn_stage != TE_ATTACK || PID_TYPE(pTurnEngine->pQueue[0].uPackedID) != OBJECT_Player) {
-            _activePlayer = 0;
+            _activeCharacter = 0;
         } else {
-            _activePlayer = PID_ID(pTurnEngine->pQueue[0].uPackedID) + 1;
+            _activeCharacter = PID_ID(pTurnEngine->pQueue[0].uPackedID) + 1;
         }
         return;
     }
@@ -277,7 +277,7 @@ void Party::switchToNextActiveCharacter() {
             playerAlreadyPicked[i] = true;
             if (i > 0) { // TODO(_) check if this condition really should be here. it is
                 // equal to the original source but still seems kind of weird
-                _activePlayer = i + 1;
+                _activeCharacter = i + 1;
                 return;
             }
             break;
@@ -295,7 +295,7 @@ void Party::switchToNextActiveCharacter() {
             }
         }
     }
-    _activePlayer = v12;
+    _activeCharacter = v12;
     return;
 }
 
@@ -640,7 +640,7 @@ void Party::Reset() {
 
     bTurnBasedModeOn = false;
 
-    pParty->_activePlayer = 1;
+    pParty->_activeCharacter = 1;
     for (int i = 0; i < pPlayers.size(); ++i) {
         ::pPlayers[i + 1] = &pPlayers[i];
     }
@@ -1083,9 +1083,9 @@ void Party::PickedItem_PlaceInInventory_or_Drop() {
     auto texture = assets->GetImage_ColorKey(pParty->pPickedItem.GetIconName());
 
     // check if active player has room in inventory
-    int inventIndex = ::pPlayers[pParty->_activePlayer]->AddItem(-1, pParty->pPickedItem.uItemID);
-    if (pParty->_activePlayer && inventIndex != 0) {
-        ::pPlayers[pParty->_activePlayer]->pInventoryItemList[inventIndex - 1] = pParty->pPickedItem;
+    int inventIndex = ::pPlayers[pParty->_activeCharacter]->AddItem(-1, pParty->pPickedItem.uItemID);
+    if (pParty->_activeCharacter && inventIndex != 0) {
+        ::pPlayers[pParty->_activeCharacter]->pInventoryItemList[inventIndex - 1] = pParty->pPickedItem;
         mouse->RemoveHoldingItem();
     } else {
         // see if any other char has room
@@ -1129,7 +1129,7 @@ void Party::PickedItem_PlaceInInventory_or_Drop() {
 bool Party::AddItemToParty(ItemGen *pItem) {
     int v10;        // eax@11
 
-    assert(pParty->hasActivePlayer()); // code in this function couldn't handle pParty->_activePlayer = 0 and crash
+    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->_activeCharacter = 0 and crash
 
     if (!pItemTable->pItems[pItem->uItemID].uItemID_Rep_St) {
         pItem->SetIdentified();
@@ -1138,7 +1138,7 @@ bool Party::AddItemToParty(ItemGen *pItem) {
     char *iconName = pItemTable->pItems[pItem->uItemID].pIconName;
     if (iconName) {
         auto texture = assets->GetImage_ColorKey(iconName);
-        int current_player = pParty->_activePlayer - 1;
+        int current_player = pParty->_activeCharacter - 1;
         for (int i = 0; i < pPlayers.size(); i++, current_player++) {
             if (current_player >= pPlayers.size()) {
                 current_player = 0;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -210,12 +210,12 @@ struct Party {
     void setHoldingItem(ItemGen *pItem);
 
     /**
-    * Sets _activePlayer to the first character that can act
+    * Sets _activeCharacter to the first character that can act
     * Added to fix some nzi access problems
     */
     void setActiveToFirstCanAct();
     /**
-    * Sets _activePlayer to the first active (recoverd) character
+    * Sets _activeCharacter to the first active (recoverd) character
     */
     void switchToNextActiveCharacter();
     bool _497FC5_check_party_perception_against_level();
@@ -474,22 +474,22 @@ struct Party {
 
     uint _roundingDt{ 0 };  // keeps track of rounding remainder for recovery
 
-    inline uint activePlayerIndex() const {
-        assert(hasActivePlayer());
-        return _activePlayer;
+    inline uint activeCharacterIndex() const {
+        assert(hasActiveCharacter());
+        return _activeCharacter;
     }
-    inline void setActivePlayerByIndex(uint id) {
+    inline void setActiveCharacterIndex(uint id) {
         assert(id >= 0 && id <= pPlayers.size());
-        _activePlayer = id;
+        _activeCharacter = id;
     }
-    inline bool hasActivePlayer() const {
-        return _activePlayer > 0;
+    inline bool hasActiveCharacter() const {
+        return _activeCharacter > 0;
     }
     // TODO(pskelton): function for returning ref pPlayers[pParty->getActiveCharacter()]
 
  private:
      // TODO(pskelton): change to signed int - make 0 based with -1 for none??
-     unsigned int _activePlayer;  // which character is active - 1 based; 0 for none
+     unsigned int _activeCharacter;  // which character is active - 1 based; 0 for none
 };
 
 extern Party *pParty;  // idb

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -210,12 +210,12 @@ struct Party {
     void setHoldingItem(ItemGen *pItem);
 
     /**
-    * Sets _activeCharacter to the first character that can act
+    * Sets _activePlayer to the first character that can act
     * Added to fix some nzi access problems
     */
     void setActiveToFirstCanAct();
     /**
-    * Sets _activeCharacter to the first active (recoverd) character
+    * Sets _activePlayer to the first active (recoverd) character
     */
     void switchToNextActiveCharacter();
     bool _497FC5_check_party_perception_against_level();
@@ -474,23 +474,22 @@ struct Party {
 
     uint _roundingDt{ 0 };  // keeps track of rounding remainder for recovery
 
-    inline uint getActiveCharacter() const {
-        assert(hasActiveCharacter());
-        return _activeCharacter;
+    inline uint activePlayerIndex() const {
+        assert(hasActivePlayer());
+        return _activePlayer;
     }
-    inline void setActiveCharacter(uint id) {
+    inline void setActivePlayerIndex(uint id) {
         assert(id >= 0 && id <= pPlayers.size());
-        _activeCharacter = id;
+        _activePlayer = id;
     }
-    inline bool hasActiveCharacter() const {
-        return _activeCharacter > 0;
+    inline bool hasActivePlayer() const {
+        return _activePlayer > 0;
     }
     // TODO(pskelton): function for returning ref pPlayers[pParty->getActiveCharacter()]
 
  private:
-     // TODO(pskelton): rename activePlayer
      // TODO(pskelton): change to signed int - make 0 based with -1 for none??
-     unsigned int _activeCharacter;  // which character is active - 1 based; 0 for none
+     unsigned int _activePlayer;  // which character is active - 1 based; 0 for none
 };
 
 extern Party *pParty;  // idb

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -478,7 +478,7 @@ struct Party {
         assert(hasActivePlayer());
         return _activePlayer;
     }
-    inline void setActivePlayerIndex(uint id) {
+    inline void setActivePlayerByIndex(uint id) {
         assert(id >= 0 && id <= pPlayers.size());
         _activePlayer = id;
     }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -147,7 +147,7 @@ void LoadGame(unsigned int uSlot) {
         }
     }
 
-    pParty->setActiveCharacter(0);
+    pParty->setActivePlayerIndex(0);
     pParty->setActiveToFirstCanAct();
 
 /*

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -147,7 +147,7 @@ void LoadGame(unsigned int uSlot) {
         }
     }
 
-    pParty->setActivePlayerIndex(0);
+    pParty->setActivePlayerByIndex(0);
     pParty->setActiveToFirstCanAct();
 
 /*

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -147,7 +147,7 @@ void LoadGame(unsigned int uSlot) {
         }
     }
 
-    pParty->setActivePlayerByIndex(0);
+    pParty->setActiveCharacterIndex(0);
     pParty->setActiveToFirstCanAct();
 
 /*

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -3174,7 +3174,7 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
         if (flags & ON_CAST_TargetedEnchantment) {
             pGUIWindow_CastTargetedSpell = pCastSpellInfo[result].GetCastSpellInInventoryWindow();
             IsEnchantingInProgress = true;
-            enchantingActiveCharacter = pParty->activePlayerIndex();
+            enchantingActiveCharacter = pParty->activeCharacterIndex();
             pParty->PickedItem_PlaceInInventory_or_Drop();
             return;
         }
@@ -3195,7 +3195,7 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
 void pushTempleSpell(SPELL_TYPE spell) {
     PLAYER_SKILL skill_value = ConstructSkillValue(PLAYER_SKILL_MASTERY_MASTER, pParty->uCurrentDayOfMonth % 7 + 1);
 
-    pushSpellOrRangedAttack(spell, pParty->activePlayerIndex() - 1, skill_value,
+    pushSpellOrRangedAttack(spell, pParty->activeCharacterIndex() - 1, skill_value,
                             ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
 }
 

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -3174,7 +3174,7 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
         if (flags & ON_CAST_TargetedEnchantment) {
             pGUIWindow_CastTargetedSpell = pCastSpellInfo[result].GetCastSpellInInventoryWindow();
             IsEnchantingInProgress = true;
-            enchantingActiveCharacter = pParty->getActiveCharacter();
+            enchantingActiveCharacter = pParty->activePlayerIndex();
             pParty->PickedItem_PlaceInInventory_or_Drop();
             return;
         }
@@ -3195,7 +3195,7 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
 void pushTempleSpell(SPELL_TYPE spell) {
     PLAYER_SKILL skill_value = ConstructSkillValue(PLAYER_SKILL_MASTERY_MASTER, pParty->uCurrentDayOfMonth % 7 + 1);
 
-    pushSpellOrRangedAttack(spell, pParty->getActiveCharacter() - 1, skill_value,
+    pushSpellOrRangedAttack(spell, pParty->activePlayerIndex() - 1, skill_value,
                             ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
 }
 

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -80,10 +80,10 @@ void stru262_TurnBased::SortTurnQueue() {
     }
     uActorQueueSize = active_actors;
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player) {  // we have player at queue top
-        pParty->setActiveCharacter(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
         flags |= TE_PLAYER_TURN;
     } else {
-        pParty->setActiveCharacter(0);
+        pParty->setActivePlayerIndex(0);
         flags &= ~TE_PLAYER_TURN;
     }
     for (i = 0; i < uActorQueueSize; ++i) {
@@ -391,9 +391,9 @@ void stru262_TurnBased::NextTurn() {
 
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActiveCharacter(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActiveCharacter(0);
+        pParty->setActivePlayerIndex(0);
 
     if (pending_actions) {
         pTurnEngine->flags |= TE_HAVE_PENDING_ACTIONS;
@@ -525,9 +525,9 @@ void stru262_TurnBased::_406457(int a2) {
     pQueue[a2].actor_initiative = v6;
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActiveCharacter(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActiveCharacter(0);
+        pParty->setActivePlayerIndex(0);
     while ((pQueue[0].actor_initiative > 0) && (turn_initiative > 0)) {
         for (i = 0; i < uActorQueueSize; ++i) {
             --pQueue[i].actor_initiative;
@@ -577,9 +577,9 @@ void stru262_TurnBased::_4065B0() {
     } else {
         StepTurnQueue();
         if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-            pParty->setActiveCharacter(PID_ID(pQueue[0].uPackedID) + 1);
+            pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
         else
-            pParty->setActiveCharacter(0);
+            pParty->setActivePlayerIndex(0);
     }
     for (i = 0; i < uActorQueueSize; ++i) AIAttacks(i);
 }
@@ -788,7 +788,7 @@ void stru262_TurnBased::ActorAISetMovementDecision() {
 
     this->ai_turn_timer = 64;
     dword_50C994 = 0;
-    pParty->setActiveCharacter(0);
+    pParty->setActivePlayerIndex(0);
     for (i = 0; i < uActorQueueSize; ++i) {
         if (PID_TYPE(pQueue[i].uPackedID) == OBJECT_Actor) {
             target_pid =

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -80,10 +80,10 @@ void stru262_TurnBased::SortTurnQueue() {
     }
     uActorQueueSize = active_actors;
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player) {  // we have player at queue top
-        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActiveCharacterIndex(PID_ID(pQueue[0].uPackedID) + 1);
         flags |= TE_PLAYER_TURN;
     } else {
-        pParty->setActivePlayerByIndex(0);
+        pParty->setActiveCharacterIndex(0);
         flags &= ~TE_PLAYER_TURN;
     }
     for (i = 0; i < uActorQueueSize; ++i) {
@@ -391,9 +391,9 @@ void stru262_TurnBased::NextTurn() {
 
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActiveCharacterIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActivePlayerByIndex(0);
+        pParty->setActiveCharacterIndex(0);
 
     if (pending_actions) {
         pTurnEngine->flags |= TE_HAVE_PENDING_ACTIONS;
@@ -525,9 +525,9 @@ void stru262_TurnBased::_406457(int a2) {
     pQueue[a2].actor_initiative = v6;
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActiveCharacterIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActivePlayerByIndex(0);
+        pParty->setActiveCharacterIndex(0);
     while ((pQueue[0].actor_initiative > 0) && (turn_initiative > 0)) {
         for (i = 0; i < uActorQueueSize; ++i) {
             --pQueue[i].actor_initiative;
@@ -577,9 +577,9 @@ void stru262_TurnBased::_4065B0() {
     } else {
         StepTurnQueue();
         if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-            pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
+            pParty->setActiveCharacterIndex(PID_ID(pQueue[0].uPackedID) + 1);
         else
-            pParty->setActivePlayerByIndex(0);
+            pParty->setActiveCharacterIndex(0);
     }
     for (i = 0; i < uActorQueueSize; ++i) AIAttacks(i);
 }
@@ -788,7 +788,7 @@ void stru262_TurnBased::ActorAISetMovementDecision() {
 
     this->ai_turn_timer = 64;
     dword_50C994 = 0;
-    pParty->setActivePlayerByIndex(0);
+    pParty->setActiveCharacterIndex(0);
     for (i = 0; i < uActorQueueSize; ++i) {
         if (PID_TYPE(pQueue[i].uPackedID) == OBJECT_Actor) {
             target_pid =

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -80,10 +80,10 @@ void stru262_TurnBased::SortTurnQueue() {
     }
     uActorQueueSize = active_actors;
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player) {  // we have player at queue top
-        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
         flags |= TE_PLAYER_TURN;
     } else {
-        pParty->setActivePlayerIndex(0);
+        pParty->setActivePlayerByIndex(0);
         flags &= ~TE_PLAYER_TURN;
     }
     for (i = 0; i < uActorQueueSize; ++i) {
@@ -391,9 +391,9 @@ void stru262_TurnBased::NextTurn() {
 
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActivePlayerIndex(0);
+        pParty->setActivePlayerByIndex(0);
 
     if (pending_actions) {
         pTurnEngine->flags |= TE_HAVE_PENDING_ACTIONS;
@@ -525,9 +525,9 @@ void stru262_TurnBased::_406457(int a2) {
     pQueue[a2].actor_initiative = v6;
     SortTurnQueue();
     if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-        pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
+        pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
     else
-        pParty->setActivePlayerIndex(0);
+        pParty->setActivePlayerByIndex(0);
     while ((pQueue[0].actor_initiative > 0) && (turn_initiative > 0)) {
         for (i = 0; i < uActorQueueSize; ++i) {
             --pQueue[i].actor_initiative;
@@ -577,9 +577,9 @@ void stru262_TurnBased::_4065B0() {
     } else {
         StepTurnQueue();
         if (PID_TYPE(pQueue[0].uPackedID) == OBJECT_Player)
-            pParty->setActivePlayerIndex(PID_ID(pQueue[0].uPackedID) + 1);
+            pParty->setActivePlayerByIndex(PID_ID(pQueue[0].uPackedID) + 1);
         else
-            pParty->setActivePlayerIndex(0);
+            pParty->setActivePlayerByIndex(0);
     }
     for (i = 0; i < uActorQueueSize; ++i) AIAttacks(i);
 }
@@ -788,7 +788,7 @@ void stru262_TurnBased::ActorAISetMovementDecision() {
 
     this->ai_turn_timer = 64;
     dword_50C994 = 0;
-    pParty->setActivePlayerIndex(0);
+    pParty->setActivePlayerByIndex(0);
     for (i = 0; i < uActorQueueSize; ++i) {
         if (PID_TYPE(pQueue[i].uPackedID) == OBJECT_Actor) {
             target_pid =

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -489,7 +489,7 @@ void GUIWindow::HouseDialogManager() {
         pNPCPortraits_y[0][0] / 480.0f,
         pDialogueNPCPortraits[v4]);
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
         if (pDialogueNPCCount == uNumDialogueNPCPortraits && uHouse_ExitPic) {
             render->DrawTextureNew(556 / 640.0f, 451 / 480.0f,
                 dialogue_ui_x_x_u);
@@ -1290,7 +1290,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
         case DIALOGUE_13_hiring_related:
             current_npc_text = BuildDialogueString(
                 pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                pParty->activePlayerIndex() - 1, 0, 0, 0
+                pParty->activeCharacterIndex() - 1, 0, 0, 0
             );
             NPCHireableDialogPrepare();
             dialogue_show_profession_details = false;
@@ -1354,20 +1354,20 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
             if (dialogue_show_profession_details) {
                 current_npc_text = BuildDialogueString(
                     pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                    pParty->activePlayerIndex() - 1, 0, 0, 0);
+                    pParty->activeCharacterIndex() - 1, 0, 0, 0);
             } else {
                 current_npc_text = BuildDialogueString(
                     pNPCStats->pProfessions[pCurrentNPCInfo->profession].pBenefits,
-                    pParty->activePlayerIndex() - 1, 0, 0, 0);
+                    pParty->activeCharacterIndex() - 1, 0, 0, 0);
             }
             dialogue_show_profession_details = ~dialogue_show_profession_details;
         } else {
             if (topic == DIALOGUE_79_mastery_teacher) {
                 if (guild_membership_approved) {
                     pParty->TakeGold(gold_transaction_amount);
-                    if (pParty->hasActivePlayer()) {
-                        pPlayers[pParty->activePlayerIndex()]->SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillMasteryInc);
+                    if (pParty->hasActiveCharacter()) {
+                        pPlayers[pParty->activeCharacterIndex()]->SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_SkillMasteryInc);
                     }
                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 }
@@ -1413,8 +1413,8 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
                         break;
                     }
                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
-                    if (pParty->hasActivePlayer()) {
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_JoinedGuild);
+                    if (pParty->hasActiveCharacter()) {
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_JoinedGuild);
                         BackToHouseMenu();
                         return;
                     }
@@ -1444,9 +1444,9 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
             uDialogueType = DIALOGUE_13_hiring_related;
             current_npc_text = BuildDialogueString(
                 pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                pParty->activePlayerIndex() - 1, 0, 0, 0);
-            if (pParty->hasActivePlayer()) {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughGold);
+                pParty->activeCharacterIndex() - 1, 0, 0, 0);
+            if (pParty->hasActiveCharacter()) {
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NotEnoughGold);
             }
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
             BackToHouseMenu();
@@ -1472,8 +1472,8 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     dialog_menu_id = DIALOGUE_MAIN;
 
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
-    if (pParty->hasActivePlayer()) {
-        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_HireNPC);
+    if (pParty->hasActiveCharacter()) {
+        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_HireNPC);
     }
 
     BackToHouseMenu();
@@ -1560,7 +1560,7 @@ void OracleDialogue() {
 std::string _4B254D_SkillMasteryTeacher(int trainerInfo) {
     uint8_t teacherLevel = (trainerInfo - 200) % 3;
     PLAYER_SKILL_TYPE skillBeingTaught = static_cast<PLAYER_SKILL_TYPE>((trainerInfo - 200) / 3);
-    Player *activePlayer = pPlayers[pParty->activePlayerIndex()];
+    Player *activePlayer = pPlayers[pParty->activeCharacterIndex()];
     PLAYER_CLASS_TYPE pClassType = activePlayer->classType;
     PLAYER_SKILL_MASTERY currClassMaxMastery = skillMaxMasteryPerClass[pClassType][skillBeingTaught];
     PLAYER_SKILL_MASTERY masteryLevelBeingTaught = dword_F8B1B0_MasteryBeingTaught = static_cast<PLAYER_SKILL_MASTERY>(teacherLevel + 2);
@@ -2360,7 +2360,7 @@ static std::string SeekKnowledgeElswhereString(Player *player) {
 }
 
 void SeekKnowledgeElswhereDialogueOption(GUIWindow *dialogue, Player *player) {
-    std::string str = SeekKnowledgeElswhereString(pPlayers[pParty->activePlayerIndex()]);
+    std::string str = SeekKnowledgeElswhereString(pPlayers[pParty->activeCharacterIndex()]);
     int text_height = pFontArrus->CalcTextHeight(str, dialogue->uFrameWidth, 0);
 
     dialogue->DrawTitleText(pFontArrus, 0, (174 - text_height) / 2 + 138, colorTable.PaleCanary.c16(), str, 3);
@@ -2376,7 +2376,7 @@ void SkillTrainingDialogue(
     if (!num_skills_avaiable) {
         SeekKnowledgeElswhereDialogueOption(
             dialogue,
-            pPlayers[pParty->activePlayerIndex()]
+            pPlayers[pParty->activeCharacterIndex()]
         );
 
         return;
@@ -2420,8 +2420,8 @@ void SkillTrainingDialogue(
                 (DIALOGUE_TYPE)pButton->msg_param
             );
 
-            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill_id] == PLAYER_SKILL_MASTERY_NONE
-                || pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill_id]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill_id] == PLAYER_SKILL_MASTERY_NONE
+                || pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill_id]) {
                 pButton->uW = 0;
                 pButton->uHeight = 0;
                 pButton->uY = 0;
@@ -2458,11 +2458,11 @@ const char *GetJoinGuildDialogueOption(GUILD_ID guild_id) {
     gold_transaction_amount = price_for_membership[guild_id];
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActivePlayer())
+    if (!pParty->hasActiveCharacter())
         pParty->setActiveToFirstCanAct();  // avoid nzi
 
-    if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
-        if (_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, dword_F8B1AC_award_bit_number)) {
+    if (pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
+        if (_449B57_test_bit(pPlayers[pParty->activeCharacterIndex()]->_achieved_awards_bits, dword_F8B1AC_award_bit_number)) {
             return pNPCTopics[dialogue_base + 13].pText;
         } else {
             if (gold_transaction_amount <= pParty->GetGold()) {

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -489,7 +489,7 @@ void GUIWindow::HouseDialogManager() {
         pNPCPortraits_y[0][0] / 480.0f,
         pDialogueNPCPortraits[v4]);
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-        CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
         if (pDialogueNPCCount == uNumDialogueNPCPortraits && uHouse_ExitPic) {
             render->DrawTextureNew(556 / 640.0f, 451 / 480.0f,
                 dialogue_ui_x_x_u);
@@ -1290,7 +1290,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
         case DIALOGUE_13_hiring_related:
             current_npc_text = BuildDialogueString(
                 pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                pParty->getActiveCharacter() - 1, 0, 0, 0
+                pParty->activePlayerIndex() - 1, 0, 0, 0
             );
             NPCHireableDialogPrepare();
             dialogue_show_profession_details = false;
@@ -1354,20 +1354,20 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
             if (dialogue_show_profession_details) {
                 current_npc_text = BuildDialogueString(
                     pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                    pParty->getActiveCharacter() - 1, 0, 0, 0);
+                    pParty->activePlayerIndex() - 1, 0, 0, 0);
             } else {
                 current_npc_text = BuildDialogueString(
                     pNPCStats->pProfessions[pCurrentNPCInfo->profession].pBenefits,
-                    pParty->getActiveCharacter() - 1, 0, 0, 0);
+                    pParty->activePlayerIndex() - 1, 0, 0, 0);
             }
             dialogue_show_profession_details = ~dialogue_show_profession_details;
         } else {
             if (topic == DIALOGUE_79_mastery_teacher) {
                 if (guild_membership_approved) {
                     pParty->TakeGold(gold_transaction_amount);
-                    if (pParty->hasActiveCharacter()) {
-                        pPlayers[pParty->getActiveCharacter()]->SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_SkillMasteryInc);
+                    if (pParty->hasActivePlayer()) {
+                        pPlayers[pParty->activePlayerIndex()]->SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillMasteryInc);
                     }
                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 }
@@ -1413,8 +1413,8 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
                         break;
                     }
                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
-                    if (pParty->hasActiveCharacter()) {
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_JoinedGuild);
+                    if (pParty->hasActivePlayer()) {
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_JoinedGuild);
                         BackToHouseMenu();
                         return;
                     }
@@ -1444,9 +1444,9 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
             uDialogueType = DIALOGUE_13_hiring_related;
             current_npc_text = BuildDialogueString(
                 pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                pParty->getActiveCharacter() - 1, 0, 0, 0);
-            if (pParty->hasActiveCharacter()) {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NotEnoughGold);
+                pParty->activePlayerIndex() - 1, 0, 0, 0);
+            if (pParty->hasActivePlayer()) {
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughGold);
             }
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
             BackToHouseMenu();
@@ -1472,8 +1472,8 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     dialog_menu_id = DIALOGUE_MAIN;
 
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
-    if (pParty->hasActiveCharacter()) {
-        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_HireNPC);
+    if (pParty->hasActivePlayer()) {
+        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_HireNPC);
     }
 
     BackToHouseMenu();
@@ -1560,7 +1560,7 @@ void OracleDialogue() {
 std::string _4B254D_SkillMasteryTeacher(int trainerInfo) {
     uint8_t teacherLevel = (trainerInfo - 200) % 3;
     PLAYER_SKILL_TYPE skillBeingTaught = static_cast<PLAYER_SKILL_TYPE>((trainerInfo - 200) / 3);
-    Player *activePlayer = pPlayers[pParty->getActiveCharacter()];
+    Player *activePlayer = pPlayers[pParty->activePlayerIndex()];
     PLAYER_CLASS_TYPE pClassType = activePlayer->classType;
     PLAYER_SKILL_MASTERY currClassMaxMastery = skillMaxMasteryPerClass[pClassType][skillBeingTaught];
     PLAYER_SKILL_MASTERY masteryLevelBeingTaught = dword_F8B1B0_MasteryBeingTaught = static_cast<PLAYER_SKILL_MASTERY>(teacherLevel + 2);
@@ -2360,7 +2360,7 @@ static std::string SeekKnowledgeElswhereString(Player *player) {
 }
 
 void SeekKnowledgeElswhereDialogueOption(GUIWindow *dialogue, Player *player) {
-    std::string str = SeekKnowledgeElswhereString(pPlayers[pParty->getActiveCharacter()]);
+    std::string str = SeekKnowledgeElswhereString(pPlayers[pParty->activePlayerIndex()]);
     int text_height = pFontArrus->CalcTextHeight(str, dialogue->uFrameWidth, 0);
 
     dialogue->DrawTitleText(pFontArrus, 0, (174 - text_height) / 2 + 138, colorTable.PaleCanary.c16(), str, 3);
@@ -2376,7 +2376,7 @@ void SkillTrainingDialogue(
     if (!num_skills_avaiable) {
         SeekKnowledgeElswhereDialogueOption(
             dialogue,
-            pPlayers[pParty->getActiveCharacter()]
+            pPlayers[pParty->activePlayerIndex()]
         );
 
         return;
@@ -2420,8 +2420,8 @@ void SkillTrainingDialogue(
                 (DIALOGUE_TYPE)pButton->msg_param
             );
 
-            if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill_id] == PLAYER_SKILL_MASTERY_NONE
-                || pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill_id]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill_id] == PLAYER_SKILL_MASTERY_NONE
+                || pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill_id]) {
                 pButton->uW = 0;
                 pButton->uHeight = 0;
                 pButton->uY = 0;
@@ -2458,11 +2458,11 @@ const char *GetJoinGuildDialogueOption(GUILD_ID guild_id) {
     gold_transaction_amount = price_for_membership[guild_id];
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActiveCharacter())
+    if (!pParty->hasActivePlayer())
         pParty->setActiveToFirstCanAct();  // avoid nzi
 
-    if (pPlayers[pParty->getActiveCharacter()]->CanAct()) {
-        if (_449B57_test_bit(pPlayers[pParty->getActiveCharacter()]->_achieved_awards_bits, dword_F8B1AC_award_bit_number)) {
+    if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+        if (_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, dword_F8B1AC_award_bit_number)) {
             return pNPCTopics[dialogue_base + 13].pText;
         } else {
             if (gold_transaction_amount <= pParty->GetGold()) {

--- a/src/GUI/UI/Spellbook.cpp
+++ b/src/GUI/UI/Spellbook.cpp
@@ -67,7 +67,7 @@ GUIWindow_Spellbook::GUIWindow_Spellbook()
 
 void GUIWindow_Spellbook::OpenSpellbookPage(int page) {
     OnCloseSpellBookPage();
-    pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage = page;
+    pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage = page;
     OpenSpellbook();
     pAudioPlayer->playUISound(vrng->randomBool() ? SOUND_TurnPage2 : SOUND_TurnPage1);
 }
@@ -81,7 +81,7 @@ void GUIWindow_Spellbook::OpenSpellbook() {
     int a2;  // [sp+10h] [bp-8h]@1
     // int v7; // [sp+14h] [bp-4h]@1
 
-    pPlayer = pPlayers[pParty->getActiveCharacter()];
+    pPlayer = pPlayers[pParty->activePlayerIndex()];
     // pWindow = this;
     LoadSpellbook(pPlayer->lastOpenedSpellbookPage);
     // v3 = 0;
@@ -137,7 +137,7 @@ void GUIWindow_Spellbook::OpenSpellbook() {
 }
 
 void GUIWindow_Spellbook::Update() {
-    auto player = pPlayers[pParty->getActiveCharacter()];
+    auto player = pPlayers[pParty->activePlayerIndex()];
 
     Image *pTexture;        // edx@5
     int v10;                // eax@13
@@ -269,15 +269,15 @@ void LoadSpellbook(unsigned int spell_school) {
     byte_506550 = 0;
 
     // TODO(captainurist): encapsulate this enum arithmetic properly
-    if (pPlayers[pParty->getActiveCharacter()]->uQuickSpell != SPELL_NONE &&
-        (uint8_t)pPlayers[pParty->getActiveCharacter()]->uQuickSpell / 11 == spell_school)
+    if (pPlayers[pParty->activePlayerIndex()]->uQuickSpell != SPELL_NONE &&
+        (uint8_t)pPlayers[pParty->activePlayerIndex()]->uQuickSpell / 11 == spell_school)
         quick_spell_at_page =
-            (uint8_t)pPlayers[pParty->getActiveCharacter()]->uQuickSpell - 11 * spell_school;
+            (uint8_t)pPlayers[pParty->activePlayerIndex()]->uQuickSpell - 11 * spell_school;
     else
         quick_spell_at_page = 0;
 
     for (unsigned int i = 1; i <= 11; ++i) {
-        if (pPlayers[pParty->getActiveCharacter()]->spellbook.pChapters[spell_school].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
+        if (pPlayers[pParty->activePlayerIndex()]->spellbook.pChapters[spell_school].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
             char pContainer[20];
             sprintf(pContainer, "SB%sS%02d",
                     spellbook_texture_filename_suffices[spell_school],
@@ -294,8 +294,8 @@ void LoadSpellbook(unsigned int spell_school) {
 
 static void BookUI_Spellbook_DrawCurrentSchoolBackground() {
     int pTexID = 0;
-    if (pParty->hasActiveCharacter()) {
-        pTexID = pParty->pPlayers[pParty->getActiveCharacter() - 1].lastOpenedSpellbookPage;
+    if (pParty->hasActivePlayer()) {
+        pTexID = pParty->pPlayers[pParty->activePlayerIndex() - 1].lastOpenedSpellbookPage;
     }
     render->DrawTextureNew(8 / 640.0f, 8 / 480.0f,
                                 ui_spellbook_school_backgrounds[pTexID]);

--- a/src/GUI/UI/Spellbook.cpp
+++ b/src/GUI/UI/Spellbook.cpp
@@ -67,7 +67,7 @@ GUIWindow_Spellbook::GUIWindow_Spellbook()
 
 void GUIWindow_Spellbook::OpenSpellbookPage(int page) {
     OnCloseSpellBookPage();
-    pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage = page;
+    pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage = page;
     OpenSpellbook();
     pAudioPlayer->playUISound(vrng->randomBool() ? SOUND_TurnPage2 : SOUND_TurnPage1);
 }
@@ -81,7 +81,7 @@ void GUIWindow_Spellbook::OpenSpellbook() {
     int a2;  // [sp+10h] [bp-8h]@1
     // int v7; // [sp+14h] [bp-4h]@1
 
-    pPlayer = pPlayers[pParty->activePlayerIndex()];
+    pPlayer = pPlayers[pParty->activeCharacterIndex()];
     // pWindow = this;
     LoadSpellbook(pPlayer->lastOpenedSpellbookPage);
     // v3 = 0;
@@ -137,7 +137,7 @@ void GUIWindow_Spellbook::OpenSpellbook() {
 }
 
 void GUIWindow_Spellbook::Update() {
-    auto player = pPlayers[pParty->activePlayerIndex()];
+    auto player = pPlayers[pParty->activeCharacterIndex()];
 
     Image *pTexture;        // edx@5
     int v10;                // eax@13
@@ -269,15 +269,15 @@ void LoadSpellbook(unsigned int spell_school) {
     byte_506550 = 0;
 
     // TODO(captainurist): encapsulate this enum arithmetic properly
-    if (pPlayers[pParty->activePlayerIndex()]->uQuickSpell != SPELL_NONE &&
-        (uint8_t)pPlayers[pParty->activePlayerIndex()]->uQuickSpell / 11 == spell_school)
+    if (pPlayers[pParty->activeCharacterIndex()]->uQuickSpell != SPELL_NONE &&
+        (uint8_t)pPlayers[pParty->activeCharacterIndex()]->uQuickSpell / 11 == spell_school)
         quick_spell_at_page =
-            (uint8_t)pPlayers[pParty->activePlayerIndex()]->uQuickSpell - 11 * spell_school;
+            (uint8_t)pPlayers[pParty->activeCharacterIndex()]->uQuickSpell - 11 * spell_school;
     else
         quick_spell_at_page = 0;
 
     for (unsigned int i = 1; i <= 11; ++i) {
-        if (pPlayers[pParty->activePlayerIndex()]->spellbook.pChapters[spell_school].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
+        if (pPlayers[pParty->activeCharacterIndex()]->spellbook.pChapters[spell_school].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
             char pContainer[20];
             sprintf(pContainer, "SB%sS%02d",
                     spellbook_texture_filename_suffices[spell_school],
@@ -294,8 +294,8 @@ void LoadSpellbook(unsigned int spell_school) {
 
 static void BookUI_Spellbook_DrawCurrentSchoolBackground() {
     int pTexID = 0;
-    if (pParty->hasActivePlayer()) {
-        pTexID = pParty->pPlayers[pParty->activePlayerIndex() - 1].lastOpenedSpellbookPage;
+    if (pParty->hasActiveCharacter()) {
+        pTexID = pParty->pPlayers[pParty->activeCharacterIndex() - 1].lastOpenedSpellbookPage;
     }
     render->DrawTextureNew(8 / 640.0f, 8 / 480.0f,
                                 ui_spellbook_school_backgrounds[pTexID]);

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -613,7 +613,7 @@ GUIWindow_CharacterRecord::GUIWindow_CharacterRecord(
 }
 
 void GUIWindow_CharacterRecord::Update() {
-    auto player = pPlayers[pParty->getActiveCharacter()];
+    auto player = pPlayers[pParty->activePlayerIndex()];
 
     render->ClearZBuffer();
     switch (current_character_screen_window) {
@@ -628,7 +628,7 @@ void GUIWindow_CharacterRecord::Update() {
             break;
         }
         case WINDOW_CharacterWindow_Skills: {
-            if (dword_507CC0_activ_ch != pParty->getActiveCharacter()) {
+            if (dword_507CC0_activ_ch != pParty->activePlayerIndex()) {
                 CharacterUI_ReleaseButtons();
                 CharacterUI_SkillsTab_CreateButtons();
             }
@@ -1455,7 +1455,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
 
     int buttons_count = 0;
     if (dword_507CC0_activ_ch) CharacterUI_ReleaseButtons();
-    dword_507CC0_activ_ch = pParty->getActiveCharacter();
+    dword_507CC0_activ_ch = pParty->activePlayerIndex();
     for (GUIButton *pButton : pGUIWindow_CurrentMenu->vButtons) {
         if (pButton->msg == UIMSG_InventoryLeftClick) {
             dword_50698C_uX = pButton->uX;
@@ -1470,7 +1470,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
         buttons_count++;
     }
     int first_rows = 0;
-    Player *curr_player = &pParty->pPlayers[pParty->getActiveCharacter() - 1];
+    Player *curr_player = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
 
     int uCurrFontHeght = pFontLucida->GetHeight();
     int current_Y = 2 * uCurrFontHeght + 13;
@@ -1703,7 +1703,7 @@ bool awardSort(int i, int j) {
 
 //----- (00419100) --------------------------------------------------------
 void FillAwardsData() {
-    Player *pPlayer = pPlayers[pParty->getActiveCharacter()];
+    Player *pPlayer = pPlayers[pParty->activePlayerIndex()];
 
     memset(achieved_awards.data(), 0, 4000);
     num_achieved_awards = 0;
@@ -1831,10 +1831,10 @@ void OnPaperdollLeftClick() {
     int twohandedequip = 0;
     ItemGen _this;  // [sp+Ch] [bp-40h]@1
     _this.Reset();
-    int mainhandequip = pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand;
-    unsigned int shieldequip = pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand;
+    int mainhandequip = pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand;
+    unsigned int shieldequip = pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand;
 
-    if (mainhandequip && pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip - 1].GetItemEquipType() == EQUIP_TWO_HANDED) {
+    if (mainhandequip && pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip - 1].GetItemEquipType() == EQUIP_TWO_HANDED) {
         twohandedequip = mainhandequip;
     }
 
@@ -1847,8 +1847,8 @@ void OnPaperdollLeftClick() {
         if (pSkillType == PLAYER_SKILL_SPEAR) {
             if (shieldequip) {
                 // cant use spear in one hand till master
-                if (pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
 
                     return;
                 }
@@ -1857,23 +1857,23 @@ void OnPaperdollLeftClick() {
             }
         } else {
             if ((pSkillType == PLAYER_SKILL_SHIELD || pSkillType == PLAYER_SKILL_SWORD || pSkillType == PLAYER_SKILL_DAGGER) && mainhandequip &&
-                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip - 1].GetPlayerSkillType() == PLAYER_SKILL_SPEAR) {
+                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip - 1].GetPlayerSkillType() == PLAYER_SKILL_SPEAR) {
                 // cant use spear in one hand till master
-                if (pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
             }
         }
 
-        if (!pPlayers[pParty->getActiveCharacter()]->CanEquip_RaceAndAlignmentCheck(pickeditem)) {  // special item checks
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+        if (!pPlayers[pParty->activePlayerIndex()]->CanEquip_RaceAndAlignmentCheck(pickeditem)) {  // special item checks
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
             return;
         }
 
         if (pParty->pPickedItem.uItemID == ITEM_QUEST_WETSUIT) {  // wetsuit check is done above
-            pPlayers[pParty->getActiveCharacter()]->EquipBody(EQUIP_ARMOUR);
-            WetsuitOn(pParty->getActiveCharacter());
+            pPlayers[pParty->activePlayerIndex()]->EquipBody(EQUIP_ARMOUR);
+            WetsuitOn(pParty->activePlayerIndex());
             return;
         }
 
@@ -1887,28 +1887,28 @@ void OnPaperdollLeftClick() {
             case EQUIP_BOOTS:
             case EQUIP_AMULET:
 
-                if (!pPlayers[pParty->getActiveCharacter()]->HasSkill(pSkillType)) {  // hasnt got the skill to use that
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {  // hasnt got the skill to use that
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
 
-                if (pPlayers[pParty->getActiveCharacter()]->hasUnderwaterSuitEquipped() &&
+                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped() &&
                     (pEquipType != EQUIP_ARMOUR || engine->IsUnderwater())) {  // cant put anything on wearing wetsuit
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
 
-                pPlayers[pParty->getActiveCharacter()]->EquipBody(pEquipType);  // equips item
+                pPlayers[pParty->activePlayerIndex()]->EquipBody(pEquipType);  // equips item
 
                 if (pParty->pPickedItem.uItemID == ITEM_QUEST_WETSUIT) // just taken wetsuit off
-                    WetsuitOff(pParty->getActiveCharacter());
+                    WetsuitOff(pParty->activePlayerIndex());
 
                 return;
 
                 // ------------------------dress rings(одевание
                 // колец)----------------------------------
             case EQUIP_RING:
-                if (pPlayers[pParty->getActiveCharacter()]->hasUnderwaterSuitEquipped()) {  // cant put anything
+                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {  // cant put anything
                                                                                         // on wearing wetsuit
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
@@ -1919,12 +1919,12 @@ void OnPaperdollLeftClick() {
                     // equippos = 0;
 
                     for (ITEM_SLOT equippos : RingSlots()) {
-                        if (!pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[equippos]) {
-                            freeslot = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                        if (!pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[equippos]) {
+                            freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                             if (freeslot >= 0) {  // drop ring into free space
                                 pParty->pPickedItem.uBodyAnchor = equippos;
-                                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[equippos] = freeslot + 1;
+                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[equippos] = freeslot + 1;
                                 mouse->RemoveHoldingItem();
                                 return;
                             }
@@ -1932,14 +1932,14 @@ void OnPaperdollLeftClick() {
                     }
 
                     // cant fit rings so swap out
-                    freeslot = pPlayers[pParty->getActiveCharacter()]->pEquipment.uRings[5] - 1;  // slot of last ring
+                    freeslot = pPlayers[pParty->activePlayerIndex()]->pEquipment.uRings[5] - 1;  // slot of last ring
                     _this = pParty->pPickedItem;  // copy hold item to this
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();  // drop holding item
-                    pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
+                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
                     _this.uBodyAnchor = ITEM_SLOT_RING6;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = _this;  // swap from this in
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uRings[5] = freeslot + 1;  // anchor
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uRings[5] = freeslot + 1;  // anchor
                     return;
 
                 } else {  // rings displayed if in ring area
@@ -1953,25 +1953,25 @@ void OnPaperdollLeftClick() {
                     }
 
                     if (pos != ITEM_SLOT_INVALID) {  // we have a position to aim for
-                        pitem = pPlayers[pParty->getActiveCharacter()]->GetNthEquippedIndexItem(pos);
+                        pitem = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
                         if (!pitem) {  // no item in slot so just drop
-                            freeslot = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                            freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                             if (freeslot >= 0) {  // drop ring into free space
                                 pParty->pPickedItem.uBodyAnchor = pos;
-                                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pos] = freeslot + 1;
+                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] = freeslot + 1;
                                 mouse->RemoveHoldingItem();
                                 return;
                             }
                         } else {  // item so swap out
-                            freeslot = pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pos] - 1; // slot of ring selected
+                            freeslot = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] - 1; // slot of ring selected
                             _this = pParty->pPickedItem;  // copy hold item to this
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
                             pParty->pPickedItem.Reset();  // drop holding item
-                            pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
+                            pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
                             _this.uBodyAnchor = pos;
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = _this;  // swap from this in
-                            pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pos] = freeslot + 1;  // anchor
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
+                            pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] = freeslot + 1;  // anchor
                             return;
                         }
                     } else {  // not click on right area so exit
@@ -1984,128 +1984,128 @@ void OnPaperdollLeftClick() {
                 // ------------------dress shield(одеть
                 // щит)------------------------------------------------------
             case EQUIP_SHIELD:  //Щит
-                if (pPlayers[pParty->getActiveCharacter()]->hasUnderwaterSuitEquipped()) {  // в акваланге
+                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {  // в акваланге
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->getActiveCharacter()]->HasSkill(pSkillType)) {  // нет навыка
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {  // нет навыка
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 if (shieldequip) {  // смена щита щитом
                     --shieldequip;
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
                     _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip] = _this;
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = shieldequip + 1;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip] = _this;
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = shieldequip + 1;
                     if (twohandedequip == 0) {
                         return;
                     }
                 } else {
-                    freeslot = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                    freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                     if (freeslot < 0) return;
                     if (!twohandedequip) {  // обычная установка щита на пустую
                                             // руку
                         pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_OFF_HAND;
                         v17 = freeslot + 1;
-                        pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                        pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = v17;
+                        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                        pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = v17;
                         mouse->RemoveHoldingItem();
                         return;
                     }
                     mainhandequip--;  //ставим щит когда держит двуручный меч
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
                     _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = _this;
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = freeslot + 1;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = freeslot + 1;
                 }
-                pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = 0;
+                pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = 0;
                 return;
                 // -------------------------taken in hand(взять в
                 // руку)-------------------------------------------
             case EQUIP_SINGLE_HANDED:
             case EQUIP_WAND:
-                if (pPlayers[pParty->getActiveCharacter()]->hasUnderwaterSuitEquipped() &&
+                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped() &&
                     pParty->pPickedItem.uItemID != ITEM_BLASTER &&
                     pParty->pPickedItem.uItemID != ITEM_BLASTER_RIFLE) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->getActiveCharacter()]->HasSkill(pSkillType)) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 v50 = ITEM_NULL;
                 // dagger at expert or sword at master in left hand
-                if (pSkillType == PLAYER_SKILL_DAGGER && (pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_DAGGER) >= PLAYER_SKILL_MASTERY_EXPERT)
-                    || pSkillType == PLAYER_SKILL_SWORD && (pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_SWORD) >= PLAYER_SKILL_MASTERY_MASTER)) {
+                if (pSkillType == PLAYER_SKILL_DAGGER && (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_DAGGER) >= PLAYER_SKILL_MASTERY_EXPERT)
+                    || pSkillType == PLAYER_SKILL_SWORD && (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SWORD) >= PLAYER_SKILL_MASTERY_MASTER)) {
                     if ((signed int)mouse->uMouseX >= 560) {
                         if (!twohandedequip) {
                             if (shieldequip) {
                                 --shieldequip;
                                 _this = pParty->pPickedItem;
-                                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                                 pParty->pPickedItem.Reset();
-                                pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip]);
+                                pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
                                 _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip] = _this;
-                                pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = shieldequip + 1;
+                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip] = _this;
+                                pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = shieldequip + 1;
                                 if (pEquipType != EQUIP_WAND) {
                                     return;
                                 }
                                 v50 = _this.uItemID;
                                 break;
                             }
-                            v23 = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                            v23 = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                             if (v23 < 0) return;
                             pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v23] = pParty->pPickedItem;
-                            pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = v23 + 1;
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v23] = pParty->pPickedItem;
+                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = v23 + 1;
                             mouse->RemoveHoldingItem();
                             if (pEquipType != EQUIP_WAND) return;
-                            v50 = pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v23].uItemID;
+                            v50 = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v23].uItemID;
                             break;
                         }
                     }
                 }
                 if (!mainhandequip) {
-                    v26 = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                    v26 = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                     if (v26 < 0) return;
                     pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v26] = pParty->pPickedItem;
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = v26 + 1;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v26] = pParty->pPickedItem;
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = v26 + 1;
                     mouse->RemoveHoldingItem();
                     if (pEquipType != EQUIP_WAND) return;
                     break;
                 }
                 --mainhandequip;
                 _this = pParty->pPickedItem;
-                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                 pParty->pPickedItem.Reset();
-                pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip]);
+                pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
                 _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip] = _this;
-                pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = mainhandequip + 1;
+                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip] = _this;
+                pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = mainhandequip + 1;
                 if (pEquipType == EQUIP_WAND) v50 = _this.uItemID;
                 if (twohandedequip) {
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = 0;
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = 0;
                 }
                 break;
                 // ---------------------------take two hands(взять двумя
                 // руками)---------------------------------
             case EQUIP_TWO_HANDED:
-                if (pPlayers[pParty->getActiveCharacter()]->hasUnderwaterSuitEquipped()) {
+                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->getActiveCharacter()]->HasSkill(pSkillType)) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 if (mainhandequip) {  // взять двуручный меч когда нет
@@ -2116,30 +2116,30 @@ void OnPaperdollLeftClick() {
                     }
                     --mainhandequip;
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
                     _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[mainhandequip] = _this;
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = mainhandequip + 1;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip] = _this;
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = mainhandequip + 1;
                 } else {
-                    freeslot = pPlayers[pParty->getActiveCharacter()]->findFreeInventoryListSlot();
+                    freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
                     if (freeslot >= 0) {
                         if (shieldequip) {  // взять двуручный меч когда есть
                                             // щит(замещение щитом)
                             shieldequip--;
                             _this = pParty->pPickedItem;
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                             pParty->pPickedItem.Reset();
-                            pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[shieldequip]);
+                            pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
                             _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = _this;
-                            pPlayers[pParty->getActiveCharacter()]->pEquipment.uOffHand = 0;
-                            pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = freeslot + 1;
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;
+                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = 0;
+                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = freeslot + 1;
                         } else {
                             pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                            pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                            pPlayers[pParty->getActiveCharacter()]->pEquipment.uMainHand = freeslot + 1;
+                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = freeslot + 1;
                             mouse->RemoveHoldingItem();
                         }
                     }
@@ -2147,7 +2147,7 @@ void OnPaperdollLeftClick() {
                 return;
                 //-------------------------------------------------------------------------------
             default:
-                pPlayers[pParty->getActiveCharacter()]->useItem(pParty->getActiveCharacter() - 1, false);
+                pPlayers[pParty->activePlayerIndex()]->useItem(pParty->activePlayerIndex() - 1, false);
                 return;
         }
         return;
@@ -2165,14 +2165,14 @@ void OnPaperdollLeftClick() {
         if (mousex >= amuletx && mousex <= (amuletx + slot) &&
             mousey >= amulety && mousey <= (amulety + 2 * slot)) {
             // amulet
-            // pitem = pPlayers[pParty->getActiveCharacter()]->GetAmuletItem(); //9
+            // pitem = pPlayers[pParty->activePlayerIndex()]->GetAmuletItem(); //9
             pos = ITEM_SLOT_AMULET;
         }
 
         if (mousex >= glovex && mousex <= (glovex + slot) && mousey >= glovey &&
             mousey <= (glovey + 2 * slot)) {
             // glove
-            // pitem = pPlayers[pParty->getActiveCharacter()]->GetGloveItem(); //7
+            // pitem = pPlayers[pParty->activePlayerIndex()]->GetGloveItem(); //7
             pos = ITEM_SLOT_GAUTNLETS;
         }
 
@@ -2180,30 +2180,30 @@ void OnPaperdollLeftClick() {
             if (mousex >= RingsX[i] && mousex <= (RingsX[i] + slot) &&
                 mousey >= RingsY[i] && mousey <= (RingsY[i] + slot)) {
                 // ring
-                // pitem = pPlayers[pParty->getActiveCharacter()]->GetNthRingItem(i); //10+i
+                // pitem = pPlayers[pParty->activePlayerIndex()]->GetNthRingItem(i); //10+i
                 pos = RingSlot(i);
             }
         }
 
         if (pos != ITEM_SLOT_INVALID)
-            pitem = pPlayers[pParty->getActiveCharacter()]->GetNthEquippedIndexItem(pos);
+            pitem = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
 
         if (!pitem) return;
-        // pPlayers[pParty->getActiveCharacter()]->get
+        // pPlayers[pParty->activePlayerIndex()]->get
 
         // enchant / recharge item
         if (IsEnchantingInProgress) {
             /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
              *0x7Fu;//CastSpellInfo
              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-             *pParty->getActiveCharacter() - 1;
+             *pParty->activePlayerIndex() - 1;
              *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
              *pEquipType;*/
             pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
             pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-            pSpellInfo->uPlayerID_2 = pParty->getActiveCharacter() - 1;
-            pSpellInfo->spell_target_pid = pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pos];
+            pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
+            pSpellInfo->spell_target_pid = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos];
             pSpellInfo->field_6 = std::to_underlying(pitem->GetItemEquipType());
 
             ptr_50C9A4_ItemToEnchant = pitem;
@@ -2216,14 +2216,14 @@ void OnPaperdollLeftClick() {
         } else {
             if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
                 pParty->setHoldingItem(pitem);
-                pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pitem->uBodyAnchor] = 0;
+                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pitem->uBodyAnchor] = 0;
                 pitem->Reset();
 
-                // pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34
+                // pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34
                 // - 1]);
-                //  pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34
+                //  pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34
                 //  - 1].uBodyAnchor - 1] = 0;
-                //  pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 -
+                //  pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 -
                 //  1].Reset();
 
                 // return
@@ -2255,31 +2255,31 @@ void OnPaperdollLeftClick() {
         if (v34) {
             // v36 = v34 - 1;
             // v38 = &pPlayers[pParty->_activeCharacter]->pInventoryItemList[v34 - 1];
-            pEquipType = pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1].GetItemEquipType();
-            if (pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1].uItemID == ITEM_QUEST_WETSUIT) {
+            pEquipType = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].GetItemEquipType();
+            if (pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].uItemID == ITEM_QUEST_WETSUIT) {
                 if (engine->IsUnderwater()) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                WetsuitOff(pParty->getActiveCharacter());
+                WetsuitOff(pParty->activePlayerIndex());
             }
 
             if (IsEnchantingInProgress) {  // наложить закл на экипировку
                 /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
                  *0x7Fu;//CastSpellInfo
                  *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                 *pParty->getActiveCharacter() - 1;
+                 *pParty->activePlayerIndex() - 1;
                  *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
                  *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                  *pEquipType;*/
                 pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
                 pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-                pSpellInfo->uPlayerID_2 = pParty->getActiveCharacter() - 1;
+                pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
                 pSpellInfo->spell_target_pid = v34 - 1;
                 pSpellInfo->field_6 = std::to_underlying(pEquipType);
 
                 ptr_50C9A4_ItemToEnchant =
-                    &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1];
+                    &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1];
                 IsEnchantingInProgress = false;
                 pCurrentFrameMessageQueue->Flush();
                 mouse->SetCursorImage("MICON1");
@@ -2288,17 +2288,17 @@ void OnPaperdollLeftClick() {
                 AfterEnchClickEventTimeout = Timer::Second * 2;
             } else {
                 if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
-                    pParty->setHoldingItem(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1]);
-                    pPlayers[pParty->getActiveCharacter()]->pEquipment.pIndices[pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1].uBodyAnchor] = 0;
-                    pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v34 - 1].Reset();
+                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1]);
+                    pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].uBodyAnchor] = 0;
+                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].Reset();
                 }
             }
         } else {  // снять лук
-            if (pPlayers[pParty->getActiveCharacter()]->pEquipment.uBow) {
-                _this = pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pPlayers[pParty->getActiveCharacter()]->pEquipment.uBow - 1];
+            if (pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow) {
+                _this = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow - 1];
                 pParty->setHoldingItem(&_this);
                 _this.Reset();
-                pPlayers[pParty->getActiveCharacter()]->pEquipment.uBow = 0;
+                pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow = 0;
             }
         }
     }

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -613,7 +613,7 @@ GUIWindow_CharacterRecord::GUIWindow_CharacterRecord(
 }
 
 void GUIWindow_CharacterRecord::Update() {
-    auto player = pPlayers[pParty->activePlayerIndex()];
+    auto player = pPlayers[pParty->activeCharacterIndex()];
 
     render->ClearZBuffer();
     switch (current_character_screen_window) {
@@ -628,7 +628,7 @@ void GUIWindow_CharacterRecord::Update() {
             break;
         }
         case WINDOW_CharacterWindow_Skills: {
-            if (dword_507CC0_activ_ch != pParty->activePlayerIndex()) {
+            if (dword_507CC0_activ_ch != pParty->activeCharacterIndex()) {
                 CharacterUI_ReleaseButtons();
                 CharacterUI_SkillsTab_CreateButtons();
             }
@@ -1455,7 +1455,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
 
     int buttons_count = 0;
     if (dword_507CC0_activ_ch) CharacterUI_ReleaseButtons();
-    dword_507CC0_activ_ch = pParty->activePlayerIndex();
+    dword_507CC0_activ_ch = pParty->activeCharacterIndex();
     for (GUIButton *pButton : pGUIWindow_CurrentMenu->vButtons) {
         if (pButton->msg == UIMSG_InventoryLeftClick) {
             dword_50698C_uX = pButton->uX;
@@ -1470,7 +1470,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
         buttons_count++;
     }
     int first_rows = 0;
-    Player *curr_player = &pParty->pPlayers[pParty->activePlayerIndex() - 1];
+    Player *curr_player = &pParty->pPlayers[pParty->activeCharacterIndex() - 1];
 
     int uCurrFontHeght = pFontLucida->GetHeight();
     int current_Y = 2 * uCurrFontHeght + 13;
@@ -1703,7 +1703,7 @@ bool awardSort(int i, int j) {
 
 //----- (00419100) --------------------------------------------------------
 void FillAwardsData() {
-    Player *pPlayer = pPlayers[pParty->activePlayerIndex()];
+    Player *pPlayer = pPlayers[pParty->activeCharacterIndex()];
 
     memset(achieved_awards.data(), 0, 4000);
     num_achieved_awards = 0;
@@ -1831,10 +1831,10 @@ void OnPaperdollLeftClick() {
     int twohandedequip = 0;
     ItemGen _this;  // [sp+Ch] [bp-40h]@1
     _this.Reset();
-    int mainhandequip = pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand;
-    unsigned int shieldequip = pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand;
+    int mainhandequip = pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand;
+    unsigned int shieldequip = pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand;
 
-    if (mainhandequip && pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip - 1].GetItemEquipType() == EQUIP_TWO_HANDED) {
+    if (mainhandequip && pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip - 1].GetItemEquipType() == EQUIP_TWO_HANDED) {
         twohandedequip = mainhandequip;
     }
 
@@ -1847,8 +1847,8 @@ void OnPaperdollLeftClick() {
         if (pSkillType == PLAYER_SKILL_SPEAR) {
             if (shieldequip) {
                 // cant use spear in one hand till master
-                if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
 
                     return;
                 }
@@ -1857,23 +1857,23 @@ void OnPaperdollLeftClick() {
             }
         } else {
             if ((pSkillType == PLAYER_SKILL_SHIELD || pSkillType == PLAYER_SKILL_SWORD || pSkillType == PLAYER_SKILL_DAGGER) && mainhandequip &&
-                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip - 1].GetPlayerSkillType() == PLAYER_SKILL_SPEAR) {
+                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip - 1].GetPlayerSkillType() == PLAYER_SKILL_SPEAR) {
                 // cant use spear in one hand till master
-                if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_SPEAR) < PLAYER_SKILL_MASTERY_MASTER) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
             }
         }
 
-        if (!pPlayers[pParty->activePlayerIndex()]->CanEquip_RaceAndAlignmentCheck(pickeditem)) {  // special item checks
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+        if (!pPlayers[pParty->activeCharacterIndex()]->CanEquip_RaceAndAlignmentCheck(pickeditem)) {  // special item checks
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
             return;
         }
 
         if (pParty->pPickedItem.uItemID == ITEM_QUEST_WETSUIT) {  // wetsuit check is done above
-            pPlayers[pParty->activePlayerIndex()]->EquipBody(EQUIP_ARMOUR);
-            WetsuitOn(pParty->activePlayerIndex());
+            pPlayers[pParty->activeCharacterIndex()]->EquipBody(EQUIP_ARMOUR);
+            WetsuitOn(pParty->activeCharacterIndex());
             return;
         }
 
@@ -1887,28 +1887,28 @@ void OnPaperdollLeftClick() {
             case EQUIP_BOOTS:
             case EQUIP_AMULET:
 
-                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {  // hasnt got the skill to use that
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activeCharacterIndex()]->HasSkill(pSkillType)) {  // hasnt got the skill to use that
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
 
-                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped() &&
+                if (pPlayers[pParty->activeCharacterIndex()]->hasUnderwaterSuitEquipped() &&
                     (pEquipType != EQUIP_ARMOUR || engine->IsUnderwater())) {  // cant put anything on wearing wetsuit
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
 
-                pPlayers[pParty->activePlayerIndex()]->EquipBody(pEquipType);  // equips item
+                pPlayers[pParty->activeCharacterIndex()]->EquipBody(pEquipType);  // equips item
 
                 if (pParty->pPickedItem.uItemID == ITEM_QUEST_WETSUIT) // just taken wetsuit off
-                    WetsuitOff(pParty->activePlayerIndex());
+                    WetsuitOff(pParty->activeCharacterIndex());
 
                 return;
 
                 // ------------------------dress rings(одевание
                 // колец)----------------------------------
             case EQUIP_RING:
-                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {  // cant put anything
+                if (pPlayers[pParty->activeCharacterIndex()]->hasUnderwaterSuitEquipped()) {  // cant put anything
                                                                                         // on wearing wetsuit
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
@@ -1919,12 +1919,12 @@ void OnPaperdollLeftClick() {
                     // equippos = 0;
 
                     for (ITEM_SLOT equippos : RingSlots()) {
-                        if (!pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[equippos]) {
-                            freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                        if (!pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[equippos]) {
+                            freeslot = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                             if (freeslot >= 0) {  // drop ring into free space
                                 pParty->pPickedItem.uBodyAnchor = equippos;
-                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[equippos] = freeslot + 1;
+                                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                                pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[equippos] = freeslot + 1;
                                 mouse->RemoveHoldingItem();
                                 return;
                             }
@@ -1932,14 +1932,14 @@ void OnPaperdollLeftClick() {
                     }
 
                     // cant fit rings so swap out
-                    freeslot = pPlayers[pParty->activePlayerIndex()]->pEquipment.uRings[5] - 1;  // slot of last ring
+                    freeslot = pPlayers[pParty->activeCharacterIndex()]->pEquipment.uRings[5] - 1;  // slot of last ring
                     _this = pParty->pPickedItem;  // copy hold item to this
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();  // drop holding item
-                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
+                    pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
                     _this.uBodyAnchor = ITEM_SLOT_RING6;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uRings[5] = freeslot + 1;  // anchor
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uRings[5] = freeslot + 1;  // anchor
                     return;
 
                 } else {  // rings displayed if in ring area
@@ -1953,25 +1953,25 @@ void OnPaperdollLeftClick() {
                     }
 
                     if (pos != ITEM_SLOT_INVALID) {  // we have a position to aim for
-                        pitem = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
+                        pitem = pPlayers[pParty->activeCharacterIndex()]->GetNthEquippedIndexItem(pos);
                         if (!pitem) {  // no item in slot so just drop
-                            freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                            freeslot = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                             if (freeslot >= 0) {  // drop ring into free space
                                 pParty->pPickedItem.uBodyAnchor = pos;
-                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] = freeslot + 1;
+                                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                                pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pos] = freeslot + 1;
                                 mouse->RemoveHoldingItem();
                                 return;
                             }
                         } else {  // item so swap out
-                            freeslot = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] - 1; // slot of ring selected
+                            freeslot = pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pos] - 1; // slot of ring selected
                             _this = pParty->pPickedItem;  // copy hold item to this
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot].uBodyAnchor = ITEM_SLOT_INVALID;
                             pParty->pPickedItem.Reset();  // drop holding item
-                            pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
+                            pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot]); // set holding item to ring to swap out
                             _this.uBodyAnchor = pos;
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
-                            pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos] = freeslot + 1;  // anchor
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = _this;  // swap from this in
+                            pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pos] = freeslot + 1;  // anchor
                             return;
                         }
                     } else {  // not click on right area so exit
@@ -1984,128 +1984,128 @@ void OnPaperdollLeftClick() {
                 // ------------------dress shield(одеть
                 // щит)------------------------------------------------------
             case EQUIP_SHIELD:  //Щит
-                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {  // в акваланге
+                if (pPlayers[pParty->activeCharacterIndex()]->hasUnderwaterSuitEquipped()) {  // в акваланге
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {  // нет навыка
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activeCharacterIndex()]->HasSkill(pSkillType)) {  // нет навыка
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 if (shieldequip) {  // смена щита щитом
                     --shieldequip;
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip]);
                     _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip] = _this;
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = shieldequip + 1;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip] = _this;
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = shieldequip + 1;
                     if (twohandedequip == 0) {
                         return;
                     }
                 } else {
-                    freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                    freeslot = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                     if (freeslot < 0) return;
                     if (!twohandedequip) {  // обычная установка щита на пустую
                                             // руку
                         pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_OFF_HAND;
                         v17 = freeslot + 1;
-                        pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                        pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = v17;
+                        pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                        pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = v17;
                         mouse->RemoveHoldingItem();
                         return;
                     }
                     mainhandequip--;  //ставим щит когда держит двуручный меч
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip]);
                     _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = freeslot + 1;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = _this;
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = freeslot + 1;
                 }
-                pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = 0;
+                pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = 0;
                 return;
                 // -------------------------taken in hand(взять в
                 // руку)-------------------------------------------
             case EQUIP_SINGLE_HANDED:
             case EQUIP_WAND:
-                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped() &&
+                if (pPlayers[pParty->activeCharacterIndex()]->hasUnderwaterSuitEquipped() &&
                     pParty->pPickedItem.uItemID != ITEM_BLASTER &&
                     pParty->pPickedItem.uItemID != ITEM_BLASTER_RIFLE) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activeCharacterIndex()]->HasSkill(pSkillType)) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 v50 = ITEM_NULL;
                 // dagger at expert or sword at master in left hand
-                if (pSkillType == PLAYER_SKILL_DAGGER && (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_DAGGER) >= PLAYER_SKILL_MASTERY_EXPERT)
-                    || pSkillType == PLAYER_SKILL_SWORD && (pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_SWORD) >= PLAYER_SKILL_MASTERY_MASTER)) {
+                if (pSkillType == PLAYER_SKILL_DAGGER && (pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_DAGGER) >= PLAYER_SKILL_MASTERY_EXPERT)
+                    || pSkillType == PLAYER_SKILL_SWORD && (pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_SWORD) >= PLAYER_SKILL_MASTERY_MASTER)) {
                     if ((signed int)mouse->uMouseX >= 560) {
                         if (!twohandedequip) {
                             if (shieldequip) {
                                 --shieldequip;
                                 _this = pParty->pPickedItem;
-                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                                 pParty->pPickedItem.Reset();
-                                pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
+                                pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip]);
                                 _this.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip] = _this;
-                                pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = shieldequip + 1;
+                                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip] = _this;
+                                pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = shieldequip + 1;
                                 if (pEquipType != EQUIP_WAND) {
                                     return;
                                 }
                                 v50 = _this.uItemID;
                                 break;
                             }
-                            v23 = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                            v23 = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                             if (v23 < 0) return;
                             pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_OFF_HAND;
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v23] = pParty->pPickedItem;
-                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = v23 + 1;
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v23] = pParty->pPickedItem;
+                            pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = v23 + 1;
                             mouse->RemoveHoldingItem();
                             if (pEquipType != EQUIP_WAND) return;
-                            v50 = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v23].uItemID;
+                            v50 = pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v23].uItemID;
                             break;
                         }
                     }
                 }
                 if (!mainhandequip) {
-                    v26 = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                    v26 = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                     if (v26 < 0) return;
                     pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v26] = pParty->pPickedItem;
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = v26 + 1;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v26] = pParty->pPickedItem;
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = v26 + 1;
                     mouse->RemoveHoldingItem();
                     if (pEquipType != EQUIP_WAND) return;
                     break;
                 }
                 --mainhandequip;
                 _this = pParty->pPickedItem;
-                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                 pParty->pPickedItem.Reset();
-                pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
+                pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip]);
                 _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip] = _this;
-                pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = mainhandequip + 1;
+                pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip] = _this;
+                pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = mainhandequip + 1;
                 if (pEquipType == EQUIP_WAND) v50 = _this.uItemID;
                 if (twohandedequip) {
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = 0;
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = 0;
                 }
                 break;
                 // ---------------------------take two hands(взять двумя
                 // руками)---------------------------------
             case EQUIP_TWO_HANDED:
-                if (pPlayers[pParty->activePlayerIndex()]->hasUnderwaterSuitEquipped()) {
+                if (pPlayers[pParty->activeCharacterIndex()]->hasUnderwaterSuitEquipped()) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                if (!pPlayers[pParty->activePlayerIndex()]->HasSkill(pSkillType)) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_CantEquip);
+                if (!pPlayers[pParty->activeCharacterIndex()]->HasSkill(pSkillType)) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_CantEquip);
                     return;
                 }
                 if (mainhandequip) {  // взять двуручный меч когда нет
@@ -2116,30 +2116,30 @@ void OnPaperdollLeftClick() {
                     }
                     --mainhandequip;
                     _this = pParty->pPickedItem;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip].uBodyAnchor = ITEM_SLOT_INVALID;
                     pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip]);
+                    pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip]);
                     _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[mainhandequip] = _this;
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = mainhandequip + 1;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[mainhandequip] = _this;
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = mainhandequip + 1;
                 } else {
-                    freeslot = pPlayers[pParty->activePlayerIndex()]->findFreeInventoryListSlot();
+                    freeslot = pPlayers[pParty->activeCharacterIndex()]->findFreeInventoryListSlot();
                     if (freeslot >= 0) {
                         if (shieldequip) {  // взять двуручный меч когда есть
                                             // щит(замещение щитом)
                             shieldequip--;
                             _this = pParty->pPickedItem;
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip].uBodyAnchor = ITEM_SLOT_INVALID;
                             pParty->pPickedItem.Reset();
-                            pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[shieldequip]);
+                            pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[shieldequip]);
                             _this.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = _this;
-                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uOffHand = 0;
-                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = freeslot + 1;
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = _this;
+                            pPlayers[pParty->activeCharacterIndex()]->pEquipment.uOffHand = 0;
+                            pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = freeslot + 1;
                         } else {
                             pParty->pPickedItem.uBodyAnchor = ITEM_SLOT_MAIN_HAND;
-                            pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
-                            pPlayers[pParty->activePlayerIndex()]->pEquipment.uMainHand = freeslot + 1;
+                            pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[freeslot] = pParty->pPickedItem;
+                            pPlayers[pParty->activeCharacterIndex()]->pEquipment.uMainHand = freeslot + 1;
                             mouse->RemoveHoldingItem();
                         }
                     }
@@ -2147,7 +2147,7 @@ void OnPaperdollLeftClick() {
                 return;
                 //-------------------------------------------------------------------------------
             default:
-                pPlayers[pParty->activePlayerIndex()]->useItem(pParty->activePlayerIndex() - 1, false);
+                pPlayers[pParty->activeCharacterIndex()]->useItem(pParty->activeCharacterIndex() - 1, false);
                 return;
         }
         return;
@@ -2165,14 +2165,14 @@ void OnPaperdollLeftClick() {
         if (mousex >= amuletx && mousex <= (amuletx + slot) &&
             mousey >= amulety && mousey <= (amulety + 2 * slot)) {
             // amulet
-            // pitem = pPlayers[pParty->activePlayerIndex()]->GetAmuletItem(); //9
+            // pitem = pPlayers[pParty->activeCharacterIndex()]->GetAmuletItem(); //9
             pos = ITEM_SLOT_AMULET;
         }
 
         if (mousex >= glovex && mousex <= (glovex + slot) && mousey >= glovey &&
             mousey <= (glovey + 2 * slot)) {
             // glove
-            // pitem = pPlayers[pParty->activePlayerIndex()]->GetGloveItem(); //7
+            // pitem = pPlayers[pParty->activeCharacterIndex()]->GetGloveItem(); //7
             pos = ITEM_SLOT_GAUTNLETS;
         }
 
@@ -2180,30 +2180,30 @@ void OnPaperdollLeftClick() {
             if (mousex >= RingsX[i] && mousex <= (RingsX[i] + slot) &&
                 mousey >= RingsY[i] && mousey <= (RingsY[i] + slot)) {
                 // ring
-                // pitem = pPlayers[pParty->activePlayerIndex()]->GetNthRingItem(i); //10+i
+                // pitem = pPlayers[pParty->activeCharacterIndex()]->GetNthRingItem(i); //10+i
                 pos = RingSlot(i);
             }
         }
 
         if (pos != ITEM_SLOT_INVALID)
-            pitem = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
+            pitem = pPlayers[pParty->activeCharacterIndex()]->GetNthEquippedIndexItem(pos);
 
         if (!pitem) return;
-        // pPlayers[pParty->activePlayerIndex()]->get
+        // pPlayers[pParty->activeCharacterIndex()]->get
 
         // enchant / recharge item
         if (IsEnchantingInProgress) {
             /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
              *0x7Fu;//CastSpellInfo
              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-             *pParty->activePlayerIndex() - 1;
+             *pParty->activeCharacterIndex() - 1;
              *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
              *pEquipType;*/
             pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
             pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-            pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
-            pSpellInfo->spell_target_pid = pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pos];
+            pSpellInfo->uPlayerID_2 = pParty->activeCharacterIndex() - 1;
+            pSpellInfo->spell_target_pid = pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pos];
             pSpellInfo->field_6 = std::to_underlying(pitem->GetItemEquipType());
 
             ptr_50C9A4_ItemToEnchant = pitem;
@@ -2216,14 +2216,14 @@ void OnPaperdollLeftClick() {
         } else {
             if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
                 pParty->setHoldingItem(pitem);
-                pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pitem->uBodyAnchor] = 0;
+                pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pitem->uBodyAnchor] = 0;
                 pitem->Reset();
 
-                // pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34
+                // pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34
                 // - 1]);
-                //  pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34
+                //  pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34
                 //  - 1].uBodyAnchor - 1] = 0;
-                //  pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 -
+                //  pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 -
                 //  1].Reset();
 
                 // return
@@ -2255,31 +2255,31 @@ void OnPaperdollLeftClick() {
         if (v34) {
             // v36 = v34 - 1;
             // v38 = &pPlayers[pParty->_activeCharacter]->pInventoryItemList[v34 - 1];
-            pEquipType = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].GetItemEquipType();
-            if (pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].uItemID == ITEM_QUEST_WETSUIT) {
+            pEquipType = pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1].GetItemEquipType();
+            if (pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1].uItemID == ITEM_QUEST_WETSUIT) {
                 if (engine->IsUnderwater()) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
                 }
-                WetsuitOff(pParty->activePlayerIndex());
+                WetsuitOff(pParty->activeCharacterIndex());
             }
 
             if (IsEnchantingInProgress) {  // наложить закл на экипировку
                 /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
                  *0x7Fu;//CastSpellInfo
                  *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                 *pParty->activePlayerIndex() - 1;
+                 *pParty->activeCharacterIndex() - 1;
                  *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
                  *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
                  *pEquipType;*/
                 pSpellInfo = static_cast<CastSpellInfo *>(pGUIWindow_CastTargetedSpell->wData.ptr);
                 pSpellInfo->uFlags &= ~ON_CAST_TargetedEnchantment;
-                pSpellInfo->uPlayerID_2 = pParty->activePlayerIndex() - 1;
+                pSpellInfo->uPlayerID_2 = pParty->activeCharacterIndex() - 1;
                 pSpellInfo->spell_target_pid = v34 - 1;
                 pSpellInfo->field_6 = std::to_underlying(pEquipType);
 
                 ptr_50C9A4_ItemToEnchant =
-                    &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1];
+                    &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1];
                 IsEnchantingInProgress = false;
                 pCurrentFrameMessageQueue->Flush();
                 mouse->SetCursorImage("MICON1");
@@ -2288,17 +2288,17 @@ void OnPaperdollLeftClick() {
                 AfterEnchClickEventTimeout = Timer::Second * 2;
             } else {
                 if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
-                    pParty->setHoldingItem(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1]);
-                    pPlayers[pParty->activePlayerIndex()]->pEquipment.pIndices[pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].uBodyAnchor] = 0;
-                    pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v34 - 1].Reset();
+                    pParty->setHoldingItem(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1]);
+                    pPlayers[pParty->activeCharacterIndex()]->pEquipment.pIndices[pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1].uBodyAnchor] = 0;
+                    pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v34 - 1].Reset();
                 }
             }
         } else {  // снять лук
-            if (pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow) {
-                _this = pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow - 1];
+            if (pPlayers[pParty->activeCharacterIndex()]->pEquipment.uBow) {
+                _this = pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pPlayers[pParty->activeCharacterIndex()]->pEquipment.uBow - 1];
                 pParty->setHoldingItem(&_this);
                 _this.Reset();
-                pPlayers[pParty->activePlayerIndex()]->pEquipment.uBow = 0;
+                pPlayers[pParty->activeCharacterIndex()]->pEquipment.uBow = 0;
             }
         }
     }

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -34,7 +34,7 @@ void GUIWindow_Chest::Update() {
     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
         render->ClearZBuffer();
         draw_leather();
-        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
         render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f,
                                     pBtn_ExitCancel->uY / 480.0f,
                                     ui_exit_cancel_button_background);

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -34,7 +34,7 @@ void GUIWindow_Chest::Update() {
     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
         render->ClearZBuffer();
         draw_leather();
-        CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+        CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
         render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f,
                                     pBtn_ExitCancel->uY / 480.0f,
                                     ui_exit_cancel_button_background);

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -103,11 +103,11 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     pDialogueWindow->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
     pDialogueWindow->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4);
 
-    if (bPlayerSaysHello && pParty->hasActivePlayer() && !pNPCInfo->Hired()) {
+    if (bPlayerSaysHello && pParty->hasActiveCharacter() && !pNPCInfo->Hired()) {
         if (pParty->uCurrentHour < 5 || pParty->uCurrentHour > 21) {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_GoodEvening);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_GoodEvening);
         } else {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_GoodDay);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_GoodDay);
         }
     }
 }
@@ -589,8 +589,8 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
                     GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                     dialogue_show_profession_details = false;
                     uDialogueType = DIALOGUE_13_hiring_related;
-                    if (pParty->hasActivePlayer()) {
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughGold);
+                    if (pParty->hasActiveCharacter()) {
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NotEnoughGold);
                     }
                     if (!dword_7241C8) {
                         engine->Draw();
@@ -613,8 +613,8 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             if (sDialogue_SpeakingActorNPC_ID >= 0)
                 pDialogue_SpeakingActor->uAIState = Removed;
-            if (pParty->hasActivePlayer()) {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_HireNPC);
+            if (pParty->hasActiveCharacter()) {
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_HireNPC);
             }
         }
     } else if (option >= DIALOGUE_ARENA_SELECT_PAGE && option <= DIALOGUE_ARENA_SELECT_CHAMPION) {

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -103,11 +103,11 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     pDialogueWindow->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
     pDialogueWindow->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4);
 
-    if (bPlayerSaysHello && pParty->hasActiveCharacter() && !pNPCInfo->Hired()) {
+    if (bPlayerSaysHello && pParty->hasActivePlayer() && !pNPCInfo->Hired()) {
         if (pParty->uCurrentHour < 5 || pParty->uCurrentHour > 21) {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_GoodEvening);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_GoodEvening);
         } else {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_GoodDay);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_GoodDay);
         }
     }
 }
@@ -589,8 +589,8 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
                     GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                     dialogue_show_profession_details = false;
                     uDialogueType = DIALOGUE_13_hiring_related;
-                    if (pParty->hasActiveCharacter()) {
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NotEnoughGold);
+                    if (pParty->hasActivePlayer()) {
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NotEnoughGold);
                     }
                     if (!dword_7241C8) {
                         engine->Draw();
@@ -613,8 +613,8 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             if (sDialogue_SpeakingActorNPC_ID >= 0)
                 pDialogue_SpeakingActor->uAIState = Removed;
-            if (pParty->hasActiveCharacter()) {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_HireNPC);
+            if (pParty->hasActivePlayer()) {
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_HireNPC);
             }
         }
     } else if (option >= DIALOGUE_ARENA_SELECT_PAGE && option <= DIALOGUE_ARENA_SELECT_CHAMPION) {

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -574,25 +574,25 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
         }
 
         if (!player->CanAct()) {
-            player = pPlayers[pParty->activePlayerIndex()];
+            player = pPlayers[pParty->activeCharacterIndex()];
         }
-        if (player->CanAct() || !pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+        if (player->CanAct() || !pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
             player->playReaction(SPEECH_NoRoom);
         }
     }
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME) {
-        if (pParty->hasActivePlayer()) {
-            if (pParty->activePlayerIndex() != uPlayerID) {
+        if (pParty->hasActiveCharacter()) {
+            if (pParty->activeCharacterIndex() != uPlayerID) {
                 if (pPlayers[uPlayerID]->uTimeToRecovery || !pPlayers[uPlayerID]->CanAct()) {
                     return;
                 }
 
-                pParty->setActivePlayerByIndex(uPlayerID);
+                pParty->setActiveCharacterIndex(uPlayerID);
                 return;
             }
             pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(
-                pParty->activePlayerIndex(),
+                pParty->activeCharacterIndex(),
                 CURRENT_SCREEN::SCREEN_CHARACTERS);  // CharacterUI_Initialize(SCREEN_CHARACTERS);
             return;
         }
@@ -601,56 +601,56 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) return;
     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
-        if (pParty->activePlayerIndex() == uPlayerID) {
+        if (pParty->activeCharacterIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActivePlayerByIndex(uPlayerID);
+            pParty->setActiveCharacterIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActivePlayerByIndex(uPlayerID);
+        pParty->setActiveCharacterIndex(uPlayerID);
         return;
     }
     if (current_screen_type != CURRENT_SCREEN::SCREEN_HOUSE) {
         if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY || current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActivePlayerByIndex(uPlayerID);
+            pParty->setActiveCharacterIndex(uPlayerID);
             return;
         }
         if (current_screen_type != CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActivePlayerByIndex(uPlayerID);
+            pParty->setActiveCharacterIndex(uPlayerID);
             if (current_character_screen_window ==
                 WINDOW_CharacterWindow_Awards) {
                 FillAwardsData();
             }
             return;
         }
-        if (pParty->activePlayerIndex() == uPlayerID) {
+        if (pParty->activeCharacterIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActivePlayerByIndex(uPlayerID);
+            pParty->setActiveCharacterIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActivePlayerByIndex(uPlayerID);
+        pParty->setActiveCharacterIndex(uPlayerID);
         return;
     }
     if (window_SpeakInHouse->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
         return;
     }
 
-    if (pParty->activePlayerIndex() != uPlayerID) {
-        pParty->setActivePlayerByIndex(uPlayerID);
+    if (pParty->activeCharacterIndex() != uPlayerID) {
+        pParty->setActiveCharacterIndex(uPlayerID);
         return;
     }
 
     if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD || dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL) {
         current_character_screen_window = WINDOW_CharacterWindow_Inventory;
         pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(
-            pParty->activePlayerIndex(), CURRENT_SCREEN::SCREEN_SHOP_INVENTORY);  // CharacterUI_Initialize(SCREEN_SHOP_INVENTORY);
+            pParty->activeCharacterIndex(), CURRENT_SCREEN::SCREEN_SHOP_INVENTORY);  // CharacterUI_Initialize(SCREEN_SHOP_INVENTORY);
         return;
     }
 }
@@ -704,7 +704,7 @@ void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
                 popup_window.DrawTitleText(pFontArrus, 0, 12, colorTable.PaleCanary.c16(), NameAndTitle(pNPC), 3);
                 popup_window.uFrameWidth -= 24;
                 popup_window.uFrameZ = popup_window.uFrameX + popup_window.uFrameWidth - 1;
-                popup_window.DrawText(pFontArrus, {100, 36}, 0, BuildDialogueString((char *)lpsz, pParty->activePlayerIndex() - 1, 0, 0, 0));
+                popup_window.DrawText(pFontArrus, {100, 36}, 0, BuildDialogueString((char *)lpsz, pParty->activeCharacterIndex() - 1, 0, 0, 0));
             }
         }
     }
@@ -1123,11 +1123,11 @@ void GameUI_WritePointedObjectStatusString() {
                     // if (mouse.x <= 13 || mouse.x >= 462)
                     // return;
                     // testing =
-                    // pPlayers[pParty->activePlayerIndex()]->GetItemIDAtInventoryIndex(invmatrixindex);
+                    // pPlayers[pParty->activeCharacterIndex()]->GetItemIDAtInventoryIndex(invmatrixindex);
                     pItemGen =
-                        pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(
+                        pPlayers[pParty->activeCharacterIndex()]->GetItemAtInventoryIndex(
                             invmatrixindex);  // (ItemGen
-                                              // *)&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[testing
+                                              // *)&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[testing
                                               // - 1];
 
                     // TODO(captainurist): get rid of this std::to_underlying cast.
@@ -1135,7 +1135,7 @@ void GameUI_WritePointedObjectStatusString() {
                     // if (!pItemID)
                     // return;
                     // item =
-                    // &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID -
+                    // &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID -
                     // 1];
 
                     // v14 = render->pActiveZBuffer[pX +
@@ -1206,13 +1206,13 @@ void GameUI_WritePointedObjectStatusString() {
                         case 3:  // hovering over buttons
                             if (pButton->Contains(pX, pY)) {
                                 PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pButton->msg_param);
-                                PLAYER_SKILL_LEVEL skillLevel = pPlayers[pParty->activePlayerIndex()]->GetSkillLevel(skill);
+                                PLAYER_SKILL_LEVEL skillLevel = pPlayers[pParty->activeCharacterIndex()]->GetSkillLevel(skill);
                                 requiredSkillpoints = skillLevel + 1;
 
                                 if (skills_max_level[skill] <= skillLevel)
                                     GameUI_StatusBar_Set(localization->GetString(LSTR_SKILL_ALREADY_MASTERED));
-                                else if (pPlayers[pParty->activePlayerIndex()]->uSkillPoints < requiredSkillpoints)
-                                    GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints - pPlayers[pParty->activePlayerIndex()]->uSkillPoints));
+                                else if (pPlayers[pParty->activeCharacterIndex()]->uSkillPoints < requiredSkillpoints)
+                                    GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints - pPlayers[pParty->activeCharacterIndex()]->uSkillPoints));
                                 else
                                     GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_CLICKING_WILL_SPEND_POINTS, requiredSkillpoints));
 
@@ -1326,15 +1326,15 @@ void GameUI_WritePointedObjectStatusString() {
                              && pY >= pButton->uY && pY <= pButton->uW)
                              {
                              requiredSkillpoints =
-                             (pPlayers[pParty->activePlayerIndex()]->pActiveSkills[pButton->msg_param]
+                             (pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[pButton->msg_param]
                              & 0x3F) + 1;
 
                              std::string str;
-                             if (pPlayers[pParty->activePlayerIndex()]->uSkillPoints <
+                             if (pPlayers[pParty->activeCharacterIndex()]->uSkillPoints <
                              requiredSkillpoints)      str =
                              localization->FormatString(
                              LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints -
-                             pPlayers[pParty->activePlayerIndex()]->uSkillPoints);
+                             pPlayers[pParty->activeCharacterIndex()]->uSkillPoints);
                              else      str =
                              localization->FormatString(
                              LSTR_FMT_CLICKING_WILL_SPEND_POINTS, requiredSkillpoints);
@@ -1359,10 +1359,10 @@ void GameUI_WritePointedObjectStatusString() {
 
 //----- (0044158F) --------------------------------------------------------
 void GameUI_DrawCharacterSelectionFrame() {
-    if (pParty->hasActivePlayer())
+    if (pParty->hasActiveCharacter())
         render->DrawTextureNew(
             (pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing
-                 [pParty->activePlayerIndex() - 1] -
+                 [pParty->activeCharacterIndex() - 1] -
              9) /
                 640.0f,
             380 / 480.0f, game_ui_player_selection_frame);

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -588,7 +588,7 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
                     return;
                 }
 
-                pParty->setActivePlayerIndex(uPlayerID);
+                pParty->setActivePlayerByIndex(uPlayerID);
                 return;
             }
             pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(
@@ -604,22 +604,22 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
         if (pParty->activePlayerIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActivePlayerIndex(uPlayerID);
+            pParty->setActivePlayerByIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActivePlayerIndex(uPlayerID);
+        pParty->setActivePlayerByIndex(uPlayerID);
         return;
     }
     if (current_screen_type != CURRENT_SCREEN::SCREEN_HOUSE) {
         if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY || current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActivePlayerIndex(uPlayerID);
+            pParty->setActivePlayerByIndex(uPlayerID);
             return;
         }
         if (current_screen_type != CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActivePlayerIndex(uPlayerID);
+            pParty->setActivePlayerByIndex(uPlayerID);
             if (current_character_screen_window ==
                 WINDOW_CharacterWindow_Awards) {
                 FillAwardsData();
@@ -629,13 +629,13 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
         if (pParty->activePlayerIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActivePlayerIndex(uPlayerID);
+            pParty->setActivePlayerByIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActivePlayerIndex(uPlayerID);
+        pParty->setActivePlayerByIndex(uPlayerID);
         return;
     }
     if (window_SpeakInHouse->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
@@ -643,7 +643,7 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
     }
 
     if (pParty->activePlayerIndex() != uPlayerID) {
-        pParty->setActivePlayerIndex(uPlayerID);
+        pParty->setActivePlayerByIndex(uPlayerID);
         return;
     }
 

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -574,25 +574,25 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
         }
 
         if (!player->CanAct()) {
-            player = pPlayers[pParty->getActiveCharacter()];
+            player = pPlayers[pParty->activePlayerIndex()];
         }
-        if (player->CanAct() || !pPlayers[pParty->getActiveCharacter()]->CanAct()) {
+        if (player->CanAct() || !pPlayers[pParty->activePlayerIndex()]->CanAct()) {
             player->playReaction(SPEECH_NoRoom);
         }
     }
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME) {
-        if (pParty->hasActiveCharacter()) {
-            if (pParty->getActiveCharacter() != uPlayerID) {
+        if (pParty->hasActivePlayer()) {
+            if (pParty->activePlayerIndex() != uPlayerID) {
                 if (pPlayers[uPlayerID]->uTimeToRecovery || !pPlayers[uPlayerID]->CanAct()) {
                     return;
                 }
 
-                pParty->setActiveCharacter(uPlayerID);
+                pParty->setActivePlayerIndex(uPlayerID);
                 return;
             }
             pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(
-                pParty->getActiveCharacter(),
+                pParty->activePlayerIndex(),
                 CURRENT_SCREEN::SCREEN_CHARACTERS);  // CharacterUI_Initialize(SCREEN_CHARACTERS);
             return;
         }
@@ -601,56 +601,56 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SPELL_BOOK) return;
     if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
-        if (pParty->getActiveCharacter() == uPlayerID) {
+        if (pParty->activePlayerIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActiveCharacter(uPlayerID);
+            pParty->setActivePlayerIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActiveCharacter(uPlayerID);
+        pParty->setActivePlayerIndex(uPlayerID);
         return;
     }
     if (current_screen_type != CURRENT_SCREEN::SCREEN_HOUSE) {
         if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY || current_screen_type == CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActiveCharacter(uPlayerID);
+            pParty->setActivePlayerIndex(uPlayerID);
             return;
         }
         if (current_screen_type != CURRENT_SCREEN::SCREEN_CHEST_INVENTORY) {
-            pParty->setActiveCharacter(uPlayerID);
+            pParty->setActivePlayerIndex(uPlayerID);
             if (current_character_screen_window ==
                 WINDOW_CharacterWindow_Awards) {
                 FillAwardsData();
             }
             return;
         }
-        if (pParty->getActiveCharacter() == uPlayerID) {
+        if (pParty->activePlayerIndex() == uPlayerID) {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             current_screen_type = CURRENT_SCREEN::SCREEN_CHEST_INVENTORY;
-            pParty->setActiveCharacter(uPlayerID);
+            pParty->setActivePlayerIndex(uPlayerID);
             return;
         }
         if (pPlayers[uPlayerID]->uTimeToRecovery) {
             return;
         }
-        pParty->setActiveCharacter(uPlayerID);
+        pParty->setActivePlayerIndex(uPlayerID);
         return;
     }
     if (window_SpeakInHouse->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
         return;
     }
 
-    if (pParty->getActiveCharacter() != uPlayerID) {
-        pParty->setActiveCharacter(uPlayerID);
+    if (pParty->activePlayerIndex() != uPlayerID) {
+        pParty->setActivePlayerIndex(uPlayerID);
         return;
     }
 
     if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD || dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL) {
         current_character_screen_window = WINDOW_CharacterWindow_Inventory;
         pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(
-            pParty->getActiveCharacter(), CURRENT_SCREEN::SCREEN_SHOP_INVENTORY);  // CharacterUI_Initialize(SCREEN_SHOP_INVENTORY);
+            pParty->activePlayerIndex(), CURRENT_SCREEN::SCREEN_SHOP_INVENTORY);  // CharacterUI_Initialize(SCREEN_SHOP_INVENTORY);
         return;
     }
 }
@@ -704,7 +704,7 @@ void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
                 popup_window.DrawTitleText(pFontArrus, 0, 12, colorTable.PaleCanary.c16(), NameAndTitle(pNPC), 3);
                 popup_window.uFrameWidth -= 24;
                 popup_window.uFrameZ = popup_window.uFrameX + popup_window.uFrameWidth - 1;
-                popup_window.DrawText(pFontArrus, {100, 36}, 0, BuildDialogueString((char *)lpsz, pParty->getActiveCharacter() - 1, 0, 0, 0));
+                popup_window.DrawText(pFontArrus, {100, 36}, 0, BuildDialogueString((char *)lpsz, pParty->activePlayerIndex() - 1, 0, 0, 0));
             }
         }
     }
@@ -1123,11 +1123,11 @@ void GameUI_WritePointedObjectStatusString() {
                     // if (mouse.x <= 13 || mouse.x >= 462)
                     // return;
                     // testing =
-                    // pPlayers[pParty->getActiveCharacter()]->GetItemIDAtInventoryIndex(invmatrixindex);
+                    // pPlayers[pParty->activePlayerIndex()]->GetItemIDAtInventoryIndex(invmatrixindex);
                     pItemGen =
-                        pPlayers[pParty->getActiveCharacter()]->GetItemAtInventoryIndex(
+                        pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(
                             invmatrixindex);  // (ItemGen
-                                              // *)&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[testing
+                                              // *)&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[testing
                                               // - 1];
 
                     // TODO(captainurist): get rid of this std::to_underlying cast.
@@ -1135,7 +1135,7 @@ void GameUI_WritePointedObjectStatusString() {
                     // if (!pItemID)
                     // return;
                     // item =
-                    // &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID -
+                    // &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID -
                     // 1];
 
                     // v14 = render->pActiveZBuffer[pX +
@@ -1206,13 +1206,13 @@ void GameUI_WritePointedObjectStatusString() {
                         case 3:  // hovering over buttons
                             if (pButton->Contains(pX, pY)) {
                                 PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pButton->msg_param);
-                                PLAYER_SKILL_LEVEL skillLevel = pPlayers[pParty->getActiveCharacter()]->GetSkillLevel(skill);
+                                PLAYER_SKILL_LEVEL skillLevel = pPlayers[pParty->activePlayerIndex()]->GetSkillLevel(skill);
                                 requiredSkillpoints = skillLevel + 1;
 
                                 if (skills_max_level[skill] <= skillLevel)
                                     GameUI_StatusBar_Set(localization->GetString(LSTR_SKILL_ALREADY_MASTERED));
-                                else if (pPlayers[pParty->getActiveCharacter()]->uSkillPoints < requiredSkillpoints)
-                                    GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints - pPlayers[pParty->getActiveCharacter()]->uSkillPoints));
+                                else if (pPlayers[pParty->activePlayerIndex()]->uSkillPoints < requiredSkillpoints)
+                                    GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints - pPlayers[pParty->activePlayerIndex()]->uSkillPoints));
                                 else
                                     GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_CLICKING_WILL_SPEND_POINTS, requiredSkillpoints));
 
@@ -1326,15 +1326,15 @@ void GameUI_WritePointedObjectStatusString() {
                              && pY >= pButton->uY && pY <= pButton->uW)
                              {
                              requiredSkillpoints =
-                             (pPlayers[pParty->getActiveCharacter()]->pActiveSkills[pButton->msg_param]
+                             (pPlayers[pParty->activePlayerIndex()]->pActiveSkills[pButton->msg_param]
                              & 0x3F) + 1;
 
                              std::string str;
-                             if (pPlayers[pParty->getActiveCharacter()]->uSkillPoints <
+                             if (pPlayers[pParty->activePlayerIndex()]->uSkillPoints <
                              requiredSkillpoints)      str =
                              localization->FormatString(
                              LSTR_FMT_NEED_MORE_SKILL_POINTS, requiredSkillpoints -
-                             pPlayers[pParty->getActiveCharacter()]->uSkillPoints);
+                             pPlayers[pParty->activePlayerIndex()]->uSkillPoints);
                              else      str =
                              localization->FormatString(
                              LSTR_FMT_CLICKING_WILL_SPEND_POINTS, requiredSkillpoints);
@@ -1359,10 +1359,10 @@ void GameUI_WritePointedObjectStatusString() {
 
 //----- (0044158F) --------------------------------------------------------
 void GameUI_DrawCharacterSelectionFrame() {
-    if (pParty->hasActiveCharacter())
+    if (pParty->hasActivePlayer())
         render->DrawTextureNew(
             (pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing
-                 [pParty->getActiveCharacter() - 1] -
+                 [pParty->activePlayerIndex() - 1] -
              9) /
                 640.0f,
             380 / 480.0f, game_ui_player_selection_frame);

--- a/src/GUI/UI/UIGuilds.cpp
+++ b/src/GUI/UI/UIGuilds.cpp
@@ -38,11 +38,11 @@ void GuildDialog() {
     working_window.uFrameWidth = 148;
     working_window.uFrameZ = 334;
 
-    int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
+    int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activeCharacterIndex()],
                                                              p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {  // change to switch??
-        if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE])) {
+        if (!_449B57_test_bit(pPlayers[pParty->activeCharacterIndex()]->_achieved_awards_bits, guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE])) {
             // you must be a member
             pTextHeight = pFontArrus->CalcTextHeight(
                 pNPCTopics[121].pText, working_window.uFrameWidth, 0);
@@ -63,8 +63,8 @@ void GuildDialog() {
                 dialogopts++;
             } else {
                 PLAYER_SKILL_TYPE skill = GetLearningDialogueSkill((DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param);
-                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(localization->GetSkillName(skill), working_window.uFrameWidth, 0, 0);
                     dialogopts++;
                 }
@@ -125,9 +125,9 @@ void GuildDialog() {
 
                     if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->GetWidth()) {
                         if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->GetHeight())) || (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->GetHeight()))) {
-                            std::string str = BuildDialogueString(pMerchantsBuyPhrases[pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+                            std::string str = BuildDialogueString(pMerchantsBuyPhrases[pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                                              item, BuildingType_MagicShop, window_SpeakInHouse->wData.val, 2)],
-                                pParty->activePlayerIndex() - 1, item, window_SpeakInHouse->wData.val, 2);
+                                pParty->activeCharacterIndex() - 1, item, window_SpeakInHouse->wData.val, 2);
                             pTextHeight = pFontArrus->CalcTextHeight(str, working_window.uFrameWidth, 0);
                             working_window.DrawTitleText(pFontArrus, 0, (174 - pTextHeight) / 2 + 138, colorTable.White.c16(), str, 3);
                             return;

--- a/src/GUI/UI/UIGuilds.cpp
+++ b/src/GUI/UI/UIGuilds.cpp
@@ -38,11 +38,11 @@ void GuildDialog() {
     working_window.uFrameWidth = 148;
     working_window.uFrameZ = 334;
 
-    int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->getActiveCharacter()],
+    int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
                                                              p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {  // change to switch??
-        if (!_449B57_test_bit(pPlayers[pParty->getActiveCharacter()]->_achieved_awards_bits, guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE])) {
+        if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE])) {
             // you must be a member
             pTextHeight = pFontArrus->CalcTextHeight(
                 pNPCTopics[121].pText, working_window.uFrameWidth, 0);
@@ -63,8 +63,8 @@ void GuildDialog() {
                 dialogopts++;
             } else {
                 PLAYER_SKILL_TYPE skill = GetLearningDialogueSkill((DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param);
-                if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(localization->GetSkillName(skill), working_window.uFrameWidth, 0, 0);
                     dialogopts++;
                 }
@@ -125,9 +125,9 @@ void GuildDialog() {
 
                     if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->GetWidth()) {
                         if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->GetHeight())) || (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->GetHeight()))) {
-                            std::string str = BuildDialogueString(pMerchantsBuyPhrases[pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+                            std::string str = BuildDialogueString(pMerchantsBuyPhrases[pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                                              item, BuildingType_MagicShop, window_SpeakInHouse->wData.val, 2)],
-                                pParty->getActiveCharacter() - 1, item, window_SpeakInHouse->wData.val, 2);
+                                pParty->activePlayerIndex() - 1, item, window_SpeakInHouse->wData.val, 2);
                             pTextHeight = pFontArrus->CalcTextHeight(str, working_window.uFrameWidth, 0);
                             working_window.DrawTitleText(pFontArrus, 0, (174 - pTextHeight) / 2 + 138, colorTable.White.c16(), str, 3);
                             return;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -773,11 +773,11 @@ void InitializaDialogueOptions(BuildingType type) {
 
 
 bool HouseUI_CheckIfPlayerCanInteract() {
-    if (!pParty->hasActivePlayer()) {  // to avoid access zeroeleement
+    if (!pParty->hasActiveCharacter()) {  // to avoid access zeroeleement
         return false;
     }
 
-    if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+    if (pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
         pDialogueWindow->pNumPresenceButton = dword_F8B1E0;
         return true;
     } else {
@@ -789,7 +789,7 @@ bool HouseUI_CheckIfPlayerCanInteract() {
 
         std::string str = localization->FormatString(
             LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
+            pPlayers[pParty->activeCharacterIndex()]->pName.c_str(),
             localization->GetString(LSTR_DO_ANYTHING));
         window.DrawTitleText(
             pFontArrus, 0,
@@ -835,8 +835,8 @@ bool enterHouse(HOUSE_ID uHouseID) {
         }
 
         GameUI_SetStatusBar(LSTR_FMT_OPEN_TIME, uOpenTime, localization->GetAmPm(am_pm_flag_open), uCloseTime, localization->GetAmPm(am_pm_flag_close));
-        if (pParty->hasActivePlayer()) {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_StoreClosed);
+        if (pParty->hasActiveCharacter()) {
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_StoreClosed);
         }
 
         return 0;
@@ -886,10 +886,10 @@ bool enterHouse(HOUSE_ID uHouseID) {
             int membership = guild_membership_flags[uHouseID - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE];
 
             // TODO(pskelton): check this behaviour
-            if (!pParty->hasActivePlayer())  // avoid nzi
+            if (!pParty->hasActiveCharacter())  // avoid nzi
                 pParty->setActiveToFirstCanAct();
 
-            if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, membership)) {
+            if (!_449B57_test_bit(pPlayers[pParty->activeCharacterIndex()]->_achieved_awards_bits, membership)) {
                 PlayHouseSound(uHouseID, HouseSound_Greeting_2);
                 return 1;
             }
@@ -980,15 +980,15 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
         if (in_current_building_type == BuildingType_Training) {
             if (option == DIALOGUE_TRAINING_HALL_TRAIN) {
                 experience_for_next_level = 0;
-                if (pPlayers[pParty->activePlayerIndex()]->uLevel > 0) {
-                    for (uint i = 0; i < pPlayers[pParty->activePlayerIndex()]->uLevel;
+                if (pPlayers[pParty->activeCharacterIndex()]->uLevel > 0) {
+                    for (uint i = 0; i < pPlayers[pParty->activeCharacterIndex()]->uLevel;
                         i++)
                         experience_for_next_level += i + 1;
                 }
-                if (pPlayers[pParty->activePlayerIndex()]->uLevel <
+                if (pPlayers[pParty->activeCharacterIndex()]->uLevel <
                     pMaxLevelPerTrainingHallType
                     [window_SpeakInHouse->wData.val - 89] &&
-                    (int64_t)pPlayers[pParty->activePlayerIndex()]->uExperience <
+                    (int64_t)pPlayers[pParty->activeCharacterIndex()]->uExperience <
                     1000 * experience_for_next_level)  // test experience
                     return;
             }
@@ -1012,8 +1012,8 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
                 pBtn_ExitCancel = pDialogueWindow->CreateButton({526, 445}, {75, 33}, 1, 0,
                     UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_END_CONVERSATION), {ui_buttdesc2});
                 pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0);
-            } else if (pParty->hasActivePlayer()) {
-                if (!pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple())
+            } else if (pParty->hasActiveCharacter()) {
+                if (!pPlayers[pParty->activeCharacterIndex()]->IsPlayerHealableByTemple())
                     return;
             }
         }
@@ -1195,11 +1195,11 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
     default:
     {
         if (IsSkillLearningDialogue(option)) {
-            int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
+            int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activeCharacterIndex()],
                                                                          p2DEvents[window_SpeakInHouse->wData.val - 1]);  // ecx@227
             auto skill = GetLearningDialogueSkill(option);
-            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
-                if (!pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
+                if (!pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                     if (pParty->GetGold() < pPrice) {
                         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                         if (in_current_building_type == BuildingType_Training
@@ -1213,8 +1213,8 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
                     } else {
                         pParty->TakeGold(pPrice);
                         dword_F8B1E4 = 1;
-                        pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill] = 1;
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillLearned);
+                        pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill] = 1;
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_SkillLearned);
                     }
                 }
             }
@@ -1244,9 +1244,9 @@ void TravelByTransport() {
     travel_window.uFrameWidth = 143;
     travel_window.uFrameZ = 334;
 
-    assert(pParty->hasActivePlayer()); // code in this function couldn't handle pParty->activePlayerIndex() = 0 and crash
+    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->activeCharacterIndex() = 0 and crash
 
-    int pPrice = PriceCalculator::transportCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
+    int pPrice = PriceCalculator::transportCostForPlayer(&pParty->pPlayers[pParty->activeCharacterIndex()],
                                                          p2DEvents[window_SpeakInHouse->wData.val - 1]);
     int route_id = window_SpeakInHouse->wData.val - HOUSE_STABLES_HARMONDALE;
 
@@ -1373,7 +1373,7 @@ void TravelByTransport() {
                 }
 
                 RestAndHeal(24 * 60 * traveltimedays);
-                pPlayers[pParty->activePlayerIndex()]->playReaction(pSpeech);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(pSpeech);
                 pAudioPlayer->soundDrain();
                 while (HouseDialogPressCloseBtn()) {}
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
@@ -1501,8 +1501,8 @@ void TownHallDialog() {
 
                     pParty->TakeGold(sum);
                     pParty->TakeFine(sum);
-                    if (pParty->hasActivePlayer())
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_BankDeposit);
+                    if (pParty->hasActiveCharacter())
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_BankDeposit);
                 }
             }
         }
@@ -1567,8 +1567,8 @@ void BankDialog() {
             if (sum > 0) {
                 pParty->TakeGold(sum);
                 pParty->AddBankGold(sum);
-                if (pParty->hasActivePlayer()) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_BankDeposit);
+                if (pParty->hasActiveCharacter()) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_BankDeposit);
                 }
             }
         }
@@ -1637,13 +1637,13 @@ void TavernDialog() {
     dialog_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActivePlayer())  // avoid nzi
+    if (!pParty->hasActiveCharacter())  // avoid nzi
         pParty->setActiveToFirstCanAct();
 
     const _2devent &house = p2DEvents[window_SpeakInHouse->wData.val - 1];
 
-    int pPriceRoom = PriceCalculator::tavernRoomCostForPlayer(pPlayers[pParty->activePlayerIndex()], house);
-    int pPriceFood = PriceCalculator::tavernFoodCostForPlayer(pPlayers[pParty->activePlayerIndex()], house);
+    int pPriceRoom = PriceCalculator::tavernRoomCostForPlayer(pPlayers[pParty->activeCharacterIndex()], house);
+    int pPriceFood = PriceCalculator::tavernFoodCostForPlayer(pPlayers[pParty->activeCharacterIndex()], house);
 
     switch (dialog_menu_id) {
     case DIALOGUE_MAIN:
@@ -1816,7 +1816,7 @@ void TavernDialog() {
     {
         if (!HouseUI_CheckIfPlayerCanInteract()) return;
         pSkillCount = 0;
-        int pPriceSkill = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()], house);
+        int pPriceSkill = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activeCharacterIndex()], house);
         all_text_height = 0;
         for (int i = pDialogueWindow->pStartingPosActiveItem;
             i < pDialogueWindow->pStartingPosActiveItem +
@@ -1825,8 +1825,8 @@ void TavernDialog() {
             auto skill = GetLearningDialogueSkill(
                 (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
             );
-            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                 all_text_height = pFontArrus->CalcTextHeight(
                     localization->GetSkillName(skill),
                     dialog_window.uFrameWidth, 0);
@@ -1842,8 +1842,8 @@ void TavernDialog() {
         if ((double)pParty->GetFood() >=
             p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier) {
             GameUI_SetStatusBar(LSTR_RATIONS_FULL);
-            if (pParty->hasActivePlayer())
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PacksFull);
+            if (pParty->hasActiveCharacter())
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_PacksFull);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
@@ -1924,11 +1924,11 @@ void TempleDialog() {
     tample_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActivePlayer()) {  // avoid nzi
+    if (!pParty->hasActiveCharacter()) {  // avoid nzi
         pParty->setActiveToFirstCanAct();
     }
 
-    pPrice = PriceCalculator::templeHealingCostForPlayer(pPlayers[pParty->activePlayerIndex()],
+    pPrice = PriceCalculator::templeHealingCostForPlayer(pPlayers[pParty->activeCharacterIndex()],
                                                          p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
     if (dialog_menu_id == DIALOGUE_MAIN) {
         index = 1;
@@ -1936,7 +1936,7 @@ void TempleDialog() {
             pDialogueWindow->pStartingPosActiveItem);
         pButton->uHeight = 0;
         pButton->uY = 0;
-        if (pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple()) {
+        if (pPlayers[pParty->activeCharacterIndex()]->IsPlayerHealableByTemple()) {
             static std::string shop_option_container;
             shop_option_container =
                 fmt::format("{} {} {}",
@@ -1993,7 +1993,7 @@ void TempleDialog() {
     }
     //-------------------------------------------------
     if (dialog_menu_id == DIALOGUE_TEMPLE_HEAL) {
-        if (!pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple()) return;
+        if (!pPlayers[pParty->activeCharacterIndex()]->IsPlayerHealableByTemple()) return;
         if (pParty->GetGold() < pPrice) {
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
             PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_NotEnoughMoney);
@@ -2002,64 +2002,64 @@ void TempleDialog() {
         }
         pParty->TakeGold(pPrice);
 
-        pPlayers[pParty->activePlayerIndex()]->conditions.ResetAll();
-        pPlayers[pParty->activePlayerIndex()]->sHealth =
-            pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
-        pPlayers[pParty->activePlayerIndex()]->sMana =
-            pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
+        pPlayers[pParty->activeCharacterIndex()]->conditions.ResetAll();
+        pPlayers[pParty->activeCharacterIndex()]->sHealth =
+            pPlayers[pParty->activeCharacterIndex()]->GetMaxHealth();
+        pPlayers[pParty->activeCharacterIndex()]->sMana =
+            pPlayers[pParty->activeCharacterIndex()]->GetMaxMana();
 
         if (window_SpeakInHouse->wData.val != 78 &&
             (window_SpeakInHouse->wData.val <= 80 ||
             window_SpeakInHouse->wData.val > 82)) {
-            if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(Condition_Zombie)) {
+            if (pPlayers[pParty->activeCharacterIndex()]->conditions.Has(Condition_Zombie)) {
                 // если состояние зомби
-                pPlayers[pParty->activePlayerIndex()]->uCurrentFace =
-                    pPlayers[pParty->activePlayerIndex()]->uPrevFace;
-                pPlayers[pParty->activePlayerIndex()]->uVoiceID =
-                    pPlayers[pParty->activePlayerIndex()]->uPrevVoiceID;
+                pPlayers[pParty->activeCharacterIndex()]->uCurrentFace =
+                    pPlayers[pParty->activeCharacterIndex()]->uPrevFace;
+                pPlayers[pParty->activeCharacterIndex()]->uVoiceID =
+                    pPlayers[pParty->activeCharacterIndex()]->uPrevVoiceID;
                 GameUI_ReloadPlayerPortraits(
-                    pParty->activePlayerIndex() - 1,
-                    pPlayers[pParty->activePlayerIndex()]->uPrevFace);
+                    pParty->activeCharacterIndex() - 1,
+                    pPlayers[pParty->activeCharacterIndex()]->uPrevFace);
             }
             pAudioPlayer->playExclusiveSound(SOUND_heal);
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
-            pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_TempleHeal);
+            pOtherOverlayList->_4418B1(20, pParty->activeCharacterIndex() + 99, 0, 65536);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
-        if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(Condition_Zombie)) {
-            // LODWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie])
+        if (pPlayers[pParty->activeCharacterIndex()]->conditions.Has(Condition_Zombie)) {
+            // LODWORD(pPlayers[pParty->activeCharacterIndex()]->pConditions[Condition_Zombie])
             // =
-            // LODWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie]);
+            // LODWORD(pPlayers[pParty->activeCharacterIndex()]->pConditions[Condition_Zombie]);
         } else {
-            if (pPlayers[pParty->activePlayerIndex()]->conditions.HasNone({Condition_Eradicated, Condition_Petrified, Condition_Dead})) {
+            if (pPlayers[pParty->activeCharacterIndex()]->conditions.HasNone({Condition_Eradicated, Condition_Petrified, Condition_Dead})) {
                 pAudioPlayer->playExclusiveSound(SOUND_heal);
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
-                pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_TempleHeal);
+                pOtherOverlayList->_4418B1(20, pParty->activeCharacterIndex() + 99, 0, 65536);
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
-            pPlayers[pParty->activePlayerIndex()]->uPrevFace =
-                pPlayers[pParty->activePlayerIndex()]->uCurrentFace;
-            pPlayers[pParty->activePlayerIndex()]->uPrevVoiceID =
-                pPlayers[pParty->activePlayerIndex()]->uVoiceID;
-            pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Zombie, 1);
-            pPlayers[pParty->activePlayerIndex()]->uVoiceID =
-                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23;
-            pPlayers[pParty->activePlayerIndex()]->uCurrentFace =
-                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23;
+            pPlayers[pParty->activeCharacterIndex()]->uPrevFace =
+                pPlayers[pParty->activeCharacterIndex()]->uCurrentFace;
+            pPlayers[pParty->activeCharacterIndex()]->uPrevVoiceID =
+                pPlayers[pParty->activeCharacterIndex()]->uVoiceID;
+            pPlayers[pParty->activeCharacterIndex()]->SetCondition(Condition_Zombie, 1);
+            pPlayers[pParty->activeCharacterIndex()]->uVoiceID =
+                (pPlayers[pParty->activeCharacterIndex()]->GetSexByVoice() != 0) + 23;
+            pPlayers[pParty->activeCharacterIndex()]->uCurrentFace =
+                (pPlayers[pParty->activeCharacterIndex()]->GetSexByVoice() != 0) + 23;
             GameUI_ReloadPlayerPortraits(
-                pParty->activePlayerIndex() - 1,
-                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23);
-            pPlayers[pParty->activePlayerIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+                pParty->activeCharacterIndex() - 1,
+                (pPlayers[pParty->activeCharacterIndex()]->GetSexByVoice() != 0) + 23);
+            pPlayers[pParty->activeCharacterIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
             // v39 = (GUIWindow *)HIDWORD(pParty->uTimePlayed);
         }
-        // HIDWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie]) =
+        // HIDWORD(pPlayers[pParty->activeCharacterIndex()]->pConditions[Condition_Zombie]) =
         // (int)v39;
-        pPlayers[pParty->activePlayerIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+        pPlayers[pParty->activeCharacterIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
         pAudioPlayer->playExclusiveSound(SOUND_heal);
-        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
-        pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
+        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_TempleHeal);
+        pOtherOverlayList->_4418B1(20, pParty->activeCharacterIndex() + 99, 0, 65536);
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
@@ -2077,7 +2077,7 @@ void TempleDialog() {
                 ddm->uReputation = ddm->uReputation - 1;
                 if (ddm->uReputation - 1 < -5) ddm->uReputation = -5;
             }
-            if ((uint8_t)byte_F8B1EF[pParty->activePlayerIndex()] == pParty->uCurrentDayOfMonth % 7) {
+            if ((uint8_t)byte_F8B1EF[pParty->activeCharacterIndex()] == pParty->uCurrentDayOfMonth % 7) {
                 if (ddm->uReputation <= -5) {
                     pushTempleSpell(SPELL_AIR_WIZARD_EYE);
                 }
@@ -2094,8 +2094,8 @@ void TempleDialog() {
                     pushTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
                 }
             }
-            ++byte_F8B1EF[pParty->activePlayerIndex()];
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleDonate);
+            ++byte_F8B1EF[pParty->activeCharacterIndex()];
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_TempleDonate);
             GameUI_SetStatusBar(LSTR_THANK_YOU);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
@@ -2110,7 +2110,7 @@ void TempleDialog() {
     if (dialog_menu_id == DIALOGUE_LEARN_SKILLS) {
         if (HouseUI_CheckIfPlayerCanInteract()) {
             all_text_height = 0;
-            v64 = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
+            v64 = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activeCharacterIndex()],
                                                               p2DEvents[window_SpeakInHouse->wData.val - 1]);
             pCurrentItem = 0;
             for (int i = pDialogueWindow->pStartingPosActiveItem;
@@ -2120,8 +2120,8 @@ void TempleDialog() {
                 auto skill = GetLearningDialogueSkill(
                     (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
                 );
-                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(
                         localization->GetSkillName(skill),
                         tample_window.uFrameWidth, 0);
@@ -2155,12 +2155,12 @@ void TrainingDialog(const char *s) {
     training_dialog_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActivePlayer())  // avoid nzi
+    if (!pParty->hasActiveCharacter())  // avoid nzi
         pParty->setActiveToFirstCanAct();
 
-    int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
+    int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->pPlayers[pParty->activeCharacterIndex()],
                                                         p2DEvents[window_SpeakInHouse->wData.val - 1]);
-    expForNextLevel = 1000ull * pParty->pPlayers[pParty->activePlayerIndex()].uLevel * (pParty->pPlayers[pParty->activePlayerIndex()].uLevel + 1) / 2;
+    expForNextLevel = 1000ull * pParty->pPlayers[pParty->activeCharacterIndex()].uLevel * (pParty->pPlayers[pParty->activeCharacterIndex()].uLevel + 1) / 2;
     //-------------------------------------------------------
     all_text_height = 0;
     if (HouseUI_CheckIfPlayerCanInteract()) {
@@ -2181,7 +2181,7 @@ void TrainingDialog(const char *s) {
                         if (pDialogueWindow->GetControl(i)->msg_param ==
                             DIALOGUE_TRAINING_HALL_TRAIN) {
                             static std::string shop_option_str_container;
-                            if (pPlayers[pParty->activePlayerIndex()]->uLevel >=
+                            if (pPlayers[pParty->activeCharacterIndex()]->uLevel >=
                                 pMaxLevelPerTrainingHallType
                                 [window_SpeakInHouse->wData.val -
                                 HOUSE_TRAINING_HALL_EMERALD_ISLE]) {
@@ -2192,15 +2192,15 @@ void TrainingDialog(const char *s) {
                                 pShopOptions[index] = shop_option_str_container.c_str();
 
                             } else {
-                                if (pPlayers[pParty->activePlayerIndex()]->uExperience < expForNextLevel)
+                                if (pPlayers[pParty->activeCharacterIndex()]->uExperience < expForNextLevel)
                                     shop_option_str_container = localization->FormatString(
                                         LSTR_XP_UNTIL_NEXT_LEVEL,
-                                        (uint)(expForNextLevel - pPlayers[pParty->activePlayerIndex()]->uExperience),
-                                        pPlayers[pParty->activePlayerIndex()]->uLevel + 1);
+                                        (uint)(expForNextLevel - pPlayers[pParty->activeCharacterIndex()]->uExperience),
+                                        pPlayers[pParty->activeCharacterIndex()]->uLevel + 1);
                                 else
                                     shop_option_str_container = localization->FormatString(
                                         LSTR_FMT_TRAIN_LEVEL_D_FOR_D_GOLD,
-                                        pPlayers[pParty->activePlayerIndex()]->uLevel + 1,
+                                        pPlayers[pParty->activeCharacterIndex()]->uLevel + 1,
                                         pPrice);
                                 pShopOptions[index] = shop_option_str_container.c_str();
                             }
@@ -2255,31 +2255,31 @@ void TrainingDialog(const char *s) {
                 pDialogueWindow->pNumPresenceButton = 0;
                 return;
             }
-            if (pPlayers[pParty->activePlayerIndex()]->uLevel <
+            if (pPlayers[pParty->activeCharacterIndex()]->uLevel <
                 pMaxLevelPerTrainingHallType
                 [window_SpeakInHouse->wData.val -
                 HOUSE_TRAINING_HALL_EMERALD_ISLE]) {
-                if ((int64_t)pPlayers[pParty->activePlayerIndex()]->uExperience >=
+                if ((int64_t)pPlayers[pParty->activeCharacterIndex()]->uExperience >=
                     expForNextLevel) {
                     if (pParty->GetGold() >= pPrice) {
                         pParty->TakeGold(pPrice);
                         PlayHouseSound(
                             window_SpeakInHouse->wData.val,
                             HouseSound_NotEnoughMoney);
-                        ++pPlayers[pParty->activePlayerIndex()]->uLevel;
-                        pPlayers[pParty->activePlayerIndex()]->uSkillPoints +=
-                            pPlayers[pParty->activePlayerIndex()]->uLevel / 10 + 5;
-                        pPlayers[pParty->activePlayerIndex()]->sHealth =
-                            pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
-                        pPlayers[pParty->activePlayerIndex()]->sMana =
-                            pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
+                        ++pPlayers[pParty->activeCharacterIndex()]->uLevel;
+                        pPlayers[pParty->activeCharacterIndex()]->uSkillPoints +=
+                            pPlayers[pParty->activeCharacterIndex()]->uLevel / 10 + 5;
+                        pPlayers[pParty->activeCharacterIndex()]->sHealth =
+                            pPlayers[pParty->activeCharacterIndex()]->GetMaxHealth();
+                        pPlayers[pParty->activeCharacterIndex()]->sMana =
+                            pPlayers[pParty->activeCharacterIndex()]->GetMaxMana();
                         uint max_level_in_party = player_levels[0];
                         for (uint _it = 1; _it < 4; ++_it) {
                             if (player_levels[_it] > max_level_in_party)
                                 max_level_in_party = player_levels[_it];
                         }
-                        ++player_levels[pParty->activePlayerIndex() - 1];
-                        if (player_levels[pParty->activePlayerIndex() - 1] >
+                        ++player_levels[pParty->activeCharacterIndex() - 1];
+                        if (player_levels[pParty->activeCharacterIndex() - 1] >
                             max_level_in_party) {  // if we reach new maximum party level feature is broken thou,
                                                    // since this array is always zeroed in enterHouse
                             v42 = 60 * (_494820_training_time(pParty->uCurrentHour) + 4) - pParty->uCurrentMinute;
@@ -2289,13 +2289,13 @@ void TrainingDialog(const char *s) {
                             if (uCurrentlyLoadedLevelType == LEVEL_Outdoor)
                                 pOutdoor->SetFog();
                         }
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LevelUp);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LevelUp);
 
                         GameUI_SetStatusBar(
                             LSTR_FMT_S_NOW_LEVEL_D,
-                            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
-                            pPlayers[pParty->activePlayerIndex()]->uLevel,
-                            pPlayers[pParty->activePlayerIndex()]->uLevel / 10 + 5
+                            pPlayers[pParty->activeCharacterIndex()]->pName.c_str(),
+                            pPlayers[pParty->activeCharacterIndex()]->uLevel,
+                            pPlayers[pParty->activeCharacterIndex()]->uLevel / 10 + 5
                         );
 
                         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
@@ -2309,8 +2309,8 @@ void TrainingDialog(const char *s) {
                 }
                 label = localization->FormatString(
                     LSTR_XP_UNTIL_NEXT_LEVEL,
-                    (unsigned int)(expForNextLevel - pPlayers[pParty->activePlayerIndex()]->uExperience),
-                    pPlayers[pParty->activePlayerIndex()]->uLevel + 1);
+                    (unsigned int)(expForNextLevel - pPlayers[pParty->activeCharacterIndex()]->uExperience),
+                    pPlayers[pParty->activeCharacterIndex()]->uLevel + 1);
                 v36 = (212 - pFontArrus->CalcTextHeight(
                         label, training_dialog_window.uFrameWidth, 0)) / 2 + 88;
             } else {
@@ -2333,7 +2333,7 @@ void TrainingDialog(const char *s) {
     //-------------------------------------------------------------
     if (dialog_menu_id == DIALOGUE_LEARN_SKILLS) {
         if (HouseUI_CheckIfPlayerCanInteract()) {
-            pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
+            pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activeCharacterIndex()],
                                                                  p2DEvents[window_SpeakInHouse->wData.val - 1]);
             index = 0;
             for (int i = pDialogueWindow->pStartingPosActiveItem;
@@ -2343,8 +2343,8 @@ void TrainingDialog(const char *s) {
                 auto skill = GetLearningDialogueSkill(
                     (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
                 );
-                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(
                         localization->GetSkillName(skill),
                         training_dialog_window.uFrameWidth, 0);
@@ -2384,14 +2384,14 @@ void MercenaryGuildDialog() {
      *
      *  v32 = (uint8_t)(((p2DEvents[window_SpeakInHouse->wData.val - 1].uType != BuildingType_MercenaryGuild) - 1) & 0x96) + 100;
      *  v3 = (int64_t)((double)v32 * p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-     *  pPrice = v3 * (100 - PriceCalculator::playerMerchant(pPlayers[pParty->activePlayerIndex()])) / 100;
+     *  pPrice = v3 * (100 - PriceCalculator::playerMerchant(pPlayers[pParty->activeCharacterIndex()])) / 100;
      *  if (pPrice < v3 / 3) pPrice = v3 / 3;
      */
     int pPrice =
-        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
+        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activeCharacterIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {
-        if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, word_4F0754[2 * window_SpeakInHouse->wData.val])) {
+        if (!_449B57_test_bit(pPlayers[pParty->activeCharacterIndex()]->_achieved_awards_bits, word_4F0754[2 * window_SpeakInHouse->wData.val])) {
             // 171 looks like Mercenary Stronghold message from NPCNews.txt in MM6
             pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[171].pText, dialog_window.uFrameWidth, 0);
             dialog_window.DrawTitleText(pFontArrus, 0, (212 - pTextHeight) / 2 + 101, colorTable.PaleCanary.c16(), pNPCTopics[171].pText, 3);
@@ -2404,8 +2404,8 @@ void MercenaryGuildDialog() {
         for (int i = pDialogueWindow->pStartingPosActiveItem; i < pDialogueWindow->pNumPresenceButton + pDialogueWindow->pStartingPosActiveItem; ++i) {
             auto skill = GetLearningDialogueSkill((DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param);
             // Was class type / 3
-            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
                 all_text_height += pFontArrus->CalcTextHeight(localization->GetSkillName(skill), dialog_window.uFrameWidth, 0);
                 ++index;
             }
@@ -2427,7 +2427,7 @@ void MercenaryGuildDialog() {
         __debugbreak();  // whacky condition - fix
         if (false
             // if ( !*(&byte_4ED94C[37 * v1->uClass / 3] + dword_F8B19C)
-            || (v6 = (short *)(&pPlayers[pParty->activePlayerIndex()]->uIntelligence +
+            || (v6 = (short *)(&pPlayers[pParty->activeCharacterIndex()]->uIntelligence +
                 dialog_menu_id),
                 *(short *)v6)) {
             pAudioPlayer->playUISound(SOUND_error);

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -773,11 +773,11 @@ void InitializaDialogueOptions(BuildingType type) {
 
 
 bool HouseUI_CheckIfPlayerCanInteract() {
-    if (!pParty->hasActiveCharacter()) {  // to avoid access zeroeleement
+    if (!pParty->hasActivePlayer()) {  // to avoid access zeroeleement
         return false;
     }
 
-    if (pPlayers[pParty->getActiveCharacter()]->CanAct()) {
+    if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
         pDialogueWindow->pNumPresenceButton = dword_F8B1E0;
         return true;
     } else {
@@ -789,7 +789,7 @@ bool HouseUI_CheckIfPlayerCanInteract() {
 
         std::string str = localization->FormatString(
             LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-            pPlayers[pParty->getActiveCharacter()]->pName.c_str(),
+            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
             localization->GetString(LSTR_DO_ANYTHING));
         window.DrawTitleText(
             pFontArrus, 0,
@@ -835,8 +835,8 @@ bool enterHouse(HOUSE_ID uHouseID) {
         }
 
         GameUI_SetStatusBar(LSTR_FMT_OPEN_TIME, uOpenTime, localization->GetAmPm(am_pm_flag_open), uCloseTime, localization->GetAmPm(am_pm_flag_close));
-        if (pParty->hasActiveCharacter()) {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_StoreClosed);
+        if (pParty->hasActivePlayer()) {
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_StoreClosed);
         }
 
         return 0;
@@ -886,10 +886,10 @@ bool enterHouse(HOUSE_ID uHouseID) {
             int membership = guild_membership_flags[uHouseID - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE];
 
             // TODO(pskelton): check this behaviour
-            if (!pParty->hasActiveCharacter())  // avoid nzi
+            if (!pParty->hasActivePlayer())  // avoid nzi
                 pParty->setActiveToFirstCanAct();
 
-            if (!_449B57_test_bit(pPlayers[pParty->getActiveCharacter()]->_achieved_awards_bits, membership)) {
+            if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, membership)) {
                 PlayHouseSound(uHouseID, HouseSound_Greeting_2);
                 return 1;
             }
@@ -980,15 +980,15 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
         if (in_current_building_type == BuildingType_Training) {
             if (option == DIALOGUE_TRAINING_HALL_TRAIN) {
                 experience_for_next_level = 0;
-                if (pPlayers[pParty->getActiveCharacter()]->uLevel > 0) {
-                    for (uint i = 0; i < pPlayers[pParty->getActiveCharacter()]->uLevel;
+                if (pPlayers[pParty->activePlayerIndex()]->uLevel > 0) {
+                    for (uint i = 0; i < pPlayers[pParty->activePlayerIndex()]->uLevel;
                         i++)
                         experience_for_next_level += i + 1;
                 }
-                if (pPlayers[pParty->getActiveCharacter()]->uLevel <
+                if (pPlayers[pParty->activePlayerIndex()]->uLevel <
                     pMaxLevelPerTrainingHallType
                     [window_SpeakInHouse->wData.val - 89] &&
-                    (int64_t)pPlayers[pParty->getActiveCharacter()]->uExperience <
+                    (int64_t)pPlayers[pParty->activePlayerIndex()]->uExperience <
                     1000 * experience_for_next_level)  // test experience
                     return;
             }
@@ -1012,8 +1012,8 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
                 pBtn_ExitCancel = pDialogueWindow->CreateButton({526, 445}, {75, 33}, 1, 0,
                     UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_END_CONVERSATION), {ui_buttdesc2});
                 pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0);
-            } else if (pParty->hasActiveCharacter()) {
-                if (!pPlayers[pParty->getActiveCharacter()]->IsPlayerHealableByTemple())
+            } else if (pParty->hasActivePlayer()) {
+                if (!pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple())
                     return;
             }
         }
@@ -1195,11 +1195,11 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
     default:
     {
         if (IsSkillLearningDialogue(option)) {
-            int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->getActiveCharacter()],
+            int pPrice = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
                                                                          p2DEvents[window_SpeakInHouse->wData.val - 1]);  // ecx@227
             auto skill = GetLearningDialogueSkill(option);
-            if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
-                if (!pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
+                if (!pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                     if (pParty->GetGold() < pPrice) {
                         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                         if (in_current_building_type == BuildingType_Training
@@ -1213,8 +1213,8 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
                     } else {
                         pParty->TakeGold(pPrice);
                         dword_F8B1E4 = 1;
-                        pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill] = 1;
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_SkillLearned);
+                        pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill] = 1;
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillLearned);
                     }
                 }
             }
@@ -1244,9 +1244,9 @@ void TravelByTransport() {
     travel_window.uFrameWidth = 143;
     travel_window.uFrameZ = 334;
 
-    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->getActiveCharacter() = 0 and crash
+    assert(pParty->hasActivePlayer()); // code in this function couldn't handle pParty->activePlayerIndex() = 0 and crash
 
-    int pPrice = PriceCalculator::transportCostForPlayer(&pParty->pPlayers[pParty->getActiveCharacter()],
+    int pPrice = PriceCalculator::transportCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
                                                          p2DEvents[window_SpeakInHouse->wData.val - 1]);
     int route_id = window_SpeakInHouse->wData.val - HOUSE_STABLES_HARMONDALE;
 
@@ -1373,7 +1373,7 @@ void TravelByTransport() {
                 }
 
                 RestAndHeal(24 * 60 * traveltimedays);
-                pPlayers[pParty->getActiveCharacter()]->playReaction(pSpeech);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(pSpeech);
                 pAudioPlayer->soundDrain();
                 while (HouseDialogPressCloseBtn()) {}
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
@@ -1501,8 +1501,8 @@ void TownHallDialog() {
 
                     pParty->TakeGold(sum);
                     pParty->TakeFine(sum);
-                    if (pParty->hasActiveCharacter())
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_BankDeposit);
+                    if (pParty->hasActivePlayer())
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_BankDeposit);
                 }
             }
         }
@@ -1567,8 +1567,8 @@ void BankDialog() {
             if (sum > 0) {
                 pParty->TakeGold(sum);
                 pParty->AddBankGold(sum);
-                if (pParty->hasActiveCharacter()) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_BankDeposit);
+                if (pParty->hasActivePlayer()) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_BankDeposit);
                 }
             }
         }
@@ -1637,13 +1637,13 @@ void TavernDialog() {
     dialog_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActiveCharacter())  // avoid nzi
+    if (!pParty->hasActivePlayer())  // avoid nzi
         pParty->setActiveToFirstCanAct();
 
     const _2devent &house = p2DEvents[window_SpeakInHouse->wData.val - 1];
 
-    int pPriceRoom = PriceCalculator::tavernRoomCostForPlayer(pPlayers[pParty->getActiveCharacter()], house);
-    int pPriceFood = PriceCalculator::tavernFoodCostForPlayer(pPlayers[pParty->getActiveCharacter()], house);
+    int pPriceRoom = PriceCalculator::tavernRoomCostForPlayer(pPlayers[pParty->activePlayerIndex()], house);
+    int pPriceFood = PriceCalculator::tavernFoodCostForPlayer(pPlayers[pParty->activePlayerIndex()], house);
 
     switch (dialog_menu_id) {
     case DIALOGUE_MAIN:
@@ -1816,7 +1816,7 @@ void TavernDialog() {
     {
         if (!HouseUI_CheckIfPlayerCanInteract()) return;
         pSkillCount = 0;
-        int pPriceSkill = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->getActiveCharacter()], house);
+        int pPriceSkill = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()], house);
         all_text_height = 0;
         for (int i = pDialogueWindow->pStartingPosActiveItem;
             i < pDialogueWindow->pStartingPosActiveItem +
@@ -1825,8 +1825,8 @@ void TavernDialog() {
             auto skill = GetLearningDialogueSkill(
                 (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
             );
-            if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                 all_text_height = pFontArrus->CalcTextHeight(
                     localization->GetSkillName(skill),
                     dialog_window.uFrameWidth, 0);
@@ -1842,8 +1842,8 @@ void TavernDialog() {
         if ((double)pParty->GetFood() >=
             p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier) {
             GameUI_SetStatusBar(LSTR_RATIONS_FULL);
-            if (pParty->hasActiveCharacter())
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_PacksFull);
+            if (pParty->hasActivePlayer())
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PacksFull);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
@@ -1924,11 +1924,11 @@ void TempleDialog() {
     tample_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActiveCharacter()) {  // avoid nzi
+    if (!pParty->hasActivePlayer()) {  // avoid nzi
         pParty->setActiveToFirstCanAct();
     }
 
-    pPrice = PriceCalculator::templeHealingCostForPlayer(pPlayers[pParty->getActiveCharacter()],
+    pPrice = PriceCalculator::templeHealingCostForPlayer(pPlayers[pParty->activePlayerIndex()],
                                                          p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
     if (dialog_menu_id == DIALOGUE_MAIN) {
         index = 1;
@@ -1936,7 +1936,7 @@ void TempleDialog() {
             pDialogueWindow->pStartingPosActiveItem);
         pButton->uHeight = 0;
         pButton->uY = 0;
-        if (pPlayers[pParty->getActiveCharacter()]->IsPlayerHealableByTemple()) {
+        if (pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple()) {
             static std::string shop_option_container;
             shop_option_container =
                 fmt::format("{} {} {}",
@@ -1993,7 +1993,7 @@ void TempleDialog() {
     }
     //-------------------------------------------------
     if (dialog_menu_id == DIALOGUE_TEMPLE_HEAL) {
-        if (!pPlayers[pParty->getActiveCharacter()]->IsPlayerHealableByTemple()) return;
+        if (!pPlayers[pParty->activePlayerIndex()]->IsPlayerHealableByTemple()) return;
         if (pParty->GetGold() < pPrice) {
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
             PlayHouseSound(window_SpeakInHouse->wData.val, HouseSound_NotEnoughMoney);
@@ -2002,64 +2002,64 @@ void TempleDialog() {
         }
         pParty->TakeGold(pPrice);
 
-        pPlayers[pParty->getActiveCharacter()]->conditions.ResetAll();
-        pPlayers[pParty->getActiveCharacter()]->sHealth =
-            pPlayers[pParty->getActiveCharacter()]->GetMaxHealth();
-        pPlayers[pParty->getActiveCharacter()]->sMana =
-            pPlayers[pParty->getActiveCharacter()]->GetMaxMana();
+        pPlayers[pParty->activePlayerIndex()]->conditions.ResetAll();
+        pPlayers[pParty->activePlayerIndex()]->sHealth =
+            pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
+        pPlayers[pParty->activePlayerIndex()]->sMana =
+            pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
 
         if (window_SpeakInHouse->wData.val != 78 &&
             (window_SpeakInHouse->wData.val <= 80 ||
             window_SpeakInHouse->wData.val > 82)) {
-            if (pPlayers[pParty->getActiveCharacter()]->conditions.Has(Condition_Zombie)) {
+            if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(Condition_Zombie)) {
                 // если состояние зомби
-                pPlayers[pParty->getActiveCharacter()]->uCurrentFace =
-                    pPlayers[pParty->getActiveCharacter()]->uPrevFace;
-                pPlayers[pParty->getActiveCharacter()]->uVoiceID =
-                    pPlayers[pParty->getActiveCharacter()]->uPrevVoiceID;
+                pPlayers[pParty->activePlayerIndex()]->uCurrentFace =
+                    pPlayers[pParty->activePlayerIndex()]->uPrevFace;
+                pPlayers[pParty->activePlayerIndex()]->uVoiceID =
+                    pPlayers[pParty->activePlayerIndex()]->uPrevVoiceID;
                 GameUI_ReloadPlayerPortraits(
-                    pParty->getActiveCharacter() - 1,
-                    pPlayers[pParty->getActiveCharacter()]->uPrevFace);
+                    pParty->activePlayerIndex() - 1,
+                    pPlayers[pParty->activePlayerIndex()]->uPrevFace);
             }
             pAudioPlayer->playExclusiveSound(SOUND_heal);
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TempleHeal);
-            pOtherOverlayList->_4418B1(20, pParty->getActiveCharacter() + 99, 0, 65536);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
+            pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
-        if (pPlayers[pParty->getActiveCharacter()]->conditions.Has(Condition_Zombie)) {
-            // LODWORD(pPlayers[pParty->getActiveCharacter()]->pConditions[Condition_Zombie])
+        if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(Condition_Zombie)) {
+            // LODWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie])
             // =
-            // LODWORD(pPlayers[pParty->getActiveCharacter()]->pConditions[Condition_Zombie]);
+            // LODWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie]);
         } else {
-            if (pPlayers[pParty->getActiveCharacter()]->conditions.HasNone({Condition_Eradicated, Condition_Petrified, Condition_Dead})) {
+            if (pPlayers[pParty->activePlayerIndex()]->conditions.HasNone({Condition_Eradicated, Condition_Petrified, Condition_Dead})) {
                 pAudioPlayer->playExclusiveSound(SOUND_heal);
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TempleHeal);
-                pOtherOverlayList->_4418B1(20, pParty->getActiveCharacter() + 99, 0, 65536);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
+                pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 return;
             }
-            pPlayers[pParty->getActiveCharacter()]->uPrevFace =
-                pPlayers[pParty->getActiveCharacter()]->uCurrentFace;
-            pPlayers[pParty->getActiveCharacter()]->uPrevVoiceID =
-                pPlayers[pParty->getActiveCharacter()]->uVoiceID;
-            pPlayers[pParty->getActiveCharacter()]->SetCondition(Condition_Zombie, 1);
-            pPlayers[pParty->getActiveCharacter()]->uVoiceID =
-                (pPlayers[pParty->getActiveCharacter()]->GetSexByVoice() != 0) + 23;
-            pPlayers[pParty->getActiveCharacter()]->uCurrentFace =
-                (pPlayers[pParty->getActiveCharacter()]->GetSexByVoice() != 0) + 23;
+            pPlayers[pParty->activePlayerIndex()]->uPrevFace =
+                pPlayers[pParty->activePlayerIndex()]->uCurrentFace;
+            pPlayers[pParty->activePlayerIndex()]->uPrevVoiceID =
+                pPlayers[pParty->activePlayerIndex()]->uVoiceID;
+            pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Zombie, 1);
+            pPlayers[pParty->activePlayerIndex()]->uVoiceID =
+                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23;
+            pPlayers[pParty->activePlayerIndex()]->uCurrentFace =
+                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23;
             GameUI_ReloadPlayerPortraits(
-                pParty->getActiveCharacter() - 1,
-                (pPlayers[pParty->getActiveCharacter()]->GetSexByVoice() != 0) + 23);
-            pPlayers[pParty->getActiveCharacter()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+                pParty->activePlayerIndex() - 1,
+                (pPlayers[pParty->activePlayerIndex()]->GetSexByVoice() != 0) + 23);
+            pPlayers[pParty->activePlayerIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
             // v39 = (GUIWindow *)HIDWORD(pParty->uTimePlayed);
         }
-        // HIDWORD(pPlayers[pParty->getActiveCharacter()]->pConditions[Condition_Zombie]) =
+        // HIDWORD(pPlayers[pParty->activePlayerIndex()]->pConditions[Condition_Zombie]) =
         // (int)v39;
-        pPlayers[pParty->getActiveCharacter()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
+        pPlayers[pParty->activePlayerIndex()]->conditions.Set(Condition_Zombie, pParty->GetPlayingTime());
         pAudioPlayer->playExclusiveSound(SOUND_heal);
-        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TempleHeal);
-        pOtherOverlayList->_4418B1(20, pParty->getActiveCharacter() + 99, 0, 65536);
+        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleHeal);
+        pOtherOverlayList->_4418B1(20, pParty->activePlayerIndex() + 99, 0, 65536);
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
@@ -2077,7 +2077,7 @@ void TempleDialog() {
                 ddm->uReputation = ddm->uReputation - 1;
                 if (ddm->uReputation - 1 < -5) ddm->uReputation = -5;
             }
-            if ((uint8_t)byte_F8B1EF[pParty->getActiveCharacter()] == pParty->uCurrentDayOfMonth % 7) {
+            if ((uint8_t)byte_F8B1EF[pParty->activePlayerIndex()] == pParty->uCurrentDayOfMonth % 7) {
                 if (ddm->uReputation <= -5) {
                     pushTempleSpell(SPELL_AIR_WIZARD_EYE);
                 }
@@ -2094,8 +2094,8 @@ void TempleDialog() {
                     pushTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
                 }
             }
-            ++byte_F8B1EF[pParty->getActiveCharacter()];
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_TempleDonate);
+            ++byte_F8B1EF[pParty->activePlayerIndex()];
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_TempleDonate);
             GameUI_SetStatusBar(LSTR_THANK_YOU);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
@@ -2110,7 +2110,7 @@ void TempleDialog() {
     if (dialog_menu_id == DIALOGUE_LEARN_SKILLS) {
         if (HouseUI_CheckIfPlayerCanInteract()) {
             all_text_height = 0;
-            v64 = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->getActiveCharacter()],
+            v64 = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
                                                               p2DEvents[window_SpeakInHouse->wData.val - 1]);
             pCurrentItem = 0;
             for (int i = pDialogueWindow->pStartingPosActiveItem;
@@ -2120,8 +2120,8 @@ void TempleDialog() {
                 auto skill = GetLearningDialogueSkill(
                     (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
                 );
-                if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(
                         localization->GetSkillName(skill),
                         tample_window.uFrameWidth, 0);
@@ -2155,12 +2155,12 @@ void TrainingDialog(const char *s) {
     training_dialog_window.uFrameZ = 334;
 
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActiveCharacter())  // avoid nzi
+    if (!pParty->hasActivePlayer())  // avoid nzi
         pParty->setActiveToFirstCanAct();
 
-    int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->pPlayers[pParty->getActiveCharacter()],
+    int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
                                                         p2DEvents[window_SpeakInHouse->wData.val - 1]);
-    expForNextLevel = 1000ull * pParty->pPlayers[pParty->getActiveCharacter()].uLevel * (pParty->pPlayers[pParty->getActiveCharacter()].uLevel + 1) / 2;
+    expForNextLevel = 1000ull * pParty->pPlayers[pParty->activePlayerIndex()].uLevel * (pParty->pPlayers[pParty->activePlayerIndex()].uLevel + 1) / 2;
     //-------------------------------------------------------
     all_text_height = 0;
     if (HouseUI_CheckIfPlayerCanInteract()) {
@@ -2181,7 +2181,7 @@ void TrainingDialog(const char *s) {
                         if (pDialogueWindow->GetControl(i)->msg_param ==
                             DIALOGUE_TRAINING_HALL_TRAIN) {
                             static std::string shop_option_str_container;
-                            if (pPlayers[pParty->getActiveCharacter()]->uLevel >=
+                            if (pPlayers[pParty->activePlayerIndex()]->uLevel >=
                                 pMaxLevelPerTrainingHallType
                                 [window_SpeakInHouse->wData.val -
                                 HOUSE_TRAINING_HALL_EMERALD_ISLE]) {
@@ -2192,15 +2192,15 @@ void TrainingDialog(const char *s) {
                                 pShopOptions[index] = shop_option_str_container.c_str();
 
                             } else {
-                                if (pPlayers[pParty->getActiveCharacter()]->uExperience < expForNextLevel)
+                                if (pPlayers[pParty->activePlayerIndex()]->uExperience < expForNextLevel)
                                     shop_option_str_container = localization->FormatString(
                                         LSTR_XP_UNTIL_NEXT_LEVEL,
-                                        (uint)(expForNextLevel - pPlayers[pParty->getActiveCharacter()]->uExperience),
-                                        pPlayers[pParty->getActiveCharacter()]->uLevel + 1);
+                                        (uint)(expForNextLevel - pPlayers[pParty->activePlayerIndex()]->uExperience),
+                                        pPlayers[pParty->activePlayerIndex()]->uLevel + 1);
                                 else
                                     shop_option_str_container = localization->FormatString(
                                         LSTR_FMT_TRAIN_LEVEL_D_FOR_D_GOLD,
-                                        pPlayers[pParty->getActiveCharacter()]->uLevel + 1,
+                                        pPlayers[pParty->activePlayerIndex()]->uLevel + 1,
                                         pPrice);
                                 pShopOptions[index] = shop_option_str_container.c_str();
                             }
@@ -2255,31 +2255,31 @@ void TrainingDialog(const char *s) {
                 pDialogueWindow->pNumPresenceButton = 0;
                 return;
             }
-            if (pPlayers[pParty->getActiveCharacter()]->uLevel <
+            if (pPlayers[pParty->activePlayerIndex()]->uLevel <
                 pMaxLevelPerTrainingHallType
                 [window_SpeakInHouse->wData.val -
                 HOUSE_TRAINING_HALL_EMERALD_ISLE]) {
-                if ((int64_t)pPlayers[pParty->getActiveCharacter()]->uExperience >=
+                if ((int64_t)pPlayers[pParty->activePlayerIndex()]->uExperience >=
                     expForNextLevel) {
                     if (pParty->GetGold() >= pPrice) {
                         pParty->TakeGold(pPrice);
                         PlayHouseSound(
                             window_SpeakInHouse->wData.val,
                             HouseSound_NotEnoughMoney);
-                        ++pPlayers[pParty->getActiveCharacter()]->uLevel;
-                        pPlayers[pParty->getActiveCharacter()]->uSkillPoints +=
-                            pPlayers[pParty->getActiveCharacter()]->uLevel / 10 + 5;
-                        pPlayers[pParty->getActiveCharacter()]->sHealth =
-                            pPlayers[pParty->getActiveCharacter()]->GetMaxHealth();
-                        pPlayers[pParty->getActiveCharacter()]->sMana =
-                            pPlayers[pParty->getActiveCharacter()]->GetMaxMana();
+                        ++pPlayers[pParty->activePlayerIndex()]->uLevel;
+                        pPlayers[pParty->activePlayerIndex()]->uSkillPoints +=
+                            pPlayers[pParty->activePlayerIndex()]->uLevel / 10 + 5;
+                        pPlayers[pParty->activePlayerIndex()]->sHealth =
+                            pPlayers[pParty->activePlayerIndex()]->GetMaxHealth();
+                        pPlayers[pParty->activePlayerIndex()]->sMana =
+                            pPlayers[pParty->activePlayerIndex()]->GetMaxMana();
                         uint max_level_in_party = player_levels[0];
                         for (uint _it = 1; _it < 4; ++_it) {
                             if (player_levels[_it] > max_level_in_party)
                                 max_level_in_party = player_levels[_it];
                         }
-                        ++player_levels[pParty->getActiveCharacter() - 1];
-                        if (player_levels[pParty->getActiveCharacter() - 1] >
+                        ++player_levels[pParty->activePlayerIndex() - 1];
+                        if (player_levels[pParty->activePlayerIndex() - 1] >
                             max_level_in_party) {  // if we reach new maximum party level feature is broken thou,
                                                    // since this array is always zeroed in enterHouse
                             v42 = 60 * (_494820_training_time(pParty->uCurrentHour) + 4) - pParty->uCurrentMinute;
@@ -2289,13 +2289,13 @@ void TrainingDialog(const char *s) {
                             if (uCurrentlyLoadedLevelType == LEVEL_Outdoor)
                                 pOutdoor->SetFog();
                         }
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LevelUp);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LevelUp);
 
                         GameUI_SetStatusBar(
                             LSTR_FMT_S_NOW_LEVEL_D,
-                            pPlayers[pParty->getActiveCharacter()]->pName.c_str(),
-                            pPlayers[pParty->getActiveCharacter()]->uLevel,
-                            pPlayers[pParty->getActiveCharacter()]->uLevel / 10 + 5
+                            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
+                            pPlayers[pParty->activePlayerIndex()]->uLevel,
+                            pPlayers[pParty->activePlayerIndex()]->uLevel / 10 + 5
                         );
 
                         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
@@ -2309,8 +2309,8 @@ void TrainingDialog(const char *s) {
                 }
                 label = localization->FormatString(
                     LSTR_XP_UNTIL_NEXT_LEVEL,
-                    (unsigned int)(expForNextLevel - pPlayers[pParty->getActiveCharacter()]->uExperience),
-                    pPlayers[pParty->getActiveCharacter()]->uLevel + 1);
+                    (unsigned int)(expForNextLevel - pPlayers[pParty->activePlayerIndex()]->uExperience),
+                    pPlayers[pParty->activePlayerIndex()]->uLevel + 1);
                 v36 = (212 - pFontArrus->CalcTextHeight(
                         label, training_dialog_window.uFrameWidth, 0)) / 2 + 88;
             } else {
@@ -2333,7 +2333,7 @@ void TrainingDialog(const char *s) {
     //-------------------------------------------------------------
     if (dialog_menu_id == DIALOGUE_LEARN_SKILLS) {
         if (HouseUI_CheckIfPlayerCanInteract()) {
-            pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->getActiveCharacter()],
+            pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->pPlayers[pParty->activePlayerIndex()],
                                                                  p2DEvents[window_SpeakInHouse->wData.val - 1]);
             index = 0;
             for (int i = pDialogueWindow->pStartingPosActiveItem;
@@ -2343,8 +2343,8 @@ void TrainingDialog(const char *s) {
                 auto skill = GetLearningDialogueSkill(
                     (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
                 );
-                if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                    && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                    && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                     all_text_height += pFontArrus->CalcTextHeight(
                         localization->GetSkillName(skill),
                         training_dialog_window.uFrameWidth, 0);
@@ -2384,14 +2384,14 @@ void MercenaryGuildDialog() {
      *
      *  v32 = (uint8_t)(((p2DEvents[window_SpeakInHouse->wData.val - 1].uType != BuildingType_MercenaryGuild) - 1) & 0x96) + 100;
      *  v3 = (int64_t)((double)v32 * p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-     *  pPrice = v3 * (100 - PriceCalculator::playerMerchant(pPlayers[pParty->getActiveCharacter()])) / 100;
+     *  pPrice = v3 * (100 - PriceCalculator::playerMerchant(pPlayers[pParty->activePlayerIndex()])) / 100;
      *  if (pPrice < v3 / 3) pPrice = v3 / 3;
      */
     int pPrice =
-        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->getActiveCharacter()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
+        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {
-        if (!_449B57_test_bit(pPlayers[pParty->getActiveCharacter()]->_achieved_awards_bits, word_4F0754[2 * window_SpeakInHouse->wData.val])) {
+        if (!_449B57_test_bit(pPlayers[pParty->activePlayerIndex()]->_achieved_awards_bits, word_4F0754[2 * window_SpeakInHouse->wData.val])) {
             // 171 looks like Mercenary Stronghold message from NPCNews.txt in MM6
             pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[171].pText, dialog_window.uFrameWidth, 0);
             dialog_window.DrawTitleText(pFontArrus, 0, (212 - pTextHeight) / 2 + 101, colorTable.PaleCanary.c16(), pNPCTopics[171].pText, 3);
@@ -2404,8 +2404,8 @@ void MercenaryGuildDialog() {
         for (int i = pDialogueWindow->pStartingPosActiveItem; i < pDialogueWindow->pNumPresenceButton + pDialogueWindow->pStartingPosActiveItem; ++i) {
             auto skill = GetLearningDialogueSkill((DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param);
             // Was class type / 3
-            if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-                && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+            if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+                && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
                 all_text_height += pFontArrus->CalcTextHeight(localization->GetSkillName(skill), dialog_window.uFrameWidth, 0);
                 ++index;
             }
@@ -2427,7 +2427,7 @@ void MercenaryGuildDialog() {
         __debugbreak();  // whacky condition - fix
         if (false
             // if ( !*(&byte_4ED94C[37 * v1->uClass / 3] + dword_F8B19C)
-            || (v6 = (short *)(&pPlayers[pParty->getActiveCharacter()]->uIntelligence +
+            || (v6 = (short *)(&pPlayers[pParty->activePlayerIndex()]->uIntelligence +
                 dialog_menu_id),
                 *(short *)v6)) {
             pAudioPlayer->playUISound(SOUND_error);

--- a/src/GUI/UI/UIInventory.cpp
+++ b/src/GUI/UI/UIInventory.cpp
@@ -49,7 +49,7 @@ GUIWindow_Inventory_CastSpell::GUIWindow_Inventory_CastSpell(Pointi position, Si
 void GUIWindow_Inventory_CastSpell::Update() {
     render->ClearZBuffer();
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
-    CharacterUI_DrawPaperdoll(pPlayers[pParty->activePlayerIndex()]);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
+    CharacterUI_DrawPaperdoll(pPlayers[pParty->activeCharacterIndex()]);
     render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, dialogue_ui_x_x_u);
 }

--- a/src/GUI/UI/UIInventory.cpp
+++ b/src/GUI/UI/UIInventory.cpp
@@ -49,7 +49,7 @@ GUIWindow_Inventory_CastSpell::GUIWindow_Inventory_CastSpell(Pointi position, Si
 void GUIWindow_Inventory_CastSpell::Update() {
     render->ClearZBuffer();
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
-    CharacterUI_DrawPaperdoll(pPlayers[pParty->getActiveCharacter()]);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+    CharacterUI_DrawPaperdoll(pPlayers[pParty->activePlayerIndex()]);
     render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, dialogue_ui_x_x_u);
 }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -241,28 +241,28 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
         GoldAmount = inspect_item->special_enchantment;
     }
 
-    if (pParty->hasActivePlayer()) {
+    if (pParty->hasActiveCharacter()) {
         // try to identify
         if (!inspect_item->IsIdentified()) {
-            if (pPlayers[pParty->activePlayerIndex()]->CanIdentify(inspect_item) == 1)
+            if (pPlayers[pParty->activeCharacterIndex()]->CanIdentify(inspect_item) == 1)
                 inspect_item->SetIdentified();
             PlayerSpeech speech = SPEECH_IndentifyItemFail;
             if (!inspect_item->IsIdentified()) {
                 GameUI_SetStatusBar(LSTR_IDENTIFY_FAILED);
             } else {
                 speech = SPEECH_IndentifyItemStrong;
-                if (inspect_item->GetValue() < 100 * (pPlayers[pParty->activePlayerIndex()]->uLevel + 5)) {
+                if (inspect_item->GetValue() < 100 * (pPlayers[pParty->activeCharacterIndex()]->uLevel + 5)) {
                     speech = SPEECH_IndentifyItemWeak;
                 }
             }
             if (dword_4E455C) {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(speech);
                 dword_4E455C = 0;
             }
         }
         inspect_item->UpdateTempBonus(pParty->GetPlayingTime());
         if (inspect_item->IsBroken()) {
-            if (pPlayers[pParty->activePlayerIndex()]->CanRepair(inspect_item) == 1)
+            if (pPlayers[pParty->activeCharacterIndex()]->CanRepair(inspect_item) == 1)
                 inspect_item->uAttributes =
                     inspect_item->uAttributes & ~ITEM_BROKEN | ITEM_IDENTIFIED;
             PlayerSpeech speech = SPEECH_RepairFail;
@@ -271,7 +271,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
             else
                 GameUI_SetStatusBar(LSTR_REPAIR_FAILED);
             if (dword_4E455C) {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(speech);
                 dword_4E455C = 0;
             }
         }
@@ -569,7 +569,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     bool monster_full_informations = false;
     static Actor pMonsterInfoUI_Doll;
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActivePlayer()) {
+    if (!pParty->hasActiveCharacter()) {
         pParty->setActiveToFirstCanAct();
     }
 
@@ -660,10 +660,10 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     PLAYER_SKILL_MASTERY skill_mastery = PLAYER_SKILL_MASTERY_NONE;
 
     pMonsterInfoUI_Doll.uCurrentActionTime += pMiscTimer->uTimeElapsed;
-    if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(
+    if (pPlayers[pParty->activeCharacterIndex()]->GetActualSkillLevel(
             PLAYER_SKILL_MONSTER_ID)) {
-        skill_points = pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(PLAYER_SKILL_MONSTER_ID);
-        skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID);
+        skill_points = pPlayers[pParty->activeCharacterIndex()]->GetActualSkillLevel(PLAYER_SKILL_MONSTER_ID);
+        skill_mastery = pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID);
         if (skill_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
             if (skill_points + 10 >= pActors[uActorID].pMonsterInfo.uLevel)
                 normal_level = 1;
@@ -692,21 +692,21 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     if (pActors[uActorID].uAIState != Dead &&
         pActors[uActorID].uAIState != Dying &&
         !dword_507BF0_is_there_popup_onscreen &&
-        pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(
+        pPlayers[pParty->activeCharacterIndex()]->GetActualSkillLevel(
             PLAYER_SKILL_MONSTER_ID)) {
         if (normal_level || expert_level || master_level || grandmaster_level) {
             if (pActors[uActorID].pMonsterInfo.uLevel >=
-                pPlayers[pParty->activePlayerIndex()]->uLevel - 5)
+                pPlayers[pParty->activeCharacterIndex()]->uLevel - 5)
                 speech = SPEECH_IDMonsterStrong;
             else
                 speech = SPEECH_IDMonsterWeak;
         } else {
             speech = SPEECH_IDMonsterFail;
         }
-        pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
+        pPlayers[pParty->activeCharacterIndex()]->playReaction(speech);
     }
 
-    if ((signed int)(pParty->pPlayers[pParty->activePlayerIndex() - 1]
+    if ((signed int)(pParty->pPlayers[pParty->activeCharacterIndex() - 1]
                          .GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID)) >= 3)
         for_effects = 1;
 
@@ -1054,7 +1054,7 @@ void CharacterUI_SkillsTab_ShowHint() {
             if (pButton->msg == UIMSG_SkillUp && pX >= pButton->uX &&
                 pX < pButton->uZ && pY >= pButton->uY && pY < pButton->uW) {
                 PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pButton->msg_param);
-                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activePlayerIndex() - 1, skill);
+                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex() - 1, skill);
                 CharacterUI_DrawTooltip(localization->GetSkillName(skill), pSkillDescText);
             }
         }
@@ -1120,10 +1120,10 @@ void CharacterUI_StatsTab_ShowHint() {
             auto str = std::string(pPlayerConditionAttributeDescription) + "\n";
 
             for (Condition condition : conditionImportancyTable()) {
-                if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(condition)) {
+                if (pPlayers[pParty->activeCharacterIndex()]->conditions.Has(condition)) {
                     str += " \n";
                     GameTime condition_time =
-                        pParty->GetPlayingTime() - pPlayers[pParty->activePlayerIndex()]->conditions.Get(condition);
+                        pParty->GetPlayingTime() - pPlayers[pParty->activeCharacterIndex()]->conditions.Get(condition);
                     pHour = condition_time.GetHoursOfDay();
                     pDay = condition_time.GetDays();
                     pTextColor = GetConditionDrawColor(condition);
@@ -1166,21 +1166,21 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 14:  // Experience
         {
-            v15 = pPlayers[pParty->activePlayerIndex()]->uLevel;
+            v15 = pPlayers[pParty->activeCharacterIndex()]->uLevel;
             do {
-                if (pPlayers[pParty->activePlayerIndex()]->uExperience < GetExperienceRequiredForLevel(v15))
+                if (pPlayers[pParty->activeCharacterIndex()]->uExperience < GetExperienceRequiredForLevel(v15))
                     break;
                 ++v15;
             } while (v15 <= 10000);
 
             std::string str1;
             std::string str2;
-            if (v15 > pPlayers[pParty->activePlayerIndex()]->uLevel)
+            if (v15 > pPlayers[pParty->activeCharacterIndex()]->uLevel)
                 str1 = localization->FormatString(
                     LSTR_ELIGIBLE_TO_LEVELUP, v15);
             str2 = localization->FormatString(
                 LSTR_XP_UNTIL_NEXT_LEVEL,
-                (int)(GetExperienceRequiredForLevel(v15) - pPlayers[pParty->activePlayerIndex()]->uExperience),
+                (int)(GetExperienceRequiredForLevel(v15) - pPlayers[pParty->activeCharacterIndex()]->uExperience),
                 v15 + 1);
             str1 += "\n" + str2;
 
@@ -1192,7 +1192,7 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 15:  // Attack Bonus
             if (pAttackBonusAttributeDescription) {
-                int meleerecov = pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(false);
+                int meleerecov = pPlayers[pParty->activeCharacterIndex()]->GetAttackRecoveryTime(false);
                 // TODO(captainurist): fmt can throw
                 std::string description = fmt::sprintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), meleerecov);
                 description = fmt::format("{}\n\n{}", pAttackBonusAttributeDescription, description.c_str());
@@ -1210,7 +1210,7 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 17:  // Missle Bonus
             if (pMissleBonusAttributeDescription) {
-                int missrecov = pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(true);
+                int missrecov = pPlayers[pParty->activeCharacterIndex()]->GetAttackRecoveryTime(true);
                 // TODO(captainurist): fmt can throw
                 std::string description = fmt::sprintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), missrecov);
                 description = fmt::format("{}\n\n{}", pAttackBonusAttributeDescription, description);
@@ -1269,9 +1269,9 @@ void CharacterUI_StatsTab_ShowHint() {
         case 26:  // Class description
         {
             CharacterUI_DrawTooltip(localization->GetClassName(
-                                        pPlayers[pParty->activePlayerIndex()]->classType),
+                                        pPlayers[pParty->activeCharacterIndex()]->classType),
                                     localization->GetClassDescription(
-                                        pPlayers[pParty->activePlayerIndex()]->classType));
+                                        pPlayers[pParty->activeCharacterIndex()]->classType));
         } break;
 
         default:
@@ -1286,7 +1286,7 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     GUIWindow spell_info_window;  // [sp+Ch] [bp-68h]@4
 
     Pointi pt = mouse->GetCursorPos();
-    SPELL_TYPE spell_id = static_cast<SPELL_TYPE>(spell_index_in_book + 11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage + 1);
+    SPELL_TYPE spell_id = static_cast<SPELL_TYPE>(spell_index_in_book + 11 * pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage + 1);
 
     spell = &pSpellStats->pInfos[spell_id];
     if (pt.y <= 250)
@@ -1332,8 +1332,8 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     spell_info_window.DrawText(pFontSmallnum, {120, 44}, 0, str, 0, 0, 0);
     spell_info_window.uFrameWidth = 108;
     spell_info_window.uFrameZ = spell_info_window.uFrameX + 107;
-    PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage + 12);
-    PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetSkillMastery(skill);
+    PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pPlayers[pParty->activeCharacterIndex()]->lastOpenedSpellbookPage + 12);
+    PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activeCharacterIndex()]->GetSkillMastery(skill);
     spell_info_window.DrawTitleText(pFontComic, 12, 75, 0, localization->GetSkillName(skill), 3);
 
     auto str2 = fmt::format(
@@ -1375,7 +1375,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
             if ((signed int)pX > RightClickPortraitXmin[i] &&
                 (signed int)pX < RightClickPortraitXmax[i] &&
                 (signed int)pY > 375 && (signed int)pY < 466) {
-                pPlayers[pParty->activePlayerIndex()]->useItem(i, true);
+                pPlayers[pParty->activeCharacterIndex()]->useItem(i, true);
                 return;
             }
         }
@@ -1388,11 +1388,11 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
             break;
         }
         case CURRENT_SCREEN::SCREEN_CHEST: {
-            if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+            if (!pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
                 static std::string hint_reference;
                 hint_reference = localization->FormatString(
                     LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-                    pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
+                    pPlayers[pParty->activeCharacterIndex()]->pName.c_str(),
                     localization->GetString(LSTR_IDENTIFY_ITEMS)
                 );
 
@@ -1733,7 +1733,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
 
             if (item_pid == -1) return;
 
-            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[item_pid];
+            item = &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[item_pid];
             GameUI_DrawItemInfo(item);
             return;
         } else {  // rings displayed
@@ -1744,14 +1744,14 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             if (mousex >= amuletx && mousex <= (amuletx + slot) &&
                 mousey >= amulety && mousey <= (amulety + 2 * slot)) {
                 // amulet
-                // pitem = pPlayers[pParty->activePlayerIndex()]->GetAmuletItem(); //9
+                // pitem = pPlayers[pParty->activeCharacterIndex()]->GetAmuletItem(); //9
                 pos = ITEM_SLOT_AMULET;
             }
 
             if (mousex >= glovex && mousex <= (glovex + slot) &&
                 mousey >= glovey && mousey <= (glovey + 2 * slot)) {
                 // glove
-                // pitem = pPlayers[pParty->activePlayerIndex()]->GetGloveItem(); //7
+                // pitem = pPlayers[pParty->activeCharacterIndex()]->GetGloveItem(); //7
                 pos = ITEM_SLOT_GAUTNLETS;
             }
 
@@ -1759,14 +1759,14 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 if (mousex >= RingsX[i] && mousex <= (RingsX[i] + slot) &&
                     mousey >= RingsY[i] && mousey <= (RingsY[i] + slot)) {
                     // ring
-                    // pitem = pPlayers[pParty->activePlayerIndex()]->GetNthRingItem(i);
+                    // pitem = pPlayers[pParty->activeCharacterIndex()]->GetNthRingItem(i);
                     // //10+i
                     pos = RingSlot(i);
                 }
             }
 
             if (pos != ITEM_SLOT_INVALID)
-                item = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
+                item = pPlayers[pParty->activeCharacterIndex()]->GetNthEquippedIndexItem(pos);
 
             if (!item) return;
 
@@ -1780,7 +1780,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
     // if (inventoryYCoord >= 0 && inventoryYCoord < INVETORYSLOTSHEIGHT &&
     // inventoryXCoord >= 0 && inventoryXCoord < INVETORYSLOTSWIDTH) {
 
-    item = pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(invMatrixIndex);
+    item = pPlayers[pParty->activeCharacterIndex()]->GetItemAtInventoryIndex(invMatrixIndex);
 
     if (!item) {  // no item
         return;
@@ -1790,11 +1790,11 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
     //    return;
 
     // check character condition(проверка состояния персонажа)
-    if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+    if (!pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
         static std::string hint_reference;
         hint_reference = localization->FormatString(
             LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
+            pPlayers[pParty->activeCharacterIndex()]->pName.c_str(),
             localization->GetString(LSTR_IDENTIFY_ITEMS)
         );
 
@@ -1810,8 +1810,8 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         return;
     }
 
-    PLAYER_SKILL_LEVEL alchemy_skill_points = pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(PLAYER_SKILL_ALCHEMY);
-    PLAYER_SKILL_MASTERY alchemy_skill_level = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_ALCHEMY);
+    PLAYER_SKILL_LEVEL alchemy_skill_points = pPlayers[pParty->activeCharacterIndex()]->GetActualSkillLevel(PLAYER_SKILL_ALCHEMY);
+    PLAYER_SKILL_MASTERY alchemy_skill_level = pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(PLAYER_SKILL_ALCHEMY);
 
     if (pParty->pPickedItem.uItemID == ITEM_POTION_BOTTLE) {
         GameUI_DrawItemInfo(item);
@@ -1953,7 +1953,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         mouse->RemoveHoldingItem();
         no_rightlick_in_inventory = 1;
         if (dword_4E455C) {
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionSuccess);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_PotionSuccess);
             dword_4E455C = 0;
         }
         return;
@@ -2009,11 +2009,11 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             }
         }
 
-        int item_pid = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invMatrixIndex);
+        int item_pid = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invMatrixIndex);
         // int pOut_x = item_pid + 1;
         // for (uint i = 0; i < 126; ++i)
         //{
-        //  if (pPlayers[pParty->activePlayerIndex()]->pInventoryMatrix[i] == pOut_x)
+        //  if (pPlayers[pParty->activeCharacterIndex()]->pInventoryMatrix[i] == pOut_x)
         // {
         //    pOut_y = i;
         //   break;
@@ -2021,19 +2021,19 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         //}
 
         if (damage_level > 0) {
-            pPlayers[pParty->activePlayerIndex()]->RemoveItemAtInventoryIndex(invMatrixIndex);  // pOut_y); ?? quickfix needs checking
+            pPlayers[pParty->activeCharacterIndex()]->RemoveItemAtInventoryIndex(invMatrixIndex);  // pOut_y); ?? quickfix needs checking
 
             if (damage_level == 1) {
-                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(11) + 10, DMGT_FIRE);
+                pPlayers[pParty->activeCharacterIndex()]->receiveDamage(grng->random(11) + 10, DMGT_FIRE);
             } else if (damage_level == 2) {
-                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(71) + 30, DMGT_FIRE);
-                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(1);  // break 1
+                pPlayers[pParty->activeCharacterIndex()]->receiveDamage(grng->random(71) + 30, DMGT_FIRE);
+                pPlayers[pParty->activeCharacterIndex()]->ItemsPotionDmgBreak(1);  // break 1
             } else if (damage_level == 3) {
-                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(201) + 50, DMGT_FIRE);
-                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(5);  // break 5
+                pPlayers[pParty->activeCharacterIndex()]->receiveDamage(grng->random(201) + 50, DMGT_FIRE);
+                pPlayers[pParty->activeCharacterIndex()]->ItemsPotionDmgBreak(5);  // break 5
             } else if (damage_level >= 4) {
-                pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Eradicated, 0);
-                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(0);  // break everything
+                pPlayers[pParty->activeCharacterIndex()]->SetCondition(Condition_Eradicated, 0);
+                pPlayers[pParty->activeCharacterIndex()]->ItemsPotionDmgBreak(0);  // break everything
             }
 
             pAudioPlayer->playUISound(SOUND_fireBall);
@@ -2043,8 +2043,8 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             Vec3i::rotate(64, pParty->_viewYaw, pParty->_viewPitch, pParty->vPosition + Vec3i(0, 0, pParty->sEyelevel), &_viewPitch, &_viewYaw, &rot_z);
             SpriteObject::dropItemAt(SPRITE_SPELL_FIRE_FIREBALL_IMPACT, {_viewPitch, _viewYaw, rot_z}, 0);
             if (dword_4E455C) {
-                if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
-                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionExplode);
+                if (pPlayers[pParty->activeCharacterIndex()]->CanAct()) {
+                    pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_PotionExplode);
                 }
                 GameUI_SetStatusBar(LSTR_OOPS);
                 dword_4E455C = 0;
@@ -2069,12 +2069,12 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 // Can be zero even for valid potion combination when resulting potion is of lower grade than it's components
                 // Example: "Cure Paralysis(white) + Cure Wounds(red) = Cure Wounds(red)"
                 if (pItemTable->potionNotes[potionSrc1][potionSrc2] != 0) {
-                    pPlayers[pParty->activePlayerIndex()]->SetVariable(VAR_AutoNotes, pItemTable->potionNotes[potionSrc1][potionSrc2]);
+                    pPlayers[pParty->activeCharacterIndex()]->SetVariable(VAR_AutoNotes, pItemTable->potionNotes[potionSrc1][potionSrc2]);
                 }
             }
-            int bottle = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, ITEM_POTION_BOTTLE);
+            int bottle = pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, ITEM_POTION_BOTTLE);
             if (bottle) {
-                pPlayers[pParty->activePlayerIndex()]->pOwnItems[bottle - 1].uAttributes = ITEM_IDENTIFIED;
+                pPlayers[pParty->activeCharacterIndex()]->pOwnItems[bottle - 1].uAttributes = ITEM_IDENTIFIED;
             }
             if (!(pItemTable->pItems[item->uItemID].uItemID_Rep_St)) {
                 item->uAttributes |= ITEM_IDENTIFIED;
@@ -2084,7 +2084,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 no_rightlick_in_inventory = 1;
                 return;
             }
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionSuccess);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_PotionSuccess);
             dword_4E455C = 0;
             mouse->RemoveHoldingItem();
             no_rightlick_in_inventory = 1;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -241,28 +241,28 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
         GoldAmount = inspect_item->special_enchantment;
     }
 
-    if (pParty->hasActiveCharacter()) {
+    if (pParty->hasActivePlayer()) {
         // try to identify
         if (!inspect_item->IsIdentified()) {
-            if (pPlayers[pParty->getActiveCharacter()]->CanIdentify(inspect_item) == 1)
+            if (pPlayers[pParty->activePlayerIndex()]->CanIdentify(inspect_item) == 1)
                 inspect_item->SetIdentified();
             PlayerSpeech speech = SPEECH_IndentifyItemFail;
             if (!inspect_item->IsIdentified()) {
                 GameUI_SetStatusBar(LSTR_IDENTIFY_FAILED);
             } else {
                 speech = SPEECH_IndentifyItemStrong;
-                if (inspect_item->GetValue() < 100 * (pPlayers[pParty->getActiveCharacter()]->uLevel + 5)) {
+                if (inspect_item->GetValue() < 100 * (pPlayers[pParty->activePlayerIndex()]->uLevel + 5)) {
                     speech = SPEECH_IndentifyItemWeak;
                 }
             }
             if (dword_4E455C) {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(speech);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
                 dword_4E455C = 0;
             }
         }
         inspect_item->UpdateTempBonus(pParty->GetPlayingTime());
         if (inspect_item->IsBroken()) {
-            if (pPlayers[pParty->getActiveCharacter()]->CanRepair(inspect_item) == 1)
+            if (pPlayers[pParty->activePlayerIndex()]->CanRepair(inspect_item) == 1)
                 inspect_item->uAttributes =
                     inspect_item->uAttributes & ~ITEM_BROKEN | ITEM_IDENTIFIED;
             PlayerSpeech speech = SPEECH_RepairFail;
@@ -271,7 +271,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
             else
                 GameUI_SetStatusBar(LSTR_REPAIR_FAILED);
             if (dword_4E455C) {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(speech);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
                 dword_4E455C = 0;
             }
         }
@@ -569,7 +569,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     bool monster_full_informations = false;
     static Actor pMonsterInfoUI_Doll;
     // TODO(pskelton): check this behaviour
-    if (!pParty->hasActiveCharacter()) {
+    if (!pParty->hasActivePlayer()) {
         pParty->setActiveToFirstCanAct();
     }
 
@@ -660,10 +660,10 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     PLAYER_SKILL_MASTERY skill_mastery = PLAYER_SKILL_MASTERY_NONE;
 
     pMonsterInfoUI_Doll.uCurrentActionTime += pMiscTimer->uTimeElapsed;
-    if (pPlayers[pParty->getActiveCharacter()]->GetActualSkillLevel(
+    if (pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(
             PLAYER_SKILL_MONSTER_ID)) {
-        skill_points = pPlayers[pParty->getActiveCharacter()]->GetActualSkillLevel(PLAYER_SKILL_MONSTER_ID);
-        skill_mastery = pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID);
+        skill_points = pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(PLAYER_SKILL_MONSTER_ID);
+        skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID);
         if (skill_mastery == PLAYER_SKILL_MASTERY_NOVICE) {
             if (skill_points + 10 >= pActors[uActorID].pMonsterInfo.uLevel)
                 normal_level = 1;
@@ -692,21 +692,21 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     if (pActors[uActorID].uAIState != Dead &&
         pActors[uActorID].uAIState != Dying &&
         !dword_507BF0_is_there_popup_onscreen &&
-        pPlayers[pParty->getActiveCharacter()]->GetActualSkillLevel(
+        pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(
             PLAYER_SKILL_MONSTER_ID)) {
         if (normal_level || expert_level || master_level || grandmaster_level) {
             if (pActors[uActorID].pMonsterInfo.uLevel >=
-                pPlayers[pParty->getActiveCharacter()]->uLevel - 5)
+                pPlayers[pParty->activePlayerIndex()]->uLevel - 5)
                 speech = SPEECH_IDMonsterStrong;
             else
                 speech = SPEECH_IDMonsterWeak;
         } else {
             speech = SPEECH_IDMonsterFail;
         }
-        pPlayers[pParty->getActiveCharacter()]->playReaction(speech);
+        pPlayers[pParty->activePlayerIndex()]->playReaction(speech);
     }
 
-    if ((signed int)(pParty->pPlayers[pParty->getActiveCharacter() - 1]
+    if ((signed int)(pParty->pPlayers[pParty->activePlayerIndex() - 1]
                          .GetActualSkillMastery(PLAYER_SKILL_MONSTER_ID)) >= 3)
         for_effects = 1;
 
@@ -1054,7 +1054,7 @@ void CharacterUI_SkillsTab_ShowHint() {
             if (pButton->msg == UIMSG_SkillUp && pX >= pButton->uX &&
                 pX < pButton->uZ && pY >= pButton->uY && pY < pButton->uW) {
                 PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pButton->msg_param);
-                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->getActiveCharacter() - 1, skill);
+                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activePlayerIndex() - 1, skill);
                 CharacterUI_DrawTooltip(localization->GetSkillName(skill), pSkillDescText);
             }
         }
@@ -1120,10 +1120,10 @@ void CharacterUI_StatsTab_ShowHint() {
             auto str = std::string(pPlayerConditionAttributeDescription) + "\n";
 
             for (Condition condition : conditionImportancyTable()) {
-                if (pPlayers[pParty->getActiveCharacter()]->conditions.Has(condition)) {
+                if (pPlayers[pParty->activePlayerIndex()]->conditions.Has(condition)) {
                     str += " \n";
                     GameTime condition_time =
-                        pParty->GetPlayingTime() - pPlayers[pParty->getActiveCharacter()]->conditions.Get(condition);
+                        pParty->GetPlayingTime() - pPlayers[pParty->activePlayerIndex()]->conditions.Get(condition);
                     pHour = condition_time.GetHoursOfDay();
                     pDay = condition_time.GetDays();
                     pTextColor = GetConditionDrawColor(condition);
@@ -1166,21 +1166,21 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 14:  // Experience
         {
-            v15 = pPlayers[pParty->getActiveCharacter()]->uLevel;
+            v15 = pPlayers[pParty->activePlayerIndex()]->uLevel;
             do {
-                if (pPlayers[pParty->getActiveCharacter()]->uExperience < GetExperienceRequiredForLevel(v15))
+                if (pPlayers[pParty->activePlayerIndex()]->uExperience < GetExperienceRequiredForLevel(v15))
                     break;
                 ++v15;
             } while (v15 <= 10000);
 
             std::string str1;
             std::string str2;
-            if (v15 > pPlayers[pParty->getActiveCharacter()]->uLevel)
+            if (v15 > pPlayers[pParty->activePlayerIndex()]->uLevel)
                 str1 = localization->FormatString(
                     LSTR_ELIGIBLE_TO_LEVELUP, v15);
             str2 = localization->FormatString(
                 LSTR_XP_UNTIL_NEXT_LEVEL,
-                (int)(GetExperienceRequiredForLevel(v15) - pPlayers[pParty->getActiveCharacter()]->uExperience),
+                (int)(GetExperienceRequiredForLevel(v15) - pPlayers[pParty->activePlayerIndex()]->uExperience),
                 v15 + 1);
             str1 += "\n" + str2;
 
@@ -1192,7 +1192,7 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 15:  // Attack Bonus
             if (pAttackBonusAttributeDescription) {
-                int meleerecov = pPlayers[pParty->getActiveCharacter()]->GetAttackRecoveryTime(false);
+                int meleerecov = pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(false);
                 // TODO(captainurist): fmt can throw
                 std::string description = fmt::sprintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), meleerecov);
                 description = fmt::format("{}\n\n{}", pAttackBonusAttributeDescription, description.c_str());
@@ -1210,7 +1210,7 @@ void CharacterUI_StatsTab_ShowHint() {
 
         case 17:  // Missle Bonus
             if (pMissleBonusAttributeDescription) {
-                int missrecov = pPlayers[pParty->getActiveCharacter()]->GetAttackRecoveryTime(true);
+                int missrecov = pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(true);
                 // TODO(captainurist): fmt can throw
                 std::string description = fmt::sprintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), missrecov);
                 description = fmt::format("{}\n\n{}", pAttackBonusAttributeDescription, description);
@@ -1269,9 +1269,9 @@ void CharacterUI_StatsTab_ShowHint() {
         case 26:  // Class description
         {
             CharacterUI_DrawTooltip(localization->GetClassName(
-                                        pPlayers[pParty->getActiveCharacter()]->classType),
+                                        pPlayers[pParty->activePlayerIndex()]->classType),
                                     localization->GetClassDescription(
-                                        pPlayers[pParty->getActiveCharacter()]->classType));
+                                        pPlayers[pParty->activePlayerIndex()]->classType));
         } break;
 
         default:
@@ -1286,7 +1286,7 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     GUIWindow spell_info_window;  // [sp+Ch] [bp-68h]@4
 
     Pointi pt = mouse->GetCursorPos();
-    SPELL_TYPE spell_id = static_cast<SPELL_TYPE>(spell_index_in_book + 11 * pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage + 1);
+    SPELL_TYPE spell_id = static_cast<SPELL_TYPE>(spell_index_in_book + 11 * pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage + 1);
 
     spell = &pSpellStats->pInfos[spell_id];
     if (pt.y <= 250)
@@ -1332,8 +1332,8 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     spell_info_window.DrawText(pFontSmallnum, {120, 44}, 0, str, 0, 0, 0);
     spell_info_window.uFrameWidth = 108;
     spell_info_window.uFrameZ = spell_info_window.uFrameX + 107;
-    PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pPlayers[pParty->getActiveCharacter()]->lastOpenedSpellbookPage + 12);
-    PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->getActiveCharacter()]->GetSkillMastery(skill);
+    PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pPlayers[pParty->activePlayerIndex()]->lastOpenedSpellbookPage + 12);
+    PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetSkillMastery(skill);
     spell_info_window.DrawTitleText(pFontComic, 12, 75, 0, localization->GetSkillName(skill), 3);
 
     auto str2 = fmt::format(
@@ -1375,7 +1375,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
             if ((signed int)pX > RightClickPortraitXmin[i] &&
                 (signed int)pX < RightClickPortraitXmax[i] &&
                 (signed int)pY > 375 && (signed int)pY < 466) {
-                pPlayers[pParty->getActiveCharacter()]->useItem(i, true);
+                pPlayers[pParty->activePlayerIndex()]->useItem(i, true);
                 return;
             }
         }
@@ -1388,11 +1388,11 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
             break;
         }
         case CURRENT_SCREEN::SCREEN_CHEST: {
-            if (!pPlayers[pParty->getActiveCharacter()]->CanAct()) {
+            if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
                 static std::string hint_reference;
                 hint_reference = localization->FormatString(
                     LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-                    pPlayers[pParty->getActiveCharacter()]->pName.c_str(),
+                    pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
                     localization->GetString(LSTR_IDENTIFY_ITEMS)
                 );
 
@@ -1733,7 +1733,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
 
             if (item_pid == -1) return;
 
-            item = &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[item_pid];
+            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[item_pid];
             GameUI_DrawItemInfo(item);
             return;
         } else {  // rings displayed
@@ -1744,14 +1744,14 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             if (mousex >= amuletx && mousex <= (amuletx + slot) &&
                 mousey >= amulety && mousey <= (amulety + 2 * slot)) {
                 // amulet
-                // pitem = pPlayers[pParty->getActiveCharacter()]->GetAmuletItem(); //9
+                // pitem = pPlayers[pParty->activePlayerIndex()]->GetAmuletItem(); //9
                 pos = ITEM_SLOT_AMULET;
             }
 
             if (mousex >= glovex && mousex <= (glovex + slot) &&
                 mousey >= glovey && mousey <= (glovey + 2 * slot)) {
                 // glove
-                // pitem = pPlayers[pParty->getActiveCharacter()]->GetGloveItem(); //7
+                // pitem = pPlayers[pParty->activePlayerIndex()]->GetGloveItem(); //7
                 pos = ITEM_SLOT_GAUTNLETS;
             }
 
@@ -1759,14 +1759,14 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 if (mousex >= RingsX[i] && mousex <= (RingsX[i] + slot) &&
                     mousey >= RingsY[i] && mousey <= (RingsY[i] + slot)) {
                     // ring
-                    // pitem = pPlayers[pParty->getActiveCharacter()]->GetNthRingItem(i);
+                    // pitem = pPlayers[pParty->activePlayerIndex()]->GetNthRingItem(i);
                     // //10+i
                     pos = RingSlot(i);
                 }
             }
 
             if (pos != ITEM_SLOT_INVALID)
-                item = pPlayers[pParty->getActiveCharacter()]->GetNthEquippedIndexItem(pos);
+                item = pPlayers[pParty->activePlayerIndex()]->GetNthEquippedIndexItem(pos);
 
             if (!item) return;
 
@@ -1780,7 +1780,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
     // if (inventoryYCoord >= 0 && inventoryYCoord < INVETORYSLOTSHEIGHT &&
     // inventoryXCoord >= 0 && inventoryXCoord < INVETORYSLOTSWIDTH) {
 
-    item = pPlayers[pParty->getActiveCharacter()]->GetItemAtInventoryIndex(invMatrixIndex);
+    item = pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(invMatrixIndex);
 
     if (!item) {  // no item
         return;
@@ -1790,11 +1790,11 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
     //    return;
 
     // check character condition(проверка состояния персонажа)
-    if (!pPlayers[pParty->getActiveCharacter()]->CanAct()) {
+    if (!pPlayers[pParty->activePlayerIndex()]->CanAct()) {
         static std::string hint_reference;
         hint_reference = localization->FormatString(
             LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-            pPlayers[pParty->getActiveCharacter()]->pName.c_str(),
+            pPlayers[pParty->activePlayerIndex()]->pName.c_str(),
             localization->GetString(LSTR_IDENTIFY_ITEMS)
         );
 
@@ -1810,8 +1810,8 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         return;
     }
 
-    PLAYER_SKILL_LEVEL alchemy_skill_points = pPlayers[pParty->getActiveCharacter()]->GetActualSkillLevel(PLAYER_SKILL_ALCHEMY);
-    PLAYER_SKILL_MASTERY alchemy_skill_level = pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(PLAYER_SKILL_ALCHEMY);
+    PLAYER_SKILL_LEVEL alchemy_skill_points = pPlayers[pParty->activePlayerIndex()]->GetActualSkillLevel(PLAYER_SKILL_ALCHEMY);
+    PLAYER_SKILL_MASTERY alchemy_skill_level = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(PLAYER_SKILL_ALCHEMY);
 
     if (pParty->pPickedItem.uItemID == ITEM_POTION_BOTTLE) {
         GameUI_DrawItemInfo(item);
@@ -1953,7 +1953,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         mouse->RemoveHoldingItem();
         no_rightlick_in_inventory = 1;
         if (dword_4E455C) {
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_PotionSuccess);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionSuccess);
             dword_4E455C = 0;
         }
         return;
@@ -2009,11 +2009,11 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             }
         }
 
-        int item_pid = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invMatrixIndex);
+        int item_pid = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invMatrixIndex);
         // int pOut_x = item_pid + 1;
         // for (uint i = 0; i < 126; ++i)
         //{
-        //  if (pPlayers[pParty->getActiveCharacter()]->pInventoryMatrix[i] == pOut_x)
+        //  if (pPlayers[pParty->activePlayerIndex()]->pInventoryMatrix[i] == pOut_x)
         // {
         //    pOut_y = i;
         //   break;
@@ -2021,19 +2021,19 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
         //}
 
         if (damage_level > 0) {
-            pPlayers[pParty->getActiveCharacter()]->RemoveItemAtInventoryIndex(invMatrixIndex);  // pOut_y); ?? quickfix needs checking
+            pPlayers[pParty->activePlayerIndex()]->RemoveItemAtInventoryIndex(invMatrixIndex);  // pOut_y); ?? quickfix needs checking
 
             if (damage_level == 1) {
-                pPlayers[pParty->getActiveCharacter()]->receiveDamage(grng->random(11) + 10, DMGT_FIRE);
+                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(11) + 10, DMGT_FIRE);
             } else if (damage_level == 2) {
-                pPlayers[pParty->getActiveCharacter()]->receiveDamage(grng->random(71) + 30, DMGT_FIRE);
-                pPlayers[pParty->getActiveCharacter()]->ItemsPotionDmgBreak(1);  // break 1
+                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(71) + 30, DMGT_FIRE);
+                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(1);  // break 1
             } else if (damage_level == 3) {
-                pPlayers[pParty->getActiveCharacter()]->receiveDamage(grng->random(201) + 50, DMGT_FIRE);
-                pPlayers[pParty->getActiveCharacter()]->ItemsPotionDmgBreak(5);  // break 5
+                pPlayers[pParty->activePlayerIndex()]->receiveDamage(grng->random(201) + 50, DMGT_FIRE);
+                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(5);  // break 5
             } else if (damage_level >= 4) {
-                pPlayers[pParty->getActiveCharacter()]->SetCondition(Condition_Eradicated, 0);
-                pPlayers[pParty->getActiveCharacter()]->ItemsPotionDmgBreak(0);  // break everything
+                pPlayers[pParty->activePlayerIndex()]->SetCondition(Condition_Eradicated, 0);
+                pPlayers[pParty->activePlayerIndex()]->ItemsPotionDmgBreak(0);  // break everything
             }
 
             pAudioPlayer->playUISound(SOUND_fireBall);
@@ -2043,8 +2043,8 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
             Vec3i::rotate(64, pParty->_viewYaw, pParty->_viewPitch, pParty->vPosition + Vec3i(0, 0, pParty->sEyelevel), &_viewPitch, &_viewYaw, &rot_z);
             SpriteObject::dropItemAt(SPRITE_SPELL_FIRE_FIREBALL_IMPACT, {_viewPitch, _viewYaw, rot_z}, 0);
             if (dword_4E455C) {
-                if (pPlayers[pParty->getActiveCharacter()]->CanAct()) {
-                    pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_PotionExplode);
+                if (pPlayers[pParty->activePlayerIndex()]->CanAct()) {
+                    pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionExplode);
                 }
                 GameUI_SetStatusBar(LSTR_OOPS);
                 dword_4E455C = 0;
@@ -2069,12 +2069,12 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 // Can be zero even for valid potion combination when resulting potion is of lower grade than it's components
                 // Example: "Cure Paralysis(white) + Cure Wounds(red) = Cure Wounds(red)"
                 if (pItemTable->potionNotes[potionSrc1][potionSrc2] != 0) {
-                    pPlayers[pParty->getActiveCharacter()]->SetVariable(VAR_AutoNotes, pItemTable->potionNotes[potionSrc1][potionSrc2]);
+                    pPlayers[pParty->activePlayerIndex()]->SetVariable(VAR_AutoNotes, pItemTable->potionNotes[potionSrc1][potionSrc2]);
                 }
             }
-            int bottle = pPlayers[pParty->getActiveCharacter()]->AddItem(-1, ITEM_POTION_BOTTLE);
+            int bottle = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, ITEM_POTION_BOTTLE);
             if (bottle) {
-                pPlayers[pParty->getActiveCharacter()]->pOwnItems[bottle - 1].uAttributes = ITEM_IDENTIFIED;
+                pPlayers[pParty->activePlayerIndex()]->pOwnItems[bottle - 1].uAttributes = ITEM_IDENTIFIED;
             }
             if (!(pItemTable->pItems[item->uItemID].uItemID_Rep_St)) {
                 item->uAttributes |= ITEM_IDENTIFIED;
@@ -2084,7 +2084,7 @@ void Inventory_ItemPopupAndAlchemy() {  // needs cleaning
                 no_rightlick_in_inventory = 1;
                 return;
             }
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_PotionSuccess);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_PotionSuccess);
             dword_4E455C = 0;
             mouse->RemoveHoldingItem();
             no_rightlick_in_inventory = 1;

--- a/src/GUI/UI/UIShops.cpp
+++ b/src/GUI/UI/UIShops.cpp
@@ -85,7 +85,7 @@ void ShopDialogMain(GUIWindow dialogwin) {
 void ShopDialogDisplayEquip(GUIWindow dialogwin,
                             BuildingType building = BuildingType_WeaponShop) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
 
     pShopOptions[0] = localization->GetString(LSTR_SELL);
     pShopOptions[1] = localization->GetString(LSTR_IDENTIFY);
@@ -135,7 +135,7 @@ void ShopDialogDisplayEquip(GUIWindow dialogwin,
 
 void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), 0);
@@ -146,15 +146,15 @@ void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
         if (pt.x <= 13 || pt.x >= 462)
             return;
 
-        int pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
         if (pItemID) {
             ItemGen *item =
-                &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID - 1];
+                &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
             MERCHANT_PHRASE phrases_id =
-                pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+                pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                     item, building, window_SpeakInHouse->wData.val, 3);
             auto str = BuildDialogueString(
-                pMerchantsSellPhrases[phrases_id], pParty->getActiveCharacter() - 1, item,
+                pMerchantsSellPhrases[phrases_id], pParty->activePlayerIndex() - 1, item,
                 window_SpeakInHouse->wData.val, 3);
             dialogwin.DrawTitleText(pFontArrus, 0,
                                     (174 - pFontArrus->CalcTextHeight(
@@ -167,7 +167,7 @@ void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
 
 void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), 0);
@@ -177,20 +177,20 @@ void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
         int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
         if (pt.x <= 13 || pt.x >= 462) return;
 
-        int pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
 
         if (pItemID) {
-            ItemGen *item = &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID - 1];
+            ItemGen *item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
 
             std::string str;
             if (!item->IsIdentified()) {
-                MERCHANT_PHRASE phrases_id = pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+                MERCHANT_PHRASE phrases_id = pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                     item, building, window_SpeakInHouse->wData.val, 4);
                 str = BuildDialogueString(
-                    pMerchantsIdentifyPhrases[phrases_id], pParty->getActiveCharacter() - 1,
+                    pMerchantsIdentifyPhrases[phrases_id], pParty->activePlayerIndex() - 1,
                     item, window_SpeakInHouse->wData.val, 4);
             } else {
-                str = BuildDialogueString("%24", pParty->getActiveCharacter() - 1, item,
+                str = BuildDialogueString("%24", pParty->activePlayerIndex() - 1, item,
                     window_SpeakInHouse->wData.val, 4);
             }
 
@@ -202,7 +202,7 @@ void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
 
 void ShopDialogRepair(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->getActiveCharacter()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), 0);
@@ -213,17 +213,17 @@ void ShopDialogRepair(GUIWindow dialogwin, BuildingType building) {
         if (pt.x <= 13 || pt.x >= 462)
             return;
 
-        int pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
         if (pItemID == 0)
             return;
 
-        if ((pPlayers[pParty->getActiveCharacter()]->pOwnItems[pItemID - 1].uAttributes &
+        if ((pPlayers[pParty->activePlayerIndex()]->pOwnItems[pItemID - 1].uAttributes &
              ITEM_BROKEN)) {
-            ItemGen *item = &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID - 1];
-            MERCHANT_PHRASE phrases_id = pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+            ItemGen *item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
+            MERCHANT_PHRASE phrases_id = pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                 item, building, window_SpeakInHouse->wData.val, 5);
             std::string str = BuildDialogueString(
-                pMerchantsRepairPhrases[phrases_id], pParty->getActiveCharacter() - 1, item,
+                pMerchantsRepairPhrases[phrases_id], pParty->activePlayerIndex() - 1, item,
                 window_SpeakInHouse->wData.val, 5);
             dialogwin.DrawTitleText(pFontArrus, 0,
                 (174 - pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + 138, colorTable.White.c16(), str, 3);
@@ -238,7 +238,7 @@ void ShopDialogLearn(GUIWindow dialogwin) {
     int all_text_height = 0;
 
     int pPrice =
-        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->getActiveCharacter()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
+        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     for (int i = pDialogueWindow->pStartingPosActiveItem;
         i < pDialogueWindow->pNumPresenceButton +
@@ -247,8 +247,8 @@ void ShopDialogLearn(GUIWindow dialogwin) {
         auto skill = GetLearningDialogueSkill(
             (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
         );
-        if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-            && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill]) {
+        if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+            && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
             all_text_height += pFontArrus->CalcTextHeight(
                 localization->GetSkillName(skill),
                 dialogwin.uFrameWidth, 0);
@@ -298,7 +298,7 @@ void WeaponShopWares(GUIWindow dialogwin, bool special) {
             }
         }
 
-        if (StealingMode(pParty->getActiveCharacter()))
+        if (StealingMode(pParty->activePlayerIndex()))
             GameUI_StatusBar_DrawImmediate(
                 localization->GetString(LSTR_STEAL_ITEM), 0);
         else
@@ -329,17 +329,17 @@ void WeaponShopWares(GUIWindow dialogwin, bool special) {
                         if (pt.y >= weapons_Ypos[testx] + 30 &&
                             pt.y < (weapons_Ypos[testx] + 30 + shop_ui_items_in_store[testx]->GetHeight())) {
                             std::string str;
-                            if (!StealingMode(pParty->getActiveCharacter())) {
+                            if (!StealingMode(pParty->activePlayerIndex())) {
                                 str = BuildDialogueString(
-                                    pMerchantsBuyPhrases[pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+                                    pMerchantsBuyPhrases[pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                                                  item, BuildingType_WeaponShop,
                                                  window_SpeakInHouse->wData.val, 2)],
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -448,7 +448,7 @@ void ArmorShopWares(GUIWindow dialogwin, bool special) {
                 ++pItemCount;
         }
 
-        if (!StealingMode(pParty->getActiveCharacter())) {
+        if (!StealingMode(pParty->activePlayerIndex())) {
             GameUI_StatusBar_DrawImmediate(
                 localization->GetString(LSTR_SELECT_ITEM_TO_BUY), 0);
         } else {
@@ -494,17 +494,17 @@ void ArmorShopWares(GUIWindow dialogwin, bool special) {
                             // y is 126 to 126 + height low or 98-height to 98
 
                             std::string str;
-                            if (!StealingMode(pParty->getActiveCharacter())) {
+                            if (!StealingMode(pParty->activePlayerIndex())) {
                                 str = BuildDialogueString(
                                     pMerchantsBuyPhrases
-                                        [pPlayers[pParty->getActiveCharacter()]->SelectPhrasesTransaction(
+                                        [pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
                                                  item, BuildingType_ArmorShop, window_SpeakInHouse->wData.val, 2)],
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -624,7 +624,7 @@ void AlchemyMagicShopWares(GUIWindow dialogwin, BuildingType building,
                 ++item_num;
         }
 
-        if (StealingMode(pParty->getActiveCharacter())) {
+        if (StealingMode(pParty->activePlayerIndex())) {
             GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), 0);
         } else {
             GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), 0);
@@ -664,17 +664,17 @@ void AlchemyMagicShopWares(GUIWindow dialogwin, BuildingType building,
                             // y is 152-h to 152 or 308-height to 308
 
                             std::string str;
-                            if (!StealingMode(pParty->getActiveCharacter())) {
+                            if (!StealingMode(pParty->activePlayerIndex())) {
                                 str = BuildDialogueString(
                                     pMerchantsBuyPhrases
-                                        [pPlayers[pParty->getActiveCharacter()]
+                                        [pPlayers[pParty->activePlayerIndex()]
                                              ->SelectPhrasesTransaction(item, building, window_SpeakInHouse->wData.val, 2)],
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->getActiveCharacter() - 1, item,
+                                    pParty->activePlayerIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -805,7 +805,7 @@ void UIShop_Buy_Identify_Repair() {
     int uPriceItemService;     // [sp+ACh] [bp-8h]@12
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-        pPlayers[pParty->getActiveCharacter()]->OnInventoryLeftClick();
+        pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
         return;
     }
 
@@ -819,7 +819,7 @@ void UIShop_Buy_Identify_Repair() {
     switch (dialog_menu_id) {
         case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
-            pPlayers[pParty->getActiveCharacter()]->OnInventoryLeftClick();
+            pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
             break;
         }
 
@@ -843,7 +843,7 @@ void UIShop_Buy_Identify_Repair() {
                         if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->GetHeight())) ||
                             (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->GetHeight()))) {
                             pPriceMultiplier = p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier;
-                            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->getActiveCharacter()],
+                            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activePlayerIndex()],
                                                                                           bought_item->GetValue(), pPriceMultiplier);
 
                             if (pParty->GetGold() < uPriceItemService) {
@@ -852,21 +852,21 @@ void UIShop_Buy_Identify_Repair() {
                                 return;
                             }
 
-                            taken_item = pPlayers[pParty->getActiveCharacter()]->AddItem(-1, bought_item->uItemID);
+                            taken_item = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, bought_item->uItemID);
                             if (taken_item) {
                                 bought_item->SetIdentified();
                                 memcpy(
-                                    &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[taken_item - 1],
+                                    &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[taken_item - 1],
                                     bought_item, 0x24u);
                                 dword_F8B1E4 = 1;
                                 pParty->TakeGold(uPriceItemService);
                                 bought_item->Reset();
                                 render->ClearZBuffer();
-                                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_ItemBuy);
+                                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemBuy);
                                 return;
                             }
 
-                            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NoRoom);
+                            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
                             GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
                             break;
                         }
@@ -881,22 +881,22 @@ void UIShop_Buy_Identify_Repair() {
         case DIALOGUE_SHOP_SELL: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invindex),
+                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex),
                  !pItemID))
                 return;
 
-            if (pPlayers[pParty->getActiveCharacter()]
+            if (pPlayers[pParty->activePlayerIndex()]
                     ->pInventoryItemList[pItemID - 1]
                     .MerchandiseTest(window_SpeakInHouse->wData.val)) {
                 dword_F8B1E4 = 1;
-                pPlayers[pParty->getActiveCharacter()]->SalesProcess(
+                pPlayers[pParty->activePlayerIndex()]->SalesProcess(
                     invindex, pItemID - 1, window_SpeakInHouse->wData.val);
                 render->ClearZBuffer();
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_ItemSold);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemSold);
                 return;
             }
 
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_WrongShop);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
             pAudioPlayer->playUISound(SOUND_error);
             break;
         }
@@ -904,13 +904,13 @@ void UIShop_Buy_Identify_Repair() {
         case DIALOGUE_SHOP_IDENTIFY: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(invindex),
+                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex),
                  !pItemID))
                 return;
 
             uPriceItemService = PriceCalculator::itemIdentificationPriceForPlayer(
-                pPlayers[pParty->getActiveCharacter()], p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-            item = &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID - 1];
+                pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
+            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
 
             if (!(item->uAttributes & ITEM_IDENTIFIED)) {
                 if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
@@ -918,7 +918,7 @@ void UIShop_Buy_Identify_Repair() {
                         dword_F8B1E4 = 1;
                         pParty->TakeGold(uPriceItemService);
                         item->uAttributes |= ITEM_IDENTIFIED;
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_ShopIdentify);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ShopIdentify);
                         GameUI_SetStatusBar(LSTR_DONE);
                         return;
                     }
@@ -929,28 +929,28 @@ void UIShop_Buy_Identify_Repair() {
                 }
 
                 pAudioPlayer->playUISound(SOUND_error);
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_WrongShop);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
                 return;
             }
 
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_AlreadyIdentified);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_AlreadyIdentified);
             break;
         }
 
         case DIALOGUE_SHOP_REPAIR: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(
+                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(
                          invindex),
                  !pItemID))
                 return;
 
-            item = &pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[pItemID - 1];
+            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
             pPriceMultiplier =
                 p2DEvents[window_SpeakInHouse->wData.val - 1]
                     .fPriceMultiplier;
             uPriceItemService =
-                PriceCalculator::itemRepairPriceForPlayer(pPlayers[pParty->getActiveCharacter()], item->GetValue(), pPriceMultiplier);
+                PriceCalculator::itemRepairPriceForPlayer(pPlayers[pParty->activePlayerIndex()], item->GetValue(), pPriceMultiplier);
 
             if (item->uAttributes & ITEM_BROKEN) {
                 if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
@@ -959,7 +959,7 @@ void UIShop_Buy_Identify_Repair() {
                         pParty->TakeGold(uPriceItemService);
                         item->uAttributes =
                             (item->uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_ShopRepair);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ShopRepair);
                         GameUI_SetStatusBar(LSTR_GOOD_AS_NEW);
                         return;
                     }
@@ -970,11 +970,11 @@ void UIShop_Buy_Identify_Repair() {
                 }
 
                 pAudioPlayer->playUISound(SOUND_error);
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_WrongShop);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
                 return;
             }
 
-            pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_AlreadyIdentified);
+            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_AlreadyIdentified);
             break;
         }
 
@@ -1141,7 +1141,7 @@ void UIShop_Buy_Identify_Repair() {
                     return;
             }
 
-            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->getActiveCharacter()], bought_item->GetValue(),
+            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activePlayerIndex()], bought_item->GetValue(),
                                                                           p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
             uNumSeconds = 0;
             a3 = 0;
@@ -1149,8 +1149,8 @@ void UIShop_Buy_Identify_Repair() {
                 a3 = pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)]
                          ._steal_perm;
             party_reputation = pParty->GetPartyReputation();
-            if (StealingMode(pParty->getActiveCharacter())) {
-                uNumSeconds = pPlayers[pParty->getActiveCharacter()]->StealFromShop(
+            if (StealingMode(pParty->activePlayerIndex())) {
+                uNumSeconds = pPlayers[pParty->activePlayerIndex()]->StealFromShop(
                     bought_item, a3, party_reputation, 0, &a6);
                 if (!uNumSeconds) {
                     // caught stealing no item
@@ -1163,13 +1163,13 @@ void UIShop_Buy_Identify_Repair() {
                 return;
             }
 
-            v39 = pPlayers[pParty->getActiveCharacter()]->AddItem(-1, bought_item->uItemID);
+            v39 = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, bought_item->uItemID);
             if (v39) {
                 bought_item->SetIdentified();
-                memcpy(&pPlayers[pParty->getActiveCharacter()]->pInventoryItemList[v39 - 1],
+                memcpy(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v39 - 1],
                        bought_item, sizeof(ItemGen));
                 if (uNumSeconds != 0) {  // stolen
-                    pPlayers[pParty->getActiveCharacter()]
+                    pPlayers[pParty->activePlayerIndex()]
                         ->pInventoryItemList[v39 - 1]
                         .SetStolen();
                     sub_4B1447_party_fine(window_SpeakInHouse->wData.val,
@@ -1180,10 +1180,10 @@ void UIShop_Buy_Identify_Repair() {
                 }
                 bought_item->Reset();
                 render->ClearZBuffer();
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_ItemBuy);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemBuy);
                 return;
             } else {
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_NoRoom);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
                 GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
                 return;
             }
@@ -1193,10 +1193,10 @@ void UIShop_Buy_Identify_Repair() {
         {
             if (IsSkillLearningDialogue(dialog_menu_id)) {
                 PLAYER_SKILL_TYPE skill = GetLearningDialogueSkill(dialog_menu_id);
-                uPriceItemService = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->getActiveCharacter()],
+                uPriceItemService = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
                                                                                 p2DEvents[window_SpeakInHouse->wData.val - 1]);
-                if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
-                    pSkill = &pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill];
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
+                    pSkill = &pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill];
                     if (!*pSkill) {
                         if (pParty->GetGold() < uPriceItemService) {
                             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
@@ -1212,7 +1212,7 @@ void UIShop_Buy_Identify_Repair() {
                         pParty->TakeGold(uPriceItemService);
                         dword_F8B1E4 = 1;
                         *pSkill = 1;
-                        pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_SkillLearned);
+                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillLearned);
                         return;
                     }
                 }
@@ -1233,10 +1233,10 @@ void ShowPopupShopSkills() {
             if (pX >= pButton->uX && pX < pButton->uZ && pY >= pButton->uY && pY < pButton->uW) {
                 if (IsSkillLearningDialogue((DIALOGUE_TYPE)pButton->msg_param)) {
                     auto skill_id = GetLearningDialogueSkill((DIALOGUE_TYPE)pButton->msg_param);
-                    if (skillMaxMasteryPerClass[pPlayers[pParty->getActiveCharacter()]->classType][skill_id] != PLAYER_SKILL_MASTERY_NONE
-                        && !pPlayers[pParty->getActiveCharacter()]->pActiveSkills[skill_id]) {
+                    if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill_id] != PLAYER_SKILL_MASTERY_NONE
+                        && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill_id]) {
                         // is this skill visible
-                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->getActiveCharacter() - 1, skill_id);
+                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activePlayerIndex() - 1, skill_id);
                         CharacterUI_DrawTooltip(localization->GetSkillName(skill_id), pSkillDescText);
                     }
                 }
@@ -1429,12 +1429,12 @@ void ShowPopupShopItem() {
             dialog_menu_id == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                !pPlayers[pParty->getActiveCharacter()]->GetItemListAtInventoryIndex(
+                !pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(
                     invindex))
                 return;
 
             GameUI_DrawItemInfo(
-                pPlayers[pParty->getActiveCharacter()]->GetItemAtInventoryIndex(invindex));
+                pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(invindex));
             return;
         }
     }

--- a/src/GUI/UI/UIShops.cpp
+++ b/src/GUI/UI/UIShops.cpp
@@ -85,7 +85,7 @@ void ShopDialogMain(GUIWindow dialogwin) {
 void ShopDialogDisplayEquip(GUIWindow dialogwin,
                             BuildingType building = BuildingType_WeaponShop) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
 
     pShopOptions[0] = localization->GetString(LSTR_SELL);
     pShopOptions[1] = localization->GetString(LSTR_IDENTIFY);
@@ -135,7 +135,7 @@ void ShopDialogDisplayEquip(GUIWindow dialogwin,
 
 void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), 0);
@@ -146,15 +146,15 @@ void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
         if (pt.x <= 13 || pt.x >= 462)
             return;
 
-        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invindex);
         if (pItemID) {
             ItemGen *item =
-                &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
+                &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID - 1];
             MERCHANT_PHRASE phrases_id =
-                pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+                pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                     item, building, window_SpeakInHouse->wData.val, 3);
             auto str = BuildDialogueString(
-                pMerchantsSellPhrases[phrases_id], pParty->activePlayerIndex() - 1, item,
+                pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item,
                 window_SpeakInHouse->wData.val, 3);
             dialogwin.DrawTitleText(pFontArrus, 0,
                                     (174 - pFontArrus->CalcTextHeight(
@@ -167,7 +167,7 @@ void ShopDialogSellEquip(GUIWindow dialogwin, BuildingType building) {
 
 void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), 0);
@@ -177,20 +177,20 @@ void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
         int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
         if (pt.x <= 13 || pt.x >= 462) return;
 
-        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invindex);
 
         if (pItemID) {
-            ItemGen *item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
+            ItemGen *item = &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID - 1];
 
             std::string str;
             if (!item->IsIdentified()) {
-                MERCHANT_PHRASE phrases_id = pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+                MERCHANT_PHRASE phrases_id = pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                     item, building, window_SpeakInHouse->wData.val, 4);
                 str = BuildDialogueString(
-                    pMerchantsIdentifyPhrases[phrases_id], pParty->activePlayerIndex() - 1,
+                    pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex() - 1,
                     item, window_SpeakInHouse->wData.val, 4);
             } else {
-                str = BuildDialogueString("%24", pParty->activePlayerIndex() - 1, item,
+                str = BuildDialogueString("%24", pParty->activeCharacterIndex() - 1, item,
                     window_SpeakInHouse->wData.val, 4);
             }
 
@@ -202,7 +202,7 @@ void ShopDialogIdentify(GUIWindow dialogwin, BuildingType building) {
 
 void ShopDialogRepair(GUIWindow dialogwin, BuildingType building) {
     draw_leather();
-    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activePlayerIndex()], true);
+    CharacterUI_InventoryTab_Draw(pPlayers[pParty->activeCharacterIndex()], true);
 
     if (HouseUI_CheckIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), 0);
@@ -213,17 +213,17 @@ void ShopDialogRepair(GUIWindow dialogwin, BuildingType building) {
         if (pt.x <= 13 || pt.x >= 462)
             return;
 
-        int pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex);
+        int pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invindex);
         if (pItemID == 0)
             return;
 
-        if ((pPlayers[pParty->activePlayerIndex()]->pOwnItems[pItemID - 1].uAttributes &
+        if ((pPlayers[pParty->activeCharacterIndex()]->pOwnItems[pItemID - 1].uAttributes &
              ITEM_BROKEN)) {
-            ItemGen *item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
-            MERCHANT_PHRASE phrases_id = pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+            ItemGen *item = &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID - 1];
+            MERCHANT_PHRASE phrases_id = pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                 item, building, window_SpeakInHouse->wData.val, 5);
             std::string str = BuildDialogueString(
-                pMerchantsRepairPhrases[phrases_id], pParty->activePlayerIndex() - 1, item,
+                pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item,
                 window_SpeakInHouse->wData.val, 5);
             dialogwin.DrawTitleText(pFontArrus, 0,
                 (174 - pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + 138, colorTable.White.c16(), str, 3);
@@ -238,7 +238,7 @@ void ShopDialogLearn(GUIWindow dialogwin) {
     int all_text_height = 0;
 
     int pPrice =
-        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
+        PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activeCharacterIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     for (int i = pDialogueWindow->pStartingPosActiveItem;
         i < pDialogueWindow->pNumPresenceButton +
@@ -247,8 +247,8 @@ void ShopDialogLearn(GUIWindow dialogwin) {
         auto skill = GetLearningDialogueSkill(
             (DIALOGUE_TYPE)pDialogueWindow->GetControl(i)->msg_param
         );
-        if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
-            && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill]) {
+        if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE
+            && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill]) {
             all_text_height += pFontArrus->CalcTextHeight(
                 localization->GetSkillName(skill),
                 dialogwin.uFrameWidth, 0);
@@ -298,7 +298,7 @@ void WeaponShopWares(GUIWindow dialogwin, bool special) {
             }
         }
 
-        if (StealingMode(pParty->activePlayerIndex()))
+        if (StealingMode(pParty->activeCharacterIndex()))
             GameUI_StatusBar_DrawImmediate(
                 localization->GetString(LSTR_STEAL_ITEM), 0);
         else
@@ -329,17 +329,17 @@ void WeaponShopWares(GUIWindow dialogwin, bool special) {
                         if (pt.y >= weapons_Ypos[testx] + 30 &&
                             pt.y < (weapons_Ypos[testx] + 30 + shop_ui_items_in_store[testx]->GetHeight())) {
                             std::string str;
-                            if (!StealingMode(pParty->activePlayerIndex())) {
+                            if (!StealingMode(pParty->activeCharacterIndex())) {
                                 str = BuildDialogueString(
-                                    pMerchantsBuyPhrases[pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+                                    pMerchantsBuyPhrases[pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                                                  item, BuildingType_WeaponShop,
                                                  window_SpeakInHouse->wData.val, 2)],
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -448,7 +448,7 @@ void ArmorShopWares(GUIWindow dialogwin, bool special) {
                 ++pItemCount;
         }
 
-        if (!StealingMode(pParty->activePlayerIndex())) {
+        if (!StealingMode(pParty->activeCharacterIndex())) {
             GameUI_StatusBar_DrawImmediate(
                 localization->GetString(LSTR_SELECT_ITEM_TO_BUY), 0);
         } else {
@@ -494,17 +494,17 @@ void ArmorShopWares(GUIWindow dialogwin, bool special) {
                             // y is 126 to 126 + height low or 98-height to 98
 
                             std::string str;
-                            if (!StealingMode(pParty->activePlayerIndex())) {
+                            if (!StealingMode(pParty->activeCharacterIndex())) {
                                 str = BuildDialogueString(
                                     pMerchantsBuyPhrases
-                                        [pPlayers[pParty->activePlayerIndex()]->SelectPhrasesTransaction(
+                                        [pPlayers[pParty->activeCharacterIndex()]->SelectPhrasesTransaction(
                                                  item, BuildingType_ArmorShop, window_SpeakInHouse->wData.val, 2)],
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -624,7 +624,7 @@ void AlchemyMagicShopWares(GUIWindow dialogwin, BuildingType building,
                 ++item_num;
         }
 
-        if (StealingMode(pParty->activePlayerIndex())) {
+        if (StealingMode(pParty->activeCharacterIndex())) {
             GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), 0);
         } else {
             GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), 0);
@@ -664,17 +664,17 @@ void AlchemyMagicShopWares(GUIWindow dialogwin, BuildingType building,
                             // y is 152-h to 152 or 308-height to 308
 
                             std::string str;
-                            if (!StealingMode(pParty->activePlayerIndex())) {
+                            if (!StealingMode(pParty->activeCharacterIndex())) {
                                 str = BuildDialogueString(
                                     pMerchantsBuyPhrases
-                                        [pPlayers[pParty->activePlayerIndex()]
+                                        [pPlayers[pParty->activeCharacterIndex()]
                                              ->SelectPhrasesTransaction(item, building, window_SpeakInHouse->wData.val, 2)],
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             } else {
                                 str = BuildDialogueString(
                                     localization->GetString(LSTR_STEAL_ITEM_FMT),
-                                    pParty->activePlayerIndex() - 1, item,
+                                    pParty->activeCharacterIndex() - 1, item,
                                     window_SpeakInHouse->wData.val, 2);
                             }
                             dialogwin.DrawTitleText(
@@ -805,7 +805,7 @@ void UIShop_Buy_Identify_Repair() {
     int uPriceItemService;     // [sp+ACh] [bp-8h]@12
 
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-        pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
+        pPlayers[pParty->activeCharacterIndex()]->OnInventoryLeftClick();
         return;
     }
 
@@ -819,7 +819,7 @@ void UIShop_Buy_Identify_Repair() {
     switch (dialog_menu_id) {
         case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
-            pPlayers[pParty->activePlayerIndex()]->OnInventoryLeftClick();
+            pPlayers[pParty->activeCharacterIndex()]->OnInventoryLeftClick();
             break;
         }
 
@@ -843,7 +843,7 @@ void UIShop_Buy_Identify_Repair() {
                         if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->GetHeight())) ||
                             (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->GetHeight()))) {
                             pPriceMultiplier = p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier;
-                            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activePlayerIndex()],
+                            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activeCharacterIndex()],
                                                                                           bought_item->GetValue(), pPriceMultiplier);
 
                             if (pParty->GetGold() < uPriceItemService) {
@@ -852,21 +852,21 @@ void UIShop_Buy_Identify_Repair() {
                                 return;
                             }
 
-                            taken_item = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, bought_item->uItemID);
+                            taken_item = pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, bought_item->uItemID);
                             if (taken_item) {
                                 bought_item->SetIdentified();
                                 memcpy(
-                                    &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[taken_item - 1],
+                                    &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[taken_item - 1],
                                     bought_item, 0x24u);
                                 dword_F8B1E4 = 1;
                                 pParty->TakeGold(uPriceItemService);
                                 bought_item->Reset();
                                 render->ClearZBuffer();
-                                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemBuy);
+                                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_ItemBuy);
                                 return;
                             }
 
-                            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
+                            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NoRoom);
                             GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
                             break;
                         }
@@ -881,22 +881,22 @@ void UIShop_Buy_Identify_Repair() {
         case DIALOGUE_SHOP_SELL: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex),
+                (pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invindex),
                  !pItemID))
                 return;
 
-            if (pPlayers[pParty->activePlayerIndex()]
+            if (pPlayers[pParty->activeCharacterIndex()]
                     ->pInventoryItemList[pItemID - 1]
                     .MerchandiseTest(window_SpeakInHouse->wData.val)) {
                 dword_F8B1E4 = 1;
-                pPlayers[pParty->activePlayerIndex()]->SalesProcess(
+                pPlayers[pParty->activeCharacterIndex()]->SalesProcess(
                     invindex, pItemID - 1, window_SpeakInHouse->wData.val);
                 render->ClearZBuffer();
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemSold);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_ItemSold);
                 return;
             }
 
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_WrongShop);
             pAudioPlayer->playUISound(SOUND_error);
             break;
         }
@@ -904,13 +904,13 @@ void UIShop_Buy_Identify_Repair() {
         case DIALOGUE_SHOP_IDENTIFY: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(invindex),
+                (pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(invindex),
                  !pItemID))
                 return;
 
             uPriceItemService = PriceCalculator::itemIdentificationPriceForPlayer(
-                pPlayers[pParty->activePlayerIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
+                pPlayers[pParty->activeCharacterIndex()], p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
+            item = &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID - 1];
 
             if (!(item->uAttributes & ITEM_IDENTIFIED)) {
                 if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
@@ -918,7 +918,7 @@ void UIShop_Buy_Identify_Repair() {
                         dword_F8B1E4 = 1;
                         pParty->TakeGold(uPriceItemService);
                         item->uAttributes |= ITEM_IDENTIFIED;
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ShopIdentify);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_ShopIdentify);
                         GameUI_SetStatusBar(LSTR_DONE);
                         return;
                     }
@@ -929,28 +929,28 @@ void UIShop_Buy_Identify_Repair() {
                 }
 
                 pAudioPlayer->playUISound(SOUND_error);
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_WrongShop);
                 return;
             }
 
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_AlreadyIdentified);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_AlreadyIdentified);
             break;
         }
 
         case DIALOGUE_SHOP_REPAIR: {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(
+                (pItemID = pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(
                          invindex),
                  !pItemID))
                 return;
 
-            item = &pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[pItemID - 1];
+            item = &pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[pItemID - 1];
             pPriceMultiplier =
                 p2DEvents[window_SpeakInHouse->wData.val - 1]
                     .fPriceMultiplier;
             uPriceItemService =
-                PriceCalculator::itemRepairPriceForPlayer(pPlayers[pParty->activePlayerIndex()], item->GetValue(), pPriceMultiplier);
+                PriceCalculator::itemRepairPriceForPlayer(pPlayers[pParty->activeCharacterIndex()], item->GetValue(), pPriceMultiplier);
 
             if (item->uAttributes & ITEM_BROKEN) {
                 if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
@@ -959,7 +959,7 @@ void UIShop_Buy_Identify_Repair() {
                         pParty->TakeGold(uPriceItemService);
                         item->uAttributes =
                             (item->uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ShopRepair);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_ShopRepair);
                         GameUI_SetStatusBar(LSTR_GOOD_AS_NEW);
                         return;
                     }
@@ -970,11 +970,11 @@ void UIShop_Buy_Identify_Repair() {
                 }
 
                 pAudioPlayer->playUISound(SOUND_error);
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_WrongShop);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_WrongShop);
                 return;
             }
 
-            pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_AlreadyIdentified);
+            pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_AlreadyIdentified);
             break;
         }
 
@@ -1141,7 +1141,7 @@ void UIShop_Buy_Identify_Repair() {
                     return;
             }
 
-            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activePlayerIndex()], bought_item->GetValue(),
+            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(pPlayers[pParty->activeCharacterIndex()], bought_item->GetValue(),
                                                                           p2DEvents[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
             uNumSeconds = 0;
             a3 = 0;
@@ -1149,8 +1149,8 @@ void UIShop_Buy_Identify_Repair() {
                 a3 = pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)]
                          ._steal_perm;
             party_reputation = pParty->GetPartyReputation();
-            if (StealingMode(pParty->activePlayerIndex())) {
-                uNumSeconds = pPlayers[pParty->activePlayerIndex()]->StealFromShop(
+            if (StealingMode(pParty->activeCharacterIndex())) {
+                uNumSeconds = pPlayers[pParty->activeCharacterIndex()]->StealFromShop(
                     bought_item, a3, party_reputation, 0, &a6);
                 if (!uNumSeconds) {
                     // caught stealing no item
@@ -1163,13 +1163,13 @@ void UIShop_Buy_Identify_Repair() {
                 return;
             }
 
-            v39 = pPlayers[pParty->activePlayerIndex()]->AddItem(-1, bought_item->uItemID);
+            v39 = pPlayers[pParty->activeCharacterIndex()]->AddItem(-1, bought_item->uItemID);
             if (v39) {
                 bought_item->SetIdentified();
-                memcpy(&pPlayers[pParty->activePlayerIndex()]->pInventoryItemList[v39 - 1],
+                memcpy(&pPlayers[pParty->activeCharacterIndex()]->pInventoryItemList[v39 - 1],
                        bought_item, sizeof(ItemGen));
                 if (uNumSeconds != 0) {  // stolen
-                    pPlayers[pParty->activePlayerIndex()]
+                    pPlayers[pParty->activeCharacterIndex()]
                         ->pInventoryItemList[v39 - 1]
                         .SetStolen();
                     sub_4B1447_party_fine(window_SpeakInHouse->wData.val,
@@ -1180,10 +1180,10 @@ void UIShop_Buy_Identify_Repair() {
                 }
                 bought_item->Reset();
                 render->ClearZBuffer();
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_ItemBuy);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_ItemBuy);
                 return;
             } else {
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_NoRoom);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_NoRoom);
                 GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
                 return;
             }
@@ -1193,10 +1193,10 @@ void UIShop_Buy_Identify_Repair() {
         {
             if (IsSkillLearningDialogue(dialog_menu_id)) {
                 PLAYER_SKILL_TYPE skill = GetLearningDialogueSkill(dialog_menu_id);
-                uPriceItemService = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activePlayerIndex()],
+                uPriceItemService = PriceCalculator::skillLearningCostForPlayer(pPlayers[pParty->activeCharacterIndex()],
                                                                                 p2DEvents[window_SpeakInHouse->wData.val - 1]);
-                if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
-                    pSkill = &pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill];
+                if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
+                    pSkill = &pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill];
                     if (!*pSkill) {
                         if (pParty->GetGold() < uPriceItemService) {
                             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
@@ -1212,7 +1212,7 @@ void UIShop_Buy_Identify_Repair() {
                         pParty->TakeGold(uPriceItemService);
                         dword_F8B1E4 = 1;
                         *pSkill = 1;
-                        pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_SkillLearned);
+                        pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_SkillLearned);
                         return;
                     }
                 }
@@ -1233,10 +1233,10 @@ void ShowPopupShopSkills() {
             if (pX >= pButton->uX && pX < pButton->uZ && pY >= pButton->uY && pY < pButton->uW) {
                 if (IsSkillLearningDialogue((DIALOGUE_TYPE)pButton->msg_param)) {
                     auto skill_id = GetLearningDialogueSkill((DIALOGUE_TYPE)pButton->msg_param);
-                    if (skillMaxMasteryPerClass[pPlayers[pParty->activePlayerIndex()]->classType][skill_id] != PLAYER_SKILL_MASTERY_NONE
-                        && !pPlayers[pParty->activePlayerIndex()]->pActiveSkills[skill_id]) {
+                    if (skillMaxMasteryPerClass[pPlayers[pParty->activeCharacterIndex()]->classType][skill_id] != PLAYER_SKILL_MASTERY_NONE
+                        && !pPlayers[pParty->activeCharacterIndex()]->pActiveSkills[skill_id]) {
                         // is this skill visible
-                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activePlayerIndex() - 1, skill_id);
+                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex() - 1, skill_id);
                         CharacterUI_DrawTooltip(localization->GetSkillName(skill_id), pSkillDescText);
                     }
                 }
@@ -1429,12 +1429,12 @@ void ShowPopupShopItem() {
             dialog_menu_id == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462 ||
-                !pPlayers[pParty->activePlayerIndex()]->GetItemListAtInventoryIndex(
+                !pPlayers[pParty->activeCharacterIndex()]->GetItemListAtInventoryIndex(
                     invindex))
                 return;
 
             GameUI_DrawItemInfo(
-                pPlayers[pParty->activePlayerIndex()]->GetItemAtInventoryIndex(invindex));
+                pPlayers[pParty->activeCharacterIndex()]->GetItemAtInventoryIndex(invindex));
             return;
         }
     }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -98,16 +98,16 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
         }
         if (pMapStats->GetMapInfo(v15)) {
             transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].pName.c_str());
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         } else {
             transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].pName.c_str());
             if (pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         }
@@ -116,16 +116,16 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
             transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].pName.c_str());
             if (pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         } else {
             transition_button_label = localization->GetString(LSTR_DIALOGUE_EXIT);
             if ( pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -98,16 +98,16 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
         }
         if (pMapStats->GetMapInfo(v15)) {
             transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].pName.c_str());
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         } else {
             transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].pName.c_str());
             if (pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         }
@@ -116,16 +116,16 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
             transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].pName.c_str());
             if (pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         } else {
             transition_button_label = localization->GetString(LSTR_DIALOGUE_EXIT);
             if ( pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId)
                 PlayHouseSound(anim_id, HouseSound_Greeting);
-            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActivePlayer() && pParty->GetRedOrYellowAlert())
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_LeaveDungeon);
+            if (uCurrentlyLoadedLevelType == LEVEL_Indoor && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(pLocationName);
         }

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -178,9 +178,9 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             break;
 
         case InputAction::Yell:
-            if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME && pParty->hasActiveCharacter()) {
+            if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME && pParty->hasActivePlayer()) {
                 pParty->yell();
-                pPlayers[pParty->getActiveCharacter()]->playReaction(SPEECH_Yell);
+                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_Yell);
             }
             break;
 
@@ -191,11 +191,11 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                 pTurnEngine->flags |= TE_FLAG_8_finished;
                 break;
             }
-            if (pParty->hasActiveCharacter()) {
-                if (pPlayers[pParty->getActiveCharacter()]->uTimeToRecovery == 0) {
+            if (pParty->hasActivePlayer()) {
+                if (pPlayers[pParty->activePlayerIndex()]->uTimeToRecovery == 0) {
                     if (!pParty->bTurnBasedModeOn) {
-                        pPlayers[pParty->getActiveCharacter()]->SetRecoveryTime(
-                            debug_non_combat_recovery_mul * (double)pPlayers[pParty->getActiveCharacter()]->GetAttackRecoveryTime(false) * flt_debugrecmod3
+                        pPlayers[pParty->activePlayerIndex()]->SetRecoveryTime(
+                            debug_non_combat_recovery_mul * (double)pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(false) * flt_debugrecmod3
                         );
                     }
                     CastSpellInfoHelpers::cancelSpellCastInProgress();
@@ -229,20 +229,20 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                 break;
             }
 
-            if (!pParty->hasActiveCharacter()) {
+            if (!pParty->hasActivePlayer()) {
                 break;
             }
 
-            SPELL_TYPE quickSpellNumber = pPlayers[pParty->getActiveCharacter()]->uQuickSpell;
+            SPELL_TYPE quickSpellNumber = pPlayers[pParty->activePlayerIndex()]->uQuickSpell;
 
             int uRequiredMana = 0;
             if (quickSpellNumber != SPELL_NONE && !engine->config->debug.AllMagic.value()) {
-                PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->getActiveCharacter()]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
+                PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
 
                 uRequiredMana = pSpellDatas[quickSpellNumber].mana_per_skill[std::to_underlying(skill_mastery) - 1];
             }
 
-            bool enoughMana = pPlayers[pParty->getActiveCharacter()]->sMana >= uRequiredMana;
+            bool enoughMana = pPlayers[pParty->activePlayerIndex()]->sMana >= uRequiredMana;
 
             if (quickSpellNumber == SPELL_NONE || engine->IsUnderwater() || !enoughMana) {
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Attack, 0, 0);

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -178,9 +178,9 @@ void KeyboardInputHandler::GenerateGameplayActions() {
             break;
 
         case InputAction::Yell:
-            if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME && pParty->hasActivePlayer()) {
+            if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME && pParty->hasActiveCharacter()) {
                 pParty->yell();
-                pPlayers[pParty->activePlayerIndex()]->playReaction(SPEECH_Yell);
+                pPlayers[pParty->activeCharacterIndex()]->playReaction(SPEECH_Yell);
             }
             break;
 
@@ -191,11 +191,11 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                 pTurnEngine->flags |= TE_FLAG_8_finished;
                 break;
             }
-            if (pParty->hasActivePlayer()) {
-                if (pPlayers[pParty->activePlayerIndex()]->uTimeToRecovery == 0) {
+            if (pParty->hasActiveCharacter()) {
+                if (pPlayers[pParty->activeCharacterIndex()]->uTimeToRecovery == 0) {
                     if (!pParty->bTurnBasedModeOn) {
-                        pPlayers[pParty->activePlayerIndex()]->SetRecoveryTime(
-                            debug_non_combat_recovery_mul * (double)pPlayers[pParty->activePlayerIndex()]->GetAttackRecoveryTime(false) * flt_debugrecmod3
+                        pPlayers[pParty->activeCharacterIndex()]->SetRecoveryTime(
+                            debug_non_combat_recovery_mul * (double)pPlayers[pParty->activeCharacterIndex()]->GetAttackRecoveryTime(false) * flt_debugrecmod3
                         );
                     }
                     CastSpellInfoHelpers::cancelSpellCastInProgress();
@@ -229,20 +229,20 @@ void KeyboardInputHandler::GenerateGameplayActions() {
                 break;
             }
 
-            if (!pParty->hasActivePlayer()) {
+            if (!pParty->hasActiveCharacter()) {
                 break;
             }
 
-            SPELL_TYPE quickSpellNumber = pPlayers[pParty->activePlayerIndex()]->uQuickSpell;
+            SPELL_TYPE quickSpellNumber = pPlayers[pParty->activeCharacterIndex()]->uQuickSpell;
 
             int uRequiredMana = 0;
             if (quickSpellNumber != SPELL_NONE && !engine->config->debug.AllMagic.value()) {
-                PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activePlayerIndex()]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
+                PLAYER_SKILL_MASTERY skill_mastery = pPlayers[pParty->activeCharacterIndex()]->GetActualSkillMastery(getSkillTypeForSpell(quickSpellNumber));
 
                 uRequiredMana = pSpellDatas[quickSpellNumber].mana_per_skill[std::to_underlying(skill_mastery) - 1];
             }
 
-            bool enoughMana = pPlayers[pParty->activePlayerIndex()]->sMana >= uRequiredMana;
+            bool enoughMana = pPlayers[pParty->activeCharacterIndex()]->sMana >= uRequiredMana;
 
             if (quickSpellNumber == SPELL_NONE || engine->IsUnderwater() || !enoughMana) {
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Attack, 0, 0);

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -317,9 +317,9 @@ void Mouse::UI_OnMouseLeftClick() {
     Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->get_picked_object_zbuf_val();
 
     ObjectType type = PID_TYPE(picked_object.object_pid);
-    if (type == OBJECT_Actor && pParty->hasActivePlayer() && picked_object.depth < 0x200 &&
-        pPlayers[pParty->activePlayerIndex()]->CanAct() &&
-        pPlayers[pParty->activePlayerIndex()]->CanSteal()) {
+    if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&
+        pPlayers[pParty->activeCharacterIndex()]->CanAct() &&
+        pPlayers[pParty->activeCharacterIndex()]->CanSteal()) {
         pCurrentFrameMessageQueue->AddGUIMessage(
             UIMSG_STEALFROMACTOR,
             PID_ID(picked_object.object_pid),

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -317,9 +317,9 @@ void Mouse::UI_OnMouseLeftClick() {
     Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->get_picked_object_zbuf_val();
 
     ObjectType type = PID_TYPE(picked_object.object_pid);
-    if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&
-        pPlayers[pParty->getActiveCharacter()]->CanAct() &&
-        pPlayers[pParty->getActiveCharacter()]->CanSteal()) {
+    if (type == OBJECT_Actor && pParty->hasActivePlayer() && picked_object.depth < 0x200 &&
+        pPlayers[pParty->activePlayerIndex()]->CanAct() &&
+        pPlayers[pParty->activePlayerIndex()]->CanSteal()) {
         pCurrentFrameMessageQueue->AddGUIMessage(
             UIMSG_STEALFROMACTOR,
             PID_ID(picked_object.object_pid),

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -499,8 +499,8 @@ GAME_TEST(Issues, Issue520) {
 GAME_TEST(Issues, Issue521) {
     // 500 endurance leads to asserts in Player::SetRecoveryTime
     int oldActive{};
-    test->playTraceFromTestData("issue_521.mm7", "issue_521.json", [&] { oldActive = pParty->getActiveCharacter(); });
-    EXPECT_EQ(oldActive, pParty->getActiveCharacter());
+    test->playTraceFromTestData("issue_521.mm7", "issue_521.json", [&] { oldActive = pParty->activePlayerIndex(); });
+    EXPECT_EQ(oldActive, pParty->activePlayerIndex());
 }
 
 GAME_TEST(Issues, Issue527) {
@@ -591,11 +591,11 @@ GAME_TEST(Issues, Issue613) {
 
 GAME_TEST(Issues, Issue615) {
     // test 1 - ensure that clicking between active portraits changes active character.
-    test->playTraceFromTestData("issue_615a.mm7", "issue_615a.json", []() { EXPECT_EQ(pParty->getActiveCharacter(), 1); });
-    EXPECT_EQ(pParty->getActiveCharacter(), 3);
+    test->playTraceFromTestData("issue_615a.mm7", "issue_615a.json", []() { EXPECT_EQ(pParty->activePlayerIndex(), 1); });
+    EXPECT_EQ(pParty->activePlayerIndex(), 3);
     // Assert when clicking on character portrait when no active character is present
-    test->playTraceFromTestData("issue_615b.mm7", "issue_615b.json", []() { EXPECT_EQ(pParty->getActiveCharacter(), 1); });
-    EXPECT_EQ(pParty->getActiveCharacter(), 4);
+    test->playTraceFromTestData("issue_615b.mm7", "issue_615b.json", []() { EXPECT_EQ(pParty->activePlayerIndex(), 1); });
+    EXPECT_EQ(pParty->activePlayerIndex(), 4);
 }
 
 GAME_TEST(Issues, Issue625) {

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -499,8 +499,8 @@ GAME_TEST(Issues, Issue520) {
 GAME_TEST(Issues, Issue521) {
     // 500 endurance leads to asserts in Player::SetRecoveryTime
     int oldActive{};
-    test->playTraceFromTestData("issue_521.mm7", "issue_521.json", [&] { oldActive = pParty->activePlayerIndex(); });
-    EXPECT_EQ(oldActive, pParty->activePlayerIndex());
+    test->playTraceFromTestData("issue_521.mm7", "issue_521.json", [&] { oldActive = pParty->activeCharacterIndex(); });
+    EXPECT_EQ(oldActive, pParty->activeCharacterIndex());
 }
 
 GAME_TEST(Issues, Issue527) {
@@ -591,11 +591,11 @@ GAME_TEST(Issues, Issue613) {
 
 GAME_TEST(Issues, Issue615) {
     // test 1 - ensure that clicking between active portraits changes active character.
-    test->playTraceFromTestData("issue_615a.mm7", "issue_615a.json", []() { EXPECT_EQ(pParty->activePlayerIndex(), 1); });
-    EXPECT_EQ(pParty->activePlayerIndex(), 3);
+    test->playTraceFromTestData("issue_615a.mm7", "issue_615a.json", []() { EXPECT_EQ(pParty->activeCharacterIndex(), 1); });
+    EXPECT_EQ(pParty->activeCharacterIndex(), 3);
     // Assert when clicking on character portrait when no active character is present
-    test->playTraceFromTestData("issue_615b.mm7", "issue_615b.json", []() { EXPECT_EQ(pParty->activePlayerIndex(), 1); });
-    EXPECT_EQ(pParty->activePlayerIndex(), 4);
+    test->playTraceFromTestData("issue_615b.mm7", "issue_615b.json", []() { EXPECT_EQ(pParty->activeCharacterIndex(), 1); });
+    EXPECT_EQ(pParty->activeCharacterIndex(), 4);
 }
 
 GAME_TEST(Issues, Issue625) {


### PR DESCRIPTION
Progress on issue #512. Renames:
* getActiveCharacter() -> activePlayerIndex()
* setActiveCharacter() -> setActivePlayerByIndex()
* hasActiveCharacter() -> hasActivePlayer()
* private variable '_activeCharacter' -> '_activePlayer'

Next step is to introduce function for getting active player and using it in all code that simply indexes pPlayers with active player index.