### PR TITLE
retrace and combine tests

### DIFF
--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG a02ad71a533f23cd67b55574930a7b3d84388d5b
+            GIT_TAG ef9719c56e4bd825294e6f9d6272779def1839b1
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""


### PR DESCRIPTION
Retraced some of the slower tests with new fps
Combined tests 331 + 679 and 427 + 528

Nets 10% reduction in full test suite run time for me