### PR TITLE
Numpad and tests

### DIFF
--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -30,6 +30,8 @@ using Io::InputAction;
 static char PlatformKeyToChar(PlatformKey key, PlatformModifiers mods) {
     if (key >= PlatformKey::Digit0 && key <= PlatformKey::Digit9) {
         return std::to_underlying(key) - std::to_underlying(PlatformKey::Digit0) + '0';
+    } else if (key >= PlatformKey::Numpad0 && key <= PlatformKey::Numpad9 && (mods & MOD_NUM)) {
+        return std::to_underlying(key) - std::to_underlying(PlatformKey::Numpad0) + '0';
     } else if (key >= PlatformKey::A && key <= PlatformKey::Z) {
         if (mods & MOD_SHIFT) {
             return std::to_underlying(key) - std::to_underlying(PlatformKey::A) + 'A';

--- a/src/Platform/Sdl/SdlEnumTranslation.cpp
+++ b/src/Platform/Sdl/SdlEnumTranslation.cpp
@@ -107,6 +107,7 @@ PlatformKey translateSdlKey(SDL_Scancode key) {
     case SDL_SCANCODE_KP_7:             return PlatformKey::Numpad7;
     case SDL_SCANCODE_KP_8:             return PlatformKey::Numpad8;
     case SDL_SCANCODE_KP_9:             return PlatformKey::Numpad9;
+    case SDL_SCANCODE_KP_ENTER:         return PlatformKey::Return;
 
     default:
         return PlatformKey::None;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 0093c73614a474e1724dd675ed215836f8e01e49
+            GIT_TAG 6153531d22e66db5366eb05feb0388cf00e51688
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -1105,3 +1105,17 @@ GAME_TEST(Issues, Issue872) {
     buf.Prepare();
     EXPECT_NE(buf.Get(0)->pName, "Dummy");
 }
+
+GAME_TEST(Issues, Issue878) {
+    // Test that numpad number keys are working
+    test->playTraceFromTestData("issue_878.mm7", "issue_878.json", []() { EXPECT_EQ(pParty->uNumGoldInBank, 0); });
+    EXPECT_EQ(pParty->uNumGoldInBank, 123);
+}
+
+GAME_TEST(Issues, Issue895) {
+    // Test that entering magic guild does not shift date
+    GameTime timeBefore, timeDiff;
+    test->playTraceFromTestData("issue_895.mm7", "issue_895.json", [&]() { timeBefore = pParty->GetPlayingTime(); });
+    timeDiff = pParty->GetPlayingTime() - timeBefore;
+    EXPECT_LT(timeDiff, GameTime::FromMinutes(5));
+}


### PR DESCRIPTION
Fix #878 - support entring numbers with numpad and also support numpad enter key (behaves as regular enter).
Also add tests for #878 and for #895.