### PR TITLE
Remove global award and autonote string buffer

### DIFF
--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -4588,7 +4588,7 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             this->sAgeModifier = var_value;
             return;
         case VAR_Award:
-            if (!this->_achievedAwardsBits[var_value] && pAwards[var_value].pText) {
+            if (!this->_achievedAwardsBits[var_value] && !pAwards[var_value].pText.empty()) {
                 PlayAwardSound_Anim();
                 this->playReaction(SPEECH_AwardGot);
             }
@@ -4855,7 +4855,7 @@ void Player::SetVariable(VariableType var_type, signed int var_value) {
             return;
         case VAR_AutoNotes:
             assert(var_value > 0);
-            if (!pParty->_autonoteBits[var_value] && pAutonoteTxt[var_value].pText) {
+            if (!pParty->_autonoteBits[var_value] && !pAutonoteTxt[var_value].pText.empty()) {
                 spell_fx_renderer->SetPlayerBuffAnim(BECOME_MAGIC_GUILD_MEMBER, GetPlayerIndex());
                 this->playReaction(SPEECH_AwardGot);
                 bFlashAutonotesBook = true;
@@ -5171,7 +5171,7 @@ void Player::AddVariable(VariableType var_type, signed int val) {
             this->sAgeModifier += val;
             return;
         case VAR_Award:
-            if (this->_achievedAwardsBits[val] && pAwards[val].pText) {
+            if (this->_achievedAwardsBits[val] && !pAwards[val].pText.empty()) {
                 PlayAwardSound_Anim97_Face(SPEECH_AwardGot);
             }
             this->_achievedAwardsBits.set(val);
@@ -5424,7 +5424,7 @@ void Player::AddVariable(VariableType var_type, signed int val) {
             return;
         case VAR_AutoNotes:
             assert(val > 0);
-            if (!pParty->_autonoteBits[val] && pAutonoteTxt[val].pText) {
+            if (!pParty->_autonoteBits[val] && !pAutonoteTxt[val].pText.empty()) {
                 this->playReaction(SPEECH_AwardGot);
                 bFlashAutonotesBook = true;
                 autonoteBookDisplayType = pAutonoteTxt[val].eType;

--- a/src/Engine/Tables/AutonoteTable.cpp
+++ b/src/Engine/Tables/AutonoteTable.cpp
@@ -4,7 +4,6 @@
 #include "Utility/String.h"
 
 std::array<Autonote, 196> pAutonoteTxt;
-std::string pAutonoteTXT_Raw;
 
 void initializeAutonotes() {
     int i;
@@ -15,8 +14,8 @@ void initializeAutonotes() {
     char *tmp_pos;
     int decode_step;
 
-    pAutonoteTXT_Raw = engine->_gameResourceManager->getEventsFile("autonote.txt").string_view();
-    strtok(pAutonoteTXT_Raw.data(), "\r");
+    std::string txtRaw{ engine->_gameResourceManager->getEventsFile("autonote.txt").string_view() };
+    strtok(txtRaw.data(), "\r");
 
     for (i = 0; i < 195; ++i) {
         test_string = strtok(NULL, "\r") + 1;

--- a/src/Engine/Tables/AutonoteTable.h
+++ b/src/Engine/Tables/AutonoteTable.h
@@ -14,7 +14,7 @@ enum class AUTONOTE_TYPE : uint32_t {
 using enum AUTONOTE_TYPE;
 
 struct Autonote {
-    const char *pText;
+    std::string pText;
     AUTONOTE_TYPE eType;
 };
 
@@ -24,4 +24,3 @@ struct Autonote {
 void initializeAutonotes();
 
 extern std::array<Autonote, 196> pAutonoteTxt;
-extern std::string pAutonoteTXT_Raw;

--- a/src/Engine/Tables/AwardTable.cpp
+++ b/src/Engine/Tables/AwardTable.cpp
@@ -4,7 +4,6 @@
 #include "Utility/String.h"
 
 std::array<Award, 105> pAwards;
-std::string pAwardsTXT_Raw;
 
 void initializeAwards() {
     int i;
@@ -15,8 +14,8 @@ void initializeAwards() {
     char *tmp_pos;
     int decode_step;
 
-    pAwardsTXT_Raw = engine->_gameResourceManager->getEventsFile("awards.txt").string_view();
-    strtok(pAwardsTXT_Raw.data(), "\r");
+    std::string txtRaw{ engine->_gameResourceManager->getEventsFile("awards.txt").string_view() };
+    strtok(txtRaw.data(), "\r");
 
     for (i = 1; i < 105; ++i) {
         test_string = strtok(NULL, "\r") + 1;

--- a/src/Engine/Tables/AwardTable.h
+++ b/src/Engine/Tables/AwardTable.h
@@ -113,7 +113,7 @@ enum AwardType : uint32_t {
 };
 
 struct Award {
-    const char *pText;
+    std::string pText;
     unsigned int uPriority;
 };
 
@@ -123,4 +123,3 @@ struct Award {
 void initializeAwards();
 
 extern std::array<Award, 105> pAwards;
-extern std::string pAwardsTXT_Raw;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2536,7 +2536,7 @@ std::vector<Vec3f> pTerrainNormals;
 std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;
 unsigned int uPlayerCreationUI_SelectedCharacter;
-int dword_A74CDC;
+int currentAddressingAwardBit;
 // int dword_F8B144; // nexindex [-1] to the following
 std::array<int16_t, 6> weapons_Ypos;           // word_F8B158
 int guild_membership_approved;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -190,7 +190,7 @@ extern std::vector<Vec3f> pTerrainNormals;
 extern std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 extern std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;
 extern unsigned int uPlayerCreationUI_SelectedCharacter;
-extern int dword_A74CDC;
+extern int currentAddressingAwardBit;
 extern std::array<int16_t, 6> weapons_Ypos;  // word_F8B158
 extern int guild_membership_approved;
 extern PLAYER_SKILL_MASTERY dword_F8B1B0_MasteryBeingTaught;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -99,9 +99,9 @@ DIALOGUE_TYPE _dword_F8B1D8_last_npc_topic_menu;
 AwardType dword_F8B1AC_award_bit_number;
 PLAYER_SKILL_TYPE dword_F8B1AC_skill_being_taught; // Address the same as above --- splitting a union into two variables.
 
-std::array<short, 28> word_4EE150 = {{1,  2,  3,  4,  5,  7,  32, 33, 36, 37,
-                                      38, 40, 41, 42, 43, 45, 46, 47, 48, 49,
-                                      50, 51, 52, 53, 54, 55, 56, 60}};
+std::array<int, 28> possibleAddressingAwardBits = {{1,  2,  3,  4,  5,  7,  32, 33, 36, 37,
+                                                    38, 40, 41, 42, 43, 45, 46, 47, 48, 49,
+                                                    50, 51, 52, 53, 54, 55, 56, 60}};
 
 void SetCurrentMenuID(MENU_STATE uMenu) {
     sCurrentMenuID = uMenu;
@@ -1601,11 +1601,9 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
     Player *pPlayer;       // ebx@3
     const char *pText;     // esi@7
     int64_t v18;    // qax@18
-    int v21;               // ecx@34
     int v29;               // eax@68
-    int16_t v55[56] {};       // [sp+10h] [bp-128h]@34
+    std::vector<int> addressingBits;
     SummonedItem v56;      // [sp+80h] [bp-B8h]@107
-    int v63;               // [sp+12Ch] [bp-Ch]@32
 
     pPlayer = &pParty->pPlayers[uPlayerID];
 
@@ -1617,7 +1615,6 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
 
     std::string result;
 
-    // pText = a4;
     uint len = str.length();
     for (int i = 0, dst = 0; i < len; ++i) {
         char c = str[i];  // skip through string till we find insertion point
@@ -1668,24 +1665,18 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
                     result += localization->GetString(LSTR_SIR);
                 break;
             case 8:
-                v63 = 0;
-                for (uint _i = 0; _i < 28; ++_i) {
-                    if (pPlayer->_achievedAwardsBits[word_4EE150[i]]) {
-                        v21 = v63;
-                        ++v63;
-                        v55[v63] = word_4EE150[i];
+                for (int bit : possibleAddressingAwardBits) {
+                    if (pPlayer->_achievedAwardsBits[bit]) {
+                        addressingBits.push_back(bit);
                     }
                 }
-                if (v63) {
-                    if (dword_A74CDC == -1) dword_A74CDC = vrng->random(v63);
-                    pText =
-                        pAwards[v55[dword_A74CDC]]
-                        .pText;  // (char *)dword_723E80_award_related[2
-                                 // * v55[v24]];
+                if (addressingBits.size()) {
+                    if (currentAddressingAwardBit == -1)
+                        currentAddressingAwardBit = addressingBits[vrng->random(addressingBits.size())];
+                    result += pAwards[currentAddressingAwardBit].pText;
                 } else {
-                    pText = pNPCTopics[55].pText;
+                    result += pNPCTopics[55].pText;
                 }
-                result += pText;
                 break;
             case 9:
                 if (npc->uSex)

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -26,7 +26,7 @@ void GUIWindow_AutonotesBook::recalculateCurrentNotesTypePages() {
     _activeNotesIdx.clear();
     for (int i = 1; i < pAutonoteTxt.size(); ++i) {
         if (autonoteBookDisplayType == pAutonoteTxt[i].eType) {
-            if (pParty->_autonoteBits[i] && pAutonoteTxt[i].pText) {
+            if (pParty->_autonoteBits[i] && !pAutonoteTxt[i].pText.empty()) {
                 _activeNotesIdx.push_back(i);
             }
         }

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -1729,7 +1729,7 @@ void GUIWindow_CharacterRecord::fillAwardsData() {
 
     _achievedAwardsList.clear();
     for (int i = 1; i < pAwards.size(); ++i) {
-        if (pPlayer->_achievedAwardsBits[i] && pAwards[i].pText) {
+        if (pPlayer->_achievedAwardsBits[i] && !pAwards[i].pText.empty()) {
             _achievedAwardsList.push_back(i);
         }
     }

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -32,7 +32,7 @@ const IndexedArray<const char *, PartyAlignment_Good, PartyAlignment_Evil> Dialo
 };
 
 void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
-    dword_A74CDC = -1;
+    currentAddressingAwardBit = -1;
     pNPCStats->dword_AE336C_LastMispronouncedNameFirstLetter = -1;
     pEventTimer->Pause();
     pMiscTimer->Pause();


### PR DESCRIPTION
Use std::string in autonote and award tables.
Plus little refactoring of code that builds dialogue string using achieved awards.