### PR TITLE
Refactoring of some UI classes: Spellbook, Main Menu and Chest

### DIFF
--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2434,8 +2434,6 @@ char byte_4FAA24;  // turn over break??
 
 // std::array<unsigned int, 480> pSRZBufferLineOffsets;
 
-int quick_spell_at_page;
-char byte_506550;
 int uLastPointedObjectID;
 int KeyboardPageNum;
 //int dword_506F1C;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -71,8 +71,6 @@ extern std::array<int, 500> ai_near_actors_targets_pid;
 extern std::array<unsigned int, 500> ai_near_actors_ids;
 extern int ai_arrays_size;
 
-extern int quick_spell_at_page;
-extern char byte_506550;
 extern int uLastPointedObjectID;
 extern int KeyboardPageNum;
 extern Color uGameUIFontShadow;

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -57,7 +57,7 @@ enum UIMessageType : uint32_t {
     UIMSG_PlayerCreationRemoveDownSkill = 75,  // choice skill 2
 
     UIMSG_HintSelectRemoveQuickSpellBtn = 78,
-    UIMSG_SPellbook_ShowHightlightedSpellInfo = 79,
+    UIMSG_Spellbook_ShowHightlightedSpellInfo = 79,
 
     UIMSG_BuyInShop_Identify_Repair = 81,
     UIMSG_LoadGame = 82,

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -9,22 +9,20 @@
 #include "GUI/GUIButton.h"
 #include "GUI/UI/UIChest.h"
 
-
 int pChestPixelOffsetX[8] = {42, 18, 18, 42, 42, 42, 18, 42};
 int pChestPixelOffsetY[8] = {34, 30, 30, 34, 34, 34, 30, 34};
 int pChestWidthsByType[8] = {9, 9, 9, 9, 9, 9, 9, 9};
 int pChestHeightsByType[8] = {9, 9, 9, 9, 9, 9, 9, 9};
 
-GUIWindow_Chest::GUIWindow_Chest(unsigned int chest_id)
-    : GUIWindow(WINDOW_Chest, {0, 0}, render->GetRenderDimensions(), chest_id) {
+GUIWindow_Chest::GUIWindow_Chest(unsigned int chest_id) : GUIWindow(WINDOW_Chest, {0, 0}, render->GetRenderDimensions(), chest_id) {
     CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, InputAction::SelectChar1);
     CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, InputAction::SelectChar2);
     CreateButton({292, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3);
     CreateButton({407, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4);
     CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, InputAction::CharCycle);
 
-    pBtn_ExitCancel = CreateButton({471, 445}, {169, 35}, 1, 0,
-        UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_DIALOGUE_EXIT), {ui_exit_cancel_button_background});
+    pBtn_ExitCancel = CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
+                                   localization->GetString(LSTR_DIALOGUE_EXIT), {ui_exit_cancel_button_background});
     CreateButton({7, 8}, {460, 343}, 1, 0, UIMSG_CHEST_ClickItem, 0);
     current_screen_type = CURRENT_SCREEN::SCREEN_CHEST;
     pEventTimer->Pause();
@@ -35,49 +33,37 @@ void GUIWindow_Chest::Update() {
         render->ClearZBuffer();
         draw_leather();
         CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
-        render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f,
-                                    pBtn_ExitCancel->uY / 480.0f,
-                                    ui_exit_cancel_button_background);
+        render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, ui_exit_cancel_button_background);
     } else if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
-        int uChestID = wData.val;
-
-        int *v16 = render->pActiveZBuffer;
         render->ClearZBuffer();
+
+        int uChestID = wData.val;
         int chestBitmapId = vChests[uChestID].uChestBitmapID;
         int chest_offs_x = pChestPixelOffsetX[chestBitmapId];
         int chest_offs_y = pChestPixelOffsetY[chestBitmapId];
         int chestWidthCells = pChestWidthsByType[chestBitmapId];
         int chestHeghtCells = pChestHeightsByType[chestBitmapId];
 
-        GraphicsImage *chest_background = assets->getImage_ColorKey(
-            fmt::format("chest{:02}", pChestList->vChests[chestBitmapId].uTextureID));
+        GraphicsImage *chest_background = assets->getImage_ColorKey(fmt::format("chest{:02}", pChestList->vChests[chestBitmapId].uTextureID));
         render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, chest_background);
 
-        for (int item_counter = 0;
-             item_counter < chestWidthCells * chestHeghtCells; ++item_counter) {
+        for (int item_counter = 0; item_counter < chestWidthCells * chestHeghtCells; ++item_counter) {
             int chest_item_index = vChests[uChestID].pInventoryIndices[item_counter];
             if (chest_item_index > 0) {
-                auto item_texture = assets->getImage_ColorKey(
-                    vChests[uChestID].igChestItems[chest_item_index - 1].GetIconName());
-
+                auto item_texture = assets->getImage_ColorKey(vChests[uChestID].igChestItems[chest_item_index - 1].GetIconName());
                 int itemPixelWidth = item_texture->width();
                 int itemPixelHeght = item_texture->height();
-                if (itemPixelWidth < 14) itemPixelWidth = 14;
-                if (itemPixelHeght < 14) itemPixelHeght = 14;
-                signed int X_offset = (((signed int)((itemPixelWidth - 14) & 0xFFFFFFE0) + 32) - itemPixelWidth) / 2;
-                signed int Y_offset = (((signed int)((itemPixelHeght - 14) & 0xFFFFFFE0) + 32) - itemPixelHeght) / 2;
+                if (itemPixelWidth < 14)
+                    itemPixelWidth = 14;
+                if (itemPixelHeght < 14)
+                    itemPixelHeght = 14;
+                int X_offset = ((((itemPixelWidth - 14) & 0xFFFFFFE0) + 32) - itemPixelWidth) / 2;
+                int Y_offset = ((((itemPixelHeght - 14) & 0xFFFFFFE0) + 32) - itemPixelHeght) / 2;
                 int itemPixelPosX = chest_offs_x + 32 * (item_counter % chestWidthCells) + X_offset;
                 int itemPixelPosY = chest_offs_y + 32 * (item_counter / chestHeghtCells) + Y_offset;
-                render->DrawTextureNew(itemPixelPosX / 640.0f,
-                                            itemPixelPosY / 480.0f,
-                                            item_texture);
-                //        ZBuffer_DoFill2(&v16[itemPixelPosX +
-                //        pSRZBufferLineOffsets[itemPixelPosY]], item_texture,
-                //        item_counter + 1);
+                render->DrawTextureNew(itemPixelPosX / 640.0f, itemPixelPosY / 480.0f, item_texture);
             }
         }
-        render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f,
-                                    pBtn_ExitCancel->uY / 480.0f,
-                                    ui_exit_cancel_button_background);
+        render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, ui_exit_cancel_button_background);
     }
 }

--- a/src/GUI/UI/UIMainMenu.h
+++ b/src/GUI/UI/UIMainMenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "GUI/GUIWindow.h"
 
 class GUIWindow_MainMenu : public GUIWindow {
@@ -9,10 +11,14 @@ class GUIWindow_MainMenu : public GUIWindow {
 
     virtual void Update();
 
-    static void Loop();
     void EventLoop();
 
+    static void drawCopyrightAndInit(std::function<void()> initFunc);
+    static void loop();
+
  protected:
+    static void drawMM7CopyrightWindow();
+
     GUIButton *pBtnExit;
     GUIButton *pBtnCredits;
     GUIButton *pBtnLoad;

--- a/src/GUI/UI/UISpellbook.cpp
+++ b/src/GUI/UI/UISpellbook.cpp
@@ -21,19 +21,9 @@
 
 #include "Library/Random/Random.h"
 
+std::array<std::string, 9> spellbook_texture_filename_suffices = {{"f", "a", "w", "e", "s", "m", "b", "l", "d"}};
 
-void InitializeSpellBookTextures();
-void OnCloseSpellBookPage();
-void OnCloseSpellBook();
-void LoadSpellbook(unsigned int spell_school); // TODO(captainurist): turn parameter into an enum
-static void BookUI_Spellbook_DrawCurrentSchoolBackground();
-
-std::array<const char *, 9> spellbook_texture_filename_suffices = {
-    {"f", "a", "w", "e", "s", "m", "b", "l", "d"}};
-
-std::array<std::array<unsigned char, 12>, 9>
-    pSpellbookSpellIndices =  // 4E2430    from pSpellbookSpellIndices[9][12]
-    {{                        // 0   1   2   3  4    5   6  7    8  9   10  11
+std::array<std::array<unsigned char, 12>, 9> pSpellbookSpellIndices = {{
       {0, 3, 1, 8, 11, 7, 4, 10, 6, 2, 5, 9},
       {0, 11, 2, 9, 6, 8, 5, 10, 3, 7, 1, 4},
       {0, 4, 8, 9, 1, 10, 3, 11, 7, 6, 2, 5},
@@ -42,128 +32,104 @@ std::array<std::array<unsigned char, 12>, 9>
       {0, 5, 9, 8, 3, 7, 6, 4, 1, 11, 2, 10},
       {0, 1, 6, 9, 3, 5, 8, 11, 7, 10, 4, 2},
       {0, 1, 10, 11, 9, 4, 3, 6, 5, 7, 8, 2},
-      {0, 9, 3, 7, 1, 5, 2, 10, 11, 8, 6, 4}}};
+      {0, 9, 3, 7, 1, 5, 2, 10, 11, 8, 6, 4}
+}};
 
-GraphicsImage *ui_spellbook_btn_quckspell = nullptr;
-GraphicsImage *ui_spellbook_btn_quckspell_click = nullptr;
-GraphicsImage *ui_spellbook_btn_close = nullptr;
-GraphicsImage *ui_spellbook_btn_close_click = nullptr;
+std::array<std::string, 9> texNames = {{"SBFB00", "SBAB00", "SBWB00", "SBEB00", "SBSB00", "SBMB00", "SBBB00", "SBLB00", "SBDB00"}};
 
-std::array<GraphicsImage *, 12> SBPageCSpellsTextureList;
-std::array<GraphicsImage *, 12> SBPageSSpellsTextureList;
+std::array<std::array<int, 2>, 9> texture_tab_coord1 = {{
+        {406, 9},   {406, 46},  {406, 84},  {406, 121}, {407, 158},
+        {405, 196}, {405, 234}, {405, 272}, {405, 309}
+}};
 
-std::array<GraphicsImage *, 9> ui_spellbook_school_backgrounds;
-std::array<std::array<GraphicsImage *, 2>, 9> ui_spellbook_school_tabs;
+std::array<std::array<int, 2>, 9> texture_tab_coord0 = {{
+        {415, 10},  {415, 46},  {415, 83},  {415, 121}, {415, 158},
+        {416, 196}, {416, 234}, {416, 271}, {416, 307}
+}};
 
-GUIWindow_Spellbook::GUIWindow_Spellbook()
-    : GUIWindow(WINDOW_SpellBook, {0, 0}, render->GetRenderDimensions(), 0) {
+SPELL_TYPE spellbookSelectedSpell;
+
+GUIWindow_Spellbook::GUIWindow_Spellbook() : GUIWindow(WINDOW_SpellBook, {0, 0}, render->GetRenderDimensions(), 0) {
     current_screen_type = CURRENT_SCREEN::SCREEN_SPELL_BOOK;
     pEventTimer->Pause();
 
-    InitializeSpellBookTextures();
-    OpenSpellbook();
+    initializeTextures();
+    openSpellbook();
 
     // Sound 48 is absent in MM7
     pAudioPlayer->playUISound(SOUND_48);
 }
 
-void GUIWindow_Spellbook::OpenSpellbookPage(int page) {
-    OnCloseSpellBookPage();
+void GUIWindow_Spellbook::openSpellbookPage(int page) {
+    onCloseSpellBookPage();
     pParty->activeCharacter().lastOpenedSpellbookPage = page;
-    OpenSpellbook();
+    openSpellbook();
     pAudioPlayer->playUISound(vrng->randomBool() ? SOUND_TurnPage2 : SOUND_TurnPage1);
 }
 
-void GUIWindow_Spellbook::OpenSpellbook() {
-    Player *pPlayer;  // edi@1
-    // GUIWindow *pWindow; // esi@1
-    // unsigned int v3; // ebp@1
-    int v4;  // eax@3
-    /// GUIButton *result; // eax@25
-    int a2;  // [sp+10h] [bp-8h]@1
-    // int v7; // [sp+14h] [bp-4h]@1
+void GUIWindow_Spellbook::openSpellbook() {
+    int pageSpells = 0;
+    const Player &player = pParty->activeCharacter();
 
-    pPlayer = &pParty->activeCharacter();
-    // pWindow = this;
-    LoadSpellbook(pPlayer->lastOpenedSpellbookPage);
-    // v3 = 0;
-    a2 = 0;
+    loadSpellbook();
 
-    PlayerSpellbookChapter *chapter = &pPlayer->spellbook.pChapters[pPlayer->lastOpenedSpellbookPage];
-    for (uint i = 0; i < 11; ++i) {
+    const PlayerSpellbookChapter *chapter = &player.spellbook.pChapters[player.lastOpenedSpellbookPage];
+    for (int i = 0; i < 11; ++i) {
         if (!chapter->bIsSpellAvailable[i] && !engine->config->debug.AllMagic.value())
             continue;
 
-        v4 = pPlayer->lastOpenedSpellbookPage;
-        // v4 = (12 * pPlayer->lastOpenedSpellbookPage +
-        // pSpellbookSpellIndices[pPlayer->lastOpenedSpellbookPage][i + 1]);
+        int page = player.lastOpenedSpellbookPage;
         CreateButton(fmt::format("SpellBook_Spell{}", i),
-                     {pViewport->uViewportTL_X + pIconPos[v4][pSpellbookSpellIndices[v4][i + 1]].Xpos,
-                     pViewport->uViewportTL_Y + pIconPos[v4][pSpellbookSpellIndices[v4][i + 1]].Ypos},  // dword_4E20D0
-                     SBPageSSpellsTextureList[i + 1]->size(), 1, 79,
+                     {pViewport->uViewportTL_X + pIconPos[page][pSpellbookSpellIndices[page][i + 1]].Xpos,
+                     pViewport->uViewportTL_Y + pIconPos[page][pSpellbookSpellIndices[page][i + 1]].Ypos},
+                     SBPageSSpellsTextureList[i + 1]->size(), 1, UIMSG_Spellbook_ShowHightlightedSpellInfo,
                      UIMSG_SelectSpell, i);
-        ++a2;
-        // ++v3;
+        pageSpells++;
     }
-    // while ( (signed int)v3 < 11 );
 
     CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_SpellBook_PressTab, 0, InputAction::CharCycle);
-    if (a2) _41D08F_set_keyboard_control_group(a2, 0, 0, 0);
+    if (pageSpells) {
+        _41D08F_set_keyboard_control_group(pageSpells, 0, 0, 0);
+    }
 
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_FIRE] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_FIRE] || engine->config->debug.AllMagic.value())
         CreateButton({399, 10}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 0, InputAction::Invalid, localization->GetSpellSchoolName(0));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_AIR] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_AIR] || engine->config->debug.AllMagic.value())
         CreateButton({399, 46}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 1, InputAction::Invalid, localization->GetSpellSchoolName(1));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_WATER] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_WATER] || engine->config->debug.AllMagic.value())
         CreateButton({399, 83}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 2, InputAction::Invalid, localization->GetSpellSchoolName(2));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_EARTH] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_EARTH] || engine->config->debug.AllMagic.value())
         CreateButton({399, 121}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 3, InputAction::Invalid, localization->GetSpellSchoolName(3));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_SPIRIT] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_SPIRIT] || engine->config->debug.AllMagic.value())
         CreateButton({399, 158}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 4, InputAction::Invalid, localization->GetSpellSchoolName(5));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_MIND] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_MIND] || engine->config->debug.AllMagic.value())
         CreateButton({400, 196}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 5, InputAction::Invalid, localization->GetSpellSchoolName(4));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_BODY] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_BODY] || engine->config->debug.AllMagic.value())
         CreateButton({400, 234}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 6, InputAction::Invalid, localization->GetSpellSchoolName(6));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_LIGHT] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_LIGHT] || engine->config->debug.AllMagic.value())
         CreateButton({400, 271}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 7, InputAction::Invalid, localization->GetSpellSchoolName(7));
-    if (pPlayer->pActiveSkills[PLAYER_SKILL_DARK] || engine->config->debug.AllMagic.value())
+    if (player.pActiveSkills[PLAYER_SKILL_DARK] || engine->config->debug.AllMagic.value())
         CreateButton({400, 307}, {50, 36}, 1, 0, UIMSG_OpenSpellbookPage, 8, InputAction::Invalid, localization->GetSpellSchoolName(8));
 
-    CreateButton({476, 450}, ui_spellbook_btn_quckspell->size(), 1, 78,
-                 UIMSG_ClickInstallRemoveQuickSpellBtn, 0);
-    pBtn_InstallRemoveSpell = CreateButton({476, 450}, {48, 32}, 1, 78,
-        UIMSG_ClickInstallRemoveQuickSpellBtn, 0, InputAction::Invalid, "", {ui_spellbook_btn_quckspell_click});
-    CreateButton({561, 450}, ui_spellbook_btn_close->size(), 1, 0,
-                 UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_DIALOGUE_EXIT));
-    pBtn_CloseBook = CreateButton({561, 450}, {48, 32}, 1, 0,
-        UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_DIALOGUE_EXIT), {ui_spellbook_btn_close_click});
+    pBtn_InstallRemoveSpell = CreateButton({476, 450}, ui_spellbook_btn_quckspell->size(), 1, UIMSG_HintSelectRemoveQuickSpellBtn,
+                                           UIMSG_ClickInstallRemoveQuickSpellBtn, 0, InputAction::Invalid, "", {ui_spellbook_btn_quckspell_click});
+    pBtn_CloseBook = CreateButton({561, 450}, ui_spellbook_btn_close->size(), 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
+                                  localization->GetString(LSTR_DIALOGUE_EXIT), {ui_spellbook_btn_close_click});
 }
 
 void GUIWindow_Spellbook::Update() {
-    auto player = &pParty->activeCharacter();
+    const Player &player = pParty->activeCharacter();
+    unsigned int pX_coord, pY_coord;
 
-    GraphicsImage *pTexture;        // edx@5
-    int v10;                // eax@13
-    unsigned int pX_coord;  // esi@18
-    unsigned int pY_coord;  // edi@18
-
-    static unsigned int texture_tab_coord1[9][2] = {
-        {406, 9},   {406, 46},  {406, 84},  {406, 121}, {407, 158},
-        {405, 196}, {405, 234}, {405, 272}, {405, 309}};
-
-    static unsigned int texture_tab_coord0[9][2] = {
-        {415, 10},  {415, 46},  {415, 83},  {415, 121}, {415, 158},
-        {416, 196}, {416, 234}, {416, 271}, {416, 307}};
-
-    BookUI_Spellbook_DrawCurrentSchoolBackground();
+    drawCurrentSchoolBackground();
 
     render->ClearZBuffer();
 
     int page = 0;
     for (PLAYER_SKILL_TYPE i : allMagicSkills()) {
-        if (player->pActiveSkills[i] || engine->config->debug.AllMagic.value()) {
+        if (player.pActiveSkills[i] || engine->config->debug.AllMagic.value()) {
             auto pPageTexture = ui_spellbook_school_tabs[page][0];
-            if (player->lastOpenedSpellbookPage == page) {
+            if (player.lastOpenedSpellbookPage == page) {
                 pPageTexture = ui_spellbook_school_tabs[page][1];
                 pX_coord = texture_tab_coord1[page][0];
                 pY_coord = texture_tab_coord1[page][1];
@@ -172,54 +138,23 @@ void GUIWindow_Spellbook::Update() {
                 pX_coord = texture_tab_coord0[page][0];
                 pY_coord = texture_tab_coord0[page][1];
             }
-            render->DrawTextureNew(pX_coord / 640.0f, pY_coord / 480.0f,
-                                        pPageTexture);
+            render->DrawTextureNew(pX_coord / 640.0f, pY_coord / 480.0f, pPageTexture);
 
-            PlayerSpellbookChapter *chapter =
-                &player->spellbook.pChapters[player->lastOpenedSpellbookPage];
-            for (unsigned int i = 0; i < 11; ++i) {
+            const PlayerSpellbookChapter *chapter = &player.spellbook.pChapters[player.lastOpenedSpellbookPage];
+            for (int i = 0; i < 11; ++i) {
                 if (chapter->bIsSpellAvailable[i] || engine->config->debug.AllMagic.value()) {
-                        // this should check if oplayer knows spell
-                    if (SBPageSSpellsTextureList[i+1]) {
-                        if (quick_spell_at_page == i+1)
-                            pTexture = SBPageCSpellsTextureList[i+1];
-                        else
-                            pTexture = SBPageSSpellsTextureList[i+1];
+                    // this should check if player knows spell
+                    if (SBPageSSpellsTextureList[i + 1]) {
+                        SPELL_TYPE spellFlat = static_cast<SPELL_TYPE>(11 * player.lastOpenedSpellbookPage + i + 1);
+                        GraphicsImage *pTexture = (spellbookSelectedSpell == spellFlat) ? SBPageCSpellsTextureList[i + 1] : SBPageSSpellsTextureList[i + 1];
                         if (pTexture) {
-                            pX_coord =
-                                pViewport->uViewportTL_X +
-                                pIconPos[player->lastOpenedSpellbookPage]
-                                        [pSpellbookSpellIndices
-                                             [player->lastOpenedSpellbookPage]
-                                             [i+1]]
-                                            .Xpos;
-                            pY_coord =
-                                pViewport->uViewportTL_Y +
-                                pIconPos[player->lastOpenedSpellbookPage]
-                                        [pSpellbookSpellIndices
-                                             [player->lastOpenedSpellbookPage]
-                                             [i+1]]
-                                            .Ypos;
+                            SpellBookIconPos &iconPos = pIconPos[player.lastOpenedSpellbookPage][pSpellbookSpellIndices[player.lastOpenedSpellbookPage][i + 1]];
 
-                            render->DrawTextureNew(
-                                pX_coord / 640.0f, pY_coord / 480.0f, pTexture);
+                            pX_coord = pViewport->uViewportTL_X + iconPos.Xpos;
+                            pY_coord = pViewport->uViewportTL_Y + iconPos.Ypos;
 
-                            //
-
-                            render->ZDrawTextureAlpha(
-                                pIconPos[player->lastOpenedSpellbookPage]
-                                        [pSpellbookSpellIndices
-                                             [player->lastOpenedSpellbookPage]
-                                             [i+1]]
-                                            .Xpos /
-                                    640.0f,
-                                pIconPos[player->lastOpenedSpellbookPage]
-                                        [pSpellbookSpellIndices
-                                             [player->lastOpenedSpellbookPage]
-                                             [i+1]]
-                                            .Ypos /
-                                    480.0f,
-                                pTexture, i+1);
+                            render->DrawTextureNew(pX_coord / 640.0f, pY_coord / 480.0f, pTexture);
+                            render->ZDrawTextureAlpha(iconPos.Xpos / 640.0f, iconPos.Ypos / 480.0f, pTexture, i + 1);
                         }
                     }
                 }
@@ -229,86 +164,64 @@ void GUIWindow_Spellbook::Update() {
         page++;
     }
 
-    // if ((11 * player->lastOpenedSpellbookPage) || ((11 *
-    // player->lastOpenedSpellbookPage) + 11))//??? maybe structure need fix
-    //{
-
-    // }
-
     Pointi pt = mouse->GetCursorPos();
     Sizei renDims = render->GetRenderDimensions();
     if (pt.x < renDims.w && pt.y < renDims.h) {
-        v10 = render->pActiveZBuffer[pt.x + pt.y * render->GetRenderDimensions().w] & 0xFFFF;
-        if (v10) {
-            if (SBPageCSpellsTextureList[v10]) {
-                pX_coord =
-                    pViewport->uViewportTL_X +
-                    pIconPos[player->lastOpenedSpellbookPage]
-                    [pSpellbookSpellIndices[player->lastOpenedSpellbookPage]
-                    [v10]]
-                .Xpos;
-                pY_coord =
-                    pViewport->uViewportTL_Y +
-                    pIconPos[player->lastOpenedSpellbookPage]
-                    [pSpellbookSpellIndices[player->lastOpenedSpellbookPage]
-                    [v10]]
-                .Ypos;
+        int idx = render->pActiveZBuffer[pt.x + pt.y * render->GetRenderDimensions().w] & 0xFFFF;
+        if (idx) {
+            if (SBPageCSpellsTextureList[idx]) {
+                SpellBookIconPos &iconPos = pIconPos[player.lastOpenedSpellbookPage][pSpellbookSpellIndices[player.lastOpenedSpellbookPage][idx]];
 
-                render->DrawTextureNew(pX_coord / 640.0f, pY_coord / 480.0f,
-                    SBPageCSpellsTextureList[v10]);
+                pX_coord = pViewport->uViewportTL_X + iconPos.Xpos;
+                pY_coord = pViewport->uViewportTL_Y + iconPos.Ypos;
+
+                render->DrawTextureNew(pX_coord / 640.0f, pY_coord / 480.0f, SBPageCSpellsTextureList[idx]);
             }
         }
     }
 }
 
 void GUIWindow_Spellbook::Release() {
-    OnCloseSpellBookPage();
-    OnCloseSpellBook();
+    onCloseSpellBookPage();
+    onCloseSpellBook();
 
     GUIWindow::Release();
 }
 
-void LoadSpellbook(unsigned int spell_school) {
-    byte_506550 = 0;
-
+void GUIWindow_Spellbook::loadSpellbook() {
     // TODO(captainurist): encapsulate this enum arithmetic properly
-    if (pParty->activeCharacter().uQuickSpell != SPELL_NONE &&
-        (uint8_t)pParty->activeCharacter().uQuickSpell / 11 == spell_school)
-        quick_spell_at_page =
-            (uint8_t)pParty->activeCharacter().uQuickSpell - 11 * spell_school;
+    // TODO(Nik-RE-dev): turn variable into an enum
+    int spellSchool = pParty->activeCharacter().lastOpenedSpellbookPage;
+    if (pParty->activeCharacter().uQuickSpell != SPELL_NONE && pParty->activeCharacter().uQuickSpell / 11 == spellSchool)
+        spellbookSelectedSpell = pParty->activeCharacter().uQuickSpell;
     else
-        quick_spell_at_page = 0;
+        spellbookSelectedSpell = SPELL_NONE;
 
-    for (unsigned int i = 1; i <= 11; ++i) {
-        if (pParty->activeCharacter().spellbook.pChapters[spell_school].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
-            std::string pContainer = fmt::format("SB{}S{:02}",
-                    spellbook_texture_filename_suffices[spell_school],
-                    pSpellbookSpellIndices[spell_school][i]);
+    for (int i = 1; i <= 11; ++i) {
+        if (pParty->activeCharacter().spellbook.pChapters[spellSchool].bIsSpellAvailable[i - 1] || engine->config->debug.AllMagic.value()) {
+            std::string pContainer;
+
+            pContainer = fmt::format("SB{}S{:02}", spellbook_texture_filename_suffices[spellSchool], pSpellbookSpellIndices[spellSchool][i]);
             SBPageSSpellsTextureList[i] = assets->getImage_Solid(pContainer);
 
-            pContainer = fmt::format("SB{}C{:02}",
-                    spellbook_texture_filename_suffices[spell_school],
-                    pSpellbookSpellIndices[spell_school][i]);
+            pContainer = fmt::format("SB{}C{:02}", spellbook_texture_filename_suffices[spellSchool], pSpellbookSpellIndices[spellSchool][i]);
             SBPageCSpellsTextureList[i] = assets->getImage_Solid(pContainer);
         }
     }
 }
 
-static void BookUI_Spellbook_DrawCurrentSchoolBackground() {
+void GUIWindow_Spellbook::drawCurrentSchoolBackground() {
     int pTexID = 0;
     if (pParty->hasActiveCharacter()) {
         pTexID = pParty->activeCharacter().lastOpenedSpellbookPage;
     }
-    render->DrawTextureNew(8 / 640.0f, 8 / 480.0f,
-                                ui_spellbook_school_backgrounds[pTexID]);
+    render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, ui_spellbook_school_backgrounds[pTexID]);
 
-    render->DrawTextureNew(476 / 640.0f, 450 / 480.0f,
-                                ui_spellbook_btn_quckspell);
-    render->DrawTextureNew(561 / 640.0f, 450 / 480.0f,
-                                ui_spellbook_btn_close);
+    render->DrawTextureNew(476 / 640.0f, 450 / 480.0f, ui_spellbook_btn_quckspell);
+    render->DrawTextureNew(561 / 640.0f, 450 / 480.0f, ui_spellbook_btn_close);
 }
 
-void InitializeSpellBookTextures() {
+void GUIWindow_Spellbook::initializeTextures() {
     pAudioPlayer->playUISound(SOUND_openbook);
 
     ui_spellbook_btn_close = assets->getImage_Solid("ib-m5-u");
@@ -316,20 +229,14 @@ void InitializeSpellBookTextures() {
     ui_spellbook_btn_quckspell = assets->getImage_Solid("ib-m6-u");
     ui_spellbook_btn_quckspell_click = assets->getImage_Solid("ib-m6-d");
 
-    static const char *texNames[9] = {"SBFB00", "SBAB00", "SBWB00",
-                                      "SBEB00", "SBSB00", "SBMB00",
-                                      "SBBB00", "SBLB00", "SBDB00"};
-
-    for (unsigned int i = 0; i < 9; ++i) {
+    for (int i = 0; i < 9; ++i) {
         ui_spellbook_school_backgrounds[i] = assets->getImage_ColorKey(texNames[i]);
-        ui_spellbook_school_tabs[i][0] =
-            assets->getImage_Alpha(fmt::format("tab{}a", i + 1));
-        ui_spellbook_school_tabs[i][1] =
-            assets->getImage_Alpha(fmt::format("tab{}b", i + 1));
+        ui_spellbook_school_tabs[i][0] = assets->getImage_Alpha(fmt::format("tab{}a", i + 1));
+        ui_spellbook_school_tabs[i][1] = assets->getImage_Alpha(fmt::format("tab{}b", i + 1));
     }
 }
 
-void OnCloseSpellBook() {
+void GUIWindow_Spellbook::onCloseSpellBook() {
     if (ui_spellbook_btn_close) {
         ui_spellbook_btn_close->Release();
         ui_spellbook_btn_close = nullptr;
@@ -348,7 +255,7 @@ void OnCloseSpellBook() {
         ui_spellbook_btn_quckspell_click = nullptr;
     }
 
-    for (uint i = 0; i < 9; ++i) {
+    for (int i = 0; i < 9; ++i) {
         if (ui_spellbook_school_backgrounds[i]) {
             ui_spellbook_school_backgrounds[i]->Release();
             ui_spellbook_school_backgrounds[i] = nullptr;
@@ -367,7 +274,7 @@ void OnCloseSpellBook() {
     pAudioPlayer->playUISound(SOUND_closebook);
 }
 
-void OnCloseSpellBookPage() {
+void GUIWindow_Spellbook::onCloseSpellBookPage() {
     for (unsigned int i = 1; i <= 11; i++) {
         if (SBPageCSpellsTextureList[i]) {
             SBPageCSpellsTextureList[i]->Release();

--- a/src/GUI/UI/UISpellbook.h
+++ b/src/GUI/UI/UISpellbook.h
@@ -1,5 +1,10 @@
 #pragma once
+
+#include <array>
+
 #include "GUI/GUIWindow.h"
+#include "Engine/Graphics/Image.h"
+#include "Engine/Spells/SpellEnums.h"
 
 class GUIWindow_Spellbook : public GUIWindow {
  public:
@@ -9,12 +14,27 @@ class GUIWindow_Spellbook : public GUIWindow {
     virtual void Update();
     virtual void Release();
 
-    void OpenSpellbook();
-    void OpenSpellbookPage(int page);
+    // TODO(captainurist): turn parameter into an enum
+    void openSpellbookPage(int page);
+
+ protected:
+    void loadSpellbook();
+    void openSpellbook();
+    void initializeTextures();
+    void drawCurrentSchoolBackground();
+    void onCloseSpellBook();
+    void onCloseSpellBookPage();
+
+    GraphicsImage *ui_spellbook_btn_quckspell = nullptr;
+    GraphicsImage *ui_spellbook_btn_quckspell_click = nullptr;
+    GraphicsImage *ui_spellbook_btn_close = nullptr;
+    GraphicsImage *ui_spellbook_btn_close_click = nullptr;
+
+    std::array<GraphicsImage *, 9> ui_spellbook_school_backgrounds{};
+    std::array<std::array<GraphicsImage *, 2>, 9> ui_spellbook_school_tabs{};
+
+    std::array<GraphicsImage *, 12> SBPageCSpellsTextureList{};
+    std::array<GraphicsImage *, 12> SBPageSSpellsTextureList{};
 };
 
-class GraphicsImage;
-extern GraphicsImage *ui_spellbook_btn_quckspell;
-extern GraphicsImage *ui_spellbook_btn_quckspell_click;
-extern GraphicsImage *ui_spellbook_btn_close;
-extern GraphicsImage *ui_spellbook_btn_close_click;
+extern SPELL_TYPE spellbookSelectedSpell;


### PR DESCRIPTION
Refactor code of some UI classes.
1) Chest: just style.
2) Main Menu: move secondary initialization (and drawing copyright window) out of main menu loop which removed static variable.
3) Spellbook:
- Move different functions and some globals inside class.
- Move global `quick_spell_at_page` into UISpellbook.cpp file and change it's semantics. Instead of containing selected spell within page it now contains flat SPELL_TYPE.
- Remove global `byte_506550`. This causes slight change in quick spell set semantics.

`byte_506550` controlled whenever spell was clicked after spellbook was opened and used to control if quick spell must be set or cleared.
- Before it's removal you can open spellbook on the page with quick spell, select some different spell, select previously set quick spell - game will allow to set quick spell, the same one which was set previously.
- After it's removal clicks are not tracked so quick spell setting works uniformly now. If selected spell are quick spell - it will be cleared.