### PR TITLE
Some changes in save/load UI

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2306,7 +2306,7 @@ void Game::gameLoop() {
     SetCurrentMenuID((MENU_STATE)-1);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        LoadGame(uLoadGameUI_SelectedSlot);
+        LoadGame(pSavegameList->selectedSlot);
     }
 
     extern bool use_music_folder;

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -165,14 +165,14 @@ void EngineController::loadGame(const std::string &path) {
     std::string dst = MakeDataPath("saves", saveName);
     std::filesystem::copy_file(path, dst, std::filesystem::copy_options::overwrite_existing); // This might throw.
 
-    pSaveListPosition = 0; // Make sure we start at the top of the list.
+    pSavegameList->saveListPosition = 0; // Make sure we start at the top of the list.
 
     goToMainMenu();
     pressGuiButton("MainMenu_LoadGame");
     tick(3);
 
     // TODO(captainurist): the tricks above might fail if we have more than 45 save files
-    assert(pSavegameUsedSlots[0]);
+    assert(pSavegameList->pSavegameUsedSlots[0]);
     assert(pSavegameList->pFileList[0] == saveName);
 
     pressGuiButton("LoadMenu_Slot0");

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -7,6 +7,12 @@
 
 constexpr unsigned int MAX_SAVE_SLOTS = 45;
 
+struct SaveGameHeader {
+    std::string pName;
+    std::string pLocationName;
+    GameTime playing_time;
+};
+
 struct SavegameList {
     static void Initialize();
     SavegameList();
@@ -14,12 +20,14 @@ struct SavegameList {
     void Reset();
 
     std::array<std::string, MAX_SAVE_SLOTS> pFileList;
-};
+    std::array<bool, MAX_SAVE_SLOTS> pSavegameUsedSlots;
+    std::array<SaveGameHeader, MAX_SAVE_SLOTS> pSavegameHeader;
+    std::array<class Image *, MAX_SAVE_SLOTS> pSavegameThumbnails;
 
-struct SaveGameHeader {
-    std::string pName;
-    std::string pLocationName;
-    GameTime playing_time;
+    int numSavegameFiles = 0;
+    int selectedSlot = 0;
+    int saveListPosition = 0;
+    std::string lastLoadedSave{};
 };
 
 void LoadGame(unsigned int uSlot);
@@ -28,11 +36,4 @@ void DoSavegame(unsigned int uSlot);
 bool Initialize_GamesLOD_NewLOD();
 void SaveNewGame();
 
-extern int pSaveListPosition;
-extern unsigned int uLoadGameUI_SelectedSlot;
-extern unsigned int uNumSavegameFiles;
-extern std::array<unsigned int, MAX_SAVE_SLOTS> pSavegameUsedSlots;
 extern struct SavegameList *pSavegameList;
-extern std::array<SaveGameHeader, MAX_SAVE_SLOTS> pSavegameHeader;
-
-extern std::array<class Image *, MAX_SAVE_SLOTS> pSavegameThumbnails;

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -152,6 +152,9 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     render->Present();
 
     pSavegameList->Initialize();
+    // Reset position in case that last loaded save will not be found
+    pSavegameList->selectedSlot = 0;
+    pSavegameList->saveListPosition = 0;
 
     LOD::File pLODFile;
     for (uint i = 0; i < pSavegameList->numSavegameFiles; ++i) {

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -34,8 +34,8 @@ Image *scrollstop = nullptr;
 
 GUIWindow_Save::GUIWindow_Save() :
     GUIWindow(WINDOW_Save, {0, 0}, render->GetRenderDimensions(), 0) {
-    memset(&pSavegameUsedSlots, 0, sizeof(pSavegameUsedSlots));
-    memset(&pSavegameThumbnails, 0, sizeof(pSavegameThumbnails));
+    pSavegameList->pSavegameUsedSlots.fill(false);
+    pSavegameList->pSavegameThumbnails.fill(nullptr);
 
     saveload_ui_loadsave = assets->GetImage_ColorKey("loadsave");
     saveload_ui_save_up = assets->GetImage_ColorKey("save_up");
@@ -43,6 +43,9 @@ GUIWindow_Save::GUIWindow_Save() :
     saveload_ui_x_u = assets->GetImage_ColorKey("x_u");
 
     pSavegameList->Initialize();
+    // Reset positions for save UI
+    pSavegameList->selectedSlot = 0;
+    pSavegameList->saveListPosition = 0;
 
     LOD::File pLODFile;
     for (uint i = 0; i < MAX_SAVE_SLOTS; ++i) {
@@ -54,30 +57,26 @@ GUIWindow_Save::GUIWindow_Save() :
 
         std::string str = MakeDataPath("saves", file_name);
         if (!std::filesystem::exists(str)) {
-            pSavegameUsedSlots[i] = 0;
-            pSavegameHeader[i].pName = localization->GetString(LSTR_EMPTY_SAVESLOT);
+            pSavegameList->pSavegameUsedSlots[i] = false;
+            pSavegameList->pSavegameHeader[i].pName = localization->GetString(LSTR_EMPTY_SAVESLOT);
         } else {
             pLODFile.Open(str);
-            BlobDeserializer(pLODFile.LoadRaw("header.bin")).ReadLegacy<SaveGameHeader_MM7>(&pSavegameHeader[i]);
+            BlobDeserializer(pLODFile.LoadRaw("header.bin")).ReadLegacy<SaveGameHeader_MM7>(&pSavegameList->pSavegameHeader[i]);
 
-            if (pSavegameHeader[i].pName.empty()) {
+            if (pSavegameList->pSavegameHeader[i].pName.empty()) {
                 // blank so add something - suspect quicksaves
                 std::string newname = pSavegameList->pFileList[i];
                 std::string test = newname.substr(0, newname.size() - 4);
-                pSavegameHeader[i].pName = test;
+                pSavegameList->pSavegameHeader[i].pName = test;
             }
 
-            pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
-            if (pSavegameThumbnails[i]->GetWidth() == 0) {
-                pSavegameThumbnails[i]->Release();
-                pSavegameThumbnails[i] = nullptr;
+            pSavegameList->pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
+            if (pSavegameList->pSavegameThumbnails[i]->GetWidth() == 0) {
+                pSavegameList->pSavegameThumbnails[i]->Release();
+                pSavegameList->pSavegameThumbnails[i] = nullptr;
             }
 
-            if (pSavegameThumbnails[i] != nullptr) {
-                pSavegameUsedSlots[i] = 1;
-            } else {
-                pSavegameUsedSlots[i] = 0;
-            }
+            pSavegameList->pSavegameUsedSlots[i] = (pSavegameList->pSavegameThumbnails[i] != nullptr);
         }
     }
 
@@ -122,8 +121,8 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     dword_6BE138 = -1;
     pIcons_LOD->_inlined_sub2();
 
-    memset(pSavegameUsedSlots.data(), 0, sizeof(pSavegameUsedSlots));
-    memset(pSavegameThumbnails.data(), 0, MAX_SAVE_SLOTS * sizeof(Image *));
+    pSavegameList->pSavegameUsedSlots.fill(false);
+    pSavegameList->pSavegameThumbnails.fill(nullptr);
 
     saveload_ui_loadsave = assets->GetImage_ColorKey("loadsave");
     saveload_ui_load_up = assets->GetImage_ColorKey("load_up");
@@ -155,43 +154,50 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     pSavegameList->Initialize();
 
     LOD::File pLODFile;
-    for (uint i = 0; i < uNumSavegameFiles; ++i) {
+    for (uint i = 0; i < pSavegameList->numSavegameFiles; ++i) {
         std::string str = MakeDataPath("saves", pSavegameList->pFileList[i]);
         if (!std::filesystem::exists(str)) {
-            pSavegameUsedSlots[i] = 0;
-            pSavegameHeader[i].pName = localization->GetString(LSTR_EMPTY_SAVESLOT);
+            pSavegameList->pSavegameUsedSlots[i] = false;
+            pSavegameList->pSavegameHeader[i].pName = localization->GetString(LSTR_EMPTY_SAVESLOT);
             continue;
         }
 
-        if (!pLODFile.Open(str)) __debugbreak();
-        BlobDeserializer(pLODFile.LoadRaw("header.bin")).ReadLegacy<SaveGameHeader_MM7>(&pSavegameHeader[i]);
-
-        if (iequals(pSavegameList->pFileList[i], localization->GetString(LSTR_AUTOSAVE_MM7))) {
-            pSavegameHeader[i].pName = localization->GetString(LSTR_AUTOSAVE);
+        if (pSavegameList->pFileList[i] == pSavegameList->lastLoadedSave) {
+            pSavegameList->selectedSlot = i;
+            pSavegameList->saveListPosition = i;
+            if (pSavegameList->saveListPosition + 7 > pSavegameList->numSavegameFiles) {
+                pSavegameList->saveListPosition = pSavegameList->numSavegameFiles - 7;
+            }
         }
 
-        if (pSavegameHeader[i].pName.empty()) {
+        if (!pLODFile.Open(str)) __debugbreak();
+        BlobDeserializer(pLODFile.LoadRaw("header.bin")).ReadLegacy<SaveGameHeader_MM7>(&pSavegameList->pSavegameHeader[i]);
+
+        if (iequals(pSavegameList->pFileList[i], localization->GetString(LSTR_AUTOSAVE_MM7))) {
+            pSavegameList->pSavegameHeader[i].pName = localization->GetString(LSTR_AUTOSAVE);
+        }
+
+        if (pSavegameList->pSavegameHeader[i].pName.empty()) {
             // blank so add something - suspect quicksaves
             std::string newname = pSavegameList->pFileList[i];
             std::string test = newname.substr(0, newname.size() - 4);
-            pSavegameHeader[i].pName = test;
+            pSavegameList->pSavegameHeader[i].pName = test;
         }
 
-        // pSavegameThumbnails[i] = Image::Create(new PCX_LOD_Raw_Loader(&pLODFile, "image.pcx"));
-        pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
+        pSavegameList->pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
 
-        if (pSavegameThumbnails[i]->GetWidth() == 0) {
-            pSavegameThumbnails[i]->Release();
-            pSavegameThumbnails[i] = nullptr;
+        if (pSavegameList->pSavegameThumbnails[i]->GetWidth() == 0) {
+            pSavegameList->pSavegameThumbnails[i]->Release();
+            pSavegameList->pSavegameThumbnails[i] = nullptr;
         }
 
-        pSavegameUsedSlots[i] = 1;
-        if (pSavegameThumbnails[i] != nullptr) {
-           // pSavegameUsedSlots[i] = 1;
-        } else {
-            // pSavegameUsedSlots[i] = 0;
-            // pSavegameList->pFileList[i].clear();
-        }
+        pSavegameList->pSavegameUsedSlots[i] = true;
+        //if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
+        //    pSavegameUsedSlots[i] = 1;
+        //} else {
+        //    pSavegameUsedSlots[i] = 0;
+        //    pSavegameList->pFileList[i].clear();
+        //}
     }
 
     saveload_ui_x_d = assets->GetImage_Alpha("x_d");
@@ -212,9 +218,9 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     pBtnLoadSlot = CreateButton("LoadMenu_Load", {241, 302}, {105, 40}, 1, 0, UIMSG_SaveLoadBtn, 0, InputAction::Invalid, "", {saveload_ui_ls_saved});
     pBtnCancel = CreateButton({350, 302}, {105, 40}, 1, 0, UIMSG_Cancel, 0, InputAction::Invalid, "", {saveload_ui_x_d});
     pBtnArrowUp = CreateButton({215, 199}, {17, 17}, 1, 0, UIMSG_ArrowUp, 0, InputAction::Invalid, "", {ui_ar_up_dn});
-    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, 1, 0, UIMSG_DownArrow, MAX_SAVE_SLOTS, InputAction::Invalid, "", {ui_ar_dn_dn});
+    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, 1, 0, UIMSG_DownArrow, pSavegameList->numSavegameFiles, InputAction::Invalid, "", {ui_ar_dn_dn});
 
-    CreateButton({215, 216}, {17, 107}, 1, 0, UIMSG_SaveLoadScroll, uNumSavegameFiles);
+    CreateButton({215, 216}, {17, 107}, 1, 0, UIMSG_SaveLoadScroll, pSavegameList->numSavegameFiles);
 }
 
 void GUIWindow_Load::Update() {
@@ -234,7 +240,7 @@ static void UI_DrawSaveLoad(bool save) {
     GUIWindow save_load_window;
     int pSaveFiles;
 
-    if (pSavegameUsedSlots[uLoadGameUI_SelectedSlot]) {
+    if (pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
         save_load_window.Init();
         save_load_window.uFrameX = pGUIWindow_CurrentMenu->uFrameX + 240;
         save_load_window.uFrameWidth = 220;
@@ -242,13 +248,16 @@ static void UI_DrawSaveLoad(bool save) {
         save_load_window.uFrameZ = save_load_window.uFrameX + 219;
         save_load_window.uFrameHeight = pFontSmallnum->GetHeight();
         save_load_window.uFrameW = pFontSmallnum->GetHeight() + save_load_window.uFrameY - 1;
-        if (pSavegameThumbnails[uLoadGameUI_SelectedSlot])
-            render->DrawTextureNew((pGUIWindow_CurrentMenu->uFrameX + 276) / 640.0f, (pGUIWindow_CurrentMenu->uFrameY + 171) / 480.0f, pSavegameThumbnails[uLoadGameUI_SelectedSlot]);
+        if (pSavegameList->pSavegameThumbnails[pSavegameList->selectedSlot]) {
+            render->DrawTextureNew((pGUIWindow_CurrentMenu->uFrameX + 276) / 640.0f, (pGUIWindow_CurrentMenu->uFrameY + 171) / 480.0f,
+                                   pSavegameList->pSavegameThumbnails[pSavegameList->selectedSlot]);
+        }
         // Draw map name
-        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, 0, pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameHeader[uLoadGameUI_SelectedSlot].pLocationName)].pName, 3);
+        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, 0,
+                                       pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pLocationName)].pName, 3);
 
         // Draw date
-        GameTime savegame_time = pSavegameHeader[uLoadGameUI_SelectedSlot].playing_time;
+        GameTime savegame_time = pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].playing_time;
         auto savegame_hour = savegame_time.GetHoursOfDay();
 
         save_load_window.uFrameY = pGUIWindow_CurrentMenu->uFrameY + 261;
@@ -278,7 +287,7 @@ static void UI_DrawSaveLoad(bool save) {
 
     if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
         pGUIWindow_CurrentMenu->keyboard_input_status = WINDOW_INPUT_NONE;
-        pSavegameHeader[uLoadGameUI_SelectedSlot].pName = keyboardInputHandler->GetTextInput();
+        pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName = keyboardInputHandler->GetTextInput();
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveGame, 0, 0);
     } else {
         if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_CANCELLED)
@@ -290,8 +299,8 @@ static void UI_DrawSaveLoad(bool save) {
             {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_LOADING)) + 25, 220}, 0,
             localization->GetString(LSTR_LOADING), 0, 0, 0);
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum,
-            {pFontSmallnum->AlignText_Center(186, pSavegameHeader[uLoadGameUI_SelectedSlot].pName) + 25, 262}, 0,
-            pSavegameHeader[uLoadGameUI_SelectedSlot].pName, 185, 0);
+            {pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName) + 25, 262}, 0,
+            pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName, 185, 0);
         pGUIWindow_CurrentMenu->DrawText(pFontSmallnum,
             {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_PLEASE_WAIT)) + 25, 304}, 0,
             localization->GetString(LSTR_PLEASE_WAIT), 0, 0, 0);
@@ -302,30 +311,33 @@ static void UI_DrawSaveLoad(bool save) {
             // ingame save scroll bar
             int ypos{ 0 };
             if (pSaveFiles > 7)
-                ypos = (float(pSaveListPosition) / (pSaveFiles - 7)) * 89.0f;
-            if (pSaveListPosition > pSaveFiles - 7) ypos = 89;
+                ypos = (float(pSavegameList->saveListPosition) / (pSaveFiles - 7)) * 89.0f;
+            if (pSavegameList->saveListPosition > pSaveFiles - 7)
+                ypos = 89;
             render->DrawTextureNew(216 / 640.f, (217 + ypos) / 480.f, scrollstop);
         } else {
-            pSaveFiles = uNumSavegameFiles;
+            pSaveFiles = pSavegameList->numSavegameFiles;
 
             // load scroll bar
             int ypos{ 0 };
             if (pSaveFiles > 7)
-                ypos = (float(pSaveListPosition) / (pSaveFiles - 7)) * 89.0f;
-            if (pSaveListPosition > pSaveFiles - 7) ypos = 89;
+                ypos = (float(pSavegameList->saveListPosition) / (pSaveFiles - 7)) * 89.0f;
+            if (pSavegameList->saveListPosition > pSaveFiles - 7)
+                ypos = 89;
             render->DrawTextureNew((216+ pGUIWindow_CurrentMenu->uFrameX) / 640.f, (217 + pGUIWindow_CurrentMenu->uFrameY + ypos) / 480.f, scrollstop);
         }
 
         int slot_Y = 199;
-        for (uint i = pSaveListPosition; i < pSaveFiles; ++i) {
+        for (int i = pSavegameList->saveListPosition; i < pSaveFiles; ++i) {
             if (slot_Y >= 346) {
                 break;
             }
-            if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || i != uLoadGameUI_SelectedSlot) {
-                pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y}, i == uLoadGameUI_SelectedSlot ? colorTable.LaserLemon.c16() : 0, pSavegameHeader[i].pName, 185, 0);
+            if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || i != pSavegameList->selectedSlot) {
+                pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y}, i == pSavegameList->selectedSlot ? colorTable.LaserLemon.c16() : 0,
+                                                       pSavegameList->pSavegameHeader[i].pName, 185, 0);
             } else {
                 pGUIWindow_CurrentMenu->DrawFlashingInputCursor(pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y},
-                    i == uLoadGameUI_SelectedSlot ? colorTable.LaserLemon.c16() : 0, keyboardInputHandler->GetTextInput().c_str(), 175, 1) + 27, slot_Y, pFontSmallnum);
+                    i == pSavegameList->selectedSlot ? colorTable.LaserLemon.c16() : 0, keyboardInputHandler->GetTextInput().c_str(), 175, 1) + 27, slot_Y, pFontSmallnum);
             }
             slot_Y += 21;
         }
@@ -340,8 +352,9 @@ void MainMenuLoad_EventLoop() {
 
         switch (msg) {
         case UIMSG_LoadGame: {
-            if (!pSavegameUsedSlots[uLoadGameUI_SelectedSlot])
+            if (!pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
                 break;
+            }
             SetCurrentMenuID(MENU_LoadingProcInMainMenu);
             break;
         }
@@ -349,20 +362,20 @@ void MainMenuLoad_EventLoop() {
             // main menu save/load wnd   clicking on savegame lines
             if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
                 keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_NONE);
-            if (current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME || uLoadGameUI_SelectedSlot != param + pSaveListPosition) {
+            if (current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME || pSavegameList->selectedSlot != param + pSavegameList->saveListPosition) {
                 // load clicked line
-                int v26 = param + pSaveListPosition;
+                int v26 = param + pSavegameList->saveListPosition;
                 if (dword_6BE138 == v26) {
                     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
                     // Breaks UI interaction after save load
                     // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
                 }
-                uLoadGameUI_SelectedSlot = v26;
+                pSavegameList->selectedSlot = v26;
                 dword_6BE138 = v26;
             } else {
                 // typing in the line
                 keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu);
-                keyboardInputHandler->SetTextInput(pSavegameHeader[uLoadGameUI_SelectedSlot].pName);
+                keyboardInputHandler->SetTextInput(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName);
             }
             break;
         }
@@ -371,16 +384,16 @@ void MainMenuLoad_EventLoop() {
             break;
         }
         case UIMSG_DownArrow: {
-            ++pSaveListPosition;
-            if (pSaveListPosition > (param - 7))
-                pSaveListPosition = (param - 7);
+            if (pSavegameList->saveListPosition + 7 < param) {
+                ++pSavegameList->saveListPosition;
+            }
             new OnButtonClick2({pGUIWindow_CurrentMenu->uFrameX + 215, pGUIWindow_CurrentMenu->uFrameY + 323}, {0, 0}, pBtnDownArrow);
             break;
         }
         case UIMSG_ArrowUp: {
-            --pSaveListPosition;
-            if (pSaveListPosition < 0)
-                pSaveListPosition = 0;
+            --pSavegameList->saveListPosition;
+            if (pSavegameList->saveListPosition < 0)
+                pSavegameList->saveListPosition = 0;
             new OnButtonClick2({pGUIWindow_CurrentMenu->uFrameX + 215, pGUIWindow_CurrentMenu->uFrameY + 197}, {0, 0}, pBtnArrowUp);
             break;
         }
@@ -402,8 +415,7 @@ void MainMenuLoad_EventLoop() {
         }
         case UIMSG_SaveLoadScroll: {
             // pskelton add for scroll click
-            int pSaveFiles{ static_cast<int>(uNumSavegameFiles) };
-            if (pSaveFiles < 7) {
+            if (param < 7) {
                 // Too few saves to scroll yet
                 break;
             }
@@ -415,7 +427,7 @@ void MainMenuLoad_EventLoop() {
             float fmy = static_cast<float>(my) / 107.0f;
             int newlistpost = std::round((param - 7) * fmy);
             newlistpost = std::clamp(newlistpost, 0, (param - 7));
-            pSaveListPosition = newlistpost;
+            pSavegameList->saveListPosition = newlistpost;
             new OnButtonClick2({pGUIWindow_CurrentMenu->uFrameX + 215, pGUIWindow_CurrentMenu->uFrameY + 197}, {0, 0}, pBtnArrowUp);
             break;
         }

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -70,7 +70,7 @@ GAME_TEST(Issues, Issue163) {
 
     game->pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game->tick(10);
-    for (bool used : pSavegameUsedSlots)
+    for (bool used : pSavegameList->pSavegameUsedSlots)
         EXPECT_FALSE(used); // All slots unused.
 
     game->pressGuiButton("LoadMenu_Load");
@@ -632,7 +632,7 @@ GAME_TEST(Issues, Issue626) {
     test->playTraceFromTestData("issue_626.mm7", "issue_626.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
 
     // TODO(captainurist): this will fail if we don't have any saves in saves folder
-    EXPECT_EQ(uLoadGameUI_SelectedSlot, 5);
+    EXPECT_EQ(pSavegameList->selectedSlot, 5);
 }
 
 GAME_TEST(Issue, Issue645) {


### PR DESCRIPTION
Fix #689 for both main menu and game cases.
Also do a little refactoring around save/load - move globals into SavegameList class.
And also do some changes relating to save and load game lists:
- Split remembered position mechanism between save and load menus.
- For save menu always reset remembered position to zero because this position have meaning only in corresponding menu. When opening save menu after load it can point to completely unrelated save file.
- For load menu instead of remembering picked item slot and scroll position remember last loaded save. When load menu is opened again this save if found and pointed at.
- Make scrolling through load menu correct. So now you can't scroll load menu down (with down button) so that there's no valid save slots on screen.