### PR TITLE
Fix game menu issues

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -253,7 +253,7 @@ bool Game::loop() {
                 uGameState = GAME_STATE_PLAYING;
                 gameLoop();
             }
-            break;
+            continue;
         } else if (GetCurrentMenuID() == MENU_NEWGAME) {
             pActiveOverlayList->Reset();
             if (!PartyCreationUI_Loop()) {
@@ -658,7 +658,6 @@ void Game::processQueuedMessages() {
                     _render->ClearZBuffer();
                     if (current_screen_type == CURRENT_SCREEN::SCREEN_GAME) {
                         if (!pGUIWindow_CastTargetedSpell) {  // Draw Menu
-                            dword_6BE138 = -1;
                             new OnButtonClick2({602, 450}, {0, 0}, pBtn_GameSettings, std::string(), false);
 
                             pCurrentFrameMessageQueue->Flush();

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -33,12 +33,21 @@ using Io::TextInputType;
 using Io::KeyToggleType;
 using Io::InputAction;
 
+enum class CurrentConfirmationState {
+    CONFIRM_NONE,
+    CONFIRM_NEW_GAME,
+    CONFIRM_QUIT
+};
+using enum CurrentConfirmationState;
+
+CurrentConfirmationState confirmationState = CONFIRM_NONE;
+
 InputAction currently_selected_action_for_binding = InputAction::Invalid;  // 506E68
 std::map<InputAction, bool> key_map_conflicted;  // 506E6C
 std::map<InputAction, PlatformKey> curr_key_map;
 
 void Game_StartNewGameWhilePlaying(bool force_start) {
-    if (dword_6BE138 == 124 || force_start) {
+    if (confirmationState == CONFIRM_NEW_GAME || force_start) {
         pCurrentFrameMessageQueue->Flush();
         // pGUIWindow_CurrentMenu->Release();
         uGameState = GAME_STATE_NEWGAME_OUT_GAMEMENU;
@@ -46,12 +55,12 @@ void Game_StartNewGameWhilePlaying(bool force_start) {
     } else {
         GameUI_SetStatusBar(LSTR_START_NEW_GAME_PROMPT);
         pAudioPlayer->playUISound(SOUND_quest);
-        dword_6BE138 = 124;
+        confirmationState = CONFIRM_NEW_GAME;
     }
 }
 
 void Game_QuitGameWhilePlaying(bool force_quit) {
-    if (dword_6BE138 == 132 || force_quit) {
+    if (confirmationState == CONFIRM_QUIT || force_quit) {
         pCurrentFrameMessageQueue->Flush();
         // pGUIWindow_CurrentMenu->Release();
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
@@ -61,7 +70,7 @@ void Game_QuitGameWhilePlaying(bool force_quit) {
     } else {
         GameUI_SetStatusBar(LSTR_EXIT_GAME_PROMPT);
         pAudioPlayer->playUISound(SOUND_quest);
-        dword_6BE138 = 132;
+        confirmationState = CONFIRM_QUIT;
     }
 }
 
@@ -113,26 +122,21 @@ void Menu::EventLoop() {
             case UIMSG_SaveLoadBtn:
                 new OnSaveLoad({241, 302}, {106, 42}, pBtnLoadSlot);
                 continue;
-            case UIMSG_SelectLoadSlot: {
+            case UIMSG_SelectLoadSlot:
                 if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
                     keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_NONE);
 
-                int v10 = pSavegameList->saveListPosition + param;
-                if (current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME ||
-                    pSavegameList->selectedSlot != v10) {
-                    if (dword_6BE138 == pSavegameList->saveListPosition + param) {
-                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
-                        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
-                    }
-                    pSavegameList->selectedSlot = v10;
-                    dword_6BE138 = v10;
-                } else {
+                if (pSavegameList->selectedSlot != pSavegameList->saveListPosition + param) {
+                    pSavegameList->selectedSlot = pSavegameList->saveListPosition + param;
+                } else if (current_screen_type == CURRENT_SCREEN::SCREEN_SAVEGAME) {
                     keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu);
                     if (pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name == localization->GetString(LSTR_EMPTY_SAVESLOT)) {
                         keyboardInputHandler->SetTextInput(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name);
                     }
+                } else {
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
+                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
                 }
-            }
                 continue;
             case UIMSG_LoadGame:
                 if (pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
@@ -369,6 +373,7 @@ void Menu::EventLoop() {
                     continue;
                 }
                 render->ClearZBuffer();
+                confirmationState = CONFIRM_NONE;
 
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_MENU) {
                     pEventTimer->Resume();
@@ -434,6 +439,7 @@ void Menu::MenuLoop() {
     current_screen_type = CURRENT_SCREEN::SCREEN_MENU;
 
     pGUIWindow_CurrentMenu = new GUIWindow_GameMenu();
+    confirmationState = CONFIRM_NONE;
 
     if (gamma_preview_image) {
         gamma_preview_image->Release();

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2647,7 +2647,6 @@ int day_fogrange_2; // fog end dist
 struct TileTable *pTileTable;                                        // idb
 std::array<char, 777> pDefaultSkyTexture;                            // idb
 int _6BE134_odm_main_tile_group;
-int dword_6BE138;  // are you sure check game menu - load slots
 int dword_6BE13C_uCurrentlyLoadedLocationID;
 float fWalkSpeedMultiplier = 1.0f;
 float fBackwardWalkSpeedMultiplier = 1.0f;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -249,7 +249,6 @@ extern int day_fogrange_2;
 extern struct TileTable *pTileTable;              // idb
 extern std::array<char, 777> pDefaultSkyTexture;  // idb
 extern int _6BE134_odm_main_tile_group;
-extern int dword_6BE138;
 extern int dword_6BE13C_uCurrentlyLoadedLocationID;
 extern float fWalkSpeedMultiplier;
 extern float fBackwardWalkSpeedMultiplier;

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -118,7 +118,6 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     GUIWindow(WINDOW_Load, {0, 0}, {0, 0}, 0) {
     current_screen_type = CURRENT_SCREEN::SCREEN_LOADGAME;
 
-    dword_6BE138 = -1;
     pIcons_LOD->_inlined_sub2();
 
     pSavegameList->pSavegameUsedSlots.fill(false);
@@ -365,20 +364,13 @@ void MainMenuLoad_EventLoop() {
             // main menu save/load wnd   clicking on savegame lines
             if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
                 keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_NONE);
-            if (current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME || pSavegameList->selectedSlot != param + pSavegameList->saveListPosition) {
-                // load clicked line
-                int v26 = param + pSavegameList->saveListPosition;
-                if (dword_6BE138 == v26) {
-                    pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
-                    // Breaks UI interaction after save load
-                    // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
-                }
-                pSavegameList->selectedSlot = v26;
-                dword_6BE138 = v26;
+            assert(current_screen_type != CURRENT_SCREEN::SCREEN_SAVEGAME); // No savegame in main menu
+            if (pSavegameList->selectedSlot == param + pSavegameList->saveListPosition) {
+                pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_SaveLoadBtn, 0, 0);
+                // Breaks UI interaction after save load
+                // pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_LoadGame, 0, 0);
             } else {
-                // typing in the line
-                keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu);
-                keyboardInputHandler->SetTextInput(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name);
+                pSavegameList->selectedSlot = param + pSavegameList->saveListPosition;
             }
             break;
         }


### PR DESCRIPTION
Fix #779 and #790.
Resolve dword_6BE138 global - it does not needed in save/load menus and for newgame/quit confirmation it can be replaced with more straightforward variable.