### PR TITLE
Cleanup of item combining function

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1429,7 +1429,7 @@ void setDecorationSprite(uint16_t uCog, bool bHide, const std::string &pFileName
 void back_to_game() {
     holdingMouseRightButton = false;
     rightClickItemActionPerformed = false;
-    identifyReactionPlayed = false;
+    identifyOrRepairReactionPlayed = false;
 
     if (pGUIWindow_ScrollWindow) free_book_subwindow();
     if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME && !pGUIWindow_CastTargetedSpell)
@@ -1835,7 +1835,7 @@ void RegeneratePartyHealthMana() {
                     if (player.HasItemEquipped(idx)) {
                         uint _idx = player.pEquipment.pIndices[idx];
                         ItemGen equppedItem = player.pInventoryItemList[_idx - 1];
-                        if (!IsRegular(equppedItem.uItemID)) {
+                        if (!isRegular(equppedItem.uItemID)) {
                             if (equppedItem.uItemID == ITEM_RELIC_ETHRICS_STAFF) {
                                 decrease_HP = true;
                             }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -354,7 +354,7 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
 void Chest::PlaceItemAt(unsigned int put_cell_pos, unsigned int item_at_cell, int uChestID) {  // only used for setup?
     ITEM_TYPE uItemID = vChests[uChestID].igChestItems[item_at_cell].uItemID;
     pItemTable->SetSpecialBonus(&vChests[uChestID].igChestItems[item_at_cell]);
-    if (IsWand(uItemID) && !vChests[uChestID].igChestItems[item_at_cell].uNumCharges) {
+    if (isWand(uItemID) && !vChests[uChestID].igChestItems[item_at_cell].uNumCharges) {
         int v6 = grng->random(21) + 10;
         vChests[uChestID].igChestItems[item_at_cell].uNumCharges = v6;
         vChests[uChestID].igChestItems[item_at_cell].uMaxCharges = v6;
@@ -571,12 +571,12 @@ void GenerateItemsInChest() {
     for (int i = 0; i < 20; ++i) {
         for (int j = 0; j < 140; ++j) {
             ItemGen *currItem = &vChests[i].igChestItems[j];
-            if (IsRandomItem(currItem->uItemID)) {
+            if (isRandomItem(currItem->uItemID)) {
                 currItem->placedInChest = false;
                 int additionaItemCount = grng->random(5);  // additional items in chect
                 additionaItemCount++;  // + 1 because it's the item at pChests[i].igChestItems[j] and the additional ones
                 ITEM_TREASURE_LEVEL resultTreasureLevel = grng->randomSample(
-                    RemapTreasureLevel(RandomItemTreasureLevel(currItem->uItemID), currMapInfo->Treasure_prob));
+                    RemapTreasureLevel(randomItemTreasureLevel(currItem->uItemID), currMapInfo->Treasure_prob));
                 if (resultTreasureLevel != ITEM_TREASURE_LEVEL_GUARANTEED_ARTIFACT) {
                     for (int k = 0; k < additionaItemCount; k++) {
                         int whatToGenerateProb = grng->random(100);

--- a/src/Engine/Objects/ItemEnums.h
+++ b/src/Engine/Objects/ItemEnums.h
@@ -983,6 +983,9 @@ enum class ITEM_TYPE : int32_t {
     ITEM_FIRST_REGULAR = ITEM_CRUDE_LONGSWORD,
     ITEM_LAST_REGULAR = ITEM_SUN_AMULET,
 
+    ITEM_FIRST_ARTIFACT = ITEM_ARTIFACT_PUCK,
+    ITEM_LAST_ARTIFACT = ITEM_RARE_GROGNARDS_CUTLASS,
+
     ITEM_FIRST_SPAWNABLE_ARTIFACT = ITEM_ARTIFACT_PUCK,
     ITEM_LAST_SPAWNABLE_ARTIFACT = ITEM_RELIC_MEKORIGS_HAMMER,
 
@@ -991,6 +994,9 @@ enum class ITEM_TYPE : int32_t {
 
     ITEM_FIRST_RECIPE = ITEM_RECIPE_REJUVENATION,
     ITEM_LAST_RECIPE = ITEM_RECIPE_BODY_RESISTANCE,
+
+    ITEM_FIRST_REAGENT = ITEM_REAGENT_WIDOWSWEEP_BERRIES,
+    ITEM_LAST_REAGENT = ITEM_REAGENT_PHILOSOPHERS_STONE,
 
     ITEM_FIRST_REAL_POTION = ITEM_POTION_CURE_WOUNDS,
     ITEM_LAST_REAL_POTION = ITEM_POTION_REJUVENATION,
@@ -1024,40 +1030,52 @@ using enum ITEM_TYPE;
  * @param type                          Item type to check.
  * @return                              Whether the provided item is a regular item.
  */
-inline bool IsRegular(ITEM_TYPE type) {
+inline bool isRegular(ITEM_TYPE type) {
     return type >= ITEM_FIRST_REGULAR && type <= ITEM_LAST_REGULAR;
 }
 
-inline bool IsRecipe(ITEM_TYPE type) {
+inline bool isRecipe(ITEM_TYPE type) {
     return type >= ITEM_FIRST_RECIPE && type <= ITEM_LAST_RECIPE;
 }
 
-inline bool IsWand(ITEM_TYPE type) {
+inline bool isWand(ITEM_TYPE type) {
     return type >= ITEM_FIRST_WAND && type <= ITEM_LAST_WAND;
 }
 
-inline bool IsPotion(ITEM_TYPE type) {
+inline bool isPotion(ITEM_TYPE type) {
     return type >= ITEM_FIRST_POTION && type <= ITEM_LAST_POTION;
 }
 
-inline bool IsMessageScroll(ITEM_TYPE type) {
+inline bool isReagent(ITEM_TYPE type) {
+    return type >= ITEM_FIRST_REAGENT && type <= ITEM_LAST_REAGENT;
+}
+
+inline bool isEnchantingPotion(ITEM_TYPE type) {
+    return type >= ITEM_FIRST_ENCHANTING_POTION && type <= ITEM_LAST_ENCHANTING_POTION || type == ITEM_POTION_SLAYING;
+}
+
+inline bool isMessageScroll(ITEM_TYPE type) {
     return type >= ITEM_FIRST_MESSAGE_SCROLL && type <= ITEM_LAST_MESSAGE_SCROLL;
 }
 
-inline bool IsSpawnableArtifact(ITEM_TYPE type) {
+inline bool isArtifact(ITEM_TYPE type) {
+    return type >= ITEM_FIRST_ARTIFACT && type <= ITEM_LAST_ARTIFACT;
+}
+
+inline bool isSpawnableArtifact(ITEM_TYPE type) {
     return type >= ITEM_FIRST_SPAWNABLE_ARTIFACT && type <= ITEM_LAST_SPAWNABLE_ARTIFACT;
 }
 
-inline bool IsRandomItem(ITEM_TYPE type) {
+inline bool isRandomItem(ITEM_TYPE type) {
     return type >= ITEM_FIRST_RANDOM && type <= ITEM_LAST_RANDOM;
 }
 
-inline ITEM_TREASURE_LEVEL RandomItemTreasureLevel(ITEM_TYPE type) {
-    Assert(IsRandomItem(type));
+inline ITEM_TREASURE_LEVEL randomItemTreasureLevel(ITEM_TYPE type) {
+    Assert(isRandomItem(type));
     return ITEM_TREASURE_LEVEL(-std::to_underlying(type));
 }
 
-inline Segment<ITEM_TYPE> RecipeScrolls() {
+inline Segment<ITEM_TYPE> recipeScrolls() {
     return Segment(ITEM_FIRST_RECIPE, ITEM_LAST_RECIPE);
 }
 

--- a/src/Engine/Objects/Items.cpp
+++ b/src/Engine/Objects/Items.cpp
@@ -750,7 +750,7 @@ bool ItemGen::MerchandiseTest(int _2da_idx) {
     bool test;
 
     // TODO(captainurist): move these checks into functions in ItemEnums.h?
-    if ((p2DEvents[_2da_idx - 1].uType != BuildingType_AlchemistShop || !IsRecipe(this->uItemID)) &&
+    if ((p2DEvents[_2da_idx - 1].uType != BuildingType_AlchemistShop || !isRecipe(this->uItemID)) &&
         (this->uItemID >= ITEM_QUEST_HEART_OF_THE_WOOD || this->uItemID >= ITEM_ARTIFACT_HERMES_SANDALS && this->uItemID <= ITEM_599) ||
         this->IsStolen())
         return false;
@@ -771,7 +771,7 @@ bool ItemGen::MerchandiseTest(int _2da_idx) {
         case BuildingType_AlchemistShop: {
             test = this->isReagent() ||
                    this->isPotion() ||
-                   (this->isMessageScroll() && IsRecipe(this->uItemID));
+                   (this->isMessageScroll() && isRecipe(this->uItemID));
             break;
         }
         default: {

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -365,7 +365,7 @@ void Player::ItemsPotionDmgBreak(int enchant_count) {
     memset(item_index_tabl, 0, sizeof(item_index_tabl));  // set to zero
 
     for (int i = 0; i < TOTAL_ITEM_SLOT_COUNT; ++i)  // scan through and log in table
-        if (IsRegular(pOwnItems[i].uItemID))
+        if (isRegular(pOwnItems[i].uItemID))
             item_index_tabl[avalible_items++] = i;
 
     if (avalible_items) {  // is there anything to break
@@ -1266,7 +1266,7 @@ std::string Player::GetRangedDamageString() {
 
     ItemGen *mainHandItem = GetMainHandItem();
 
-    if (mainHandItem != nullptr && IsWand(mainHandItem->uItemID)) {
+    if (mainHandItem != nullptr && isWand(mainHandItem->uItemID)) {
         return std::string(localization->GetString(LSTR_WAND));
     } else if (mainHandItem != nullptr &&
                (mainHandItem->uItemID == ITEM_BLASTER ||
@@ -1702,7 +1702,7 @@ int Player::ReceiveSpecialAttackEffect(
                     itemtocheck = &this->pEquippedItems[i - INVENTORY_SLOT_COUNT];
                 }
 
-                if (IsRegular(itemtocheck->uItemID) && !itemtocheck->IsBroken()) {
+                if (isRegular(itemtocheck->uItemID) && !itemtocheck->IsBroken()) {
                     itemstobreaklist[itemstobreakcounter++] = i;
                 }
             }
@@ -1772,7 +1772,7 @@ int Player::ReceiveSpecialAttackEffect(
                 if (ItemPosInList > 0) {
                     itemtocheck = &this->pInventoryItemList[ItemPosInList - 1];
 
-                    if (IsRegular(itemtocheck->uItemID)) {
+                    if (isRegular(itemtocheck->uItemID)) {
                         itemstobreaklist[itemstobreakcounter++] = i;
                     }
                 }
@@ -4654,7 +4654,7 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             item.uItemID = ITEM_TYPE(var_value);
             item.uAttributes = ITEM_IDENTIFIED;
             pParty->setHoldingItem(&item);
-            if (IsSpawnableArtifact(ITEM_TYPE(var_value)))
+            if (isSpawnableArtifact(ITEM_TYPE(var_value)))
                 pParty->pIsArtifactFound[ITEM_TYPE(var_value)] = true;
             return;
         case VAR_FixedGold:
@@ -5237,9 +5237,9 @@ void Player::AddVariable(VariableType var_type, signed int val) {
             item.Reset();
             item.uAttributes = ITEM_IDENTIFIED;
             item.uItemID = ITEM_TYPE(val);
-            if (IsSpawnableArtifact(ITEM_TYPE(val))) {
+            if (isSpawnableArtifact(ITEM_TYPE(val))) {
                 pParty->pIsArtifactFound[ITEM_TYPE(val)] = true;
-            } else if (IsWand(ITEM_TYPE(val))) {
+            } else if (isWand(ITEM_TYPE(val))) {
                 item.uNumCharges = grng->random(6) + item.GetDamageMod() + 1;
                 item.uMaxCharges = item.uNumCharges;
             }
@@ -7432,7 +7432,7 @@ MERCHANT_PHRASE Player::SelectPhrasesTransaction(ItemGen *pItem, BuildingType bu
                 return MERCHANT_PHRASE_INCOMPATIBLE_ITEM;
             break;
         case BuildingType_AlchemistShop:
-            if (idemId >= ITEM_ARTIFACT_HERMES_SANDALS && !IsRecipe(idemId))
+            if (idemId >= ITEM_ARTIFACT_HERMES_SANDALS && !isRecipe(idemId))
                 return MERCHANT_PHRASE_INVALID_ACTION;
             if (equipType != EQUIP_REAGENT && equipType != EQUIP_POTION && equipType != EQUIP_MESSAGE_SCROLL)
                 return MERCHANT_PHRASE_INCOMPATIBLE_ITEM;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1414,7 +1414,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
 
                     if ((spell_mastery == PLAYER_SKILL_MASTERY_MASTER || spell_mastery == PLAYER_SKILL_MASTERY_GRANDMASTER) &&
-                            IsRegular(spell_item_to_enchant->uItemID) &&
+                            isRegular(spell_item_to_enchant->uItemID) &&
                             spell_item_to_enchant->special_enchantment == ITEM_ENCHANTMENT_NULL &&
                             spell_item_to_enchant->uEnchantmentType == 0 &&
                             spell_item_to_enchant->m_enchantmentStrength == 0 &&

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -964,7 +964,7 @@ void CreateScrollWindow() {
 
 //----- (00467F48) --------------------------------------------------------
 void CreateMsgScrollWindow(ITEM_TYPE mscroll_id) {
-    if (!pGUIWindow_ScrollWindow && IsMessageScroll(mscroll_id)) {
+    if (!pGUIWindow_ScrollWindow && isMessageScroll(mscroll_id)) {
         pGUIWindow_ScrollWindow = new GUIWindow_Scroll({0, 0}, render->GetRenderDimensions(), mscroll_id, "");
     }
 }

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -107,7 +107,7 @@ class GUIWindow_Scroll : public GUIWindow {
  public:
     GUIWindow_Scroll(Pointi position, Sizei dimensions, ITEM_TYPE scroll_type, const std::string &hint = std::string()) :
         GUIWindow(WINDOW_Scroll, position, dimensions, 0, hint) {
-        Assert(IsMessageScroll(scroll_type));
+        Assert(isMessageScroll(scroll_type));
 
         this->scroll_type = scroll_type;
         CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1, "");

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -3210,7 +3210,7 @@ void GenerateSpecialShopItems() {
                 if (item_count < 6) {
                     pParty->SpecialItemsInShops[shop_index][item_count].Reset();
                     pParty->SpecialItemsInShops[shop_index][item_count]
-                        .uItemID = grng->randomSample(RecipeScrolls());  // mscrool
+                        .uItemID = grng->randomSample(recipeScrolls());  // mscrool
                     continue;
                 } else {
                     treasure_lvl = shopAlchSpc_treasure_lvl[shop_index - 41];

--- a/src/GUI/UI/UIPopup.h
+++ b/src/GUI/UI/UIPopup.h
@@ -19,4 +19,4 @@ extern Image *messagebox_border_right;   // 5076A0
 
 extern bool holdingMouseRightButton;
 extern bool rightClickItemActionPerformed;
-extern bool identifyReactionPlayed;
+extern bool identifyOrRepairReactionPlayed;

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -693,7 +693,7 @@ GAME_TEST(Issues, Issue675) {
     for (int i = 0; i < 200; i++) {
         for (ITEM_TREASURE_LEVEL level : levels) {
             pItemTable->generateItem(level, 0, &item);
-            if (IsPotion(item.uItemID)) {
+            if (isPotion(item.uItemID)) {
                 // For potions, uEnchantmentType is potion strength.
                 EXPECT_GE(item.uEnchantmentType, 1);
             } else {


### PR DESCRIPTION
Refactor `Inventory_ItemPopupAndAlchemy` function.

Fix #724 - do not just draw popup when right click items on ragdoll.

Fix #571 - do not waste potions when applying them to wrong items.
For this we now have 2 strategies.
- Just show item popup - this is now default behavior when right clicking on reagents, scroll, quest items etc. with potion in hand. Fir example now recharge item potion can only be used on wands and on other potions, otherwise popup is showing.
- Play error sound and forbid right clicking action until next mouse right button down event. Here's more complicated: harden potion can be applied to any equipment which is not broken or not an artifact. In case of broken and artifact items error will be sound, otherwise item popup is drawn. For enchantment potions only weapons can be enchanted. So trying to apply it to armor will result in error sound.

Also move code for alchemy before item potions to avoid useless checks when apply potion to potion in item potion applying cases.