### PR TITLE
Move or remove some more globals

### DIFF
--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -35,7 +35,6 @@
 struct SavegameList *pSavegameList = new SavegameList;
 
 void LoadGame(unsigned int uSlot) {
-    MapsLongTimers_count = 0;
     if (!pSavegameList->pSavegameUsedSlots[uSlot]) {
         pAudioPlayer->playUISound(SOUND_error);
         logger->warning("LoadGame: slot {} is empty", uSlot);

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -166,10 +166,6 @@ int game_viewport_y;
 int game_viewport_z;
 int game_viewport_w;
 
-std::array<unsigned int, 2> saveload_dlg_xs = {{82, 0}};
-std::array<unsigned int, 2> saveload_dlg_ys = {{60, 0}};
-std::array<unsigned int, 2> saveload_dlg_zs = {{460, 640}};
-std::array<unsigned int, 2> saveload_dlg_ws = {{344, 480}};
 int pWindowList_at_506F50_minus1_indexing[1];
 int dword_4C9890[10];
 int dword_4C9920[16];
@@ -190,19 +186,6 @@ std::array<int, 8> BtnTurnCoord = {{
     0x7,
     0x3B,
 }};
-std::array<int16_t, 4> RightClickPortraitXmin = {{20, 131, 242, 357}};
-std::array<int16_t, 4> RightClickPortraitXmax = {{83, 198, 312, 423}};
-
-std::array<unsigned int, 4> pHealthBarPos = {{23, 138, 251, 366}}; //was 22, 137
-std::array<unsigned int, 4> pManaBarPos = {{102, 217, 331, 447}};
-
-std::array<int8_t, 88> monster_popup_y_offsets = {
-    {-20, 20, 0,   -40, 0,   0,   0,   0,   0,   0,   -50, 20,  0,   -10, -10,
-     -20, 10, -10, 0,   0,   0,   -20, 10,  -10, 0,   0,   0,   -20, -10, 0,
-     0,   0,  -40, -20, 0,   0,   0,   -50, -30, -30, -30, -30, -30, -30, 0,
-     0,   0,  0,   0,   0,   -20, -20, -20, 20,  20,  20,  10,  10,  10,  10,
-     10,  10, -90, -60, -40, -20, -20, -80, -10, 0,   0,   -40, 0,   0,   0,
-     -20, 10, 0,   0,   0,   0,   0,   0,   -60, 0,   0,   0,   0}};
 
 std::array<int, 6> dword_4E4560;
 std::array<int, 6> dword_4E4578;
@@ -213,31 +196,6 @@ std::array<float, 10> flt_4E4A80 = {{
     0.60000002f,  1.0f,  6.0f,        25.0f,
     50.0f,        100.0f
 }};
-
-std::array<std::array<int, 2>, 14> pPartySpellbuffsUI_XYs = {{
-    {{477, 247}},
-    {{497, 247}},
-    {{522, 247}},
-    {{542, 247}},
-    {{564, 247}},
-    {{581, 247}},
-    {{614, 247}},
-    {{477, 279}},
-    {{497, 279}},
-    {{522, 279}},
-    {{542, 279}},
-    {{564, 279}},
-    {{589, 279}},
-    {{612, 279}}
-}};
-std::array<unsigned char, 14> byte_4E5DD8 = {
-    {PARTY_BUFF_FEATHER_FALL, PARTY_BUFF_RESIST_FIRE, PARTY_BUFF_RESIST_AIR,
-     PARTY_BUFF_RESIST_WATER, PARTY_BUFF_RESIST_MIND, PARTY_BUFF_RESIST_EARTH,
-     PARTY_BUFF_RESIST_BODY, PARTY_BUFF_HEROISM, PARTY_BUFF_HASTE,
-     PARTY_BUFF_SHIELD, PARTY_BUFF_STONE_SKIN, PARTY_BUFF_PROTECTION_FROM_MAGIC,
-     PARTY_BUFF_IMMOLATION, PARTY_BUFF_DAY_OF_GODS}};
-std::array<uint8_t, 14> pPartySpellbuffsUI_smthns = {
-    {14, 1, 10, 4, 7, 2, 9, 3, 6, 15, 8, 3, 12, 0}};
 
 std::array<std::array<int, 6>, 6> pNPCPortraits_x = {{
     {{521, 0, 0, 0, 0, 0}},
@@ -2446,8 +2404,6 @@ IndexedArray<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL
         {PLAYER_SKILL_MISC, PLAYER_SKILL_MASTERY_NOVICE}
     }}
 }};
-std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX = {{489, 559}};
-std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY = {{152, 152}};
 std::array<short, 28> word_4EE150 = {{1,  2,  3,  4,  5,  7,  32, 33, 36, 37,
                                       38, 40, 41, 42, 43, 45, 46, 47, 48, 49,
                                       50, 51, 52, 53, 54, 55, 56, 60}};
@@ -2553,19 +2509,12 @@ std::array<uint16_t, 50> pBlueFacesInBLVMinimapIDs;
 std::array<class Image *, 14> party_buff_icons;
 unsigned int uIconIdx_FlySpell;
 unsigned int uIconIdx_WaterWalk;
-GameTime _5773B8_event_timer;
 
 struct Actor *pDialogue_SpeakingActor;
 DIALOGUE_TYPE uDialogueType;
 int sDialogue_SpeakingActorNPC_ID;
 int uCurrentHouse_Animation;
 std::string Party_Teleport_Map_Name;
-// int Party_Teleport_Z_Speed;
-// int Party_Teleport_Cam_Pitch;
-// int Party_Teleport_Cam_Yaw;
-// int Party_Teleport_Z_Pos;
-// int Party_Teleport_Y_Pos;
-// int Party_Teleport_X_Pos;
 std::array<std::array<char, 100>, 6> byte_591180;  // idb
 std::array<struct NPCData *, 7> HouseNPCData;  // 0 zero element holds standart house npc
 GUIButton *HouseNPCPortraitsButtonsList[6];  // dword_5913F4
@@ -2579,8 +2528,6 @@ int Party_Teleport_Cam_Pitch;
 int Party_Teleport_Z_Speed;
 int Start_Party_Teleport_Flag;
 int dword_5B65C4_cancelEventProcessing;
-int MapsLongTimers_count;  // dword_5B65C8 счётчик таймеров для колодцев,
-                           // фаерволов-ловушек
 int npcIdToDismissAfterDialogue;
 // std::array<char, 777> byte_5C3427;
 
@@ -2684,7 +2631,6 @@ std::vector<Vec3f> pTerrainNormals;
 std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;
 int dword_A74C88;
-int uPlayerCreationUI_ArrowAnim;
 unsigned int uPlayerCreationUI_SelectedCharacter;
 int dword_A74CDC;
 char byte_AE5B91;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -42,10 +42,6 @@ extern float flt_4D84E8;
 
 extern unsigned int uGammaPos;
 extern std::array<int, 8> BtnTurnCoord;
-extern std::array<int16_t, 4> RightClickPortraitXmin;
-extern std::array<int16_t, 4> RightClickPortraitXmax;
-extern std::array<unsigned int, 4> pHealthBarPos;
-extern std::array<unsigned int, 4> pManaBarPos;
 // extern std::array<char, 80> _4E2B21_buff_spell_tooltip_colors;
 extern std::array<int8_t, 88> monster_popup_y_offsets;
 
@@ -55,9 +51,6 @@ extern std::array<int, 6> dword_4E4590;
 extern std::array<int, 6> dword_4E45A8;
 extern std::array<float, 10> flt_4E4A80;
 
-extern std::array<std::array<int, 2>, 14> pPartySpellbuffsUI_XYs;
-extern std::array<unsigned char, 14> byte_4E5DD8;
-extern std::array<uint8_t, 14> pPartySpellbuffsUI_smthns;
 extern std::array<std::array<int, 6>, 6> pNPCPortraits_x;  // 004E5E50
 extern std::array<std::array<int, 6>, 6> pNPCPortraits_y;  // 004E5EE0
 extern std::array<const char *, 11> pHouse_ExitPictures;
@@ -66,10 +59,6 @@ extern std::array<int16_t, 11> word_4E8152;
 extern char _4E94D0_light_type;
 extern char _4E94D2_light_type;
 extern char _4E94D3_light_type;
-extern std::array<unsigned int, 2> saveload_dlg_xs;
-extern std::array<unsigned int, 2> saveload_dlg_ys;
-extern std::array<unsigned int, 2> saveload_dlg_zs;
-extern std::array<unsigned int, 2> saveload_dlg_ws;
 extern std::array<const char *, 465> pTransitionStrings;  // 4EB080
 extern std::array<int, 9> dword_4EC268;
 extern std::array<int, 7> dword_4EC28C;
@@ -83,8 +72,6 @@ extern IndexedArray<PLAYER_SKILL_LEVEL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST> s
 extern IndexedArray<uint, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST> base_recovery_times_per_weapon_type;
 extern std::array<IndexedArray<CLASS_SKILL, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST>, 9> pSkillAvailabilityPerClass;
 extern IndexedArray<IndexedArray<PLAYER_SKILL_MASTERY, PLAYER_SKILL_FIRST, PLAYER_SKILL_LAST>, PLAYER_CLASS_FIRST, PLAYER_CLASS_LAST> skillMaxMasteryPerClass;
-extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsX;
-extern std::array<unsigned int, 2> pHiredNPCsIconsOffsetsY;
 extern std::array<short, 28> word_4EE150;
 extern int16_t word_4F0576[];
 
@@ -156,7 +143,6 @@ extern std::array<uint16_t, 50> pBlueFacesInBLVMinimapIDs;
 extern std::array<class Image *, 14> party_buff_icons;
 extern unsigned int uIconIdx_FlySpell;
 extern unsigned int uIconIdx_WaterWalk;
-extern GameTime _5773B8_event_timer;  // 5773B8
 
 extern Actor *pDialogue_SpeakingActor;
 extern DIALOGUE_TYPE uDialogueType;
@@ -189,7 +175,6 @@ extern int Party_Teleport_Z_Speed;
 extern int Start_Party_Teleport_Flag;
 
 extern int dword_5B65C4_cancelEventProcessing;
-extern int MapsLongTimers_count;  // dword_5B65C8
 extern int npcIdToDismissAfterDialogue;
 // extern std::array<char, 777> byte_5C3427;
 extern std::string game_ui_status_bar_event_string;
@@ -316,7 +301,6 @@ extern std::vector<Vec3f> pTerrainNormals;
 extern std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 extern std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;
 extern int dword_A74C88;
-extern int uPlayerCreationUI_ArrowAnim;
 extern unsigned int uPlayerCreationUI_SelectedCharacter;
 extern int dword_A74CDC;
 extern char byte_AE5B91;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -47,8 +47,10 @@ Image *ui_partycreation_buttmake = nullptr;
 std::array<Image *, 9> ui_partycreation_class_icons;
 std::array<Image *, 22> ui_partycreation_portraits;
 
-std::array<Image *, 20> ui_partycreation_arrow_r;
-std::array<Image *, 20> ui_partycreation_arrow_l;
+std::array<Image *, 19> ui_partycreation_arrow_r;
+std::array<Image *, 19> ui_partycreation_arrow_l;
+
+static const int ARROW_SPIN_PERIOD_MS = 475;
 
 bool PartyCreationUI_LoopInternal();
 void PartyCreationUI_DeleteFont();
@@ -345,10 +347,10 @@ void GUIWindow_PartyCreation::Update() {
     pFrame = pIconsFrameTable->GetFrame(uIconID_CharacterFrame, pEventTimer->uStartTime);
     render->DrawTextureNew(pX / oldDims.w, 29 / oldDims.h, pFrame->GetTexture());
     uPosActiveItem = pGUIWindow_CurrentMenu->GetControl(pGUIWindow_CurrentMenu->pCurrentPosActiveItem);
-    // TODO(pskelton): check tickcount usage here
-    uPlayerCreationUI_ArrowAnim = 18 - (platform->tickCount() % 450) / 25;
-    render->DrawTextureNew((uPosActiveItem->uZ - 4) / oldDims.w, uPosActiveItem->uY / oldDims.h, ui_partycreation_arrow_l[uPlayerCreationUI_ArrowAnim + 1]);
-    render->DrawTextureNew((uPosActiveItem->uX - 12) / oldDims.w, uPosActiveItem->uY / oldDims.h, ui_partycreation_arrow_r[uPlayerCreationUI_ArrowAnim + 1]);
+    // cycle arrows backwards
+    int arrowAnimTextureNum = ui_partycreation_arrow_l.size() - 1 - (platform->tickCount() % ARROW_SPIN_PERIOD_MS) / (ARROW_SPIN_PERIOD_MS / ui_partycreation_arrow_l.size());
+    render->DrawTextureNew((uPosActiveItem->uZ - 4) / oldDims.w, uPosActiveItem->uY / oldDims.h, ui_partycreation_arrow_l[arrowAnimTextureNum]);
+    render->DrawTextureNew((uPosActiveItem->uX - 12) / oldDims.w, uPosActiveItem->uY / oldDims.h, ui_partycreation_arrow_r[arrowAnimTextureNum]);
 
     memset(pText, 0, sizeof(pText));
     strcpy(pText, localization->GetString(LSTR_SKILLS));
@@ -615,7 +617,6 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     main_menu_background = assets->GetImage_PCXFromIconsLOD("makeme.pcx");
 
     current_screen_type = CURRENT_SCREEN::SCREEN_PARTY_CREATION;
-    uPlayerCreationUI_ArrowAnim = 0;
     uPlayerCreationUI_SelectedCharacter = 0;
     int v0 = pFontCreate->GetHeight() - 2;
 
@@ -641,9 +642,12 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     ui_partycreation_right = assets->GetImage_ColorKey("presrigh");
     ui_partycreation_left = assets->GetImage_ColorKey("presleft");
 
-    for (int i = 1; i < 20; ++i) {
-        ui_partycreation_arrow_l[i] = assets->GetImage_Alpha(fmt::format("arrowl{}", i));
-        ui_partycreation_arrow_r[i] = assets->GetImage_Alpha(fmt::format("arrowr{}", i));
+    // sprites number go from (1 to 19)
+    assert(ui_partycreation_arrow_l.size() == 19);
+    assert(ui_partycreation_arrow_r.size() == 19);
+    for (int i = 0; i < ui_partycreation_arrow_l.size(); ++i) {
+        ui_partycreation_arrow_l[i] = assets->GetImage_Alpha(fmt::format("arrowl{}", i + 1));
+        ui_partycreation_arrow_r[i] = assets->GetImage_Alpha(fmt::format("arrowr{}", i + 1));
     }
 
     // pGUIWindow_CurrentMenu = new GUIWindow(0, 0, window->GetWidth(), window->GetHeight(), 0);

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -71,6 +71,16 @@ std::array<stat_coord, 26> stat_string_coord =  // 4E2940
      {0x111, 0x129, 0xBA, 0x12}, {0x13E, 0x12, 0x89, 0x12},
 }};
 
+std::array<int16_t, 4> RightClickPortraitXmin = {{20, 131, 242, 357}};
+std::array<int16_t, 4> RightClickPortraitXmax = {{83, 198, 312, 423}};
+
+std::array<int8_t, 88> monster_popup_y_offsets = {
+    {-20, 20, 0,   -40, 0,   0,   0,   0,   0,   0,   -50, 20,  0,   -10, -10,
+     -20, 10, -10, 0,   0,   0,   -20, 10,  -10, 0,   0,   0,   -20, -10, 0,
+     0,   0,  -40, -20, 0,   0,   0,   -50, -30, -30, -30, -30, -30, -30, 0,
+     0,   0,  0,   0,   0,   -20, -20, -20, 20,  20,  20,  10,  10,  10,  10,
+     10,  10, -90, -60, -40, -20, -20, -80, -10, 0,   0,   -40, 0,   0,   0,
+     -20, 10, 0,   0,   0,   0,   0,   0,   -60, 0,   0,   0,   0}};
 
 //----- (004179BC) --------------------------------------------------------
 void CharacterUI_DrawTooltip(const char *title, std::string &content) {
@@ -572,24 +582,21 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         pParty->setActiveToFirstCanAct();
     }
 
-    int Popup_Y_Offset =
-        monster_popup_y_offsets[(pActors[uActorID].pMonsterInfo.uID - 1) / 3] -
-        40;
+    int Popup_Y_Offset = monster_popup_y_offsets[(pActors[uActorID].pMonsterInfo.uID - 1) / 3] - 40;
 
-    uint16_t v9 = 0;
-    if (pActors[uActorID].pMonsterInfo.uID ==
-        pMonsterInfoUI_Doll.pMonsterInfo.uID) {
-        v9 = pMonsterInfoUI_Doll.uCurrentActionLength;
+    uint16_t actionLen = 0;
+    if (pActors[uActorID].pMonsterInfo.uID == pMonsterInfoUI_Doll.pMonsterInfo.uID) {
+        actionLen = pMonsterInfoUI_Doll.uCurrentActionLength;
     } else {
         // copy actor info if different
         pMonsterInfoUI_Doll = pActors[uActorID];
         pMonsterInfoUI_Doll.uCurrentActionAnimation = ANIM_Bored;
         pMonsterInfoUI_Doll.uCurrentActionTime = 0;
-        v9 = vrng->random(256) + 128;
-        pMonsterInfoUI_Doll.uCurrentActionLength = v9;
+        actionLen = vrng->random(256) + 128;
+        pMonsterInfoUI_Doll.uCurrentActionLength = actionLen;
     }
 
-    if (pMonsterInfoUI_Doll.uCurrentActionTime > v9) {
+    if (pMonsterInfoUI_Doll.uCurrentActionTime > actionLen) {
         pMonsterInfoUI_Doll.uCurrentActionTime = 0;
         if (pMonsterInfoUI_Doll.uCurrentActionAnimation == ANIM_Bored ||
             pMonsterInfoUI_Doll.uCurrentActionAnimation == ANIM_AtkMelee) {

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -26,6 +26,11 @@ using Io::TextInputType;
 
 static void UI_DrawSaveLoad(bool save);
 
+std::array<unsigned int, 2> saveload_dlg_xs = {{82, 0}};
+std::array<unsigned int, 2> saveload_dlg_ys = {{60, 0}};
+std::array<unsigned int, 2> saveload_dlg_zs = {{460, 640}};
+std::array<unsigned int, 2> saveload_dlg_ws = {{344, 480}};
+
 Image *saveload_ui_ls_saved = nullptr;
 Image *saveload_ui_x_d = nullptr;
 Image *scrollstop = nullptr;


### PR DESCRIPTION
- Move some read-only tables from mm7_data.cpp to their respective cpp files where they are exclusively used.
- Remove some already unused global definitions.
- Convert `uPlayerCreationUI_ArrowAnim` global to local and remove some magic numbers around it.

P.S. In order to use only integral numbers when computing frame number of arrow in character creation UI increase arrow rotation period from 450ms to 475ms.