### PR TITLE
Use std::bitset for bit arrays

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -273,7 +273,7 @@ bool Game::loop() {
             pMediaPlayer->PlayFullscreenMovie("Intro Post");
             SaveNewGame();
             if (_engine->config->debug.NoMargaret.value()) {
-                _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_MARGARETH_OFF, 1);
+                pParty->_questBits.set(QBIT_EMERALD_ISLAND_MARGARETH_OFF);
             }
 
             gameLoop();
@@ -1223,7 +1223,7 @@ void Game::processQueuedMessages() {
                     //if (uGameState == GAME_STATE_CHANGE_LOCATION) continue;
 
                     // check if tp location is unlocked
-                    if (!_449B57_test_bit(pParty->_quest_bits, townPortalQuestBits[uMessageParam]) && !_engine->config->debug.TownPortal.value()) {
+                    if (!pParty->_questBits[townPortalQuestBits[uMessageParam]] && !_engine->config->debug.TownPortal.value()) {
                         continue;
                     }
 
@@ -1279,7 +1279,7 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 case UIMSG_HintTownPortal: {
-                    if (!_449B57_test_bit(pParty->_quest_bits, townPortalQuestBits[uMessageParam]) && !_engine->config->debug.TownPortal.value()) {
+                    if (!pParty->_questBits[townPortalQuestBits[uMessageParam]] && !_engine->config->debug.TownPortal.value()) {
                         _render->DrawTextureNew(0, 352 / 480.0f, game_ui_statusbar);
                         continue;
                     }
@@ -2451,7 +2451,7 @@ void Game::gameLoop() {
                 }
                 pParty->setActiveCharacterIndex(1);
 
-                if (_449B57_test_bit(pParty->_quest_bits, QBIT_ESCAPED_EMERALD_ISLE)) {
+                if (pParty->_questBits[QBIT_ESCAPED_EMERALD_ISLE]) {
                     pParty->vPosition.x = -17331;  // respawn in harmondale
                     pParty->vPosition.y = 12547;
                     pParty->vPosition.z = 465;

--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -2867,20 +2867,23 @@ void GameResultsApply() {
             if (!pParty->pArcomageWins[i - 108]) break;
             tavern_num++;
         }
-        if (tavern_num == 13)
-            _449B7E_toggle_bit(pParty->_quest_bits, QBIT_ARCOMAGE_CHAMPION, 1);
+        if (tavern_num == 13) {
+            pParty->_questBits.set(QBIT_ARCOMAGE_CHAMPION);
+        }
 
         for (int i = 0; i < 4; ++i) {
-            if (!_449B57_test_bit(pParty->pPlayers[i]._achieved_awards_bits, Award_Fine))
-                _449B7E_toggle_bit(pParty->pPlayers[i]._achieved_awards_bits, Award_ArcomageWins, 1);
+            if (!pParty->pPlayers[i]._achievedAwardsBits[Award_Fine]) {
+                pParty->pPlayers[i]._achievedAwardsBits.set(Award_ArcomageWins);
+            }
         }
         ++pParty->uNumArcomageWins;
         if (pParty->uNumArcomageWins > 1000000)
             pParty->uNumArcomageWins = 1000000;
     } else {  //проигрыш
         for (int i = 0; i < 4; ++i) {
-            if (!_449B57_test_bit(pParty->pPlayers[i]._achieved_awards_bits, Award_Fine))
-                _449B7E_toggle_bit(pParty->pPlayers[i]._achieved_awards_bits, Award_ArcomageLoses, 1);
+            if (!pParty->pPlayers[i]._achievedAwardsBits[Award_Fine]) {
+                pParty->pPlayers[i]._achievedAwardsBits.set(Award_ArcomageLoses);
+            }
         }
         ++pParty->uNumArcomageLoses;
         if (pParty->uNumArcomageLoses > 1000000)

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -230,10 +230,10 @@ void ItemInteraction(unsigned int item_id) {
 
         // TODO: WTF? 184 / 185 qbits are associated with Tatalia's Mercenery Guild Harmondale raids. Are these about castle's tapestries ?
         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER) {
-            _449B7E_toggle_bit(pParty->_quest_bits, QBIT_SPLITTER_FOUND, 1);
+            pParty->_questBits.set(QBIT_SPLITTER_FOUND);
         }
         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_SPELLBOOK_REMOVE_FEAR) {
-            _449B7E_toggle_bit(pParty->_quest_bits, 185, 1);
+            pParty->_questBits.set(185);
         }
         if (!pParty->addItemToParty(&pSpriteObjects[item_id].containing_item)) {
             pParty->setHoldingItem(&pSpriteObjects[item_id].containing_item);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1223,8 +1223,9 @@ void Actor::ApplyFineForKillingPeasant(unsigned int uActorID) {
 
     if (pParty->uFine) {
         for (Player &player : pParty->pPlayers) {
-            if (!_449B57_test_bit(player._achieved_awards_bits, Award_Fine))
-                _449B7E_toggle_bit(player._achieved_awards_bits, Award_Fine, 1);
+            if (!player._achievedAwardsBits[Award_Fine]) {
+                player._achievedAwardsBits.set(Award_Fine);
+            }
         }
     }
 }

--- a/src/Engine/Objects/ItemTable.cpp
+++ b/src/Engine/Objects/ItemTable.cpp
@@ -579,7 +579,7 @@ void ItemTable::generateItem(ITEM_TREASURE_LEVEL treasure_level, unsigned int uT
         outItem->uEnchantmentType = outItem->uEnchantmentType * std::to_underlying(treasure_level);
     }
 
-    if (outItem->uItemID == ITEM_SPELLBOOK_DIVINE_INTERVENTION && !_449B57_test_bit(pParty->_quest_bits, 239))
+    if (outItem->uItemID == ITEM_SPELLBOOK_DIVINE_INTERVENTION && !pParty->_questBits[239])
         outItem->uItemID = ITEM_SPELLBOOK_SUNRAY;
     if (pItemTable->pItems[outItem->uItemID].uItemID_Rep_St)
         outItem->uAttributes = 0;

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -6127,9 +6127,9 @@ void Player::SubtractVariable(VariableType VarNum, signed int pValue) {
             PlayAwardSound_Anim98();
             return;
         case VAR_AutoNotes:
-            // TODO(Nik-RE-dev): decreasing 2 seems wrong, also bits indexing was changed
+            // TODO(Nik-RE-dev): decreasing 1 seems wrong, also bits indexing was changed
             assert(false);
-            //pParty->_autonoteBits.reset(pValue - 2);
+            //pParty->_autonoteBits.reset(pValue - 1);
             return;
         case VAR_NPCs2:
             npcIndex = 0;

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -3315,7 +3315,7 @@ void Player::Reset(PLAYER_CLASS_TYPE cls) {
     pActiveSkills.fill(0);
     pActiveSkills[PLAYER_SKILL_CLUB] = 1; // Hidden skills, always at 1.
     pActiveSkills[PLAYER_SKILL_MISC] = 1;
-    _achieved_awards_bits.fill(0);
+    _achievedAwardsBits.reset();
     memset(&spellbook, 0, sizeof(spellbook));
     uQuickSpell = SPELL_NONE;
 
@@ -4162,11 +4162,11 @@ bool Player::CompareVariable(VariableType VarNum, int pValue) {
         case VAR_Age:
             return GetActualAge() >= (unsigned int)pValue;
         case VAR_Award:
-            return _449B57_test_bit(_achieved_awards_bits, pValue);
+            return _achievedAwardsBits[pValue];
         case VAR_Experience:
             return this->experience >= pValue;  // TODO(_) change pValue to long long
         case VAR_QBits_QuestsDone:
-            return _449B57_test_bit(pParty->_quest_bits, pValue);
+            return pParty->_questBits[pValue];
         case VAR_PlayerItemInHands:
             // for (int i = 0; i < 138; i++)
             for (int i = 0; i < INVENTORY_SLOT_COUNT; i++) {
@@ -4391,11 +4391,11 @@ bool Player::CompareVariable(VariableType VarNum, int pValue) {
             }
             return true;
         }
-        case VAR_AutoNotes:  // TODO(_): find out why the double subtraction. or
-                             // whether this is even used
-            test_bit_value = 0x80u >> (pValue - 2) % 8;
-            byteWithRequestedBit = pParty->_autonote_bits[(pValue - 2) / 8];
-            return (test_bit_value & byteWithRequestedBit) != 0;
+        case VAR_AutoNotes:
+            // TODO(_): find out why the double subtraction. or whether this is even used
+            // also bit indexing was changed
+            assert(false);
+            return pParty->_autonoteBits[pValue - 2];
         case VAR_IsMightMoreThanBase:
             actStat = GetActualMight();
             baseStat = GetBaseStrength();
@@ -4425,10 +4425,7 @@ bool Player::CompareVariable(VariableType VarNum, int pValue) {
             baseStat = GetBaseLuck();
             return (actStat >= baseStat);
         case VAR_PlayerBits:
-            test_bit_value = 0x80u >> ((int16_t)pValue - 1) % 8;
-            byteWithRequestedBit =
-                this->playerEventBits[((int16_t)pValue - 1) / 8];
-            return (test_bit_value & byteWithRequestedBit) != 0;
+            return this->_playerEventBits[pValue];
         case VAR_NPCs2:
             return pNPCStats->pNewNPCData[pValue].Hired();
         case VAR_IsFlying:
@@ -4630,25 +4627,24 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             this->sAgeModifier = var_value;
             return;
         case VAR_Award:
-            if (!_449B57_test_bit(this->_achieved_awards_bits, var_value) &&
-                pAwards[var_value].pText) {
+            if (!this->_achievedAwardsBits[var_value] && pAwards[var_value].pText) {
                 PlayAwardSound_Anim();
                 this->playReaction(SPEECH_AwardGot);
             }
-            _449B7E_toggle_bit(this->_achieved_awards_bits, var_value, 1u);
+            this->_achievedAwardsBits.set(var_value);
             return;
         case VAR_Experience:
             this->experience = var_value;
             PlayAwardSound_Anim();
             return;
         case VAR_QBits_QuestsDone:
-            if (!_449B57_test_bit(pParty->_quest_bits, var_value) && pQuestTable[var_value]) {
+            if (!pParty->_questBits[var_value] && pQuestTable[var_value]) {
                 bFlashQuestBook = true;
                 spell_fx_renderer->SetPlayerBuffAnim(BECOME_MAGIC_GUILD_MEMBER, GetPlayerIndex());
                 PlayAwardSound();
                 this->playReaction(SPEECH_QuestGot);
             }
-            _449B7E_toggle_bit(pParty->_quest_bits, var_value, 1u);
+            pParty->_questBits.set(var_value);
             return;
         case VAR_PlayerItemInHands:
             item.Reset();
@@ -4656,7 +4652,7 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             item.uAttributes = ITEM_IDENTIFIED;
             pParty->setHoldingItem(&item);
             if (IsSpawnableArtifact(ITEM_TYPE(var_value)))
-                pParty->pIsArtifactFound[ITEM_TYPE(var_value)] = 1;
+                pParty->pIsArtifactFound[ITEM_TYPE(var_value)] = true;
             return;
         case VAR_FixedGold:
             pParty->SetGold(var_value);
@@ -4898,17 +4894,17 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             return;
         case VAR_AutoNotes:
             assert(var_value > 0);
-            if (!_449B57_test_bit(pParty->_autonote_bits, var_value) && pAutonoteTxt[var_value - 1].pText) {
+            if (!pParty->_autonoteBits[var_value] && pAutonoteTxt[var_value].pText) {
                 spell_fx_renderer->SetPlayerBuffAnim(BECOME_MAGIC_GUILD_MEMBER, GetPlayerIndex());
                 this->playReaction(SPEECH_AwardGot);
                 bFlashAutonotesBook = true;
-                autonoteBookDisplayType = pAutonoteTxt[var_value - 1].eType;  // dword_72371C[2 * a3];
+                autonoteBookDisplayType = pAutonoteTxt[var_value].eType;  // dword_72371C[2 * a3];
             }
-            _449B7E_toggle_bit(pParty->_autonote_bits, var_value, 1u);
+            pParty->_autonoteBits.set(var_value);
             PlayAwardSound();
             return;
         case VAR_PlayerBits:
-            _449B7E_toggle_bit(playerEventBits, var_value, 1u);
+            _playerEventBits.set(var_value);
             return;
         case VAR_NPCs2:
             pParty->hirelingScrollPosition = 0;
@@ -5218,29 +5214,28 @@ void Player::AddVariable(VariableType var_type, signed int val) {
             this->sAgeModifier += val;
             return;
         case VAR_Award:
-            if (_449B57_test_bit(this->_achieved_awards_bits, val) &&
-                pAwards[val].pText) {
+            if (this->_achievedAwardsBits[val] && pAwards[val].pText) {
                 PlayAwardSound_Anim97_Face(SPEECH_AwardGot);
             }
-            _449B7E_toggle_bit(this->_achieved_awards_bits, val, 1);
+            this->_achievedAwardsBits.set(val);
             return;
         case VAR_Experience:
             this->experience = std::min((uint64_t)(this->experience + val), UINT64_C(4000000000));
             PlayAwardSound_Anim97();
             return;
         case VAR_QBits_QuestsDone:
-            if (!_449B57_test_bit(pParty->_quest_bits, val) && pQuestTable[val]) {
+            if (!pParty->_questBits[val] && pQuestTable[val]) {
                 bFlashQuestBook = true;
                 PlayAwardSound_Anim97_Face(SPEECH_QuestGot);
             }
-            _449B7E_toggle_bit(pParty->_quest_bits, val, 1);
+            pParty->_questBits.set(val);
             return;
         case VAR_PlayerItemInHands:
             item.Reset();
             item.uAttributes = ITEM_IDENTIFIED;
             item.uItemID = ITEM_TYPE(val);
             if (IsSpawnableArtifact(ITEM_TYPE(val))) {
-                pParty->pIsArtifactFound[ITEM_TYPE(val)] = 1;
+                pParty->pIsArtifactFound[ITEM_TYPE(val)] = true;
             } else if (IsWand(ITEM_TYPE(val))) {
                 item.uNumCharges = grng->random(6) + item.GetDamageMod() + 1;
                 item.uMaxCharges = item.uNumCharges;
@@ -5471,18 +5466,18 @@ void Player::AddVariable(VariableType var_type, signed int val) {
             PlayAwardSound_Anim97();
             return;
         case VAR_AutoNotes:
-            if (!_449B57_test_bit(pParty->_autonote_bits, val) &&
-                pAutonoteTxt[val].pText) {
+            assert(val > 0);
+            if (!pParty->_autonoteBits[val] && pAutonoteTxt[val].pText) {
                 this->playReaction(SPEECH_AwardGot);
                 bFlashAutonotesBook = true;
                 autonoteBookDisplayType = pAutonoteTxt[val].eType;
                 spell_fx_renderer->SetPlayerBuffAnim(SPELL_QUEST_COMPLETED, GetPlayerIndex());
             }
-            _449B7E_toggle_bit(pParty->_autonote_bits, val, 1);
+            pParty->_autonoteBits.set(val);
             PlayAwardSound();
             return;
         case VAR_PlayerBits:
-            _449B7E_toggle_bit(playerEventBits, val, 1u);
+            _playerEventBits.set(val);
             return;
         case VAR_NPCs2:
             pParty->hirelingScrollPosition = 0;
@@ -5710,15 +5705,14 @@ void Player::SubtractVariable(VariableType VarNum, signed int pValue) {
             this->sAgeModifier -= (int16_t)pValue;
             return;
         case VAR_Award:
-            _449B7E_toggle_bit(this->_achieved_awards_bits,
-                               (int16_t)pValue, 0);
+            this->_achievedAwardsBits.reset(pValue);
             return;
         case VAR_Experience:
             this->experience -= pValue;
             PlayAwardSound_Anim98();
             return;
         case VAR_QBits_QuestsDone:
-            _449B7E_toggle_bit(pParty->_quest_bits, (int16_t)pValue, 0);
+            pParty->_questBits.reset(pValue);
             this->playReaction(SPEECH_AwardGot);
             return;
         case VAR_PlayerItemInHands:
@@ -6133,7 +6127,9 @@ void Player::SubtractVariable(VariableType VarNum, signed int pValue) {
             PlayAwardSound_Anim98();
             return;
         case VAR_AutoNotes:
-            _449B7E_toggle_bit(pParty->_autonote_bits, pValue - 1, 0);
+            // TODO(Nik-RE-dev): decreasing 2 seems wrong, also bits indexing was changed
+            assert(false);
+            //pParty->_autonoteBits.reset(pValue - 2);
             return;
         case VAR_NPCs2:
             npcIndex = 0;
@@ -7375,13 +7371,13 @@ bool Player::isClass(PLAYER_CLASS_TYPE class_type, bool check_honorary) {
 
     switch (class_type) {
     case PLAYER_CLASS_PRIEST_OF_SUN:
-        return _449B57_test_bit(_achieved_awards_bits, Award_Promotion_PriestOfLight_Honorary);
+        return _achievedAwardsBits[Award_Promotion_PriestOfLight_Honorary];
     case PLAYER_CLASS_PRIEST_OF_MOON:
-        return _449B57_test_bit(_achieved_awards_bits, Award_Promotion_PriestOfDark_Honorary);
+        return _achievedAwardsBits[Award_Promotion_PriestOfDark_Honorary];
     case PLAYER_CLASS_ARCHMAGE:
-        return _449B57_test_bit(_achieved_awards_bits, Award_Promotion_Archmage_Honorary);
+        return _achievedAwardsBits[Award_Promotion_Archmage_Honorary];
     case PLAYER_CLASS_LICH:
-        return _449B57_test_bit(_achieved_awards_bits, Award_Promotion_Lich_Honorary);
+        return _achievedAwardsBits[Award_Promotion_Lich_Honorary];
         break;
     default:
         Error("Should not be able to get here (%u)", class_type);
@@ -7552,7 +7548,7 @@ Player::Player() {
     uNumFireSpikeCasts = 0;
 
     field_1988.fill(0);
-    playerEventBits.fill(0);
+    _playerEventBits.reset();
 
     field_E0 = 0;
     field_E4 = 0;

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <bitset>
 #include <utility>
 
 #include "Engine/Engine.h"
@@ -529,7 +530,7 @@ struct Player {
         };
         IndexedArray<PLAYER_SKILL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST> pActiveSkills;
     };
-    std::array<unsigned char, 64> _achieved_awards_bits;
+    std::bitset<513> _achievedAwardsBits;
     PlayerSpells spellbook;
     char _1F6_padding[2];
     int pure_luck_used;
@@ -589,7 +590,7 @@ struct Player {
     char field_1A4D;
     char lastOpenedSpellbookPage;
     SPELL_TYPE uQuickSpell;
-    std::array<unsigned char, 64> playerEventBits;
+    std::bitset<513> _playerEventBits;
     char _some_attack_bonus;
     char field_1A91;
     char _melee_dmg_bonus;

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -2,7 +2,6 @@
 
 #include <vector>
 #include <string>
-#include <bitset>
 #include <utility>
 
 #include "Engine/Engine.h"
@@ -17,6 +16,7 @@
 #include "Engine/Spells/Spells.h"
 
 #include "Utility/IndexedArray.h"
+#include "Utility/IndexedBitset.h"
 
 struct LloydBeacon {
     LloydBeacon() {
@@ -530,7 +530,7 @@ struct Player {
         };
         IndexedArray<PLAYER_SKILL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST> pActiveSkills;
     };
-    std::bitset<513> _achievedAwardsBits;
+    IndexedBitset<1, 512> _achievedAwardsBits;
     PlayerSpells spellbook;
     char _1F6_padding[2];
     int pure_luck_used;
@@ -590,7 +590,7 @@ struct Player {
     char field_1A4D;
     char lastOpenedSpellbookPage;
     SPELL_TYPE uQuickSpell;
-    std::bitset<513> _playerEventBits;
+    IndexedBitset<1, 512> _playerEventBits;
     char _some_attack_bonus;
     char field_1A91;
     char _melee_dmg_bonus;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -130,13 +130,13 @@ void Party::Zero() {
     monster_id_for_hunting.fill(0);
     monster_for_hunting_killed.fill(0);
     days_played_without_rest = 0;
-    _quest_bits.fill(0);
+    _questBits.reset();
     pArcomageWins.fill(0);
     field_7B5_in_arena_quest = 0;
     uNumArenaWins.fill(0);
-    pIsArtifactFound.fill(0);
+    pIsArtifactFound.fill(false);
     field_7d7_set0_unused.fill(0);
-    _autonote_bits.fill(0);
+    _autonoteBits.reset();
     field_818_set0_unused.fill(0);
     random_order_num_unused.fill(0);
     uNumArcomageWins = 0;
@@ -696,9 +696,9 @@ void Party::Reset() {
 
     current_character_screen_window = WINDOW_CharacterWindow_Stats;  // default character ui - stats
     uFlags = 0;
-    _autonote_bits.fill(0);
-    _quest_bits.fill(0);
-    pIsArtifactFound.fill(0);
+    _autonoteBits.reset();
+    _questBits.reset();
+    pIsArtifactFound.fill(false);
 
     PartyTimes._shop_ban_times.fill(GameTime(0));
 
@@ -986,7 +986,7 @@ void Party::restOneFrame() {
 }
 
 bool TestPartyQuestBit(PARTY_QUEST_BITS bit) {
-    return _449B57_test_bit(pParty->_quest_bits, bit);
+    return pParty->_questBits[bit];
 }
 
 //----- (0047752B) --------------------------------------------------------
@@ -1147,9 +1147,9 @@ bool Party::addItemToParty(ItemGen *pItem, bool isSilent) {
     return false;
 }
 
-bool Party::isPartyEvil() { return _449B57_test_bit(_quest_bits, QBIT_DARK_PATH); }
+bool Party::isPartyEvil() { return _questBits[QBIT_DARK_PATH]; }
 
-bool Party::isPartyGood() { return _449B57_test_bit(_quest_bits, QBIT_LIGHT_PATH); }
+bool Party::isPartyGood() { return _questBits[QBIT_LIGHT_PATH]; }
 
 size_t Party::immolationAffectedActors(int *affected, size_t affectedArrSize, size_t effectRange) {
     int x, y, z;
@@ -1188,26 +1188,6 @@ int getTravelTime() {
     return new_travel_time;
 }
 // 6BD07C: using guessed type int uDefaultTravelTime_ByFoot;
-
-//----- (00449B57) --------------------------------------------------------
-bool _449B57_test_bit(std::span<const uint8_t> bits, int index) {
-    assert(index > 0 && index <= bits.size() * 8);
-    index--;
-
-    return bits[index / 8] & (0x80 >> index % 8);
-}
-
-//----- (00449B7E) --------------------------------------------------------
-void _449B7E_toggle_bit(std::span<uint8_t> bits, int index, bool value) {
-    assert(index > 0 && index <= bits.size() * 8);
-    index--;
-
-    uint8_t mask = 0x80 >> index % 8;
-    if (value)
-        bits[index / 8] |= mask;
-    else
-        bits[index / 8] &= ~mask;
-}
 
 //----- (004760D5) --------------------------------------------------------
 PartyAction ActionQueue::Next() {

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <bitset>
 
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/NPC.h"
@@ -441,13 +442,13 @@ struct Party {
     IndexedArray<int16_t, HOUSE_FIRST_TOWNHALL, HOUSE_LAST_TOWNHALL> monster_id_for_hunting;
     IndexedArray<int16_t, HOUSE_FIRST_TOWNHALL, HOUSE_LAST_TOWNHALL> monster_for_hunting_killed; // TODO(captainurist): bool
     unsigned char days_played_without_rest;
-    std::array<uint8_t, 64> _quest_bits;
+    std::bitset<513> _questBits;
     std::array<uint8_t, 16> pArcomageWins;
     char field_7B5_in_arena_quest; // 0, DIALOGUE_ARENA_SELECT_PAGE..DIALOGUE_ARENA_SELECT_CHAMPION, or -1 for win
     std::array<char, 4> uNumArenaWins; // 0=page, 1=squire, 2=knight, 3=lord
     IndexedArray<bool, ITEM_FIRST_SPAWNABLE_ARTIFACT, ITEM_LAST_SPAWNABLE_ARTIFACT> pIsArtifactFound;  // 7ba
     std::array<char, 39> field_7d7_set0_unused;
-    std::array<unsigned char, 26> _autonote_bits;
+    std::bitset<209> _autonoteBits;
     std::array<char, 60> field_818_set0_unused;
     std::array<char, 32> random_order_num_unused;
     int uNumArcomageWins;
@@ -519,6 +520,3 @@ void RestAndHeal(int uNumMinutes);  // idb
  * @offset 0x444D80
  */
 int getTravelTime();
-
-bool _449B57_test_bit(std::span<const uint8_t> bits, int index);
-void _449B7E_toggle_bit(std::span<uint8_t> bits, int index, bool value);  // idb

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -5,7 +5,6 @@
 #include <array>
 #include <vector>
 #include <string>
-#include <bitset>
 
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/NPC.h"
@@ -14,6 +13,7 @@
 #include "GUI/UI/UIHouseEnums.h"
 #include "Library/Random/Random.h"
 #include "Media/Audio/AudioPlayer.h"
+#include "Utility/IndexedBitset.h"
 
 #define PARTY_AUTONOTES_BIT__EMERALD_FIRE_FOUNTAIN 2
 
@@ -442,13 +442,13 @@ struct Party {
     IndexedArray<int16_t, HOUSE_FIRST_TOWNHALL, HOUSE_LAST_TOWNHALL> monster_id_for_hunting;
     IndexedArray<int16_t, HOUSE_FIRST_TOWNHALL, HOUSE_LAST_TOWNHALL> monster_for_hunting_killed; // TODO(captainurist): bool
     unsigned char days_played_without_rest;
-    std::bitset<513> _questBits;
+    IndexedBitset<1, 512> _questBits;
     std::array<uint8_t, 16> pArcomageWins;
     char field_7B5_in_arena_quest; // 0, DIALOGUE_ARENA_SELECT_PAGE..DIALOGUE_ARENA_SELECT_CHAMPION, or -1 for win
     std::array<char, 4> uNumArenaWins; // 0=page, 1=squire, 2=knight, 3=lord
     IndexedArray<bool, ITEM_FIRST_SPAWNABLE_ARTIFACT, ITEM_LAST_SPAWNABLE_ARTIFACT> pIsArtifactFound;  // 7ba
     std::array<char, 39> field_7d7_set0_unused;
-    std::bitset<209> _autonoteBits;
+    IndexedBitset<1, 208> _autonoteBits;
     std::array<char, 60> field_818_set0_unused;
     std::array<char, 32> random_order_num_unused;
     int uNumArcomageWins;

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -88,7 +88,7 @@ static void Serialize(const std::bitset<N2> &src, std::array<T, N1> *dst) {
     size_t i = 1, j = 0;
     while (i < src.size()) {
         T val = 0;
-        for (size_t k = 0; k < (sizeof(T) * 8); k++,i++) {
+        for (size_t k = 0; k < (sizeof(T) * 8); k++, i++) {
             val |= src[i] << ((sizeof(T) * 8) - k - 1);
         }
         Serialize(val, &(*dst)[j]);
@@ -105,7 +105,7 @@ static void Deserialize(const std::array<T, N1> &src, std::bitset<N2> *dst) {
     while (i < dst->size()) {
         T val = 0;
         Deserialize(src[j], &val);
-        for (size_t k = 0; k < (sizeof(T) * 8); k++,i++) {
+        for (size_t k = 0; k < (sizeof(T) * 8); k++, i++) {
             dst->set(i, !!(val & (1 << ((sizeof(T) * 8) - k - 1))));
         }
         j++;

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -20,6 +20,7 @@
 
 #include "Utility/Color.h"
 #include "Utility/Memory/MemSet.h"
+#include "Utility/IndexedBitset.h"
 
 template<class T>
 static void Serialize(const T &src, T *dst) {
@@ -81,10 +82,9 @@ static void Deserialize(const std::array<T1, N1> &src, std::array<T2, N2> *dst) 
 }
 
 // Bits inside each array element indexed backwards
-// Also bits in bitset indexing from 1 as opposed to vanilla
-template<class T, size_t N1, size_t N2>
-static void Serialize(const std::bitset<N2> &src, std::array<T, N1> *dst) {
-    assert(dst->size() * sizeof(T) * 8 == (src.size() - 1));
+template<class T, size_t N, auto L, auto H>
+static void Serialize(const IndexedBitset<L, H> &src, std::array<T, N> *dst) {
+    assert(dst->size() * sizeof(T) * 8 == src.size());
     size_t i = 1, j = 0;
     while (i < src.size()) {
         T val = 0;
@@ -97,10 +97,9 @@ static void Serialize(const std::bitset<N2> &src, std::array<T, N1> *dst) {
 }
 
 // Bits inside each array element indexed backwards
-// Also bits in bitset indexing from 1 as opposed to vanilla
-template<class T, size_t N1, size_t N2>
-static void Deserialize(const std::array<T, N1> &src, std::bitset<N2> *dst) {
-    assert((dst->size() - 1) == src.size() * sizeof(T) * 8);
+template<class T, size_t N, auto L, auto H>
+static void Deserialize(const std::array<T, N> &src, IndexedBitset<L, H> *dst) {
+    assert(dst->size() == src.size() * sizeof(T) * 8);
     size_t i = 1, j = 0;
     while (i < dst->size()) {
         T val = 0;

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <string>
+#include <bitset>
 
 #include "Engine/Engine.h"
 #include "Engine/Graphics/Indoor.h"
@@ -77,6 +78,38 @@ static void Deserialize(const std::array<T1, N1> &src, std::array<T2, N2> *dst) 
     static_assert(N1 == N2, "Expected arrays of equal size.");
     for (size_t i = 0; i < N1; i++)
         Deserialize(src[i], &(*dst)[i]);
+}
+
+// Bits inside each array element indexed backwards
+// Also bits in bitset indexing from 1 as opposed to vanilla
+template<class T, size_t N1, size_t N2>
+static void Serialize(const std::bitset<N2> &src, std::array<T, N1> *dst) {
+    assert(dst->size() * sizeof(T) * 8 == (src.size() - 1));
+    size_t i = 1, j = 0;
+    while (i < src.size()) {
+        T val = 0;
+        for (size_t k = 0; k < (sizeof(T) * 8); k++,i++) {
+            val |= src[i] << ((sizeof(T) * 8) - k - 1);
+        }
+        Serialize(val, &(*dst)[j]);
+        j++;
+    }
+}
+
+// Bits inside each array element indexed backwards
+// Also bits in bitset indexing from 1 as opposed to vanilla
+template<class T, size_t N1, size_t N2>
+static void Deserialize(const std::array<T, N1> &src, std::bitset<N2> *dst) {
+    assert((dst->size() - 1) == src.size() * sizeof(T) * 8);
+    size_t i = 1, j = 0;
+    while (i < dst->size()) {
+        T val = 0;
+        Deserialize(src[j], &val);
+        for (size_t k = 0; k < (sizeof(T) * 8); k++,i++) {
+            dst->set(i, !!(val & (1 << ((sizeof(T) * 8) - k - 1))));
+        }
+        j++;
+    }
 }
 
 template<class T1, size_t N, class T2, auto L, auto H>
@@ -374,7 +407,7 @@ void Serialize(const Party &src, Party_MM7 *dst) {
 
     dst->daysPlayedWithoutRest = src.days_played_without_rest;
 
-    Serialize(src._quest_bits, &dst->questBits);
+    Serialize(src._questBits, &dst->questBits);
     Serialize(src.pArcomageWins, &dst->arcomageWins);
 
     dst->field_7B5_in_arena_quest = src.field_7B5_in_arena_quest;
@@ -382,7 +415,7 @@ void Serialize(const Party &src, Party_MM7 *dst) {
 
     Serialize(src.pIsArtifactFound, &dst->isArtifactFound);
     Serialize(src.field_7d7_set0_unused, &dst->field_7d7);
-    Serialize(src._autonote_bits, &dst->autonoteBits);
+    Serialize(src._autonoteBits, &dst->autonoteBits);
     Serialize(src.field_818_set0_unused, &dst->field_818);
     Serialize(src.random_order_num_unused, &dst->field_854);
 
@@ -496,7 +529,7 @@ void Deserialize(const Party_MM7 &src, Party *dst) {
 
     dst->days_played_without_rest = src.daysPlayedWithoutRest;
 
-    Deserialize(src.questBits, &dst->_quest_bits);
+    Deserialize(src.questBits, &dst->_questBits);
     Deserialize(src.arcomageWins, &dst->pArcomageWins);
 
     dst->field_7B5_in_arena_quest = src.field_7B5_in_arena_quest;
@@ -504,7 +537,7 @@ void Deserialize(const Party_MM7 &src, Party *dst) {
 
     Deserialize(src.isArtifactFound, &dst->pIsArtifactFound);
     Deserialize(src.field_7d7, &dst->field_7d7_set0_unused);
-    Deserialize(src.autonoteBits, &dst->_autonote_bits);
+    Deserialize(src.autonoteBits, &dst->_autonoteBits);
     Deserialize(src.field_818, &dst->field_818_set0_unused);
     Deserialize(src.field_854, &dst->random_order_num_unused);
 
@@ -602,7 +635,7 @@ void Serialize(const Player &src, Player_MM7 *dst) {
     dst->field_104 = src.field_104;
 
     Serialize(src.pActiveSkills, &dst->activeSkills, 37);
-    Serialize(src._achieved_awards_bits, &dst->achievedAwardsBits);
+    Serialize(src._achievedAwardsBits, &dst->achievedAwardsBits);
     Serialize(src.spellbook.bHaveSpell, &dst->spellbook.haveSpell);
 
     dst->pureLuckUsed = src.pure_luck_used;
@@ -663,7 +696,7 @@ void Serialize(const Player &src, Player_MM7 *dst) {
     dst->lastOpenedSpellbookPage = src.lastOpenedSpellbookPage;
     dst->quickSpell = std::to_underlying(src.uQuickSpell);
 
-    Serialize(src.playerEventBits, &dst->playerEventBits);
+    Serialize(src._playerEventBits, &dst->playerEventBits);
 
     dst->someAttackBonus = src._some_attack_bonus;
     dst->field_1A91 = src.field_1A91;
@@ -866,7 +899,7 @@ void Deserialize(const Player_MM7 &src, Player *dst) {
     dst->field_104 = src.field_104;
 
     Deserialize(src.activeSkills, &dst->pActiveSkills, 37);
-    Deserialize(src.achievedAwardsBits, &dst->_achieved_awards_bits);
+    Deserialize(src.achievedAwardsBits, &dst->_achievedAwardsBits);
     Deserialize(src.spellbook.haveSpell, &dst->spellbook.bHaveSpell);
 
     dst->pure_luck_used = src.pureLuckUsed;
@@ -927,7 +960,7 @@ void Deserialize(const Player_MM7 &src, Player *dst) {
     dst->lastOpenedSpellbookPage = src.lastOpenedSpellbookPage;
     dst->uQuickSpell = static_cast<SPELL_TYPE>(src.quickSpell);
 
-    Deserialize(src.playerEventBits, &dst->playerEventBits);
+    Deserialize(src.playerEventBits, &dst->_playerEventBits);
 
     dst->_some_attack_bonus = src.someAttackBonus;
     dst->field_1A91 = src.field_1A91;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -1512,7 +1512,7 @@ void OracleDialogue() {
     // only items with special subquest in range 212-237 and also 241 are recoverable
     for (auto pair : _4F0882_evt_VAR_PlayerItemInHands_vals) {
         int quest_id = pair.first;
-        if (_449B57_test_bit(pParty->_quest_bits, quest_id)) {
+        if (pParty->_questBits[quest_id]) {
             ITEM_TYPE search_item_id = pair.second;
             if (!pParty->hasItem(search_item_id) && pParty->pPickedItem.uItemID != search_item_id) {
                 item_id = search_item_id;
@@ -1688,7 +1688,7 @@ std::string _4B254D_SkillMasteryTeacher(int trainerInfo) {
             gold_transaction_amount = 2000;
             break;
         case PLAYER_SKILL_MASTERY_MASTER:
-            if (!_449B57_test_bit(pParty->_quest_bits, 114))
+            if (!pParty->_questBits[114])
                 return std::string(pNPCTopics[127].pText);
             gold_transaction_amount = 5000;
             break;
@@ -1707,7 +1707,7 @@ std::string _4B254D_SkillMasteryTeacher(int trainerInfo) {
             gold_transaction_amount = 2000;
             break;
         case PLAYER_SKILL_MASTERY_MASTER:
-            if (!_449B57_test_bit(pParty->_quest_bits, 110))
+            if (!pParty->_questBits[110])
                 return std::string(pNPCTopics[127].pText);
             gold_transaction_amount = 5000;
             break;
@@ -1932,7 +1932,7 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
             case 8:
                 v63 = 0;
                 for (uint _i = 0; _i < 28; ++_i) {
-                    if (_449B57_test_bit(pPlayer->_achieved_awards_bits, word_4EE150[i])) {
+                    if (pPlayer->_achievedAwardsBits[word_4EE150[i]]) {
                         v21 = v63;
                         ++v63;
                         v55[v63] = word_4EE150[i];
@@ -2459,7 +2459,7 @@ const char *GetJoinGuildDialogueOption(GUILD_ID guild_id) {
         pParty->setActiveToFirstCanAct();  // avoid nzi
 
     if (pParty->activeCharacter().CanAct()) {
-        if (_449B57_test_bit(pParty->activeCharacter()._achieved_awards_bits, dword_F8B1AC_award_bit_number)) {
+        if (pParty->activeCharacter()._achievedAwardsBits[dword_F8B1AC_award_bit_number]) {
             return pNPCTopics[dialogue_base + 13].pText;
         } else {
             if (gold_transaction_amount <= pParty->GetGold()) {

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -27,7 +27,7 @@ void GUIWindow_AutonotesBook::recalculateCurrentNotesTypePages() {
     _activeNotesIdx.clear();
     for (int i = 1; i < pAutonoteTxt.size(); ++i) {
         if (autonoteBookDisplayType == pAutonoteTxt[i].eType) {
-            if (_449B57_test_bit(pParty->_autonote_bits, i) && pAutonoteTxt[i].pText) {
+            if (pParty->_autonoteBits[i] && pAutonoteTxt[i].pText) {
                 _activeNotesIdx.push_back(i);
             }
         }

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -42,8 +42,8 @@ GUIWindow_QuestBook::GUIWindow_QuestBook() : _startingQuestIdx(0), _currentPage(
     pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, {ui_book_button2_on->GetWidth(), ui_book_button2_on->GetHeight()}, 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NEXT_PAGE), InputAction::Invalid, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button2_on});
 
-    for (int i = 1; i <= (pParty->_quest_bits.size() * 8); ++i) {
-        if (_449B57_test_bit(pParty->_quest_bits, i) && pQuestTable[i]) {
+    for (int i = 1; i <= pQuestTable.size(); ++i) {
+        if (pParty->_questBits[i] && pQuestTable[i]) {
             _activeQuestsIdx.push_back(i);
         }
     }

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -42,7 +42,7 @@ GUIWindow_QuestBook::GUIWindow_QuestBook() : _startingQuestIdx(0), _currentPage(
     pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, {ui_book_button2_on->GetWidth(), ui_book_button2_on->GetHeight()}, 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NEXT_PAGE), InputAction::Invalid, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button2_on});
 
-    for (int i = 1; i <= pQuestTable.size(); ++i) {
+    for (int i = 1; i < pQuestTable.size(); ++i) {
         if (pParty->_questBits[i] && pQuestTable[i]) {
             _activeQuestsIdx.push_back(i);
         }

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -83,7 +83,7 @@ void GUIWindow_TownPortalBook::Update() {
     townPortalWindow.uFrameW = game_viewport_w;
 
     for (uint i = 0; i < TOWN_PORTAL_DESTINATION_COUNT; ++i) {
-        if (_449B57_test_bit(pParty->_quest_bits, townPortalQuestBits[i]) || engine->config->debug.TownPortal.value()) {
+        if (pParty->_questBits[townPortalQuestBits[i]] || engine->config->debug.TownPortal.value()) {
             render->ZDrawTextureAlpha(pTownPortalBook_xs[i] / 640.0f, pTownPortalBook_ys[i] / 480.0f, ui_book_townportal_icons[i], i + 1);
         }
     }
@@ -92,7 +92,7 @@ void GUIWindow_TownPortalBook::Update() {
     int iconPointing = render->pActiveZBuffer[pt.x + pt.y * render->GetRenderDimensions().w] & 0xFFFF;
 
     if (iconPointing) {
-        if (_449B57_test_bit(pParty->_quest_bits, townPortalQuestBits[iconPointing - 1]) || engine->config->debug.TownPortal.value()) {
+        if (pParty->_questBits[townPortalQuestBits[iconPointing - 1]] || engine->config->debug.TownPortal.value()) {
             render->DrawTextureNew(pTownPortalBook_xs[iconPointing - 1] / 640.0f, pTownPortalBook_ys[iconPointing - 1] / 480.0f, ui_book_townportal_icons[iconPointing - 1]);
         }
     }

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -1713,8 +1713,9 @@ void FillAwardsData() {
     books_page_number = 0;
     books_primary_item_per_page = 0;
     for (int i = 1; i < 105; ++i) {
-        if (_449B57_test_bit(pPlayer->_achieved_awards_bits, i) && pAwards[i].pText)
+        if (pPlayer->_achievedAwardsBits[i] && pAwards[i].pText) {
             achieved_awards[num_achieved_awards++] = (AwardType)i;
+        }
     }
     full_num_items_in_book = num_achieved_awards;
     num_achieved_awards = 0;

--- a/src/GUI/UI/UIGuilds.cpp
+++ b/src/GUI/UI/UIGuilds.cpp
@@ -42,10 +42,9 @@ void GuildDialog() {
                                                              p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {  // change to switch??
-        if (!_449B57_test_bit(pParty->activeCharacter()._achieved_awards_bits, guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE])) {
+        if (!pParty->activeCharacter()._achievedAwardsBits[guild_membership_flags[window_SpeakInHouse->wData.val - HOUSE_FIRE_GUILD_INITIATE_EMERALD_ISLE]]) {
             // you must be a member
-            pTextHeight = pFontArrus->CalcTextHeight(
-                pNPCTopics[121].pText, working_window.uFrameWidth, 0);
+            pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[121].pText, working_window.uFrameWidth, 0);
             working_window.DrawTitleText(pFontArrus, 0, (212 - pTextHeight) / 2 + 101, colorTable.PaleCanary.c16(), pNPCTopics[121].pText, 3);
             pDialogueWindow->pNumPresenceButton = 0;
             return;
@@ -169,7 +168,7 @@ void SpellBookGenerator() {  // for GuildDialogs
         }
 
         if (pItemNum == ITEM_SPELLBOOK_DIVINE_INTERVENTION) {
-            if (!_449B57_test_bit(pParty->_quest_bits, QBIT_DIVINE_INTERVENTION_RETRIEVED))
+            if (!pParty->_questBits[QBIT_DIVINE_INTERVENTION_RETRIEVED])
                 pItemNum = ITEM_SPELLBOOK_SUNRAY;
         }
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -889,7 +889,7 @@ bool enterHouse(HOUSE_ID uHouseID) {
             if (!pParty->hasActiveCharacter())  // avoid nzi
                 pParty->setActiveToFirstCanAct();
 
-            if (!_449B57_test_bit(pParty->activeCharacter()._achieved_awards_bits, membership)) {
+            if (!pParty->activeCharacter()._achievedAwardsBits[membership]) {
                 PlayHouseSound(uHouseID, HouseSound_Greeting_2);
                 return 1;
             }
@@ -915,7 +915,7 @@ void PrepareHouse(HOUSE_ID house) {
     if (uHouse_ExitPic) {
         uExitMapID = p2DEvents[house - HOUSE_SMITH_EMERALD_ISLE]._quest_bit;
         if (uExitMapID > 0) {
-            if (_449B57_test_bit(pParty->_quest_bits, uExitMapID)) {
+            if (pParty->_questBits[uExitMapID]) {
                 uHouse_ExitPic = 0;
             }
         }
@@ -1280,8 +1280,7 @@ void TravelByTransport() {
                 lastsched = schedule_id;
 
                 if (schedule_id != 255 && route_active &&
-                    (!transport_schedule[schedule_id].uQuestBit ||
-                        _449B57_test_bit(pParty->_quest_bits, transport_schedule[schedule_id].uQuestBit))) {
+                    (!transport_schedule[schedule_id].uQuestBit || pParty->_questBits[transport_schedule[schedule_id].uQuestBit])) {
                     uint16_t color{};
                     if (pDialogueWindow->pCurrentPosActiveItem == pCurrentButton)
                         color = colorTable.PaleCanary.c16();
@@ -1389,9 +1388,9 @@ bool IsTravelAvailable(int a1) {
     for (uint i = 0; i < 4; ++i) {
         if (transport_schedule[transport_routes[a1][i]]
             .pSchedule[pParty->uCurrentDayOfMonth % 7]) {
-            if (!transport_schedule[transport_routes[a1][i]].uQuestBit ||
-                _449B57_test_bit(pParty->_quest_bits, transport_schedule[transport_routes[a1][i]].uQuestBit))
+            if (!transport_schedule[transport_routes[a1][i]].uQuestBit || pParty->_questBits[transport_schedule[transport_routes[a1][i]].uQuestBit]) {
                 return true;
+            }
         }
     }
     return false;
@@ -2390,7 +2389,7 @@ void MercenaryGuildDialog() {
     int pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(), p2DEvents[window_SpeakInHouse->wData.val - 1]);
 
     if (dialog_menu_id == DIALOGUE_MAIN) {
-        if (!_449B57_test_bit(pParty->activeCharacter()._achieved_awards_bits, word_4F0754[2 * window_SpeakInHouse->wData.val])) {
+        if (!pParty->activeCharacter()._achievedAwardsBits[word_4F0754[2 * window_SpeakInHouse->wData.val]]) {
             // 171 looks like Mercenary Stronghold message from NPCNews.txt in MM6
             pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[171].pText, dialog_window.uFrameWidth, 0);
             dialog_window.DrawTitleText(pFontArrus, 0, (212 - pTextHeight) / 2 + 101, colorTable.PaleCanary.c16(), pNPCTopics[171].pText, 3);

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -260,12 +260,12 @@ bool PartyCreationUI_Loop() {
     pParty->Reset();
     pParty->createDefaultParty();
 
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_RED_POTION_ACTIVE, 1);
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_SEASHELL_ACTIVE, 1);
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_LONGBOW_ACTIVE, 1);
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_PLATE_ACTIVE, 1);
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_LUTE_ACTIVE, 1);
-    _449B7E_toggle_bit(pParty->_quest_bits, QBIT_EMERALD_ISLAND_HAT_ACTIVE, 1);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_RED_POTION_ACTIVE);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_SEASHELL_ACTIVE);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_LONGBOW_ACTIVE);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_PLATE_ACTIVE);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_LUTE_ACTIVE);
+    pParty->_questBits.set(QBIT_EMERALD_ISLAND_HAT_ACTIVE);
 
     pGUIWindow_CurrentMenu = new GUIWindow_PartyCreation();
     if (PartyCreationUI_LoopInternal()) {

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -92,7 +92,7 @@ static void calculateRequiredFood() {
     if (foodRequiredToRest < 1) {
         foodRequiredToRest = 1;
     }
-    if (pCurrentMapName == "d29.blv" && _449B57_test_bit(pParty->_quest_bits, QBIT_HARMONDALE_REBUILT)) {
+    if (pCurrentMapName == "d29.blv" && pParty->_questBits[QBIT_HARMONDALE_REBUILT]) {
         foodRequiredToRest = 0;
     }
 }

--- a/src/GUI/UI/UIShops.cpp
+++ b/src/GUI/UI/UIShops.cpp
@@ -1598,8 +1598,9 @@ void sub_4B1447_party_fine(int shopId, int stealingResult,
         }
         if (pParty->uFine) {
             for (Player &player : pParty->pPlayers) {
-                if (!_449B57_test_bit(player._achieved_awards_bits, Award_Fine))
-                    _449B7E_toggle_bit(player._achieved_awards_bits, Award_Fine, 1);
+                if (!player._achievedAwardsBits[Award_Fine]) {
+                    player._achievedAwardsBits.set(Award_Fine);
+                }
             }
         }
         if (stealingResult == 1)

--- a/src/Utility/IndexedBitset.h
+++ b/src/Utility/IndexedBitset.h
@@ -21,10 +21,6 @@ class IndexedBitset {
         _bitset.set();
     }
 
-    void set(key_type index) {
-        set(index, true);
-    }
-
     void reset() {
         _bitset.reset();
     }
@@ -33,7 +29,7 @@ class IndexedBitset {
         set(index, false);
     }
 
-    void set(key_type index, bool value) {
+    void set(key_type index, bool value = true) {
         checkIndex(index);
         _bitset.set(index - FirstIndex, value);
     }

--- a/src/Utility/IndexedBitset.h
+++ b/src/Utility/IndexedBitset.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <bitset>
+
+template<auto FirstIndex, auto LastIndex>
+class IndexedBitset {
+ public:
+    using key_type = decltype(FirstIndex);
+
+    size_t size() const { return LastIndex - FirstIndex + 1; }
+
+    void fill(bool value) {
+        if (value) {
+            set();
+        } else {
+            reset();
+        }
+    }
+
+    void set() {
+        _bitset.set();
+    }
+
+    void set(key_type index) {
+        set(index, true);
+    }
+
+    void reset() {
+        _bitset.reset();
+    }
+
+    void reset(key_type index) {
+        set(index, false);
+    }
+
+    void set(key_type index, bool value) {
+        checkIndex(index);
+        _bitset.set(index - FirstIndex, value);
+    }
+
+    bool test(key_type index) {
+        checkIndex(index);
+        return _bitset.test(index);
+    }
+
+    auto operator [](key_type index) {
+        checkIndex(index);
+        return _bitset[index - FirstIndex];
+    }
+
+    auto operator [](key_type index) const {
+        checkIndex(index);
+        return _bitset[index - FirstIndex];
+    }
+ private:
+    void checkIndex(key_type index) const {
+        assert(index >= FirstIndex && index <= LastIndex);
+    }
+
+    std::bitset<LastIndex - FirstIndex + 1> _bitset;
+};


### PR DESCRIPTION
Subj.
This changes actual bit numerations.
Before arrays that correspond to bits and indexes that were passed down to test/toggle bit functions were 1-based. But bit inside arrays numeration was 0-based.
Now bits also use 1-based numeration and serialize/deserialize functions take it into account.