### PR TITLE
Fix camera orientation for positional sound

### DIFF
--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -97,10 +97,10 @@ void OpenALSoundProvider::SetListenerPosition(float x, float y, float z) {
 
 void OpenALSoundProvider::SetOrientation(float yaw, float pitch) {
     float x = cos(pitch) * cos(yaw);
-    float y = sin(yaw) * cos(pitch);
+    float y = cos(pitch) * sin(yaw);
     float z = -sin(pitch);
 
-    ALfloat listenerOri[] = {-x, y, z, 0.f, 0.f, 1.f};
+    ALfloat listenerOri[] = {x, y, z, 0.f, 0.f, 1.f};
     alListenerfv(AL_ORIENTATION, listenerOri);
 }
 


### PR DESCRIPTION
Subj.
x/y/z describe "forward" vector of the camera. And yaw is 0 (radian) when camera looking along X axis toward positive infinity.
Fixes #826 