### PR TITLE
Fix unique NPC names

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -800,6 +800,7 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     else
         PrepareToLoadODM(bLoading, 0);
 
+    pNPCStats->setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
     if ((pCurrentMapName == "d11.blv") ||
         (pCurrentMapName == "d10.blv")) {

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -213,8 +213,7 @@ void NPCStats::InitializeNPCText() {
     pNPCDistTXT_Raw.clear();
 }
 
-//----- (00476C60) --------------------------------------------------------
-void NPCStats::OnLoadSetNPC_Names() {
+void NPCStats::setNPCNamesOnLoad() {
     for (unsigned int i = 1; i < uNumNewNPCs; ++i)
         pNewNPCData[i].pName = pNPCUnicNames[i - 1];
 

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -81,7 +81,10 @@ struct NPCStats {
     void Release();
     void InitializeAdditionalNPCs(NPCData *pNPCDataBuff, int npc_uid,
                                   int uLocation2D, int uMapId);
-    void OnLoadSetNPC_Names();
+    /**
+     * @offset 0x476C60
+     */
+    void setNPCNamesOnLoad();
     char *sub_495366_MispronounceName(uint8_t firstLetter,
                                       uint8_t genderId);
 


### PR DESCRIPTION
Fix #872.
Call unique names initialization function on map load.