### PR TITLE
Allow looting and item picking with no active character

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2046,7 +2046,7 @@ void Game::processQueuedMessages() {
                                                     // правую кнопку мыши после
                                                     // UIMSG_MouseLeftClickInGame
                     pCurrentFrameMessageQueue->Flush();
-                    _engine->OnGameViewportClick();
+                    _engine->onGameViewportClick();
                     continue;
                 case UIMSG_F:  // what event?
                     __debugbreak();

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2299,11 +2299,6 @@ void Game::onPressSpace() {
 
     uint16_t pid = _vis->get_picked_object_zbuf_val().object_pid;
     if (pid != PID_INVALID) {
-        // wasn't there, but we decided to deny interactions where there are no active character
-        if (!pParty->hasActiveCharacter()) {
-            GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
-            return;
-        }
         DoInteractionWithTopmostZObject(pid);
     }
 }

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -108,7 +108,11 @@ class Engine {
                    struct Vis_SelectionFilter *face_filter);
     bool PickKeyboard(float pick_depth, bool bOutline, struct Vis_SelectionFilter *sprite_filter,
                       struct Vis_SelectionFilter *face_filter);
-    void OnGameViewportClick();
+
+    /**
+     * @offset 0x42213C
+     */
+    void onGameViewportClick();
     void OutlineSelection();
     int _44EC23_saturate_face_odm(struct Polygon *a2, int *a3, signed int a4);
     int _44ED0A_saturate_face_blv(struct BLVFace *a2, int *a3, signed int a4);
@@ -126,7 +130,6 @@ class Engine {
     void ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
     void SecondaryInitialization();
     void _461103_load_level_sub();
-    void DropHeldItem();
     bool MM7_Initialize();
 
     bool is_underwater = false;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1794,6 +1794,8 @@ bool Check_LOS_Obscurred_Outdoors_Bmodels(const Vec3i &target, const Vec3i &from
 }
 
 //----- (0046A334) --------------------------------------------------------
+// TODO(Nik-RE-dev): does not belong here, it's common function for interaction for both indoor/outdoor
+// TODO(Nik-RE-dev): get rid of external function declaration inside
 char DoInteractionWithTopmostZObject(int pid) {
     auto id = PID_ID(pid);
     auto type = PID_TYPE(pid);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1801,7 +1801,8 @@ char DoInteractionWithTopmostZObject(int pid) {
     auto id = PID_ID(pid);
     auto type = PID_TYPE(pid);
 
-    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME /*CURRENT_SCREEN::SCREEN_BRANCHLESS_NPC_DIALOG*/) {
+    // was CURRENT_SCREEN::SCREEN_BRANCHLESS_NPC_DIALOG
+    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) {
         return 1;
     }
 

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -221,21 +221,22 @@ void ItemInteraction(unsigned int item_id) {
     if (pItemTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].uEquipType == EQUIP_GOLD) {
         pParty->partyFindsGold(pSpriteObjects[item_id].containing_item.special_enchantment, GOLD_RECEIVE_SHARE);
     } else {
-        if (pParty->pPickedItem.uItemID != ITEM_NULL)
+        if (pParty->pPickedItem.uItemID != ITEM_NULL) {
             return;
+        }
 
-        GameUI_SetStatusBar(
-            LSTR_FMT_YOU_FOUND_ITEM,
-            pItemTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName
-        );
+        GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName);
 
         // TODO: WTF? 184 / 185 qbits are associated with Tatalia's Mercenery Guild Harmondale raids. Are these about castle's tapestries ?
-        if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER)
+        if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER) {
             _449B7E_toggle_bit(pParty->_quest_bits, QBIT_SPLITTER_FOUND, 1);
-        if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_SPELLBOOK_REMOVE_FEAR)
+        }
+        if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_SPELLBOOK_REMOVE_FEAR) {
             _449B7E_toggle_bit(pParty->_quest_bits, 185, 1);
-        if (!pParty->AddItemToParty(&pSpriteObjects[item_id].containing_item))
+        }
+        if (!pParty->addItemToParty(&pSpriteObjects[item_id].containing_item)) {
             pParty->setHoldingItem(&pSpriteObjects[item_id].containing_item);
+        }
     }
     SpriteObject::OnInteraction(item_id);
 }
@@ -252,8 +253,7 @@ void InteractWithActor(unsigned int id) {
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_StartNPCDialogue, id, 0);
     } else {
         if (pNPCStats->pGroups_copy[pActors[id].uGroup]) {
-            if (pNPCStats->pCatchPhrases
-                    [pNPCStats->pGroups_copy[pActors[id].uGroup]]) {
+            if (pNPCStats->pCatchPhrases[pNPCStats->pGroups_copy[pActors[id].uGroup]]) {
                 pParty->uFlags |= PARTY_FLAGS_1_ForceRedraw;
                 branchless_dialogue_str = pNPCStats->pCatchPhrases[pNPCStats->pGroups_copy[pActors[id].uGroup]];
                 StartBranchlessDialogue(0, 0, 0);
@@ -275,45 +275,11 @@ void DecorationInteraction(unsigned int id, unsigned int pid) {
     }
 }
 
-void Engine::DropHeldItem() {
-    if (pParty->pPickedItem.uItemID == ITEM_NULL)
-        return;
-
-    SpriteObject a1;
-    a1.uType = (SPRITE_OBJECT_TYPE)pItemTable->pItems[pParty->pPickedItem.uItemID].uSpriteID;
-    a1.uObjectDescID = pObjectList->ObjectIDByItemID(a1.uType);
-    a1.vPosition.y = pParty->vPosition.y;
-    a1.spell_caster_pid = PID(OBJECT_Player, 0);
-    a1.vPosition.x = pParty->vPosition.x;
-    a1.vPosition.z = pParty->sEyelevel + pParty->vPosition.z;
-    a1.uSoundID = 0;
-    a1.uFacing = 0;
-    a1.uAttributes = SPRITE_DROPPED_BY_PLAYER;
-    a1.uSectorID = pBLVRenderParams->uPartyEyeSectorID;
-    a1.uSpriteFrameID = 0;
-    memcpy(&a1.containing_item, &pParty->pPickedItem, 0x24u);
-
-    // extern int UnprojectX(int);
-    // v9 = UnprojectX(v1->x);
-    a1.Create(pParty->_viewYaw, 184, 200, 0);  //+ UnprojectX(v1->x), 184, 200, 0);
-
-    mouse->RemoveHoldingItem();
-}
-
-//----- (0042213C) --------------------------------------------------------
-void Engine::OnGameViewportClick() {
-    int pEventID;     // ecx@21
-    SpriteObject a1;  // [sp+Ch] [bp-80h]@1
-
+void Engine::onGameViewportClick() {
     int16_t clickable_distance = 512;
 
     // bug fix - stops you entering shops while dialog still open.
-    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME /*CURRENT_SCREEN::SCREEN_NPC_DIALOGUE*/)
-        return;
-
-    // wasn't there, but we decided to deny interactions where there are no active character
-    if (!pParty->hasActiveCharacter()) {
-        GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME /*CURRENT_SCREEN::SCREEN_NPC_DIALOGUE*/) {
         return;
     }
 
@@ -327,28 +293,31 @@ void Engine::OnGameViewportClick() {
     if (PID_TYPE(pid) == OBJECT_Item) {
         int item_id = PID_ID(pid);
         // v21 = (signed int)(uint16_t)v0 >> 3;
-        if (pSpriteObjects[item_id].IsUnpickable() ||
-            item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID || !in_range) {
-            if (pParty->pPickedItem.uItemID != ITEM_NULL) {
-                DropHeldItem();
-            }
+        if (pSpriteObjects[item_id].IsUnpickable() || item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID || !in_range) {
+            pParty->dropHeldItem();
         } else {
             ItemInteraction(item_id);
         }
     } else if (PID_TYPE(pid) == OBJECT_Actor) {
         int mon_id = PID_ID(pid);
-        // a2.y = v16;
+
         if (pActors[mon_id].uAIState == Dead) {
-            if (in_range)
+            if (in_range) {
                 pActors[mon_id].LootActor();
-            else if (pParty->pPickedItem.uItemID != ITEM_NULL)
-                DropHeldItem();
+            } else {
+                pParty->dropHeldItem();
+            }
         } else if (!keyboardInputHandler->IsCastOnClickToggled()) {
             if (CanInteractWithActor(mon_id)) {
                 if (in_range) {
-                    InteractWithActor(mon_id);
-                } else if (pParty->pPickedItem.uItemID != ITEM_NULL) {
-                    DropHeldItem();
+                    if (pParty->hasActiveCharacter()) {
+                        InteractWithActor(mon_id);
+                    } else {
+                        // Do not interact with actors with no active character
+                        GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                    }
+                } else {
+                    pParty->dropHeldItem();
                 }
             } else {
                 if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
@@ -361,47 +330,56 @@ void Engine::OnGameViewportClick() {
             pParty->setAirborne(true);
         } else if (pParty->hasActiveCharacter() && IsSpellQuickCastableOnShiftClick(pPlayers[pParty->getActiveCharacter()]->uQuickSpell)) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
+        } else {
+            pParty->dropHeldItem();
         }
     } else if (PID_TYPE(pid) == OBJECT_Decoration) {
         int id = PID_ID(pid);
-        if (distance - pDecorationList->GetDecoration(pLevelDecorations[id].uDecorationDescID)->uRadius >= clickable_distance) {
-            if (pParty->pPickedItem.uItemID != ITEM_NULL) {
-                DropHeldItem();
+        if (distance - pDecorationList->GetDecoration(pLevelDecorations[id].uDecorationDescID)->uRadius < clickable_distance) {
+            if (pParty->hasActiveCharacter()) {
+                // Do not interact with decoration with no active character
+                DecorationInteraction(id, pid);
+            } else {
+                GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
             }
         } else {
-            DecorationInteraction(id, pid);
+            pParty->dropHeldItem();
         }
     } else if (PID_TYPE(pid) == OBJECT_Face && in_range) {
+        int eventId = 0;
+
         if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
             if (!pIndoor->pFaces[PID_ID(pid)].Clickable()) {
                 if (pParty->pPickedItem.uItemID == ITEM_NULL) {
                     GameUI_StatusBar_NothingHere();
-                    if (pParty->pPickedItem.uItemID == ITEM_NULL)
-                        return;
                 } else {
-                    DropHeldItem();
+                    pParty->dropHeldItem();
                 }
+                return;
             } else {
-                pEventID = pIndoor->pFaceExtras[pIndoor->pFaces[PID_ID(pid)].uFaceExtraID].uEventID;
-                EventProcessor(pEventID, pid, 1);
+                eventId = pIndoor->pFaceExtras[pIndoor->pFaces[PID_ID(pid)].uFaceExtraID].uEventID;
             }
         } else if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-            if (!pOutdoor->pBModels[(signed int)(pid) >> 9].pFaces[PID_ID(pid) & 0x3F].Clickable()) {
+            ODMFace &model = pOutdoor->pBModels[(pid) >> 9].pFaces[PID_ID(pid) & 0x3F];
+            if (!model.Clickable()) {
                 if (pParty->pPickedItem.uItemID == ITEM_NULL) {
                     GameUI_StatusBar_NothingHere();
-                    if (pParty->pPickedItem.uItemID == ITEM_NULL)
-                        return;
                 } else {
-                    DropHeldItem();
+                    pParty->dropHeldItem();
                 }
+                return;
             } else {
-                pEventID = pOutdoor->pBModels[(signed int)(pid) >> 9]
-                               .pFaces[PID_ID(pid) & 0x3F]
-                               .sCogTriggeredID;
-                EventProcessor(pEventID, pid, 1);
+                eventId = model.sCogTriggeredID;
             }
         }
-    } else if (pParty->pPickedItem.uItemID != ITEM_NULL) {
-        DropHeldItem();
+
+        if (pParty->hasActiveCharacter()) {
+            EventProcessor(eventId, pid, 1);
+        } else {
+            // Do not interact with faces with no active character
+            GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+        }
+    } else {
+        pParty->dropHeldItem();
     }
 }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -279,7 +279,8 @@ void Engine::onGameViewportClick() {
     int16_t clickable_distance = 512;
 
     // bug fix - stops you entering shops while dialog still open.
-    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME /*CURRENT_SCREEN::SCREEN_NPC_DIALOGUE*/) {
+    // was CURRENT_SCREEN::SCREEN_NPC_DIALOGUE
+    if (current_screen_type != CURRENT_SCREEN::SCREEN_GAME) {
         return;
     }
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3783,13 +3783,11 @@ void StatusBarItemFound(int num_gold_found, const char * item_unidentified_name)
 
 //----- (00426A5A) --------------------------------------------------------
 void Actor::LootActor() {
-    signed int v2;       // edi@1
     ItemGen Dst;         // [sp+Ch] [bp-2Ch]@1
     bool itemFound;      // [sp+30h] [bp-8h]@1
 
-    pParty->PickedItem_PlaceInInventory_or_Drop();
+    pParty->placeHeldItemInInventoryOrDrop();
     Dst.Reset();
-    v2 = 0;
     itemFound = false;
     int foundGold = 0;
     if (!ActorHasItem()) {
@@ -3810,10 +3808,7 @@ void Actor::LootActor() {
         Dst.Reset();
         Dst.uItemID = this->uCarriedItemID;
 
-        StatusBarItemFound(
-            foundGold,
-            pItemTable->pItems[Dst.uItemID].pUnidentifiedName
-        );
+        StatusBarItemFound(foundGold, pItemTable->pItems[Dst.uItemID].pUnidentifiedName);
 
         if (Dst.isWand()) {
             Dst.uNumCharges = grng->random(6) + Dst.GetDamageMod() + 1;
@@ -3823,20 +3818,20 @@ void Actor::LootActor() {
             Dst.uEnchantmentType = 2 * grng->random(4) + 2;
         }
         pItemTable->SetSpecialBonus(&Dst);
-        if (!pParty->AddItemToParty(&Dst)) {
+        if (!pParty->addItemToParty(&Dst)) {
             pParty->setHoldingItem(&Dst);
         }
         this->uCarriedItemID = ITEM_NULL;
         if (this->ActorHasItems[0].uItemID != ITEM_NULL) {
-            if (!pParty->AddItemToParty(&this->ActorHasItems[0])) {
-                pParty->PickedItem_PlaceInInventory_or_Drop();
+            if (!pParty->addItemToParty(&this->ActorHasItems[0])) {
+                pParty->placeHeldItemInInventoryOrDrop();
                 pParty->setHoldingItem(&this->ActorHasItems[0]);
             }
             this->ActorHasItems[0].Reset();
         }
         if (this->ActorHasItems[1].uItemID != ITEM_NULL) {
-            if (!pParty->AddItemToParty(&this->ActorHasItems[1])) {
-                pParty->PickedItem_PlaceInInventory_or_Drop();
+            if (!pParty->addItemToParty(&this->ActorHasItems[1])) {
+                pParty->placeHeldItemInInventoryOrDrop();
                 pParty->setHoldingItem(&this->ActorHasItems[1]);
             }
             this->ActorHasItems[1].Reset();
@@ -3849,48 +3844,44 @@ void Actor::LootActor() {
             Dst = this->ActorHasItems[3];
             this->ActorHasItems[3].Reset();
 
-            StatusBarItemFound(
-                foundGold,
-                pItemTable->pItems[Dst.uItemID].pUnidentifiedName
-            );
+            StatusBarItemFound(foundGold, pItemTable->pItems[Dst.uItemID].pUnidentifiedName);
 
-            if (!pParty->AddItemToParty(&Dst)) {
+            if (!pParty->addItemToParty(&Dst)) {
                 pParty->setHoldingItem(&Dst);
             }
             itemFound = true;
         }
     } else {
-        if (grng->random(100) < this->pMonsterInfo.uTreasureDropChance &&
-            this->pMonsterInfo.uTreasureLevel != ITEM_TREASURE_LEVEL_INVALID) {
-            pItemTable->generateItem(this->pMonsterInfo.uTreasureLevel, this->pMonsterInfo.uTreasureType,
-                                     &Dst);
+        if (grng->random(100) < this->pMonsterInfo.uTreasureDropChance && this->pMonsterInfo.uTreasureLevel != ITEM_TREASURE_LEVEL_INVALID) {
+            pItemTable->generateItem(this->pMonsterInfo.uTreasureLevel, this->pMonsterInfo.uTreasureType, &Dst);
 
             StatusBarItemFound(foundGold, pItemTable->pItems[Dst.uItemID].pUnidentifiedName);
 
-            if (!pParty->AddItemToParty(&Dst)) {
+            if (!pParty->addItemToParty(&Dst)) {
                 pParty->setHoldingItem(&Dst);
             }
             itemFound = true;
         }
     }
     if (this->ActorHasItems[0].uItemID != ITEM_NULL) {
-        if (!pParty->AddItemToParty(&this->ActorHasItems[0])) {
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+        if (!pParty->addItemToParty(&this->ActorHasItems[0])) {
+            pParty->placeHeldItemInInventoryOrDrop();
             pParty->setHoldingItem(&this->ActorHasItems[0]);
             itemFound = true;
         }
         this->ActorHasItems[0].Reset();
     }
     if (this->ActorHasItems[1].uItemID != ITEM_NULL) {
-        if (!pParty->AddItemToParty(&this->ActorHasItems[1])) {
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+        if (!pParty->addItemToParty(&this->ActorHasItems[1])) {
+            pParty->placeHeldItemInInventoryOrDrop();
             pParty->setHoldingItem(&this->ActorHasItems[1]);
             itemFound = true;
         }
         this->ActorHasItems[1].Reset();
     }
-    if (!itemFound || grng->random(100) < 90)  // for repeatedly get gold and item
+    if (!itemFound || grng->random(100) < 90) {  // for repeatedly get gold and item
         this->Remove();
+    }
 }
 
 //----- (00427102) --------------------------------------------------------

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -651,14 +651,15 @@ void Player::WearItem(ITEM_TYPE uItemID) {
 
 //----- (004927A8) --------------------------------------------------------
 int Player::AddItem(int index, ITEM_TYPE uItemID) {
-    if (uItemID == ITEM_NULL) return 0;
+    if (uItemID == ITEM_NULL) {
+        return 0;
+    }
+
     if (index == -1) {  // no location specified - search for space
         for (int xcoord = 0; xcoord < INVENTORY_SLOTS_WIDTH; xcoord++) {
             for (int ycoord = 0; ycoord < INVENTORY_SLOTS_HEIGHT; ycoord++) {
-                if (canFitItem(ycoord * INVENTORY_SLOTS_WIDTH + xcoord,
-                               uItemID)) {  // found space
-                    return CreateItemInInventory(
-                        ycoord * INVENTORY_SLOTS_WIDTH + xcoord, uItemID);
+                if (canFitItem(ycoord * INVENTORY_SLOTS_WIDTH + xcoord, uItemID)) {  // found space
+                    return CreateItemInInventory(ycoord * INVENTORY_SLOTS_WIDTH + xcoord, uItemID);
                 }
             }
         }

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -219,7 +219,7 @@ struct Party {
     */
     void switchToNextActiveCharacter();
     bool _497FC5_check_party_perception_against_level();
-    
+
     /**
      * @offset 0x48C6F6
      */

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -219,7 +219,11 @@ struct Party {
     */
     void switchToNextActiveCharacter();
     bool _497FC5_check_party_perception_against_level();
-    bool AddItemToParty(ItemGen *pItem);
+    
+    /**
+     * @offset 0x48C6F6
+     */
+    bool addItemToParty(ItemGen *pItem, bool isSilent = false);
 
     /**
      * @offset 0x43AD34
@@ -234,7 +238,8 @@ struct Party {
      * @offset 0x420C05
      */
     void partyFindsGold(int amount, GoldReceivePolicy policy);
-    void PickedItem_PlaceInInventory_or_Drop();
+    void placeHeldItemInInventoryOrDrop();
+    void dropHeldItem();
 
     int GetGold() const;
     void SetGold(int amount, bool silent = false);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2185,7 +2185,7 @@ void CastSpellInfoHelpers::castSpell() {
                             pParty->partyFindsGold(pSpriteObjects[obj_id].containing_item.special_enchantment, GOLD_RECEIVE_SHARE);
                         } else {
                             GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName);
-                            if (!pParty->AddItemToParty(&pSpriteObjects[obj_id].containing_item)) {
+                            if (!pParty->addItemToParty(&pSpriteObjects[obj_id].containing_item)) {
                                 pParty->setHoldingItem(&pSpriteObjects[obj_id].containing_item);
                             }
                         }
@@ -3158,35 +3158,35 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
         Sizei renDims = render->GetRenderDimensions();
         if (flags & ON_CAST_TargetedCharacter) {
             pGUIWindow_CastTargetedSpell = new TargetedSpellUI_Character({0, 0}, renDims, &pCastSpellInfo[result]);
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
         if (flags & ON_CAST_TargetedActor) {
             pGUIWindow_CastTargetedSpell = new TargetedSpellUI_Actor({0, 0}, renDims, &pCastSpellInfo[result]);
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
         if (flags & ON_CAST_TargetedTelekinesis) {
             pGUIWindow_CastTargetedSpell = new TargetedSpellUI_Telekinesis({0, 0}, renDims, &pCastSpellInfo[result]);
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
         if (flags & ON_CAST_TargetedEnchantment) {
             pGUIWindow_CastTargetedSpell = pCastSpellInfo[result].GetCastSpellInInventoryWindow();
             IsEnchantingInProgress = true;
             enchantingActiveCharacter = pParty->getActiveCharacter();
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
         if (flags & ON_CAST_TargetedActorOrCharacter) {
             pGUIWindow_CastTargetedSpell = new TargetedSpellUI_ActorOrCharacter({0, 0}, renDims, &pCastSpellInfo[result]);
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
         if (flags & ON_CAST_TargetedHireling) {
             pGUIWindow_CastTargetedSpell = new TargetedSpellUI_Hirelings({0, 0}, renDims, &pCastSpellInfo[result]);
             // Next line was added to do something with picked item on Sacrifice cast
-            pParty->PickedItem_PlaceInInventory_or_Drop();
+            pParty->placeHeldItemInInventoryOrDrop();
             return;
         }
     }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -1182,7 +1182,7 @@ void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
     case DIALOGUE_SHOP_REPAIR:
     {
         dialog_menu_id = option;
-        pParty->PickedItem_PlaceInInventory_or_Drop();
+        pParty->placeHeldItemInInventoryOrDrop();
         break;
     }
     case DIALOGUE_SHOP_DISPLAY_EQUIPMENT:


### PR DESCRIPTION
Fix #642
In #351 interaction with anything was disabled with no active character present, even when interaction will not happen message about nobody in condition is showed.
Here instead of disable every interaction forbid interaction in certain context instead:
- Interaction with friendly actor
- Interaction with decoration
- Interaction with face

In all other case actual interaction or other actions (like dropping held item, showing "Nothing here" etc.) are performed.