### PR TITLE
Fix event issues in Bracada Desert

### DIFF
--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -395,8 +395,8 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             }
             break;
         case EVENT_OnTimer:
-            assert(false); // Trigger, must be skipped
-            break;
+            // Trigger, must be skipped but can be encountered in vanilla
+            return -1;
         case EVENT_ToggleIndoorLight:
             pIndoor->toggleLight(ir.data.light_descr.light_id, ir.data.light_descr.is_enable);
             break;
@@ -413,11 +413,11 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
         case EVENT_Jmp:
             return ir.target_step;
         case EVENT_OnMapReload:
-            assert(false); // Trigger, must be skipped
-            break;
+            // Trigger, must be skipped but can be encountered in vanilla
+            return -1;
         case EVENT_OnLongTimer:
-            assert(false); // Trigger, must be skipped
-            break;
+            // Trigger, must be skipped but can be encountered in vanilla
+            return -1;
         case EVENT_SetNPCTopic:
         {
             NPCData *npc = &pNPCStats->pNewNPCData[ir.data.npc_topic_descr.npc_id];
@@ -515,8 +515,8 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             }
             break;
         case EVENT_OnMapLeave:
-            assert(false); // Trigger, must be skipped
-            break;
+            // Trigger, must be skipped but can be encountered in vanilla
+            return -1;
         case EVENT_ChangeGroup:
             // TODO: enconunter and process
             __debugbreak();

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -4390,10 +4390,7 @@ bool Player::CompareVariable(VariableType VarNum, int pValue) {
             return true;
         }
         case VAR_AutoNotes:
-            // TODO(_): find out why the double subtraction. or whether this is even used
-            // also bit indexing was changed
-            assert(false);
-            return pParty->_autonoteBits[pValue - 2];
+            return pParty->_autonoteBits[pValue];
         case VAR_IsMightMoreThanBase:
             actStat = GetActualMight();
             baseStat = GetBaseStrength();
@@ -6118,6 +6115,9 @@ void Player::SubtractVariable(VariableType VarNum, signed int pValue) {
             // TODO(Nik-RE-dev): decreasing 1 seems wrong, also bits indexing was changed
             assert(false);
             //pParty->_autonoteBits.reset(pValue - 1);
+            return;
+        case VAR_PlayerBits:
+            _playerEventBits.reset(pValue);
             return;
         case VAR_NPCs2:
             npcIndex = 0;


### PR DESCRIPTION
Fix #814 - implement compare of VAR_AutoNotes properly.
Fix #815 - add implementation of subtract of VAR_PlayerBits.
Fix #816 - do not assert on triggers, just stop execution.