### PR TITLE
Fix shift+click when no quick spell set

### DIFF
--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -330,10 +330,14 @@ void Engine::onGameViewportClick() {
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->setAirborne(true);
-        } else if (pParty->hasActiveCharacter() && IsSpellQuickCastableOnShiftClick(pParty->activeCharacter().uQuickSpell)) {
+        } else if (pParty->hasActiveCharacter() &&
+                   pParty->activeCharacter().uQuickSpell != SPELL_NONE &&
+                   IsSpellQuickCastableOnShiftClick(pParty->activeCharacter().uQuickSpell)) {
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
-        } else {
+        } else if (pParty->pPickedItem.uItemID != ITEM_NULL) {
             pParty->dropHeldItem();
+        } else {
+            pAudioPlayer->playUISound(SOUND_error);
         }
     } else if (PID_TYPE(pid) == OBJECT_Decoration) {
         int id = PID_ID(pid);


### PR DESCRIPTION
Fix #833.
Mostly retain vanilla behavior:
- Cast quick spell with shift pressed on any actor regardless of it's friendliness.
- If no quick spell is set for current character or quick spell is not castable with shift then clicking will do nothing.

Minor change from vanilla: when quick spell is not castable or absent then play error sound.