### PR TITLE
Saner implementation of Blob::subBlob

### DIFF
--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -1,7 +1,6 @@
 #include "Blob.h"
 
 #include <string>
-#include <filesystem>
 
 #include <mio/mmap.hpp>
 
@@ -10,128 +9,72 @@
 
 #include "FreeDeleter.h"
 
-class NonOwningBlobHandler : public BlobHandler {
- public:
-    virtual void destroy(Blob &self) override {
-        assert(self.handler() == this);
-    }
-
-    virtual Blob share(Blob &self) override {
-        assert(self.handler() == this);
-        return Blob(self.data(), self.size(), this);
-    }
-};
-
-class SharedBlobHandler : public BlobHandler {
- public:
-    explicit SharedBlobHandler(std::shared_ptr<Blob> base): _base(std::move(base)) {}
-
-    virtual void destroy(Blob &self) override {
-        assert(self.handler() == this);
-        delete this;
-    }
-
-    virtual Blob share(Blob &self) override {
-        assert(self.handler() == this);
-        return Blob(self.data(), self.size(), new SharedBlobHandler(_base));
-    }
-
- private:
-    std::shared_ptr<Blob> _base;
-};
-
-class SharableBlobHandler : public BlobHandler {
- public:
-    virtual Blob share(Blob &self) override {
-        assert(self.handler() == this);
-
-        std::shared_ptr<Blob> base = std::make_shared<Blob>(std::move(self));
-        self = Blob(base->data(), base->size(), new SharedBlobHandler(base));
-        return Blob(base->data(), base->size(), new SharedBlobHandler(base));
-    }
-};
-
-class FreeBlobHandler : public SharableBlobHandler {
- public:
-    virtual void destroy(Blob &self) override {
-        assert(self.handler() == this);
-        free(const_cast<void *>(self.data()));
-        // Note that we don't call `delete this` here.
-    }
-};
-
-class MemoryMapBlobHandler : public SharableBlobHandler {
- public:
-    explicit MemoryMapBlobHandler(mio::mmap_source mmap) : _mmap(std::move(mmap)) {}
-
-    virtual void destroy(Blob &self) override {
-        assert(self.handler() == this);
-        delete this;
-    }
-
- private:
-    mio::mmap_source _mmap;
-};
-
-class StringBlobHandler : public SharableBlobHandler {
- public:
-    explicit StringBlobHandler(std::string string) : _string(std::move(string)) {}
-
-    virtual void destroy(Blob &self) override {
-        assert(self.handler() == this);
-        delete this;
-    }
-
-    std::string_view view() const {
-        return _string;
-    }
-
- private:
-    std::string _string;
-};
-
-constinit FreeBlobHandler staticFreeBlobHandler = {};
-constinit NonOwningBlobHandler staticNonOwningBlobHandler = {};
-
-Blob Blob::subBlob(size_t offset, size_t size) {
-    if (!_handler || offset >= _size || size == 0)
+Blob Blob::subBlob(size_t offset, size_t size) const {
+    if (offset >= _size || size == 0)
         return Blob();
 
-    Blob result = _handler->share(*this);
-    assert(result._data == _data && result._size == _size); // Just a sanity check.
-    result._size = std::min(size, _size - offset);
+    Blob result;
     result._data = static_cast<const char *>(_data) + offset;
+    result._size = std::min(size, _size - offset);
+    result._state = _state;
     return result;
 }
 
 Blob Blob::fromMalloc(const void *data, size_t size) {
-    return Blob(data, size, &staticFreeBlobHandler);
+    if (!data)
+        return Blob();
+
+    Blob result;
+    result._data = data;
+    result._size = size;
+    result._state = std::shared_ptr<void>(const_cast<void *>(data), FreeDeleter());
+    return result;
+}
+
+Blob Blob::fromMalloc(std::unique_ptr<void, FreeDeleter> data, size_t size) {
+    return fromMalloc(data.release(), size);
 }
 
 Blob Blob::fromFile(std::string_view path) {
-    std::string cpath(path);
-    mio::mmap_source mmap(cpath); // Throws std::system_error.
-    const void *data = mmap.data();
-    size_t size = mmap.size();
-    return Blob(data, size, new MemoryMapBlobHandler(std::move(mmap)));
+    std::shared_ptr<mio::mmap_source> mmap = std::make_shared<mio::mmap_source>(std::string(path)); // Throws std::system_error.
+    if (mmap->size() == 0)
+        return Blob();
+
+    Blob result;
+    result._data = mmap->data();
+    result._size = mmap->size();
+    result._state = std::move(mmap);
+    return result;
 }
 
 Blob Blob::fromString(std::string string) {
-    std::unique_ptr<StringBlobHandler> handler = std::make_unique<StringBlobHandler>(std::move(string));
-    std::string_view view = handler->view();
-    return Blob(view.data(), view.size(), handler.release());
+    if (string.empty())
+        return Blob();
+
+    std::shared_ptr<std::string> state = std::make_shared<std::string>(std::move(string));
+
+    Blob result;
+    result._data = state->data();
+    result._size = state->size();
+    result._state = std::move(state);
+    return result;
 }
 
 Blob Blob::copy(const void *data, size_t size) { // NOLINT: this is not std::copy
+    if (size == 0)
+        return Blob();
+
     std::unique_ptr<void, FreeDeleter> memory(malloc(size)); // We don't handle allocation failures.
-
     memcpy(memory.get(), data, size);
-
-    return Blob(memory.release(), size, &staticFreeBlobHandler);
+    return fromMalloc(std::move(memory), size);
 }
 
 Blob Blob::view(const void *data, size_t size) {
-    return Blob(data, size, &staticNonOwningBlobHandler);
+    Blob result;
+    result._data = data;
+    result._size = size;
+    // state is empty!
+    return result;
 }
 
 Blob Blob::read(FILE *file, size_t size) {
@@ -144,7 +87,7 @@ Blob Blob::read(FILE *file, size_t size) {
     if (read != 1)
         throw Exception("Failed to read {} bytes from file", size);
 
-    return Blob(memory.release(), size, &staticFreeBlobHandler);
+    return fromMalloc(std::move(memory), size);
 }
 
 Blob Blob::read(FileInputStream &file, size_t size) {
@@ -153,14 +96,32 @@ Blob Blob::read(FileInputStream &file, size_t size) {
 
     std::unique_ptr<void, FreeDeleter> memory(malloc(size));
     file.readOrFail(memory.get(), size);
-    return Blob(memory.release(), size, &staticFreeBlobHandler);
+    return fromMalloc(std::move(memory), size);
 }
 
 Blob Blob::concat(const Blob &l, const Blob &r) {
-    std::unique_ptr<void, FreeDeleter> memory(malloc(l.size() + r.size()));
+    size_t lsize = l.size();
+    size_t rsize = r.size();
+    if (lsize == 0 && rsize == 0) {
+        return Blob();
+    } else if (lsize == 0) {
+        return Blob::share(r);
+    } else if (rsize == 0) {
+        return Blob::share(l);
+    }
 
-    memcpy(memory.get(), l.data(), l.size());
-    memcpy(static_cast<char *>(memory.get()) + l.size(), r.data(), r.size());
+    std::unique_ptr<void, FreeDeleter> memory(malloc(lsize + rsize));
 
-    return Blob(memory.release(), l.size() + r.size(), &staticFreeBlobHandler);
+    memcpy(memory.get(), l.data(), lsize);
+    memcpy(static_cast<char *>(memory.get()) + lsize, r.data(), rsize);
+
+    return fromMalloc(std::move(memory), lsize + rsize);
+}
+
+Blob Blob::share(const Blob &other) {
+    Blob result;
+    result._data = other._data;
+    result._size = other._size;
+    result._state = other._state;
+    return result;
 }

--- a/src/Utility/Memory/Blob.h
+++ b/src/Utility/Memory/Blob.h
@@ -2,21 +2,15 @@
 
 #include <cassert>
 #include <cstdlib>
-#include <array>
 #include <utility>
 #include <memory>
 #include <string_view>
 #include <string>
+#include <type_traits>
+
+#include "FreeDeleter.h"
 
 class FileInputStream;
-class Blob;
-
-class BlobHandler {
- public:
-    virtual ~BlobHandler() = default;
-    virtual void destroy(Blob &self) = 0;
-    virtual Blob share(Blob &self) = 0;
-};
 
 /**
  * `Blob` is an abstraction that couples a contiguous memory region with the knowledge of how to deallocate it.
@@ -28,25 +22,13 @@ class Blob final {
  public:
     Blob() {}
 
-    Blob(const void *data, size_t size, BlobHandler *handler) {
-        assert(data ? size > 0 && handler : true);
-        assert(!data ? size == 0 && !handler : true);
-
-        _data = data;
-        _size = size;
-        _handler = handler;
-    }
-
     Blob(const Blob &) = delete; // Blobs are non-copyable.
 
     Blob(Blob &&other) {
         swap(*this, other);
     }
 
-    ~Blob() {
-        if (_handler)
-            _handler->destroy(*this);
-    }
+    ~Blob() = default;
 
     Blob &operator=(const Blob &) = delete; // Blobs are non-copyable.
 
@@ -69,41 +51,42 @@ class Blob final {
      * @param size                      Size of the subblob.
      * @return                          Subblob that shares the ownership of the underlying memory with this blob.
      */
-    Blob subBlob(size_t offset, size_t size = -1);
+    [[nodiscard]] Blob subBlob(size_t offset, size_t size = -1) const;
 
     /**
      * @param data                      Pointer to a `malloc`-allocated memory region.
      * @param size                      Size of the memory region.
      * @return                          Blob that takes ownership of the provided memory region.
      */
-    static Blob fromMalloc(const void *data, size_t size);
+    [[nodiscard]] static Blob fromMalloc(const void *data, size_t size);
+    [[nodiscard]] static Blob fromMalloc(std::unique_ptr<void, FreeDeleter> data, size_t size);
 
     /**
      * @param path                      Path to a file.
      * @return                          Blob that wraps the memory mapping of the provided file.
      * @throws std::runtime_error       On error.
      */
-    static Blob fromFile(std::string_view path);
+    [[nodiscard]] static Blob fromFile(std::string_view path);
 
     /**
      * @param string                    String to create a blob from.
      * @return                          Blob that wraps the provided string.
      */
-    static Blob fromString(std::string string);
+    [[nodiscard]] static Blob fromString(std::string string);
 
     /**
      * @param data                      Memory region pointer.
      * @param size                      Memory region size.
      * @return                          Blob that owns a copy of the provided memory region.
      */
-    static Blob copy(const void *data, size_t size); // NOLINT: this is not std::copy
+    [[nodiscard]] static Blob copy(const void *data, size_t size); // NOLINT: this is not std::copy
 
     /**
      * @param data                      Memory region pointer.
      * @param size                      Memory region size.
      * @return                          Non-owning blob view into the provided memory region.
      */
-    static Blob view(const void *data, size_t size);
+    [[nodiscard]] static Blob view(const void *data, size_t size);
 
     /**
      * @param file                      File to read from.
@@ -111,7 +94,7 @@ class Blob final {
      * @return                          Blob that owns the data that was read from the provided file.
      * @throws Exception                If the provided number of bytes couldn't be read.
      */
-    static Blob read(FILE *file, size_t size);
+    [[nodiscard]] static Blob read(FILE *file, size_t size);
 
     /**
      * @param file                      File to read from.
@@ -119,7 +102,7 @@ class Blob final {
      * @return                          Blob that owns the data that was read from the provided file.
      * @throws Exception                If the provided number of bytes couldn't be read.
      */
-    static Blob read(FileInputStream &file, size_t size);
+    [[nodiscard]] static Blob read(FileInputStream &file, size_t size);
 
     /**
      * @param l                         First blob.
@@ -127,44 +110,47 @@ class Blob final {
      * @return                          Newly allocated blob that contains a concatenation of the data of the two
      *                                  provided blobs.
      */
-    static Blob concat(const Blob &l, const Blob &r);
+    [[nodiscard]] static Blob concat(const Blob &l, const Blob &r);
+
+    /**
+     * @param other                     Blob to share.
+     * @return                          Blob that shares the memory ownership with `other`.
+     */
+    [[nodiscard]] static Blob share(const Blob &other);
 
     friend void swap(Blob &l, Blob &r) {
-        std::swap(l._data, r._data);
-        std::swap(l._size, r._size);
-        std::swap(l._handler, r._handler);
+        using std::swap;
+        swap(l._data, r._data);
+        swap(l._size, r._size);
+        swap(l._state, r._state);
     }
 
-    size_t size() const {
+    [[nodiscard]] size_t size() const {
         return _size;
     }
 
-    bool empty() const {
+    [[nodiscard]] bool empty() const {
         return _size == 0;
     }
 
-    const void *data() const {
+    [[nodiscard]] const void *data() const {
         return _data;
     }
 
-    bool operator!() const {
+    [[nodiscard]] bool operator!() const {
         return empty();
     }
 
-    explicit operator bool() const {
+    [[nodiscard]] explicit operator bool() const {
         return !empty();
     }
 
-    std::string_view string_view() const {
-        return std::string_view(static_cast<const char *>(_data), _size);
-    }
-
-    BlobHandler *handler() const {
-        return _handler;
+    [[nodiscard]] std::string_view string_view() const {
+        return {static_cast<const char *>(_data), _size};
     }
 
  private:
     const void *_data = nullptr;
     size_t _size = 0;
-    BlobHandler *_handler = nullptr;
+    std::shared_ptr<void> _state;
 };


### PR DESCRIPTION
The previous implementation of `Blob::subBlob` wasn't thread-safe, and this made no sense.