### PR TITLE
Fix event timers

### DIFF
--- a/src/Engine/Events.cpp
+++ b/src/Engine/Events.cpp
@@ -147,8 +147,6 @@ void LoadLevel_InitializeLevelEvt() {
     }
     uLevelEVT_NumEvents = events_count;
 
-    registerEventTriggers();
-
     /*
     EmeraldIsle::Variables:
     [0] ???
@@ -357,7 +355,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
 
     for (v4 = 0; v4 < uSomeEVT_NumEvents; ++v4) {
         if (dword_5B65C4_cancelEventProcessing) {
-            if (v133 == 1) OnMapLeave();
+            if (v133 == 1) onMapLeave();
             return;
         }
         if (pSomeEVT_Events[v4].event_id == uEventID &&
@@ -706,7 +704,7 @@ LABEL_47:
                         game_ui_status_bar_event_string =
                             &pLevelStr[pLevelStrOffsets[EVT_DWORD(_evt->v5)]];
                         StartBranchlessDialogue(uEventID, curr_seq_num, (int)EVENT_InputString);
-                        if (v133 == 1) OnMapLeave();
+                        if (v133 == 1) onMapLeave();
                         return;
                     }
                     v84 = EVT_DWORD(_evt->v13);
@@ -838,7 +836,7 @@ LABEL_47:
                     break;
                 case EVENT_OpenChest:
                     if (!Chest::open(_evt->v5)) {
-                        if (v133 == 1) OnMapLeave();
+                        if (v133 == 1) onMapLeave();
                         return;
                     }
                     ++curr_seq_num;
@@ -860,7 +858,7 @@ LABEL_47:
                             trans_partyzspeed, (char *)&_evt->v31);
                         savedEventID = uEventID;
                         savedEventStep = curr_seq_num + 1;
-                        if (v133 == 1) OnMapLeave();
+                        if (v133 == 1) onMapLeave();
                         return;
                     }
                     Party_Teleport_Y_Pos =
@@ -920,7 +918,7 @@ LABEL_47:
                                 dialog_menu_id = DIALOGUE_NULL;
                                 pIcons_LOD->SyncLoadedFilesCount();
                             }
-                            OnMapLeave();
+                            onMapLeave();
                             return;
                         }
                     }
@@ -961,10 +959,10 @@ LABEL_47:
                     break;
                 case EVENT_PressAnyKey:
                     StartBranchlessDialogue(uEventID, curr_seq_num + 1, (int)EVENT_PressAnyKey);
-                    if (v133 == 1) OnMapLeave();
+                    if (v133 == 1) onMapLeave();
                     return;
                 case EVENT_Exit:
-                    if (v133 == 1) OnMapLeave();
+                    if (v133 == 1) onMapLeave();
                     return;
                 case EVENT_ShowMovie:
                     movieName = trimRemoveQuotes((char *) &_evt->v7);
@@ -1008,7 +1006,7 @@ LABEL_47:
             }
         }
     }
-    if (v133 == 1) OnMapLeave();
+    if (v133 == 1) onMapLeave();
     return;
 }
 

--- a/src/Engine/Events/EventIR.cpp
+++ b/src/Engine/Events/EventIR.cpp
@@ -736,7 +736,7 @@ std::string EventIR::toString() const {
                 return fmt::format("{}: ShowMessage(\"{}\")", step, &pLevelStr[pLevelStrOffsets[data.text_id]]);
             }
         case EVENT_OnTimer:
-            return fmt::format("{}: OnTimer({}yr, {}m, {}w, {}hr, {}min, {}sec, {})", step, data.timer_descr.years, data.timer_descr.months, data.timer_descr.weeks, data.timer_descr.hours, data.timer_descr.minutes, data.timer_descr.seconds, data.timer_descr.alternative_interval);
+            return fmt::format("{}: OnTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step, data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly, data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute, data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
         case EVENT_ToggleIndoorLight:
             return fmt::format("{}: ToggleIndoorLight({}, {})", step, data.light_descr.light_id, data.light_descr.is_enable);
         case EVENT_PressAnyKey:
@@ -750,7 +750,7 @@ std::string EventIR::toString() const {
         case EVENT_OnMapReload:
             return fmt::format("{}: OnMapReload", step);
         case EVENT_OnLongTimer:
-            return fmt::format("{}: OnLongTimer({}yr, {}m, {}w, {}hr, {}min, {}sec, {})", step, data.timer_descr.years, data.timer_descr.months, data.timer_descr.weeks, data.timer_descr.hours, data.timer_descr.minutes, data.timer_descr.seconds, data.timer_descr.alternative_interval);
+            return fmt::format("{}: OnLongTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step, data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly, data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute, data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
         case EVENT_SetNPCTopic:
             return fmt::format("{}: SetNPCTopic({}, {}, {})", step, data.npc_topic_descr.npc_id, data.npc_topic_descr.index, data.npc_topic_descr.event_id);
         case EVENT_MoveNPC:
@@ -964,13 +964,13 @@ EventIR EventIR::parse(void *data, size_t maxSize) {
             ir.data.text_id = EVT_DWORD(_evt->v5);
             break;
         case EVENT_OnTimer:
-            ir.data.timer_descr.years = _evt->v5;
-            ir.data.timer_descr.months = _evt->v6;
-            ir.data.timer_descr.weeks = _evt->v7;
-            ir.data.timer_descr.hours = _evt->v8;
-            ir.data.timer_descr.minutes = _evt->v9;
-            ir.data.timer_descr.seconds = _evt->v10;
-            ir.data.timer_descr.alternative_interval = _evt->v11 + (_evt->v12 << 8);
+            ir.data.timer_descr.is_yearly = _evt->v5;
+            ir.data.timer_descr.is_monthly = _evt->v6;
+            ir.data.timer_descr.is_weekly = _evt->v7;
+            ir.data.timer_descr.daily_start_hour = _evt->v8;
+            ir.data.timer_descr.daily_start_minute = _evt->v9;
+            ir.data.timer_descr.daily_start_second = _evt->v10;
+            ir.data.timer_descr.alt_halfmin_interval = _evt->v11 + (_evt->v12 << 8);
             break;
         case EVENT_ToggleIndoorLight:
             ir.data.light_descr.light_id = EVT_DWORD(_evt->v5);
@@ -998,13 +998,13 @@ EventIR EventIR::parse(void *data, size_t maxSize) {
             // Nothing?
             break;
         case EVENT_OnLongTimer:
-            ir.data.timer_descr.years = _evt->v5;
-            ir.data.timer_descr.months = _evt->v6;
-            ir.data.timer_descr.weeks = _evt->v7;
-            ir.data.timer_descr.hours = _evt->v8;
-            ir.data.timer_descr.minutes = _evt->v9;
-            ir.data.timer_descr.seconds = _evt->v10;
-            ir.data.timer_descr.alternative_interval = _evt->v11 + (_evt->v12 << 8);
+            ir.data.timer_descr.is_yearly = _evt->v5;
+            ir.data.timer_descr.is_monthly = _evt->v6;
+            ir.data.timer_descr.is_weekly = _evt->v7;
+            ir.data.timer_descr.daily_start_hour = _evt->v8;
+            ir.data.timer_descr.daily_start_minute = _evt->v9;
+            ir.data.timer_descr.daily_start_second = _evt->v10;
+            ir.data.timer_descr.alt_halfmin_interval = _evt->v11 + (_evt->v12 << 8);
             break;
         case EVENT_SetNPCTopic:
             ir.data.npc_topic_descr.npc_id = EVT_DWORD(_evt->v5);

--- a/src/Engine/Events/EventIR.h
+++ b/src/Engine/Events/EventIR.h
@@ -91,13 +91,13 @@ class EventIR {
             int name_id;
         } monster_descr;
         struct {
-            int years;
-            int months;
-            int weeks;
-            int hours;
-            int minutes;
-            int seconds;
-            int alternative_interval;
+            bool is_yearly;
+            bool is_monthly;
+            bool is_weekly;
+            int daily_start_hour;
+            int daily_start_minute;
+            int daily_start_second;
+            int alt_halfmin_interval;
         } timer_descr;
         struct {
             bool is_nop;

--- a/src/Engine/Events/Processor.cpp
+++ b/src/Engine/Events/Processor.cpp
@@ -158,7 +158,7 @@ static void registerEventTriggers() {
 }
 
 void onMapLoad() {
-    // Register triggers all triggers when map done loading
+    // Register all triggers when map done loading
     registerEventTriggers();
 
     timerGuard = pParty->GetPlayingTime();
@@ -173,7 +173,7 @@ void onMapLeave() {
         eventProcessor(triggers.eventId, 0, true, triggers.eventStep + 1);
     }
 
-    // Cleanup timers to avoid firing when on transitions
+    // Cleanup timers to avoid firing while map transition is in process
     onLongTimerTriggers.clear();
     onTimerTriggers.clear();
 }

--- a/src/Engine/Events/Processor.cpp
+++ b/src/Engine/Events/Processor.cpp
@@ -14,6 +14,7 @@
 
 struct MapTimer {
     GameTime interval = GameTime(0);
+    GameTime timeInsideDay = GameTime(0);
     GameTime altInterval = GameTime(0);
     GameTime alarmTime = GameTime(0);
     int eventId = 0;
@@ -33,6 +34,7 @@ static void registerTimerTriggers(EventType triggerType, std::vector<MapTimer> *
     // TODO(Nik-RE-dev): using time of last visit will help timers only slightly when transiting indoor<->outdoor
     //                   "once" because each saving reset these times.
     //                   To support fair timers they needed to be saved in save game and for each map separately.
+    //                   Until then timers with long interval may just never fire because of time resetting on transitions and save/loads.
     if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
         levelLastVisit = pIndoor->stru1.last_visit;
     } else {
@@ -44,19 +46,55 @@ static void registerTimerTriggers(EventType triggerType, std::vector<MapTimer> *
         MapTimer timer;
         EventIR ir = engine->_localEventMap.get(trigger.eventId, trigger.eventStep);
 
-        if (ir.data.timer_descr.alternative_interval) {
+        if (ir.data.timer_descr.alt_halfmin_interval) {
             // Alternative interval is defined in terms of half-minutes
-            timer.altInterval = GameTime::FromSeconds(ir.data.timer_descr.alternative_interval * 30);
+            timer.altInterval = GameTime::FromSeconds(ir.data.timer_descr.alt_halfmin_interval * 30);
             timer.alarmTime = pParty->GetPlayingTime() + timer.altInterval;
-            assert(timer.altInterval.Valid());
         } else {
-            timer.interval = GameTime(ir.data.timer_descr.seconds, ir.data.timer_descr.minutes, ir.data.timer_descr.hours,
-                                      ir.data.timer_descr.weeks, ir.data.timer_descr.months, ir.data.timer_descr.years);
+            GameTime timeSinceLastVisit = pParty->GetPlayingTime() - levelLastVisit;
+            if (!levelLastVisit.Valid()) {
+                timeSinceLastVisit = GameTime(0);
+            }
 
-            if (levelLastVisit) {
-                timer.alarmTime = std::max(levelLastVisit + timer.interval, pParty->GetPlayingTime());
+            if (ir.data.timer_descr.is_yearly) {
+                timer.interval = GameTime::FromYears(1);
+            } else if (ir.data.timer_descr.is_monthly) {
+                timer.interval = GameTime::FromDays(28);
+            } else if (ir.data.timer_descr.is_weekly) {
+                timer.interval = GameTime::FromDays(7);
             } else {
-                timer.alarmTime = pParty->GetPlayingTime() + timer.interval;
+                // Interval is daily with exact time of day
+                timer.interval = GameTime::FromDays(1);
+                timer.timeInsideDay = GameTime::FromHours(ir.data.timer_descr.daily_start_hour);
+                timer.timeInsideDay = timer.timeInsideDay.AddMinutes(ir.data.timer_descr.daily_start_minute);
+                timer.timeInsideDay = timer.timeInsideDay.AddSeconds(ir.data.timer_descr.daily_start_second);
+            }
+
+            if (timer.timeInsideDay) {
+                if (timeSinceLastVisit) {
+                    // Calculate alarm time inside last visit day
+                    int last_seconds = levelLastVisit.GetSecondsFraction();
+                    int last_minutes = levelLastVisit.GetMinutesFraction();
+                    int last_hours = levelLastVisit.GetHoursOfDay();
+                    timer.alarmTime = levelLastVisit - GameTime(last_seconds, last_minutes, last_hours) + timer.timeInsideDay;
+                    if (timer.alarmTime < levelLastVisit) {
+                        // Last visit time already passed alarm time inside that day so move alarm to next day
+                        timer.alarmTime = timer.alarmTime + GameTime::FromDays(1);
+                    }
+                } else {
+                    // Set alarm time on the time of the previous day because it must fire
+                    int seconds = pParty->GetPlayingTime().GetSecondsFraction();
+                    int minutes = pParty->GetPlayingTime().GetMinutesFraction();
+                    int hours = pParty->GetPlayingTime().GetHoursOfDay();
+                    timer.alarmTime = pParty->GetPlayingTime() - GameTime(seconds, minutes, hours) + timer.timeInsideDay - GameTime::FromDays(1);
+                }
+            } else {
+                if (timeSinceLastVisit) {
+                    timer.alarmTime = levelLastVisit + timer.interval;
+                } else {
+                    // Without time since last visit all timers must fire immediately
+                    timer.alarmTime = pParty->GetPlayingTime();
+                }
             }
             assert(timer.interval.Valid());
         }

--- a/src/Engine/Events/Processor.h
+++ b/src/Engine/Events/Processor.h
@@ -6,7 +6,6 @@ void eventProcessor(int eventId, int targetObj, bool canShowMessages, int startS
 bool npcDialogueEventProcessor(int eventId, int startStep = 0);
 std::string getEventHintString(int eventId);
 
-void registerEventTriggers();
 void onMapLoad();
 void onMapLeave();
 void onTimer();

--- a/src/Engine/Time.h
+++ b/src/Engine/Time.h
@@ -82,6 +82,7 @@ struct GameTime {
         return *this;
     }
 
+    bool operator==(const GameTime &rhs) const { return this->value == rhs.value; }
     bool operator>(const GameTime &rhs) const { return this->value > rhs.value; }
     bool operator>=(const GameTime &rhs) const { return this->value >= rhs.value; }
     bool operator<(const GameTime &rhs) const { return this->value < rhs.value; }


### PR DESCRIPTION
Previous attemt on new timers support were incomplete:
- Seconds/Minutes/Hours are not intervals these are time inside day for daily timers
- Year/Month/Week is also not interval they are flags that timers are yearly/monthly/weekly
- Timers must fire immediately if no time elapsed since last visit - for example when starting new game timers must fire to initialize map variables that timers reinitialize

Also with this PR #674 can be considered fixed.