### PR TITLE
Propagating Image use

### DIFF
--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -221,7 +221,8 @@ class IRender {
     virtual Texture *CreateTexture_PCXFromNewLOD(const std::string &name) = 0;
     virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) = 0;
 
-    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height, const Color *pixels = nullptr) = 0;
+    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height) = 0;
+    virtual Texture *CreateTexture_Blank(RgbaImage image) = 0;
 
     virtual Texture *CreateTexture(const std::string &name) = 0;
     virtual Texture *CreateSprite(const std::string &name, unsigned int palette_id,
@@ -230,7 +231,7 @@ class IRender {
     virtual void ClearBlack() = 0;
     virtual void PresentBlackScreen() = 0;
 
-    virtual Color *ReadScreenPixels() = 0;
+    virtual RgbaImage ReadScreenPixels() = 0;
     virtual void SaveWinnersCertificate(const std::string &filePath) = 0;
     virtual void ClearTarget(unsigned int uColor) = 0;
     virtual void Present() = 0;
@@ -326,7 +327,7 @@ class IRender {
                                 unsigned int height) = 0;
     virtual Blob PackScreenshot(const unsigned int width, const unsigned int height) = 0;
     virtual void SavePCXScreenshot() = 0;
-    virtual Color *MakeScreenshot32(const int width, const int height) = 0;
+    virtual RgbaImage MakeScreenshot32(const int width, const int height) = 0;
 
     virtual std::vector<Actor*> getActorsInViewport(int pDepth) = 0;
 

--- a/src/Engine/Graphics/Image.cpp
+++ b/src/Engine/Graphics/Image.cpp
@@ -12,25 +12,21 @@ GraphicsImage::GraphicsImage(bool lazy_initialization): _lazyInitialization(lazy
 
 GraphicsImage::~GraphicsImage() = default;
 
-GraphicsImage *GraphicsImage::Create(std::unique_ptr<ImageLoader> loader) {
-    GraphicsImage *img = new GraphicsImage();
-    img->_loader = std::move(loader);
+GraphicsImage *GraphicsImage::Create(RgbaImage image) {
+    GraphicsImage *img = new GraphicsImage(false);
+    img->_initialized = true;
+    img->_rgbaImage = std::move(image);
     return img;
 }
 
-GraphicsImage *GraphicsImage::Create(size_t width, size_t height, const Color *pixels) {
+GraphicsImage *GraphicsImage::Create(size_t width, size_t height) {
     assert(width != 0 && height != 0);
+    return Create(RgbaImage::solid(width, height, Color()));
+}
 
-    GraphicsImage *img = new GraphicsImage(false);
-
-    img->_initialized = true;
-
-    if (pixels) {
-        img->_rgbaImage = RgbaImage::copy(width, height, pixels); // NOLINT: this is not std::copy.
-    } else {
-        img->_rgbaImage = RgbaImage::solid(width, height, Color());
-    }
-
+GraphicsImage *GraphicsImage::Create(std::unique_ptr<ImageLoader> loader) {
+    GraphicsImage *img = new GraphicsImage();
+    img->_loader = std::move(loader);
     return img;
 }
 

--- a/src/Engine/Graphics/Image.h
+++ b/src/Engine/Graphics/Image.h
@@ -19,8 +19,9 @@ class GraphicsImage {
     explicit GraphicsImage(bool lazy_initialization = true);
     virtual ~GraphicsImage();
 
+    static GraphicsImage *Create(RgbaImage image);
+    static GraphicsImage *Create(size_t width, size_t height);
     static GraphicsImage *Create(std::unique_ptr<ImageLoader> loader);
-    static GraphicsImage *Create(size_t width, size_t height, const Color *pixels = nullptr);
 
     size_t width();
     size_t height();

--- a/src/Engine/Graphics/ImageLoader.cpp
+++ b/src/Engine/Graphics/ImageLoader.cpp
@@ -45,12 +45,9 @@ static Palette MakePaletteAlpha(uint8_t *palette24) {
 static Palette MakePaletteColorKey(uint8_t *palette24, Color key) {
     Palette result = MakePaletteSolid(palette24);
 
-    for (size_t i = 0; i < 256; i++) {
-        if (result.colors[i] == key) {
-            result.colors[i] = Color();
-            break;
-        }
-    }
+    for (size_t i = 0; i < 256; i++)
+        if (result.colors[i] == key)
+            result.colors[i] = Color(); // Repeated appearances of the same color do happen, so can't break early.
 
     return result;
 }
@@ -65,7 +62,7 @@ bool Paletted_Img_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImag
         return false;
 
     *indexedImage = GrayscaleImage::copy(tex->header.uTextureWidth, tex->header.uTextureHeight, tex->paletted_pixels);
-    *palette = MakePaletteAlpha(tex->pPalette24);
+    *palette = MakePaletteSolid(tex->pPalette24);
     *rgbaImage = makeRgbaImage(*indexedImage, *palette);
 
     return true;

--- a/src/Engine/Graphics/ImageLoader.h
+++ b/src/Engine/Graphics/ImageLoader.h
@@ -26,16 +26,14 @@ class ImageLoader {
 
 class Paletted_Img_Loader : public ImageLoader {
  public:
-    inline Paletted_Img_Loader(LODFile_IconsBitmaps *lod, const std::string &filename, uint16_t colorkey) {
+    inline Paletted_Img_Loader(LODFile_IconsBitmaps *lod, const std::string &filename) {
         this->resource_name = filename;
-        this->colorkey = colorkey;
         this->lod = lod;
     }
 
     virtual bool Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage, Palette *palette) override;
 
  protected:
-    uint16_t colorkey;
     LODFile_IconsBitmaps *lod;
 };
 

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -46,14 +46,15 @@ class RenderOpenGL : public RenderBase {
     virtual Texture *CreateTexture_PCXFromNewLOD(const std::string &name) override;
     virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) override;
 
-    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height, const Color *pixels = nullptr) override;
+    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height) override;
+    virtual Texture *CreateTexture_Blank(RgbaImage image) override;
 
     virtual Texture *CreateTexture(const std::string &name) override;
     virtual Texture *CreateSprite(
         const std::string &name, unsigned int palette_id,
         /*refactor*/ unsigned int lod_sprite_id) override;
 
-    virtual Color *ReadScreenPixels() override;
+    virtual RgbaImage ReadScreenPixels() override;
     virtual void SaveWinnersCertificate(const std::string &filePath) override;
     virtual void ClearTarget(unsigned int uColor) override;
     virtual void Present() override;
@@ -128,7 +129,7 @@ class RenderOpenGL : public RenderBase {
 
     virtual bool AreRenderSurfacesOk() override;
 
-    virtual Color *MakeScreenshot32(const int width, const int height) override;
+    virtual RgbaImage MakeScreenshot32(const int width, const int height) override;
 
     virtual std::vector<Actor*> getActorsInViewport(int pDepth) override;
 

--- a/src/Engine/Graphics/OpenGL/TextureOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/TextureOpenGL.cpp
@@ -1,28 +1,25 @@
 #include "Engine/Graphics/OpenGL/TextureOpenGL.h"
 
+#include <cassert>
 #include <utility>
 
 #include "Engine/Graphics/IRender.h"
 #include "Engine/Graphics/ImageLoader.h"
 #include "Engine/ErrorHandling.h"
 
-Texture *TextureOpenGL::Create(unsigned int width, unsigned int height, const Color *pixels) {
+Texture *TextureOpenGL::Create(RgbaImage image) {
     TextureOpenGL *tex = new TextureOpenGL(false);
 
+    tex->_rgbaImage = std::move(image);
     tex->_initialized = true;
-
-    if (pixels) {
-        tex->_rgbaImage = RgbaImage::copy(width, height, pixels); // NOLINT: this is not std::copy.
-    } else {
-        tex->_rgbaImage = RgbaImage::solid(width, height, Color());
-    }
-
     tex->_initialized = render->MoveTextureToDevice(tex);
-    if (!tex->_initialized) {
-        __debugbreak();
-    }
+    assert(tex->_initialized);
 
     return tex;
+}
+
+Texture *TextureOpenGL::Create(unsigned int width, unsigned int height) {
+    return Create(RgbaImage::solid(width, height, Color()));
 }
 
 Texture *TextureOpenGL::Create(std::unique_ptr<ImageLoader> loader) {

--- a/src/Engine/Graphics/OpenGL/TextureOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/TextureOpenGL.h
@@ -13,8 +13,8 @@ class TextureOpenGL : public Texture {
  protected:
     friend class RenderOpenGL;
 
-    static Texture *Create(unsigned int width, unsigned int height, const Color *pixels = nullptr);
-
+    static Texture *Create(RgbaImage image);
+    static Texture *Create(unsigned int width, unsigned int height);
     static Texture *Create(std::unique_ptr<ImageLoader> loader);
 
     void SetOpenGlTexture(int ogl_texture) { this->ogl_texture = ogl_texture; }

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -29,7 +29,7 @@ class RenderBase : public IRender {
     virtual float GetGamma() override;
 
     virtual void SavePCXScreenshot() override;
-    virtual void SavePCXImage32(const std::string &filename, const Color *picture_data, const int width, const int height);
+    virtual void SavePCXImage32(const std::string &filename, RgbaImageView image);
     virtual void SaveScreenshot(const std::string &filename, unsigned int width, unsigned int height) override;
     /**
     * @param width                         Final width of image to create.

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -1,12 +1,12 @@
 #include "Engine/Objects/Player.h"
 
 #include <algorithm>
+#include <memory>
 
 #include "Engine/Engine.h"
 #include "Engine/Spells/CastSpellInfo.h"
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Graphics/Indoor.h"
-#include "Engine/Graphics/Viewport.h"
 #include "Engine/Localization.h"
 #include "Engine/LOD.h"
 #include "Engine/Objects/Actor.h"
@@ -32,7 +32,6 @@
 #include "GUI/GUIWindow.h"
 #include "GUI/UI/UIGame.h"
 #include "GUI/UI/UIStatusBar.h"
-#include "GUI/UI/UIHouses.h"
 #include "GUI/UI/Books/AutonotesBook.h"
 
 #include "Utility/Memory/MemSet.h"
@@ -7538,8 +7537,9 @@ bool Player::SetBeacon(size_t index, size_t power) {
 
     LloydBeacon beacon;
 
-    beacon.image = render->TakeScreenshot(92, 68);
-    beacon.image = render->CreateTexture_Blank(beacon.image->width(), beacon.image->height(), beacon.image->rgba().pixels().data());
+    std::unique_ptr<GraphicsImage> tmp(render->TakeScreenshot(92, 68));
+
+    beacon.image = render->CreateTexture_Blank(std::move(tmp->rgba()));
     beacon.uBeaconTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power));
     beacon.PartyPos_X = pParty->vPosition.x;
     beacon.PartyPos_Y = pParty->vPosition.y;

--- a/src/Library/Image/ImageFunctions.cpp
+++ b/src/Library/Image/ImageFunctions.cpp
@@ -16,3 +16,13 @@ RgbaImage makeRgbaImage(GrayscaleImageView indexedImage, const Palette &palette)
 
     return result;
 }
+
+RgbaImage flipVertically(RgbaImageView image) {
+    if (!image)
+        return RgbaImage();
+
+    RgbaImage result = RgbaImage::uninitialized(image.width(), image.height());
+    for (size_t y = 0, h = image.height(); y < h; y++)
+        memcpy(result[h - y - 1].data(), image[y].data(), image[y].size_bytes());
+    return result;
+}

--- a/src/Library/Image/ImageFunctions.h
+++ b/src/Library/Image/ImageFunctions.h
@@ -4,3 +4,5 @@
 #include "Palette.h"
 
 RgbaImage makeRgbaImage(GrayscaleImageView indexedImage, const Palette &palette);
+
+RgbaImage flipVertically(RgbaImageView image);

--- a/src/Library/Image/PCX.h
+++ b/src/Library/Image/PCX.h
@@ -7,6 +7,14 @@
 #include "Utility/Memory/Blob.h"
 
 namespace PCX {
+/**
+ * Decodes a PCX image from a `Blob`.
+ *
+ * @param data                          Compressed PCX image to decode.
+ * @return                              Decoded `RgbaImage`.
+ * @throws Exception                    On error.
+ */
 RgbaImage Decode(const Blob &data);
+
 Blob Encode(RgbaImageView image);
 }  // namespace PCX

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -552,9 +552,7 @@ class Movie : public IMovie {
 
                 render->BeginScene2D();
                 // update pixels from buffer
-                Color *pix = tex->rgba().pixels().data();
-                unsigned int num_pixels_bytes = tex->rgba().pixels().size_bytes();
-                memcpy(pix, tmp_buf->data(), num_pixels_bytes);
+                tex->rgba() = RgbaImage::copy(tex->width(), tex->height(), static_cast<const Color *>(tmp_buf->data()));
 
                 // update texture
                 render->Update_Texture(tex);
@@ -821,9 +819,7 @@ void MPlayer::HouseMovieLoop() {
         rect.h = wsize.h - render->config->graphics.HouseMovieY2.value();
 
         // update pixels from buffer
-        Color *pix = tex->rgba().pixels().data();
-        unsigned int num_pixels_bytes = tex->rgba().pixels().size_bytes();
-        memcpy(pix, buffer->data(), num_pixels_bytes);
+        tex->rgba() = RgbaImage::copy(tex->width(), tex->height(), static_cast<const Color *>(buffer->data()));
 
         // update texture
         render->Update_Texture(tex);
@@ -895,9 +891,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
             }
 
             // update pixels from buffer
-            Color *pix = tex->rgba().pixels().data();
-            unsigned int num_pixels_bytes = tex->rgba().pixels().size_bytes();
-            memcpy(pix, buffer->data(), num_pixels_bytes);
+            tex->rgba() = RgbaImage::copy(tex->width(), tex->height(), static_cast<const Color *>(buffer->data()));
 
             // update texture
             render->Update_Texture(tex);


### PR DESCRIPTION
* Using Image classes where appropriate.
* Last commit introduced a bug with buff icons blinking, fixed.
* Last commit introduced a bug with the targeting cursor (e.g. when picking a target for a spell) having a black background, fixed.
* Screenshots for gamma correction screen are now scaled properly (scaling K was rounded to int before).
* Reading an invalid PCX now throws an exception.