### PR TITLE
Image renamed to GraphicsImage

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -354,7 +354,7 @@ void ShowMM7IntroVideo_and_LoadingScreen() {
 
 
 
-Image *gamma_preview_image = nullptr;  // 506E40
+GraphicsImage *gamma_preview_image = nullptr;  // 506E40
 
 void Game_StartDialogue(unsigned int actor_id) {
     if (pParty->hasActiveCharacter()) {

--- a/src/Application/Game.h
+++ b/src/Application/Game.h
@@ -55,4 +55,4 @@ class Game {
 
 void initDataPath(const std::string &dataPath);
 
-extern class Image *gamma_preview_image;  // 506E40
+extern class GraphicsImage *gamma_preview_image;  // 506E40

--- a/src/Application/GameOver.cpp
+++ b/src/Application/GameOver.cpp
@@ -45,7 +45,7 @@ void GameOver_Loop(int v15) {
 void CreateWinnerCertificate() {
     render->Present();
     render->BeginScene2D();
-    Image *background = assets->getImage_PCXFromIconsLOD("winbg.pcx");
+    GraphicsImage *background = assets->getImage_PCXFromIconsLOD("winbg.pcx");
     render->DrawTextureNew(0, 0, background);
 
     GUIWindow *tempwindow_SpeakInHouse = new GUIWindow(WINDOW_Unknown, { 0, 0 }, render->GetRenderDimensions(), 0);

--- a/src/Engine/AssetsManager.h
+++ b/src/Engine/AssetsManager.h
@@ -5,7 +5,7 @@
 
 #include "Library/Color/ColorTable.h"
 
-class Image;
+class GraphicsImage;
 class Texture;
 
 class AssetsManager {

--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -208,8 +208,8 @@ class IRender {
     virtual void NuklearRelease() = 0;
     virtual struct nk_tex_font *NuklearFontLoad(const char *font_path, size_t font_size) = 0;
     virtual void NuklearFontFree(struct nk_tex_font *tfont) = 0;
-    virtual struct nk_image NuklearImageLoad(Image *img) = 0;
-    virtual void NuklearImageFree(Image *img) = 0;
+    virtual struct nk_image NuklearImageLoad(GraphicsImage *img) = 0;
+    virtual void NuklearImageFree(GraphicsImage *img) = 0;
 
     virtual Texture *CreateTexture_Paletted(const std::string &name) = 0;
     virtual Texture *CreateTexture_ColorKey(const std::string &name, Color colorkey) = 0;
@@ -283,22 +283,22 @@ class IRender {
                                unsigned int uZ, unsigned int uW) = 0;
     virtual void ResetUIClipRect() = 0;
 
-    virtual void DrawTextureNew(float u, float v, Image *img, uint32_t colourmask32 = 0xFFFFFFFF) = 0;
-    virtual void DrawTextureCustomHeight(float u, float v, Image *, int height) = 0;
-    virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y, Image *) = 0;
-    virtual void DrawImage(Image *, const Recti &rect, const uint paletteid = 0, uint32_t colourmask32 = 0xFFFFFFFF) = 0;
+    virtual void DrawTextureNew(float u, float v, GraphicsImage *img, uint32_t colourmask32 = 0xFFFFFFFF) = 0;
+    virtual void DrawTextureCustomHeight(float u, float v, GraphicsImage *, int height) = 0;
+    virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y, GraphicsImage *) = 0;
+    virtual void DrawImage(GraphicsImage *, const Recti &rect, const uint paletteid = 0, uint32_t colourmask32 = 0xFFFFFFFF) = 0;
 
-    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal) = 0;
-    virtual void BlendTextures(int a2, int a3, Image *a4, Image *a5, int t, int start_opacity, int end_opacity) = 0;
-    virtual void TexturePixelRotateDraw(float u, float v, Image *img, int time) = 0;
+    virtual void ZDrawTextureAlpha(float u, float v, GraphicsImage *pTexture, int zVal) = 0;
+    virtual void BlendTextures(int a2, int a3, GraphicsImage *a4, GraphicsImage *a5, int t, int start_opacity, int end_opacity) = 0;
+    virtual void TexturePixelRotateDraw(float u, float v, GraphicsImage *img, int time) = 0;
     virtual void DrawMonsterPortrait(Recti rc, SpriteFrame *Portrait_Sprite, int Y_Offset) = 0;
 
-    virtual void DrawMasked(float u, float v, Image *img,
+    virtual void DrawMasked(float u, float v, GraphicsImage *img,
                             unsigned int color_dimming_level,
                             uint32_t mask = 0xFFFFFFFF) = 0;
-    virtual void DrawTextureGrayShade(float u, float v, Image *a4) = 0;
-    virtual void DrawTransparentRedShade(float u, float v, Image *a4) = 0;
-    virtual void DrawTransparentGreenShade(float u, float v, Image *pTexture) = 0;
+    virtual void DrawTextureGrayShade(float u, float v, GraphicsImage *a4) = 0;
+    virtual void DrawTransparentRedShade(float u, float v, GraphicsImage *a4) = 0;
+    virtual void DrawTransparentGreenShade(float u, float v, GraphicsImage *pTexture) = 0;
     // virtual void DrawFansTransparent(const RenderVertexD3D3 *vertices, unsigned int num_vertices) = 0;
 
     virtual void BeginTextNew(Texture *main, Texture *shadow) = 0;
@@ -321,7 +321,7 @@ class IRender {
 
     virtual bool AreRenderSurfacesOk() = 0;
 
-    virtual Image *TakeScreenshot(unsigned int width, unsigned int height) = 0;
+    virtual GraphicsImage *TakeScreenshot(unsigned int width, unsigned int height) = 0;
     virtual void SaveScreenshot(const std::string &filename, unsigned int width,
                                 unsigned int height) = 0;
     virtual Blob PackScreenshot(const unsigned int width, const unsigned int height) = 0;

--- a/src/Engine/Graphics/Image.cpp
+++ b/src/Engine/Graphics/Image.cpp
@@ -112,8 +112,8 @@ Texture_MM7::Texture_MM7() {
     pPalette24 = nullptr;
 }
 
-Image *Image::Create(ImageLoader *loader) {
-    Image *img = new Image();
+GraphicsImage *GraphicsImage::Create(ImageLoader *loader) {
+    GraphicsImage *img = new GraphicsImage();
     if (img) {
         img->loader = loader;
     }
@@ -121,7 +121,7 @@ Image *Image::Create(ImageLoader *loader) {
     return img;
 }
 
-bool Image::LoadImageData() {
+bool GraphicsImage::LoadImageData() {
     if (!initialized) {
         Color *data = nullptr;
         uint8_t *palette = nullptr;
@@ -137,7 +137,7 @@ bool Image::LoadImageData() {
     return initialized;
 }
 
-int Image::GetWidth() {
+int GraphicsImage::GetWidth() {
     if (!initialized) {
         LoadImageData();
     }
@@ -150,7 +150,7 @@ int Image::GetWidth() {
     return 0;
 }
 
-int Image::GetHeight() {
+int GraphicsImage::GetHeight() {
     if (!initialized) {
         LoadImageData();
     }
@@ -163,10 +163,10 @@ int Image::GetHeight() {
     return 0;
 }
 
-Image *Image::Create(unsigned int width, unsigned int height, const Color *pixels) {
+GraphicsImage *GraphicsImage::Create(unsigned int width, unsigned int height, const Color *pixels) {
     if (width == 0 || height == 0) __debugbreak();
 
-    Image *img = new Image(false);
+    GraphicsImage *img = new GraphicsImage(false);
 
     img->initialized = true;
     img->width = width;
@@ -183,32 +183,32 @@ Image *Image::Create(unsigned int width, unsigned int height, const Color *pixel
     return img;
 }
 
-const Color *Image::GetPixels() {
+const Color *GraphicsImage::GetPixels() {
     if (!initialized)
         LoadImageData();
     return pixels;
 }
 
 
-const uint8_t *Image::GetPalette() {
+const uint8_t *GraphicsImage::GetPalette() {
     if (!initialized)
         LoadImageData();
 
     return this->palette24;
 }
 
-const uint8_t *Image::GetPalettePixels() {
+const uint8_t *GraphicsImage::GetPalettePixels() {
     if (!initialized)
         LoadImageData();
     return this->palettepixels;
 }
 
-std::string *Image::GetName() {
+std::string *GraphicsImage::GetName() {
     if (!loader) __debugbreak();
     return loader->GetResourceNamePtr();
 }
 
-bool Image::Release() {
+bool GraphicsImage::Release() {
     if (loader) {
         if (!assets->releaseSprite(loader->GetResourceName()))
             if (!assets->releaseImage(loader->GetResourceName()))

--- a/src/Engine/Graphics/Image.h
+++ b/src/Engine/Graphics/Image.h
@@ -10,13 +10,13 @@
 #include "Library/Color/Color.h"
 
 class ImageLoader;
-class Image {
+class GraphicsImage {
  public:
-    explicit Image(bool lazy_initialization = true): lazy_initialization(lazy_initialization) {}
-    virtual ~Image() {}
+    explicit GraphicsImage(bool lazy_initialization = true): lazy_initialization(lazy_initialization) {}
+    virtual ~GraphicsImage() {}
 
-    static Image *Create(unsigned int width, unsigned int height, const Color *pixels = nullptr);
-    static Image *Create(ImageLoader *loader);
+    static GraphicsImage *Create(unsigned int width, unsigned int height, const Color *pixels = nullptr);
+    static GraphicsImage *Create(ImageLoader *loader);
 
     int GetWidth();
     int GetHeight();
@@ -52,11 +52,11 @@ class Image {
 
 class ImageHelper {
  public:
-    static int GetWidthLn2(Image *img) {
+    static int GetWidthLn2(GraphicsImage *img) {
         return ImageHelper::GetPowerOf2(img->GetWidth());
     }
 
-    static int GetHeightLn2(Image *img) {
+    static int GetHeightLn2(GraphicsImage *img) {
         return ImageHelper::GetPowerOf2(img->GetHeight());
     }
 
@@ -149,17 +149,17 @@ struct OptionsMenuSkin {
     OptionsMenuSkin();
     void Release();
 
-    Image *uTextureID_Background;       // 507C60
-    Image *uTextureID_TurnSpeed[3];     // 507C64
-    Image *uTextureID_ArrowLeft;        // 507C70
-    Image *uTextureID_ArrowRight;       // 507C74
-    Image *uTextureID_unused_0;         // 507C78
-    Image *uTextureID_unused_1;         // 507C7C
-    Image *uTextureID_unused_2;         // 507C80
-    Image *uTextureID_FlipOnExit;       // 507C84
-    Image *uTextureID_SoundLevels[10];  // 507C88
-    Image *uTextureID_AlwaysRun;        // 507CB0
-    Image *uTextureID_WalkSound;        // 507CB4
-    Image *uTextureID_ShowDamage;       // 507CB8
+    GraphicsImage *uTextureID_Background;       // 507C60
+    GraphicsImage *uTextureID_TurnSpeed[3];     // 507C64
+    GraphicsImage *uTextureID_ArrowLeft;        // 507C70
+    GraphicsImage *uTextureID_ArrowRight;       // 507C74
+    GraphicsImage *uTextureID_unused_0;         // 507C78
+    GraphicsImage *uTextureID_unused_1;         // 507C7C
+    GraphicsImage *uTextureID_unused_2;         // 507C80
+    GraphicsImage *uTextureID_FlipOnExit;       // 507C84
+    GraphicsImage *uTextureID_SoundLevels[10];  // 507C88
+    GraphicsImage *uTextureID_AlwaysRun;        // 507CB0
+    GraphicsImage *uTextureID_WalkSound;        // 507CB4
+    GraphicsImage *uTextureID_ShowDamage;       // 507CB8
 };
 extern OptionsMenuSkin options_menu_skin;  // 507C60

--- a/src/Engine/Graphics/Nuklear.cpp
+++ b/src/Engine/Graphics/Nuklear.cpp
@@ -40,7 +40,7 @@ struct nk_tex_font font_default;
 std::vector<struct hotkey> hotkeys;
 
 struct img {
-    Image *asset;
+    GraphicsImage *asset;
     struct nk_image nk;
 };
 
@@ -1409,7 +1409,7 @@ static int lua_nk_parse_image(struct context *w, lua_State *L, int idx, struct n
     return luaL_argerror(L, idx, lua_pushfstring(L, "asset is wrong"));
 }
 
-static int lua_nk_parse_image_asset(struct context *w, lua_State *L, int idx, Image **asset) {
+static int lua_nk_parse_image_asset(struct context *w, lua_State *L, int idx, GraphicsImage **asset) {
     size_t slot = luaL_checkinteger(L, idx);
     if (slot >= 0 && slot < w->imgs.size() && w->imgs[slot]->asset) {
         *asset = w->imgs[slot]->asset;
@@ -2092,7 +2092,7 @@ static int lua_nk_image_dimensions(lua_State *L) {
     lua_check_ret(lua_check_args(L, lua_gettop(L) == 2));
 
     struct context *w = (struct context *)lua_touserdata(L, 1);
-    Image *asset = NULL;
+    GraphicsImage *asset = NULL;
     luaL_checkinteger(L, 2);
 
     lua_check_ret(lua_nk_parse_image_asset(w, L, 2, &asset));

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -706,12 +706,12 @@ void RenderOpenGL::ScreenFade(unsigned int color, float t) {
 
 
 void RenderOpenGL::DrawTextureOffset(int pX, int pY, int move_X, int move_Y,
-                                     Image *pTexture) {
+                                     GraphicsImage *pTexture) {
     DrawTextureNew((float)(pX - move_X)/outputRender.w, (float)(pY - move_Y)/outputRender.h, pTexture);
 }
 
 
-void RenderOpenGL::DrawImage(Image *img, const Recti &rect, uint paletteid, uint32_t uColor32) {
+void RenderOpenGL::DrawImage(GraphicsImage *img, const Recti &rect, uint paletteid, uint32_t uColor32) {
     if (!img) {
         logger->verbose("Null img passed to DrawImage");
         return;
@@ -835,7 +835,7 @@ void RenderOpenGL::DrawImage(Image *img, const Recti &rect, uint paletteid, uint
 }
 
 // TODO(pskelton): zbuffer must go
-void RenderOpenGL::ZDrawTextureAlpha(float u, float v, Image *img, int zVal) {
+void RenderOpenGL::ZDrawTextureAlpha(float u, float v, GraphicsImage *img, int zVal) {
     if (!img) return;
 
     int uOutX = static_cast<int>(u * outputRender.w);
@@ -861,8 +861,8 @@ void RenderOpenGL::ZDrawTextureAlpha(float u, float v, Image *img, int zVal) {
 
 // TODO(pskelton): sort this - forcing the draw is slow
 // TODO(pskelton): stencil masking with opacity would be a better way to do this
-void RenderOpenGL::BlendTextures(int x, int y, Image *imgin, Image *imgblend, int time, int start_opacity,
-    int end_opacity) {
+void RenderOpenGL::BlendTextures(int x, int y, GraphicsImage *imgin, GraphicsImage *imgblend, int time, int start_opacity,
+                                 int end_opacity) {
     // thrown together as a crude estimate of the enchaintg effects
     // leaves gap where it shouldnt on dark pixels currently
     // doesnt use opacity params
@@ -948,7 +948,7 @@ void RenderOpenGL::BlendTextures(int x, int y, Image *imgin, Image *imgblend, in
 //----- (004A65CC) --------------------------------------------------------
 //_4A65CC(unsigned int x, unsigned int y, Texture_MM7 *a4, Texture_MM7 *a5, int a6, int a7, int a8)
 // a6 is time, a7 is 0, a8 is 63
-void RenderOpenGL::TexturePixelRotateDraw(float u, float v, Image *img, int time) {
+void RenderOpenGL::TexturePixelRotateDraw(float u, float v, GraphicsImage *img, int time) {
     // TODO(pskelton): sort this - precalculate/ shader
     static std::array<Texture *, 14> cachedtemp {};
     static std::array<int, 14> cachetime { -1 };
@@ -3046,7 +3046,7 @@ void RenderOpenGL::BeginScene2D() {
 }
 
 // TODO(pskelton): use alpha from mask too
-void RenderOpenGL::DrawTextureNew(float u, float v, Image *tex, uint32_t colourmask) {
+void RenderOpenGL::DrawTextureNew(float u, float v, GraphicsImage *tex, uint32_t colourmask) {
     TextureOpenGL *texture = dynamic_cast<TextureOpenGL *>(tex);
     if (!texture) {
         logger->verbose("Null texture passed to DrawTextureNew");
@@ -3174,7 +3174,7 @@ void RenderOpenGL::DrawTextureNew(float u, float v, Image *tex, uint32_t colourm
 }
 
 // TODO(pskelton): add optional colour32
-void RenderOpenGL::DrawTextureCustomHeight(float u, float v, class Image *img, int custom_height) {
+void RenderOpenGL::DrawTextureCustomHeight(float u, float v, class GraphicsImage *img, int custom_height) {
     TextureOpenGL *texture = dynamic_cast<TextureOpenGL*>(img);
     if (!texture) {
         logger->verbose("Null texture passed to DrawTextureCustomHeight");
@@ -5873,7 +5873,7 @@ void RenderOpenGL::NuklearFontFree(struct nk_tex_font *tfont) {
         glDeleteTextures(1, &tfont->texid);
 }
 
-struct nk_image RenderOpenGL::NuklearImageLoad(Image *img) {
+struct nk_image RenderOpenGL::NuklearImageLoad(GraphicsImage *img) {
     GLuint texid;
     auto t = (TextureOpenGL *)img;
     texid = t->GetOpenGlTexture();
@@ -5882,7 +5882,7 @@ struct nk_image RenderOpenGL::NuklearImageLoad(Image *img) {
     return nk_image_id(texid);
 }
 
-void RenderOpenGL::NuklearImageFree(Image *img) {
+void RenderOpenGL::NuklearImageFree(GraphicsImage *img) {
     auto t = (TextureOpenGL *)img;
     GLuint texid = t->GetOpenGlTexture();
     if (texid != -1) {

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -33,8 +33,8 @@ class RenderOpenGL : public RenderBase {
     virtual void NuklearRelease() override;
     virtual struct nk_tex_font *NuklearFontLoad(const char *font_path, size_t font_size) override;
     virtual void NuklearFontFree(struct nk_tex_font *tfont) override;
-    virtual struct nk_image NuklearImageLoad(Image *img) override;
-    virtual void NuklearImageFree(Image *img) override;
+    virtual struct nk_image NuklearImageLoad(GraphicsImage *img) override;
+    virtual void NuklearImageFree(GraphicsImage *img) override;
 
     virtual Texture *CreateTexture_Paletted(const std::string &name) override;
     virtual Texture *CreateTexture_ColorKey(const std::string &name, Color colorkey) override;
@@ -99,18 +99,18 @@ class RenderOpenGL : public RenderBase {
                                unsigned int uZ, unsigned int uW) override;
     virtual void ResetUIClipRect() override;
 
-    virtual void DrawTextureNew(float u, float v, class Image *, uint32_t colourmask = 0xFFFFFFFF) override;
+    virtual void DrawTextureNew(float u, float v, class GraphicsImage *, uint32_t colourmask = 0xFFFFFFFF) override;
 
-        virtual void DrawTextureCustomHeight(float u, float v, class Image *,
+        virtual void DrawTextureCustomHeight(float u, float v, class GraphicsImage *,
                                          int height) override;
     virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y,
-                                   Image *) override;
-    virtual void DrawImage(Image *, const Recti &rect, uint paletteid = 0, uint32_t colourmask32 = 0xFFFFFFFF) override;
+                                   GraphicsImage *) override;
+    virtual void DrawImage(GraphicsImage *, const Recti &rect, uint paletteid = 0, uint32_t colourmask32 = 0xFFFFFFFF) override;
 
-    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal) override;
-    virtual void BlendTextures(int a2, int a3, Image *a4, Image *a5, int t,
+    virtual void ZDrawTextureAlpha(float u, float v, GraphicsImage *pTexture, int zVal) override;
+    virtual void BlendTextures(int a2, int a3, GraphicsImage *a4, GraphicsImage *a5, int t,
                                int start_opacity, int end_opacity) override;
-    virtual void TexturePixelRotateDraw(float u, float v, Image *img, int time) override;
+    virtual void TexturePixelRotateDraw(float u, float v, GraphicsImage *img, int time) override;
 
     virtual void BeginTextNew(Texture *main, Texture *shadow) override;
     virtual void EndTextNew() override;

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -641,26 +641,26 @@ Blob RenderBase::PackScreenshot(const unsigned int width, const unsigned int hei
     return packedPCX;
 }
 
-Image *RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {
+GraphicsImage *RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {
     Color *pixels = MakeScreenshot32(width, height);
-    Image *image = Image::Create(width, height, pixels);
+    GraphicsImage *image = GraphicsImage::Create(width, height, pixels);
     free(pixels);
     return image;
 }
 
-void RenderBase::DrawTextureGrayShade(float a2, float a3, Image *a4) {
+void RenderBase::DrawTextureGrayShade(float a2, float a3, GraphicsImage *a4) {
     DrawMasked(a2, a3, a4, 1, colorTable.MediumGrey.c32());
 }
 
-void RenderBase::DrawTransparentRedShade(float u, float v, Image *a4) {
+void RenderBase::DrawTransparentRedShade(float u, float v, GraphicsImage *a4) {
     DrawMasked(u, v, a4, 0, colorTable.Red.c32());
 }
 
-void RenderBase::DrawTransparentGreenShade(float u, float v, Image *pTexture) {
+void RenderBase::DrawTransparentGreenShade(float u, float v, GraphicsImage *pTexture) {
     DrawMasked(u, v, pTexture, 0, colorTable.Green.c32());
 }
 
-void RenderBase::DrawMasked(float u, float v, Image *pTexture, unsigned int color_dimming_level, uint32_t mask) {
+void RenderBase::DrawMasked(float u, float v, GraphicsImage *pTexture, unsigned int color_dimming_level, uint32_t mask) {
     int b = ((mask >> 16) & 0xFF) & (0xFF >> color_dimming_level);
     int g = ((mask >> 8) & 0xFF) & (0xFF >> color_dimming_level);
     int r = ((mask) & 0xFF) & (0xFF >> color_dimming_level);

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -37,13 +37,13 @@ class RenderBase : public IRender {
     * @return                              Returns Blob containing packed pcx data and its size.
     */
     virtual Blob PackScreenshot(const unsigned int width, const unsigned int height) override;
-    virtual Image *TakeScreenshot(unsigned int width, unsigned int height) override;
+    virtual GraphicsImage *TakeScreenshot(unsigned int width, unsigned int height) override;
 
-    virtual void DrawMasked(float u, float v, class Image *img,
+    virtual void DrawMasked(float u, float v, class GraphicsImage *img,
         unsigned int color_dimming_level, uint32_t mask = 0xFFFFFFFF) override;
-    virtual void DrawTextureGrayShade(float u, float v, class Image *a4) override;
-    virtual void DrawTransparentRedShade(float u, float v, class Image *a4) override;
-    virtual void DrawTransparentGreenShade(float u, float v, class Image *pTexture) override;
+    virtual void DrawTextureGrayShade(float u, float v, class GraphicsImage *a4) override;
+    virtual void DrawTransparentRedShade(float u, float v, class GraphicsImage *a4) override;
+    virtual void DrawTransparentGreenShade(float u, float v, class GraphicsImage *pTexture) override;
     virtual void ClearBlack() override;
     virtual void BillboardSphereSpellFX(struct SpellFX_Billboard *a1, int diffuse) override;
     virtual void DrawMonsterPortrait(Recti rc, SpriteFrame *Portrait_Sprite, int Y_Offset) override;

--- a/src/Engine/Graphics/Texture.h
+++ b/src/Engine/Graphics/Texture.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "Engine/Graphics/Image.h"
 
-class Texture : public Image {
+class Texture : public GraphicsImage {
  protected:
     explicit Texture(bool lazy_initialization = true)
-        : Image(lazy_initialization) {}
+        : GraphicsImage(lazy_initialization) {}
 };

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -4,6 +4,8 @@
 
 #include "Library/Color/Color.h"
 
+class GraphicsImage;
+
 // TODO(pskelton): combined viewport and viewing params?? or at least not have multiple places
 // where screen coords and viewport coords are held
 
@@ -73,7 +75,7 @@ struct ViewingParams {
     int16_t indoor_center_x = 0;
     int16_t indoor_center_y = 0;
     int field_3C = 0;
-    class Image *location_minimap = nullptr;  // unsigned int uTextureID_LocationMap; ::40
+    GraphicsImage *location_minimap = nullptr;  // unsigned int uTextureID_LocationMap; ::40
     int field_4C = 0;
     int draw_sw_outlines = 0;
     int draw_d3d_outlines = 0;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -84,7 +84,7 @@ void Actor::DrawHealthBar(Actor *actor, GUIWindow *window) {
         bar_length = 200;
 
     // bar colour
-    Image *bar_image = game_ui_monster_hp_green;
+    GraphicsImage *bar_image = game_ui_monster_hp_green;
     if (actor->sCurrentHP <= (0.34 * actor->pMonsterInfo.uHP))
         bar_image = game_ui_monster_hp_red;
     else if (actor->sCurrentHP <= (0.67 * actor->pMonsterInfo.uHP))

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -312,7 +312,7 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
         }
     }
 
-    Image *texture = assets->getImage_ColorKey(put_item->GetIconName());
+    GraphicsImage *texture = assets->getImage_ColorKey(put_item->GetIconName());
     unsigned int slot_width = GetSizeInInventorySlots(texture->GetWidth());
     unsigned int slot_height = GetSizeInInventorySlots(texture->GetHeight());
 

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -30,7 +30,7 @@
 
 
 int pDialogueNPCCount;
-std::array<class Image *, 6> pDialogueNPCPortraits;
+std::array<class GraphicsImage *, 6> pDialogueNPCPortraits;
 int uNumDialogueNPCPortraits;
 struct NPCStats *pNPCStats = nullptr;
 

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -121,7 +121,7 @@ struct NPCStats {
 };
 
 extern int pDialogueNPCCount;
-extern std::array<class Image *, 6> pDialogueNPCPortraits;
+extern std::array<class GraphicsImage *, 6> pDialogueNPCPortraits;
 extern int uNumDialogueNPCPortraits;
 extern struct NPCStats *pNPCStats;
 

--- a/src/Engine/Objects/Player.h
+++ b/src/Engine/Objects/Player.h
@@ -47,7 +47,7 @@ struct LloydBeacon {
     int16_t _partyViewPitch;
     uint16_t unknown;
     uint16_t SaveFileID;
-    Image *image;
+    GraphicsImage *image;
 };
 
 struct PlayerSpellbookChapter {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -198,7 +198,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
                 continue;
             }
             LloydBeacon *beacon = &player->vBeacons[j];
-            Image *image = beacon->image;
+            GraphicsImage *image = beacon->image;
             if ((beacon->uBeaconTime.Valid()) && (image != nullptr)) {
                 const Color *pixels = image->GetPixels();
                 if (!pixels)

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -22,7 +22,7 @@ struct SavegameList {
     std::array<std::string, MAX_SAVE_SLOTS> pFileList;
     std::array<bool, MAX_SAVE_SLOTS> pSavegameUsedSlots;
     std::array<SaveGameHeader, MAX_SAVE_SLOTS> pSavegameHeader;
-    std::array<class Image *, MAX_SAVE_SLOTS> pSavegameThumbnails;
+    std::array<class GraphicsImage *, MAX_SAVE_SLOTS> pSavegameThumbnails;
 
     int numSavegameFiles = 0;
     int selectedSlot = 0;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2465,7 +2465,7 @@ int AfterEnchClickEventTimeout;
 unsigned int uNumBlueFacesInBLVMinimap;
 std::array<uint16_t, 50> pBlueFacesInBLVMinimapIDs;
 
-std::array<class Image *, 14> party_buff_icons;
+std::array<class GraphicsImage *, 14> party_buff_icons;
 unsigned int uIconIdx_FlySpell;
 unsigned int uIconIdx_WaterWalk;
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -99,7 +99,7 @@ extern int AfterEnchClickEventTimeout; // 50C9D8 Timer before event "AfterEnchCl
 extern unsigned int uNumBlueFacesInBLVMinimap;
 extern std::array<uint16_t, 50> pBlueFacesInBLVMinimapIDs;
 
-extern std::array<class Image *, 14> party_buff_icons;
+extern std::array<class GraphicsImage *, 14> party_buff_icons;
 extern unsigned int uIconIdx_FlySpell;
 extern unsigned int uIconIdx_WaterWalk;
 

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -6,7 +6,7 @@
 
 #include "GUI/GUIWindow.h"
 
-class Image;
+class GraphicsImage;
 
 class GUIButton {
  public:
@@ -32,7 +32,7 @@ class GUIButton {
     int field_28 = 0;
     bool field_2C_is_pushed = false;
     GUIWindow *pParent = nullptr;
-    std::vector<Image*> vTextures;
+    std::vector<GraphicsImage*> vTextures;
     InputAction action = InputAction::Invalid;
     std::string sLabel = "";
     std::string field_75 = "";

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -737,7 +737,7 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
 
 void GUIFont::DrawCreditsEntry(GUIFont *pSecondFont, int uFrameX, int uFrameY, unsigned int w, unsigned int h,
                                Color firstColor, Color secondColor, const std::string &pString,
-    Image *image) {
+                               GraphicsImage *image) {
     GUIWindow draw_window;
     draw_window.uFrameHeight = h;
     draw_window.uFrameW = uFrameY + h - 1;

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -31,7 +31,7 @@ struct FontData {
 };
 
 class GUIWindow;
-class Image;
+class GraphicsImage;
 class Texture;
 struct FontData;
 
@@ -69,7 +69,7 @@ class GUIFont {
     void DrawCreditsEntry(GUIFont *pSecondFont, int uFrameX, int uFrameY,
                           unsigned int w, unsigned int h, Color firstColor,
                           Color secondColor, const std::string &pString,
-                          Image *image);
+                          GraphicsImage *image);
     int GetStringHeight2(GUIFont *secondFont, const std::string &text_str,
                          GUIWindow *pWindow, int startX, int a6);
 

--- a/src/GUI/GUIProgressBar.h
+++ b/src/GUI/GUIProgressBar.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-class Image;
+class GraphicsImage;
 
 class GUIProgressBar {
  public:
@@ -30,9 +30,9 @@ class GUIProgressBar {
     uint8_t uProgressCurrent = 0;
     Type uType = TYPE_None;
 
-    Image *progressbar_dungeon = nullptr;  // struct Texture_MM7 pBardata;
-    Image *progressbar_loading = nullptr;  // struct Texture_MM7 pLoadingProgress;
-    Image *loading_bg = nullptr;
+    GraphicsImage *progressbar_dungeon = nullptr;  // struct Texture_MM7 pBardata;
+    GraphicsImage *progressbar_loading = nullptr;  // struct Texture_MM7 pLoadingProgress;
+    GraphicsImage *loading_bg = nullptr;
 };
 
 extern GUIProgressBar *pGameLoadingUI_ProgressBar;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -76,24 +76,24 @@ enum CURRENT_SCREEN prev_screen_type;
 struct GUIMessageQueue *pCurrentFrameMessageQueue = new GUIMessageQueue;
 struct GUIMessageQueue *pNextFrameMessageQueue = new GUIMessageQueue;
 
-Image *ui_exit_cancel_button_background = nullptr;
-Image *game_ui_right_panel_frame = nullptr;
-Image *dialogue_ui_x_ok_u = nullptr;
-Image *dialogue_ui_x_x_u = nullptr;
+GraphicsImage *ui_exit_cancel_button_background = nullptr;
+GraphicsImage *game_ui_right_panel_frame = nullptr;
+GraphicsImage *dialogue_ui_x_ok_u = nullptr;
+GraphicsImage *dialogue_ui_x_x_u = nullptr;
 
-Image *ui_buttdesc2 = nullptr;
-Image *ui_buttyes2 = nullptr;
+GraphicsImage *ui_buttdesc2 = nullptr;
+GraphicsImage *ui_buttyes2 = nullptr;
 
-Image *ui_btn_npc_right = nullptr;
-Image *ui_btn_npc_left = nullptr;
+GraphicsImage *ui_btn_npc_right = nullptr;
+GraphicsImage *ui_btn_npc_left = nullptr;
 
-Image *ui_ar_dn_dn = nullptr;
-Image *ui_ar_dn_up = nullptr;
-Image *ui_ar_up_dn = nullptr;
-Image *ui_ar_up_up = nullptr;
+GraphicsImage *ui_ar_dn_dn = nullptr;
+GraphicsImage *ui_ar_dn_up = nullptr;
+GraphicsImage *ui_ar_up_dn = nullptr;
+GraphicsImage *ui_ar_up_up = nullptr;
 
-Image *ui_leather_mm6 = nullptr;
-Image *ui_leather_mm7 = nullptr;
+GraphicsImage *ui_leather_mm6 = nullptr;
+GraphicsImage *ui_leather_mm7 = nullptr;
 
 DIALOGUE_TYPE _dword_F8B1D8_last_npc_topic_menu;
 AwardType dword_F8B1AC_award_bit_number;
@@ -396,7 +396,7 @@ GUIButton *GUIWindow::CreateButton(Pointi position, Sizei dimensions,
                                    int uButtonType, int uData, UIMessageType msg,
                                    unsigned int msg_param, InputAction action,
                                    const std::string &label,
-                                   const std::vector<Image *> &textures) {
+                                   const std::vector<GraphicsImage *> &textures) {
     GUIButton *pButton = new GUIButton();
 
     pButton->pParent = this;
@@ -427,7 +427,7 @@ GUIButton *GUIWindow::CreateButton(Pointi position, Sizei dimensions,
 
 GUIButton *GUIWindow::CreateButton(std::string id, Pointi position, Sizei dimensions, int uButtonType, int uData,
                         UIMessageType msg, unsigned int msg_param, InputAction action, const std::string &label,
-                        const std::vector<Image *> &textures) {
+                        const std::vector<GraphicsImage *> &textures) {
     GUIButton *result = CreateButton(position, dimensions, uButtonType, uData, msg, msg_param, action, label, textures);
     result->id = std::move(id);
     return result;

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -48,11 +48,11 @@ class GUIWindow {
 
     GUIButton *CreateButton(Pointi position, Sizei dimensions, int uButtonType, int uData,
                             UIMessageType msg, unsigned int msg_param, InputAction action = InputAction::Invalid, const std::string &label = {},
-                            const std::vector<Image *> &textures = {});
+                            const std::vector<GraphicsImage *> &textures = {});
 
     GUIButton *CreateButton(std::string id, Pointi position, Sizei dimensions, int uButtonType, int uData,
                             UIMessageType msg, unsigned int msg_param, InputAction action = InputAction::Invalid, const std::string &label = {},
-                            const std::vector<Image *> &textures = {});
+                            const std::vector<GraphicsImage *> &textures = {});
 
     bool Contains(unsigned int x, unsigned int y);
     void DrawFlashingInputCursor(int uX, int uY, GUIFont *a2);
@@ -457,25 +457,25 @@ extern Color ui_game_dialogue_option_highlight_color;
 extern Color ui_game_dialogue_option_normal_color;
 extern Color ui_house_player_cant_interact_color;
 
-class Image;
-extern Image *ui_exit_cancel_button_background;
-extern Image *game_ui_right_panel_frame;
-extern Image *dialogue_ui_x_ok_u;
-extern Image *dialogue_ui_x_x_u;
+class GraphicsImage;
+extern GraphicsImage *ui_exit_cancel_button_background;
+extern GraphicsImage *game_ui_right_panel_frame;
+extern GraphicsImage *dialogue_ui_x_ok_u;
+extern GraphicsImage *dialogue_ui_x_x_u;
 
-extern Image *ui_buttdesc2;
-extern Image *ui_buttyes2;
+extern GraphicsImage *ui_buttdesc2;
+extern GraphicsImage *ui_buttyes2;
 
-extern Image *ui_btn_npc_right;
-extern Image *ui_btn_npc_left;
+extern GraphicsImage *ui_btn_npc_right;
+extern GraphicsImage *ui_btn_npc_left;
 
-extern Image *ui_ar_dn_dn;
-extern Image *ui_ar_dn_up;
-extern Image *ui_ar_up_dn;
-extern Image *ui_ar_up_up;
+extern GraphicsImage *ui_ar_dn_dn;
+extern GraphicsImage *ui_ar_dn_up;
+extern GraphicsImage *ui_ar_up_dn;
+extern GraphicsImage *ui_ar_up_up;
 
-extern Image *ui_leather_mm6;
-extern Image *ui_leather_mm7;
+extern GraphicsImage *ui_leather_mm6;
+extern GraphicsImage *ui_leather_mm7;
 
 extern MENU_STATE sCurrentMenuID;
 void SetCurrentMenuID(MENU_STATE);

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -15,7 +15,7 @@
 
 #include "Media/Audio/AudioPlayer.h"
 
-Image *ui_book_autonotes_background = nullptr;
+GraphicsImage *ui_book_autonotes_background = nullptr;
 
 AUTONOTE_TYPE autonoteBookDisplayType;
 

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -16,13 +16,13 @@
 
 #include "Media/Audio/AudioPlayer.h"
 
-Image *ui_book_calendar_background = nullptr;
+GraphicsImage *ui_book_calendar_background = nullptr;
 
-Image *ui_book_calendar_moon_new = nullptr;
-Image *ui_book_calendar_moon_4 = nullptr;
-Image *ui_book_calendar_moon_2 = nullptr;
-Image *ui_book_calendar_moon_2_2 = nullptr;
-Image *ui_book_calendar_moon_full = nullptr;
+GraphicsImage *ui_book_calendar_moon_new = nullptr;
+GraphicsImage *ui_book_calendar_moon_4 = nullptr;
+GraphicsImage *ui_book_calendar_moon_2 = nullptr;
+GraphicsImage *ui_book_calendar_moon_2_2 = nullptr;
+GraphicsImage *ui_book_calendar_moon_full = nullptr;
 
 // 4E1B18
 static std::array<int, 28> pDayMoonPhase = {

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -21,7 +21,7 @@
 
 #include "Utility/Memory/MemSet.h"
 
-Image *ui_book_journal_background = nullptr;
+GraphicsImage *ui_book_journal_background = nullptr;
 
 GUIWindow_JournalBook::GUIWindow_JournalBook() : _currentIdx(0), GUIWindow_Book() {
     eWindowType = WINDOW_JournalBook;

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -22,8 +22,8 @@ bool bRecallingBeacon;
 int lloydsBeaconCasterId;
 int lloydsBeaconSpellDuration;
 
-Image *ui_book_lloyds_border = nullptr;
-std::array<Image *, 2> ui_book_lloyds_backgrounds;
+GraphicsImage *ui_book_lloyds_border = nullptr;
+std::array<GraphicsImage *, 2> ui_book_lloyds_backgrounds;
 
 GUIWindow_LloydsBook::GUIWindow_LloydsBook() : GUIWindow_Book() {
     this->eWindowType = WindowType::WINDOW_LloydsBeacon;

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -25,7 +25,7 @@
 
 void DrawBook_Map_sub(unsigned int tl_x, unsigned int tl_y, unsigned int br_x, int br_y, int dummy);
 
-Image *ui_book_map_background = nullptr;
+GraphicsImage *ui_book_map_background = nullptr;
 
 GUIWindow_MapBook::GUIWindow_MapBook() : GUIWindow_Book() {
     this->wData.val = WINDOW_MapsBook;  // inherited from GUIWindow::GUIWindow

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -17,7 +17,7 @@
 
 #include "Media/Audio/AudioPlayer.h"
 
-Image *ui_book_quests_background = nullptr;
+GraphicsImage *ui_book_quests_background = nullptr;
 
 GUIWindow_QuestBook::GUIWindow_QuestBook() : _startingQuestIdx(0), _currentPage(0), _currentPageQuests(0), GUIWindow_Book() {
     this->wData.val = WINDOW_QuestBook;  // inherited from GUIWindow::GUIWindow

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -17,7 +17,7 @@ static std::array<int, TOWN_PORTAL_DESTINATION_COUNT> pTownPortalBook_ys = {206,
 static std::array<int, TOWN_PORTAL_DESTINATION_COUNT> pTownPortalBook_ws = {80, 66, 68, 72, 67, 74};
 static std::array<int, TOWN_PORTAL_DESTINATION_COUNT> pTownPortalBook_hs = {55, 56, 65, 67, 67, 59};
 
-static std::array<Image *, TOWN_PORTAL_DESTINATION_COUNT> ui_book_townportal_icons;
+static std::array<GraphicsImage *, TOWN_PORTAL_DESTINATION_COUNT> ui_book_townportal_icons;
 
 std::array<int, TOWN_PORTAL_DESTINATION_COUNT> townPortalQuestBits = {
         QBIT_FOUNTAIN_IN_HARMONDALE_ACTIVATED,
@@ -27,7 +27,7 @@ std::array<int, TOWN_PORTAL_DESTINATION_COUNT> townPortalQuestBits = {
         QBIT_FOUNTAIN_IN_CELESTIA_ACTIVATED,
         QBIT_FOUNTAIN_IN_THE_PIT_ACTIVATED};
 
-Image *ui_book_townportal_background = nullptr;
+GraphicsImage *ui_book_townportal_background = nullptr;
 
 int townPortalCasterPid;
 

--- a/src/GUI/UI/UIBooks.cpp
+++ b/src/GUI/UI/UIBooks.cpp
@@ -12,26 +12,26 @@
 
 #include "Media/Audio/AudioPlayer.h"
 
-Image *ui_book_button8_off = nullptr;
-Image *ui_book_button8_on = nullptr;
-Image *ui_book_button7_off = nullptr;
-Image *ui_book_button7_on = nullptr;
-Image *ui_book_button6_off = nullptr;
-Image *ui_book_button6_on = nullptr;
-Image *ui_book_button5_off = nullptr;
-Image *ui_book_button5_on = nullptr;
-Image *ui_book_button4_off = nullptr;
-Image *ui_book_button4_on = nullptr;
-Image *ui_book_button3_off = nullptr;
-Image *ui_book_button3_on = nullptr;
-Image *ui_book_button2_off = nullptr;
-Image *ui_book_button2_on = nullptr;
-Image *ui_book_button1_off = nullptr;
-Image *ui_book_button1_on = nullptr;
+GraphicsImage *ui_book_button8_off = nullptr;
+GraphicsImage *ui_book_button8_on = nullptr;
+GraphicsImage *ui_book_button7_off = nullptr;
+GraphicsImage *ui_book_button7_on = nullptr;
+GraphicsImage *ui_book_button6_off = nullptr;
+GraphicsImage *ui_book_button6_on = nullptr;
+GraphicsImage *ui_book_button5_off = nullptr;
+GraphicsImage *ui_book_button5_on = nullptr;
+GraphicsImage *ui_book_button4_off = nullptr;
+GraphicsImage *ui_book_button4_on = nullptr;
+GraphicsImage *ui_book_button3_off = nullptr;
+GraphicsImage *ui_book_button3_on = nullptr;
+GraphicsImage *ui_book_button2_off = nullptr;
+GraphicsImage *ui_book_button2_on = nullptr;
+GraphicsImage *ui_book_button1_off = nullptr;
+GraphicsImage *ui_book_button1_on = nullptr;
 
-Image *ui_book_map_frame = nullptr;
+GraphicsImage *ui_book_map_frame = nullptr;
 
-Image *ui_book_quest_div_bar = nullptr;
+GraphicsImage *ui_book_quest_div_bar = nullptr;
 
 bool bookButtonClicked;
 BOOK_BUTTON_ACTION bookButtonAction;

--- a/src/GUI/UI/UIBooks.h
+++ b/src/GUI/UI/UIBooks.h
@@ -47,26 +47,26 @@ class GUIWindow_BooksButtonOverlay : public GUIWindow {
     virtual void Update();
 };
 
-class Image;
-extern Image *ui_book_button8_off;
-extern Image *ui_book_button8_on;
-extern Image *ui_book_button7_off;
-extern Image *ui_book_button7_on;
-extern Image *ui_book_button6_off;
-extern Image *ui_book_button6_on;
-extern Image *ui_book_button5_off;
-extern Image *ui_book_button5_on;
-extern Image *ui_book_button4_off;
-extern Image *ui_book_button4_on;
-extern Image *ui_book_button3_off;
-extern Image *ui_book_button3_on;
-extern Image *ui_book_button2_off;
-extern Image *ui_book_button2_on;
-extern Image *ui_book_button1_off;
-extern Image *ui_book_button1_on;
+class GraphicsImage;
+extern GraphicsImage *ui_book_button8_off;
+extern GraphicsImage *ui_book_button8_on;
+extern GraphicsImage *ui_book_button7_off;
+extern GraphicsImage *ui_book_button7_on;
+extern GraphicsImage *ui_book_button6_off;
+extern GraphicsImage *ui_book_button6_on;
+extern GraphicsImage *ui_book_button5_off;
+extern GraphicsImage *ui_book_button5_on;
+extern GraphicsImage *ui_book_button4_off;
+extern GraphicsImage *ui_book_button4_on;
+extern GraphicsImage *ui_book_button3_off;
+extern GraphicsImage *ui_book_button3_on;
+extern GraphicsImage *ui_book_button2_off;
+extern GraphicsImage *ui_book_button2_on;
+extern GraphicsImage *ui_book_button1_off;
+extern GraphicsImage *ui_book_button1_on;
 
-extern Image *ui_book_map_frame;
-extern Image *ui_book_quest_div_bar;
+extern GraphicsImage *ui_book_map_frame;
+extern GraphicsImage *ui_book_quest_div_bar;
 
 extern bool bookButtonClicked;
 extern BOOK_BUTTON_ACTION bookButtonAction;

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -212,20 +212,20 @@ void set_default_ui_skin() {
     ui_house_player_cant_interact_color = colorTable.PaleCanary;
 }
 
-Image *paperdoll_drhs[4];
-Image *paperdoll_dlhus[4];
-Image *paperdoll_dlhs[4];
-Image *paperdoll_dbods[5];
-Image *paperdoll_armor_texture[4][17][3];  // 0x511294
+GraphicsImage *paperdoll_drhs[4];
+GraphicsImage *paperdoll_dlhus[4];
+GraphicsImage *paperdoll_dlhs[4];
+GraphicsImage *paperdoll_dbods[5];
+GraphicsImage *paperdoll_armor_texture[4][17][3];  // 0x511294
 // int paperdoll_array_51132C[165];
-Image *paperdoll_dlaus[5];
-Image *paperdoll_dlads[4];
-Image *paperdoll_flying_feet[22];      // 005115E0
-Image *paperdoll_boots_texture[4][6];  // 511638
-Image *paperdoll_cloak_collar_texture[4][10];
-Image *paperdoll_cloak_texture[4][10];
-Image *paperdoll_helm_texture[2][16];  // 511698
-Image *paperdoll_belt_texture[4][7];   // 511718
+GraphicsImage *paperdoll_dlaus[5];
+GraphicsImage *paperdoll_dlads[4];
+GraphicsImage *paperdoll_flying_feet[22];      // 005115E0
+GraphicsImage *paperdoll_boots_texture[4][6];  // 511638
+GraphicsImage *paperdoll_cloak_collar_texture[4][10];
+GraphicsImage *paperdoll_cloak_texture[4][10];
+GraphicsImage *paperdoll_helm_texture[2][16];  // 511698
+GraphicsImage *paperdoll_belt_texture[4][7];   // 511718
 
 const int paperdoll_Weapon[4][16][2] = {
     // 4E4C30
@@ -551,19 +551,19 @@ const char *dlhu_texnames_by_face[25] = {
     "pc15lhu", "pc16lhu", "pc17lhu", "pc18lhu", "pc19lhu", "pc20lhu", "pc21lhu",
     "pc22lhu", "pc23lhu", "pc24lhu", "pc25lhu"};
 
-Image *ui_character_skills_background = nullptr;
-Image *ui_character_awards_background = nullptr;
-Image *ui_character_stats_background = nullptr;
-Image *ui_character_inventory_background = nullptr;
-Image *ui_character_inventory_background_strip = nullptr;
-Image *ui_character_inventory_magnification_glass = nullptr;
-Image *ui_character_inventory_paperdoll_background = nullptr;
-Image *ui_character_inventory_paperdoll_rings_background = nullptr;
-Image *ui_character_inventory_paperdoll_rings_close = nullptr;
+GraphicsImage *ui_character_skills_background = nullptr;
+GraphicsImage *ui_character_awards_background = nullptr;
+GraphicsImage *ui_character_stats_background = nullptr;
+GraphicsImage *ui_character_inventory_background = nullptr;
+GraphicsImage *ui_character_inventory_background_strip = nullptr;
+GraphicsImage *ui_character_inventory_magnification_glass = nullptr;
+GraphicsImage *ui_character_inventory_paperdoll_background = nullptr;
+GraphicsImage *ui_character_inventory_paperdoll_rings_background = nullptr;
+GraphicsImage *ui_character_inventory_paperdoll_rings_close = nullptr;
 
-static Image *scrollstop = nullptr;
+static GraphicsImage *scrollstop = nullptr;
 
-std::array<Image *, 16> paperdoll_dbrds;
+std::array<GraphicsImage *, 16> paperdoll_dbrds;
 
 int savedInventoryLeftClickButtonW;
 int savedInventoryLeftClickButtonZ;
@@ -1324,7 +1324,7 @@ void CharacterUI_InventoryTab_Draw(Player *player, bool Cover_Strip) {
         unsigned int uCellY = 32 * (i / 14) + 17;
         unsigned int uCellX = 32 * (i % 14) + 14;
 
-        Image *pTexture = assets->getImage_Alpha(player->pInventoryItemList[player->pInventoryMatrix[i] - 1].GetIconName());
+        GraphicsImage *pTexture = assets->getImage_Alpha(player->pInventoryItemList[player->pInventoryMatrix[i] - 1].GetIconName());
 
         int width = pTexture->GetWidth();
         int height = pTexture->GetHeight();
@@ -1342,7 +1342,7 @@ static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, Texture *i
         item_texture = assets->getImage_Alpha(item->GetIconName());
 
     if (item->ItemEnchanted()) { // enchant animation
-        Image *enchantment_texture = nullptr;
+        GraphicsImage *enchantment_texture = nullptr;
         if (item->AuraEffectRed())
             enchantment_texture = assets->getImage_ColorKey("sptext01");
         else if (item->AuraEffectBlue())

--- a/src/GUI/UI/UICharacter.h
+++ b/src/GUI/UI/UICharacter.h
@@ -55,12 +55,12 @@ class GUIWindow_CharacterRecord : public GUIWindow {
 bool ringscreenactive();
 static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, Texture *item_texture = nullptr, bool doZDraw = false);
 
-class Image;
-extern Image *ui_character_skills_background;
-extern Image *ui_character_awards_background;
-extern Image *ui_character_stats_background;
-extern Image *ui_character_inventory_background;
-extern Image *ui_character_inventory_background_strip;
-extern Image *ui_character_inventory_paperdoll_background;
+class GraphicsImage;
+extern GraphicsImage *ui_character_skills_background;
+extern GraphicsImage *ui_character_awards_background;
+extern GraphicsImage *ui_character_stats_background;
+extern GraphicsImage *ui_character_inventory_background;
+extern GraphicsImage *ui_character_inventory_background_strip;
+extern GraphicsImage *ui_character_inventory_paperdoll_background;
 
-extern std::array<Image *, 16> paperdoll_dbrds;
+extern std::array<GraphicsImage *, 16> paperdoll_dbrds;

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -49,7 +49,7 @@ void GUIWindow_Chest::Update() {
         int chestWidthCells = pChestWidthsByType[chestBitmapId];
         int chestHeghtCells = pChestHeightsByType[chestBitmapId];
 
-        Image *chest_background = assets->getImage_ColorKey(
+        GraphicsImage *chest_background = assets->getImage_ColorKey(
             fmt::format("chest{:02}", pChestList->vChests[chestBitmapId].uTextureID));
         render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, chest_background);
 

--- a/src/GUI/UI/UICredits.h
+++ b/src/GUI/UI/UICredits.h
@@ -18,7 +18,7 @@ class GUICredits : public GUIWindow {
     GUIFont *pFontQuick;
     GUIFont *pFontCChar;
 
-    Image *mm6title;
+    GraphicsImage *mm6title;
 
     int width;
     int height;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -84,73 +84,73 @@ std::array<PARTY_BUFF_INDEX, 14> spellBuffsAtRightPanel = {
      PARTY_BUFF_SHIELD, PARTY_BUFF_STONE_SKIN, PARTY_BUFF_PROTECTION_FROM_MAGIC,
      PARTY_BUFF_IMMOLATION, PARTY_BUFF_DAY_OF_GODS}};
 
-Image *game_ui_statusbar = nullptr;
-Image *game_ui_rightframe = nullptr;
-Image *game_ui_topframe = nullptr;
-Image *game_ui_leftframe = nullptr;
-Image *game_ui_bottomframe = nullptr;
+GraphicsImage *game_ui_statusbar = nullptr;
+GraphicsImage *game_ui_rightframe = nullptr;
+GraphicsImage *game_ui_topframe = nullptr;
+GraphicsImage *game_ui_leftframe = nullptr;
+GraphicsImage *game_ui_bottomframe = nullptr;
 
-Image *game_ui_monster_hp_green = nullptr;
-Image *game_ui_monster_hp_yellow = nullptr;
-Image *game_ui_monster_hp_red = nullptr;
-Image *game_ui_monster_hp_background = nullptr;
-Image *game_ui_monster_hp_border_left = nullptr;
-Image *game_ui_monster_hp_border_right = nullptr;
+GraphicsImage *game_ui_monster_hp_green = nullptr;
+GraphicsImage *game_ui_monster_hp_yellow = nullptr;
+GraphicsImage *game_ui_monster_hp_red = nullptr;
+GraphicsImage *game_ui_monster_hp_background = nullptr;
+GraphicsImage *game_ui_monster_hp_border_left = nullptr;
+GraphicsImage *game_ui_monster_hp_border_right = nullptr;
 
-Image *game_ui_minimap_frame = nullptr;    // 5079D8
-Image *game_ui_minimap_compass = nullptr;  // 5079B4
-std::array<Image *, 8> game_ui_minimap_dirs;
+GraphicsImage *game_ui_minimap_frame = nullptr;    // 5079D8
+GraphicsImage *game_ui_minimap_compass = nullptr;  // 5079B4
+std::array<GraphicsImage *, 8> game_ui_minimap_dirs;
 
-Image *game_ui_menu_quit = nullptr;
-Image *game_ui_menu_resume = nullptr;
-Image *game_ui_menu_controls = nullptr;
-Image *game_ui_menu_save = nullptr;
-Image *game_ui_menu_load = nullptr;
-Image *game_ui_menu_new = nullptr;
-Image *game_ui_menu_options = nullptr;
+GraphicsImage *game_ui_menu_quit = nullptr;
+GraphicsImage *game_ui_menu_resume = nullptr;
+GraphicsImage *game_ui_menu_controls = nullptr;
+GraphicsImage *game_ui_menu_save = nullptr;
+GraphicsImage *game_ui_menu_load = nullptr;
+GraphicsImage *game_ui_menu_new = nullptr;
+GraphicsImage *game_ui_menu_options = nullptr;
 
-Image *game_ui_tome_storyline = nullptr;
-Image *game_ui_tome_calendar = nullptr;
-Image *game_ui_tome_maps = nullptr;
-Image *game_ui_tome_autonotes = nullptr;
-Image *game_ui_tome_quests = nullptr;
+GraphicsImage *game_ui_tome_storyline = nullptr;
+GraphicsImage *game_ui_tome_calendar = nullptr;
+GraphicsImage *game_ui_tome_maps = nullptr;
+GraphicsImage *game_ui_tome_autonotes = nullptr;
+GraphicsImage *game_ui_tome_quests = nullptr;
 
-Image *game_ui_btn_rest = nullptr;
-Image *game_ui_btn_cast = nullptr;
-Image *game_ui_btn_zoomin = nullptr;
-Image *game_ui_btn_zoomout = nullptr;
-Image *game_ui_btn_quickref = nullptr;
-Image *game_ui_btn_settings = nullptr;
+GraphicsImage *game_ui_btn_rest = nullptr;
+GraphicsImage *game_ui_btn_cast = nullptr;
+GraphicsImage *game_ui_btn_zoomin = nullptr;
+GraphicsImage *game_ui_btn_zoomout = nullptr;
+GraphicsImage *game_ui_btn_quickref = nullptr;
+GraphicsImage *game_ui_btn_settings = nullptr;
 
-Image *game_ui_dialogue_background = nullptr;
+GraphicsImage *game_ui_dialogue_background = nullptr;
 
-Image *game_ui_menu_options_video_background = nullptr;
-Image *game_ui_menu_options_video_bloodsplats = nullptr;
-Image *game_ui_menu_options_video_coloredlights = nullptr;
-Image *game_ui_menu_options_video_tinting = nullptr;
-std::array<Image *, 10> game_ui_menu_options_video_gamma_positions;
-std::array<Image *, 5> game_ui_options_controls;
+GraphicsImage *game_ui_menu_options_video_background = nullptr;
+GraphicsImage *game_ui_menu_options_video_bloodsplats = nullptr;
+GraphicsImage *game_ui_menu_options_video_coloredlights = nullptr;
+GraphicsImage *game_ui_menu_options_video_tinting = nullptr;
+std::array<GraphicsImage *, 10> game_ui_menu_options_video_gamma_positions;
+std::array<GraphicsImage *, 5> game_ui_options_controls;
 
-Image *game_ui_evtnpc = nullptr;  // 50795C
+GraphicsImage *game_ui_evtnpc = nullptr;  // 50795C
 
-std::array<std::array<Image *, 56>, 4> game_ui_player_faces;
-Image *game_ui_player_face_eradicated = nullptr;
-Image *game_ui_player_face_dead = nullptr;
+std::array<std::array<GraphicsImage *, 56>, 4> game_ui_player_faces;
+GraphicsImage *game_ui_player_face_eradicated = nullptr;
+GraphicsImage *game_ui_player_face_dead = nullptr;
 
-Image *game_ui_player_selection_frame = nullptr;  // 50C98C
-Image *game_ui_player_alert_yellow = nullptr;     // 5079C8
-Image *game_ui_player_alert_red = nullptr;        // 5079CC
-Image *game_ui_player_alert_green = nullptr;      // 5079D0
+GraphicsImage *game_ui_player_selection_frame = nullptr;  // 50C98C
+GraphicsImage *game_ui_player_alert_yellow = nullptr;     // 5079C8
+GraphicsImage *game_ui_player_alert_red = nullptr;        // 5079CC
+GraphicsImage *game_ui_player_alert_green = nullptr;      // 5079D0
 
-Image *game_ui_bar_red = nullptr;
-Image *game_ui_bar_yellow = nullptr;
-Image *game_ui_bar_green = nullptr;
-Image *game_ui_bar_blue = nullptr;
+GraphicsImage *game_ui_bar_red = nullptr;
+GraphicsImage *game_ui_bar_yellow = nullptr;
+GraphicsImage *game_ui_bar_green = nullptr;
+GraphicsImage *game_ui_bar_blue = nullptr;
 
-Image *game_ui_playerbuff_pain_reflection = nullptr;
-Image *game_ui_playerbuff_hammerhands = nullptr;
-Image *game_ui_playerbuff_preservation = nullptr;
-Image *game_ui_playerbuff_bless = nullptr;
+GraphicsImage *game_ui_playerbuff_pain_reflection = nullptr;
+GraphicsImage *game_ui_playerbuff_hammerhands = nullptr;
+GraphicsImage *game_ui_playerbuff_preservation = nullptr;
+GraphicsImage *game_ui_playerbuff_bless = nullptr;
 
 bool bFlashHistoryBook;
 bool bFlashAutonotesBook;
@@ -794,7 +794,7 @@ std::string GameUI_GetMinimapHintText() {
 
 //----- (0041D3B7) --------------------------------------------------------
 void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
-    Image *v13;              // eax@6
+    GraphicsImage *v13;              // eax@6
     PlayerFrame *v15;        // eax@12
     const char *v29;         // eax@16
     int v36;                 // esi@22
@@ -1413,7 +1413,7 @@ void GameUI_DrawCharacterSelectionFrame() {
 void GameUI_DrawPartySpells() {
     // TODO(pskelton): check tickcount usage here
     unsigned int frameNum = platform->tickCount() / 20;
-    Image *spell_texture;  // [sp-4h] [bp-1Ch]@12
+    GraphicsImage *spell_texture;  // [sp-4h] [bp-1Ch]@12
 
     for (int i = 0; i < spellBuffsAtRightPanel.size(); ++i) {
         if (pParty->pPartyBuffs[spellBuffsAtRightPanel[i]].Active()) {
@@ -1456,7 +1456,7 @@ void GameUI_DrawPartySpells() {
 void GameUI_DrawPortraits() {
     unsigned int face_expression_ID;  // eax@17
     PlayerFrame *pFrame;              // eax@21
-    Image *pPortrait;                 // [sp-4h] [bp-1Ch]@27
+    GraphicsImage *pPortrait;                 // [sp-4h] [bp-1Ch]@27
 
     pParty->updateDelayedReaction();
 

--- a/src/GUI/UI/UIGame.h
+++ b/src/GUI/UI/UIGame.h
@@ -49,69 +49,69 @@ class GUIWindow_DebugMenu : public GUIWindow {
      virtual void Update();
 };
 
-class Image;
-extern Image *game_ui_statusbar;
-extern Image *game_ui_rightframe;
-extern Image *game_ui_topframe;
-extern Image *game_ui_leftframe;
-extern Image *game_ui_bottomframe;
+class GraphicsImage;
+extern GraphicsImage *game_ui_statusbar;
+extern GraphicsImage *game_ui_rightframe;
+extern GraphicsImage *game_ui_topframe;
+extern GraphicsImage *game_ui_leftframe;
+extern GraphicsImage *game_ui_bottomframe;
 
-extern Image *game_ui_monster_hp_green;
-extern Image *game_ui_monster_hp_yellow;
-extern Image *game_ui_monster_hp_red;
-extern Image *game_ui_monster_hp_background;
-extern Image *game_ui_monster_hp_border_left;
-extern Image *game_ui_monster_hp_border_right;
+extern GraphicsImage *game_ui_monster_hp_green;
+extern GraphicsImage *game_ui_monster_hp_yellow;
+extern GraphicsImage *game_ui_monster_hp_red;
+extern GraphicsImage *game_ui_monster_hp_background;
+extern GraphicsImage *game_ui_monster_hp_border_left;
+extern GraphicsImage *game_ui_monster_hp_border_right;
 
-extern Image *game_ui_minimap_frame;    // 5079D8
-extern Image *game_ui_minimap_compass;  // 5079B4
-extern std::array<Image *, 8> game_ui_minimap_dirs;
+extern GraphicsImage *game_ui_minimap_frame;    // 5079D8
+extern GraphicsImage *game_ui_minimap_compass;  // 5079B4
+extern std::array<GraphicsImage *, 8> game_ui_minimap_dirs;
 
-extern Image *game_ui_menu_quit;
-extern Image *game_ui_menu_resume;
-extern Image *game_ui_menu_controls;
-extern Image *game_ui_menu_save;
-extern Image *game_ui_menu_load;
-extern Image *game_ui_menu_new;
-extern Image *game_ui_menu_options;
+extern GraphicsImage *game_ui_menu_quit;
+extern GraphicsImage *game_ui_menu_resume;
+extern GraphicsImage *game_ui_menu_controls;
+extern GraphicsImage *game_ui_menu_save;
+extern GraphicsImage *game_ui_menu_load;
+extern GraphicsImage *game_ui_menu_new;
+extern GraphicsImage *game_ui_menu_options;
 
-extern Image *game_ui_tome_storyline;
-extern Image *game_ui_tome_calendar;
-extern Image *game_ui_tome_maps;
-extern Image *game_ui_tome_autonotes;
-extern Image *game_ui_tome_quests;
+extern GraphicsImage *game_ui_tome_storyline;
+extern GraphicsImage *game_ui_tome_calendar;
+extern GraphicsImage *game_ui_tome_maps;
+extern GraphicsImage *game_ui_tome_autonotes;
+extern GraphicsImage *game_ui_tome_quests;
 
-extern Image *game_ui_btn_rest;
-extern Image *game_ui_btn_cast;
-extern Image *game_ui_btn_zoomin;
-extern Image *game_ui_btn_zoomout;
-extern Image *game_ui_btn_quickref;
-extern Image *game_ui_btn_settings;
+extern GraphicsImage *game_ui_btn_rest;
+extern GraphicsImage *game_ui_btn_cast;
+extern GraphicsImage *game_ui_btn_zoomin;
+extern GraphicsImage *game_ui_btn_zoomout;
+extern GraphicsImage *game_ui_btn_quickref;
+extern GraphicsImage *game_ui_btn_settings;
 
-extern Image *game_ui_dialogue_background;
+extern GraphicsImage *game_ui_dialogue_background;
 
-extern std::array<Image *, 5> game_ui_options_controls;
+extern std::array<GraphicsImage *, 5> game_ui_options_controls;
 
-extern Image *game_ui_evtnpc;  // 50795C
+extern GraphicsImage *game_ui_evtnpc;  // 50795C
 
-extern std::array<std::array<Image *, 56>, 4> game_ui_player_faces;
-extern Image *game_ui_player_face_eradicated;
-extern Image *game_ui_player_face_dead;
+extern std::array<std::array<GraphicsImage *, 56>, 4> game_ui_player_faces;
+extern GraphicsImage *game_ui_player_face_eradicated;
+extern GraphicsImage *game_ui_player_face_dead;
 
-extern Image *game_ui_player_selection_frame;  // 50C98C
-extern Image *game_ui_player_alert_yellow;     // 5079C8
-extern Image *game_ui_player_alert_red;        // 5079CC
-extern Image *game_ui_player_alert_green;      // 5079D0
+extern GraphicsImage *game_ui_player_selection_frame;  // 50C98C
+extern GraphicsImage *game_ui_player_alert_yellow;     // 5079C8
+extern GraphicsImage *game_ui_player_alert_red;        // 5079CC
+extern GraphicsImage *game_ui_player_alert_green;      // 5079D0
 
-extern Image *game_ui_bar_red;
-extern Image *game_ui_bar_yellow;
-extern Image *game_ui_bar_green;
-extern Image *game_ui_bar_blue;
+extern GraphicsImage *game_ui_bar_red;
+extern GraphicsImage *game_ui_bar_yellow;
+extern GraphicsImage *game_ui_bar_green;
+extern GraphicsImage *game_ui_bar_blue;
 
-extern Image *game_ui_playerbuff_pain_reflection;
-extern Image *game_ui_playerbuff_hammerhands;
-extern Image *game_ui_playerbuff_preservation;
-extern Image *game_ui_playerbuff_bless;
+extern GraphicsImage *game_ui_playerbuff_pain_reflection;
+extern GraphicsImage *game_ui_playerbuff_hammerhands;
+extern GraphicsImage *game_ui_playerbuff_preservation;
+extern GraphicsImage *game_ui_playerbuff_bless;
 
 extern bool bFlashHistoryBook;
 extern bool bFlashAutonotesBook;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -66,7 +66,7 @@ int dword_591080;               // 591080
 BuildingType in_current_building_type;  // 00F8B198
 DIALOGUE_TYPE dialog_menu_id;     // 00F8B19C
 
-Image *_591428_endcap = nullptr;
+GraphicsImage *_591428_endcap = nullptr;
 
 void GenerateStandartShopItems();
 void GenerateSpecialShopItems();

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -46,7 +46,7 @@ int HouseDialogPressCloseBtn();
 
 int ItemAmountForShop(BuildingType buildingType);
 
-extern class Image *_591428_endcap;
+extern class GraphicsImage *_591428_endcap;
 
 // Originally was a packed struct.
 struct HouseAnimDescr {

--- a/src/GUI/UI/UIMainMenu.cpp
+++ b/src/GUI/UI/UIMainMenu.cpp
@@ -67,7 +67,7 @@ void GUIWindow_MainMenu::Update() {
     Pointi pt = mouse->GetCursorPos();
     GUIWindow *pWindow = this;
 
-    Image *pTexture = nullptr;
+    GraphicsImage *pTexture = nullptr;
     if (!pGameOverWindow) {  // ???
         for (GUIButton *pButton : pWindow->vButtons) {
             if (pButton->Contains(pt.x, pt.y) && pWindow == pWindow_MainMenu) {
@@ -140,7 +140,7 @@ void GUIWindow_MainMenu::EventLoop() {
 static bool first_initialization = true;
 
 void GUIWindow_MainMenu::Loop() {
-    Image *tex;
+    GraphicsImage *tex;
     nuklear->Create(WINDOW_MainMenu_Load);
 
     pAudioPlayer->stopSounds();

--- a/src/GUI/UI/UIMainMenu.h
+++ b/src/GUI/UI/UIMainMenu.h
@@ -18,12 +18,12 @@ class GUIWindow_MainMenu : public GUIWindow {
     GUIButton *pBtnLoad;
     GUIButton *pBtnNew;
 
-    Image *main_menu_background;
+    GraphicsImage *main_menu_background;
 
-    Image *ui_mainmenu_new;
-    Image *ui_mainmenu_load;
-    Image *ui_mainmenu_credits;
-    Image *ui_mainmenu_exit;
+    GraphicsImage *ui_mainmenu_new;
+    GraphicsImage *ui_mainmenu_load;
+    GraphicsImage *ui_mainmenu_credits;
+    GraphicsImage *ui_mainmenu_exit;
 };
 
 extern GUIWindow_MainMenu *pWindow_MainMenu;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -34,21 +34,21 @@ using Io::TextInputType;
 
 GUIFont *ui_partycreation_font;
 
-Image *ui_partycreation_top = nullptr;
-Image *ui_partycreation_sky_scroller = nullptr;
+GraphicsImage *ui_partycreation_top = nullptr;
+GraphicsImage *ui_partycreation_sky_scroller = nullptr;
 
-Image *ui_partycreation_left = nullptr;
-Image *ui_partycreation_right = nullptr;
-Image *ui_partycreation_minus = nullptr;
-Image *ui_partycreation_plus = nullptr;
-Image *ui_partycreation_buttmake2 = nullptr;
-Image *ui_partycreation_buttmake = nullptr;
+GraphicsImage *ui_partycreation_left = nullptr;
+GraphicsImage *ui_partycreation_right = nullptr;
+GraphicsImage *ui_partycreation_minus = nullptr;
+GraphicsImage *ui_partycreation_plus = nullptr;
+GraphicsImage *ui_partycreation_buttmake2 = nullptr;
+GraphicsImage *ui_partycreation_buttmake = nullptr;
 
-std::array<Image *, 9> ui_partycreation_class_icons;
-std::array<Image *, 22> ui_partycreation_portraits;
+std::array<GraphicsImage *, 9> ui_partycreation_class_icons;
+std::array<GraphicsImage *, 22> ui_partycreation_portraits;
 
-std::array<Image *, 19> ui_partycreation_arrow_r;
-std::array<Image *, 19> ui_partycreation_arrow_l;
+std::array<GraphicsImage *, 19> ui_partycreation_arrow_r;
+std::array<GraphicsImage *, 19> ui_partycreation_arrow_l;
 
 static const int ARROW_SPIN_PERIOD_MS = 475;
 

--- a/src/GUI/UI/UIPartyCreation.h
+++ b/src/GUI/UI/UIPartyCreation.h
@@ -2,7 +2,7 @@
 
 #include "GUI/GUIWindow.h"
 
-class Image;
+class GraphicsImage;
 
 bool PartyCreationUI_Loop();
 
@@ -14,5 +14,5 @@ class GUIWindow_PartyCreation : public GUIWindow {
     virtual void Update();
 
  protected:
-    Image *main_menu_background;
+    GraphicsImage *main_menu_background;
 };

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -34,14 +34,14 @@
 #include "Library/Random/Random.h"
 
 Texture *parchment = nullptr;
-Image *messagebox_corner_x = nullptr;       // 5076AC
-Image *messagebox_corner_y = nullptr;       // 5076B4
-Image *messagebox_corner_z = nullptr;       // 5076A8
-Image *messagebox_corner_w = nullptr;       // 5076B0
-Image *messagebox_border_top = nullptr;     // 507698
-Image *messagebox_border_bottom = nullptr;  // 5076A4
-Image *messagebox_border_left = nullptr;    // 50769C
-Image *messagebox_border_right = nullptr;   // 5076A0
+GraphicsImage *messagebox_corner_x = nullptr;       // 5076AC
+GraphicsImage *messagebox_corner_y = nullptr;       // 5076B4
+GraphicsImage *messagebox_corner_z = nullptr;       // 5076A8
+GraphicsImage *messagebox_corner_w = nullptr;       // 5076B0
+GraphicsImage *messagebox_border_top = nullptr;     // 507698
+GraphicsImage *messagebox_border_bottom = nullptr;  // 5076A4
+GraphicsImage *messagebox_border_left = nullptr;    // 50769C
+GraphicsImage *messagebox_border_right = nullptr;   // 5076A0
 
 bool holdingMouseRightButton = false;
 bool rightClickItemActionPerformed = false;

--- a/src/GUI/UI/UIPopup.h
+++ b/src/GUI/UI/UIPopup.h
@@ -5,17 +5,17 @@ Color GetSpellColor(signed int a1);
 uint64_t GetExperienceRequiredForLevel(int level);
 void CharacterUI_DrawTooltip(const char *title, std::string &content);
 
-class Image;
+class GraphicsImage;
 class Texture;
 extern Texture *parchment;
-extern Image *messagebox_corner_x;       // 5076AC
-extern Image *messagebox_corner_y;       // 5076B4
-extern Image *messagebox_corner_z;       // 5076A8
-extern Image *messagebox_corner_w;       // 5076B0
-extern Image *messagebox_border_top;     // 507698
-extern Image *messagebox_border_bottom;  // 5076A4
-extern Image *messagebox_border_left;    // 50769C
-extern Image *messagebox_border_right;   // 5076A0
+extern GraphicsImage *messagebox_corner_x;       // 5076AC
+extern GraphicsImage *messagebox_corner_y;       // 5076B4
+extern GraphicsImage *messagebox_corner_z;       // 5076A8
+extern GraphicsImage *messagebox_corner_w;       // 5076B0
+extern GraphicsImage *messagebox_border_top;     // 507698
+extern GraphicsImage *messagebox_border_bottom;  // 5076A4
+extern GraphicsImage *messagebox_border_left;    // 50769C
+extern GraphicsImage *messagebox_border_right;   // 5076A0
 
 extern bool holdingMouseRightButton;
 extern bool rightClickItemActionPerformed;

--- a/src/GUI/UI/UIQuickReference.cpp
+++ b/src/GUI/UI/UIQuickReference.cpp
@@ -18,7 +18,7 @@
 
 
 
-Image *ui_game_quickref_background = nullptr;
+GraphicsImage *ui_game_quickref_background = nullptr;
 
 GUIWindow_QuickReference::GUIWindow_QuickReference()
     : GUIWindow(WINDOW_QuickReference, {0, 0}, render->GetRenderDimensions(), 5) {

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -13,15 +13,15 @@
 #include "GUI/UI/UIRest.h"
 #include "GUI/GUIFont.h"
 
-Image *rest_ui_btn_4 = nullptr;
-Image *rest_ui_btn_exit = nullptr;
-Image *rest_ui_btn_3 = nullptr;
-Image *rest_ui_btn_1 = nullptr;
-Image *rest_ui_btn_2 = nullptr;
-Image *rest_ui_restmain = nullptr;
+GraphicsImage *rest_ui_btn_4 = nullptr;
+GraphicsImage *rest_ui_btn_exit = nullptr;
+GraphicsImage *rest_ui_btn_3 = nullptr;
+GraphicsImage *rest_ui_btn_1 = nullptr;
+GraphicsImage *rest_ui_btn_2 = nullptr;
+GraphicsImage *rest_ui_restmain = nullptr;
 
-Image *rest_ui_sky_frame_current = nullptr;
-Image *rest_ui_hourglass_frame_current = nullptr;
+GraphicsImage *rest_ui_sky_frame_current = nullptr;
+GraphicsImage *rest_ui_hourglass_frame_current = nullptr;
 
 int foodRequiredToRest;
 GameTime remainingRestTime;

--- a/src/GUI/UI/UIRest.h
+++ b/src/GUI/UI/UIRest.h
@@ -40,8 +40,8 @@ enum class REST_TYPE {
 };
 using enum REST_TYPE;
 
-extern class Image *rest_ui_sky_frame_current;
-extern class Image *rest_ui_hourglass_frame_current;
+extern class GraphicsImage *rest_ui_sky_frame_current;
+extern class GraphicsImage *rest_ui_hourglass_frame_current;
 
 extern int foodRequiredToRest;
 extern GameTime remainingRestTime;

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -31,10 +31,10 @@ std::array<unsigned int, 2> saveload_dlg_ys = {{60, 0}};
 std::array<unsigned int, 2> saveload_dlg_zs = {{460, 640}};
 std::array<unsigned int, 2> saveload_dlg_ws = {{344, 480}};
 
-Image *saveload_ui_ls_saved = nullptr;
-Image *saveload_ui_x_d = nullptr;
+GraphicsImage *saveload_ui_ls_saved = nullptr;
+GraphicsImage *saveload_ui_x_d = nullptr;
 
-static Image *scrollstop = nullptr;
+static GraphicsImage *scrollstop = nullptr;
 
 // TODO(Nik-RE-dev): drop variable and load game only on double click
 static bool isLoadSlotClicked = false;

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -12,10 +12,10 @@ class GUIWindow_Save : public GUIWindow {
  protected:
     // Image * main_menu_background;
 
-    Image *saveload_ui_save_up;
-    Image *saveload_ui_loadsave;
-    Image *saveload_ui_saveu;
-    Image *saveload_ui_x_u;
+    GraphicsImage *saveload_ui_save_up;
+    GraphicsImage *saveload_ui_loadsave;
+    GraphicsImage *saveload_ui_saveu;
+    GraphicsImage *saveload_ui_x_u;
 };
 
 class GUIWindow_Load : public GUIWindow {
@@ -26,12 +26,12 @@ class GUIWindow_Load : public GUIWindow {
     virtual void Update();
 
  protected:
-    Image *main_menu_background;
+    GraphicsImage *main_menu_background;
 
-    Image *saveload_ui_load_up;
-    Image *saveload_ui_loadsave;
-    Image *saveload_ui_loadu;
-    Image *saveload_ui_x_u;
+    GraphicsImage *saveload_ui_load_up;
+    GraphicsImage *saveload_ui_loadsave;
+    GraphicsImage *saveload_ui_loadu;
+    GraphicsImage *saveload_ui_x_u;
 };
 
 void MainMenuLoad_Loop();

--- a/src/GUI/UI/UIShops.cpp
+++ b/src/GUI/UI/UIShops.cpp
@@ -29,9 +29,9 @@
 
 #include "Library/Random/Random.h"
 
-Image *shop_ui_background = nullptr;
+GraphicsImage *shop_ui_background = nullptr;
 
-std::array<Image *, 12> shop_ui_items_in_store;
+std::array<GraphicsImage *, 12> shop_ui_items_in_store;
 
 bool isStealingModeActive() {
     return keyboardInputHandler->IsStealingToggled() && pParty->activeCharacter().CanSteal();

--- a/src/GUI/UI/UIShops.h
+++ b/src/GUI/UI/UIShops.h
@@ -14,6 +14,6 @@ void ShowPopupShopItem();
 void GetHouseGoodbyeSpeech();
 void sub_4B1447_party_fine(int shopId, int stealingResult, int fineToAdd);
 
-extern class Image *shop_ui_background;
+extern class GraphicsImage *shop_ui_background;
 
-extern std::array<class Image *, 12> shop_ui_items_in_store;
+extern std::array<class GraphicsImage *, 12> shop_ui_items_in_store;

--- a/src/GUI/UI/UISpellbook.cpp
+++ b/src/GUI/UI/UISpellbook.cpp
@@ -44,16 +44,16 @@ std::array<std::array<unsigned char, 12>, 9>
       {0, 1, 10, 11, 9, 4, 3, 6, 5, 7, 8, 2},
       {0, 9, 3, 7, 1, 5, 2, 10, 11, 8, 6, 4}}};
 
-Image *ui_spellbook_btn_quckspell = nullptr;
-Image *ui_spellbook_btn_quckspell_click = nullptr;
-Image *ui_spellbook_btn_close = nullptr;
-Image *ui_spellbook_btn_close_click = nullptr;
+GraphicsImage *ui_spellbook_btn_quckspell = nullptr;
+GraphicsImage *ui_spellbook_btn_quckspell_click = nullptr;
+GraphicsImage *ui_spellbook_btn_close = nullptr;
+GraphicsImage *ui_spellbook_btn_close_click = nullptr;
 
-std::array<Image *, 12> SBPageCSpellsTextureList;
-std::array<Image *, 12> SBPageSSpellsTextureList;
+std::array<GraphicsImage *, 12> SBPageCSpellsTextureList;
+std::array<GraphicsImage *, 12> SBPageSSpellsTextureList;
 
-std::array<Image *, 9> ui_spellbook_school_backgrounds;
-std::array<std::array<Image *, 2>, 9> ui_spellbook_school_tabs;
+std::array<GraphicsImage *, 9> ui_spellbook_school_backgrounds;
+std::array<std::array<GraphicsImage *, 2>, 9> ui_spellbook_school_tabs;
 
 GUIWindow_Spellbook::GUIWindow_Spellbook()
     : GUIWindow(WINDOW_SpellBook, {0, 0}, render->GetRenderDimensions(), 0) {
@@ -142,7 +142,7 @@ void GUIWindow_Spellbook::OpenSpellbook() {
 void GUIWindow_Spellbook::Update() {
     auto player = &pParty->activeCharacter();
 
-    Image *pTexture;        // edx@5
+    GraphicsImage *pTexture;        // edx@5
     int v10;                // eax@13
     unsigned int pX_coord;  // esi@18
     unsigned int pY_coord;  // edi@18

--- a/src/GUI/UI/UISpellbook.h
+++ b/src/GUI/UI/UISpellbook.h
@@ -13,8 +13,8 @@ class GUIWindow_Spellbook : public GUIWindow {
     void OpenSpellbookPage(int page);
 };
 
-class Image;
-extern Image *ui_spellbook_btn_quckspell;
-extern Image *ui_spellbook_btn_quckspell_click;
-extern Image *ui_spellbook_btn_close;
-extern Image *ui_spellbook_btn_close_click;
+class GraphicsImage;
+extern GraphicsImage *ui_spellbook_btn_quckspell;
+extern GraphicsImage *ui_spellbook_btn_quckspell_click;
+extern GraphicsImage *ui_spellbook_btn_close;
+extern GraphicsImage *ui_spellbook_btn_close_click;

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -22,7 +22,7 @@
 #include "Media/Audio/AudioPlayer.h"
 #include "Media/MediaPlayer.h"
 
-Image *transition_ui_icon = nullptr;
+GraphicsImage *transition_ui_icon = nullptr;
 
 std::string transition_button_label;
 

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -236,7 +236,7 @@ void Mouse::DrawPickedItem() {
     if (pParty->pPickedItem.uItemID == ITEM_NULL)
         return;
 
-    Image *pTexture = assets->getImage_Alpha(pParty->pPickedItem.GetIconName());
+    GraphicsImage *pTexture = assets->getImage_Alpha(pParty->pPickedItem.GetIconName());
     if (!pTexture) return;
 
     if (pParty->pPickedItem.IsBroken()) {

--- a/src/Io/Mouse.h
+++ b/src/Io/Mouse.h
@@ -6,7 +6,7 @@
 
 #include "Utility/Geometry/Point.h"
 
-class Image;
+class GraphicsImage;
 
 
 namespace Io {
@@ -54,11 +54,11 @@ namespace Io {
         int field_18 = 0;
         int field_1C = 0;
         int field_20 = 0;
-        Image *cursor_img = nullptr;
+        GraphicsImage *cursor_img = nullptr;
         uint16_t *pCursorBitmap_sysmem = nullptr;
         int field_34 = 0;
         uint8_t *pCursorBitmap2_sysmem = nullptr;
-        Image *pPickedItem = nullptr;
+        GraphicsImage *pPickedItem = nullptr;
         int uCursorWithItemX = 0;
         int uCursorWithItemY = 0;
         int field_50 = 0;


### PR DESCRIPTION
I'm introducing `Library/Image` with an `Image` class, and I'd rather do this in several small steps. So need to rename this one for the time being.

Will drop `GraphicsImage` a couple PRs down the line.

This PR contains only the name change and nothing else.