### PR TITLE
House UI: refactor more functions related to picking dialogue options

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -490,7 +490,7 @@ void Game::processQueuedMessages() {
                 ClickNPCTopic((DIALOGUE_TYPE)uMessageParam);
                 continue;
             case UIMSG_SelectShopDialogueOption:
-                OnSelectShopDialogueOption((DIALOGUE_TYPE)uMessageParam);
+                onSelectShopDialogueOption((DIALOGUE_TYPE)uMessageParam);
                 continue;
             case UIMSG_SelectNPCDialogueOption:
                 OnSelectNPCDialogueOption((DIALOGUE_TYPE)uMessageParam);
@@ -770,9 +770,9 @@ void Game::processQueuedMessages() {
                                         uDialogueType = DIALOGUE_NULL;
                                     }
                                     if (uGameState == GAME_STATE_CHANGE_LOCATION) {
-                                        while (HouseDialogPressCloseBtn()) {}
+                                        while (houseDialogPressEscape()) {}
                                     } else {
-                                        if (HouseDialogPressCloseBtn())
+                                        if (houseDialogPressEscape())
                                             continue;
                                     }
                                     GetHouseGoodbyeSpeech();
@@ -1105,7 +1105,7 @@ void Game::processQueuedMessages() {
                     Start_Party_Teleport_Flag =
                         v55 | Party_Teleport_Y_Pos | v56 | v57;
                 }
-                HouseDialogPressCloseBtn();
+                houseDialogPressEscape();
                 pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
                 continue;
 

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -233,7 +233,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_HOUSE) {
                     if (uGameState == GAME_STATE_CHANGE_LOCATION) {
                         dialog_menu_id = DIALOGUE_NULL;
-                        while (HouseDialogPressCloseBtn()) {}
+                        while (houseDialogPressEscape()) {}
                         pMediaPlayer->Unload();
                         window_SpeakInHouse->Release();
                         window_SpeakInHouse = nullptr;
@@ -429,7 +429,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             if (ir.data.npc_topic_descr.index == 5) npc->dialogue_6_evt_id = ir.data.npc_topic_descr.event_id;
             if (ir.data.npc_topic_descr.npc_id == 8) {
                 if (ir.data.npc_topic_descr.event_id == 78) {
-                    HouseDialogPressCloseBtn();
+                    houseDialogPressEscape();
                     window_SpeakInHouse->Release();
                     pParty->uFlags &= ~PARTY_FLAGS_1_ForceRedraw;
                     if (enterHouse(HOUSE_DARK_GUILD_PARAMOUNT_PIT)) {
@@ -446,7 +446,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
 #if 0
             if (window_SpeakInHouse) {
                 if (window_SpeakInHouse->wData.val == HOUSE_BODY_GUILD_MASTER_ERATHIA) {
-                    HouseDialogPressCloseBtn();
+                    houseDialogPressEscape();
                     pMediaPlayer->Unload();
                     window_SpeakInHouse->Release();
                     pParty->uFlags &= ~PARTY_FLAGS_1_ForceRedraw;

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -197,7 +197,9 @@ void _4B4224_UpdateNPCTopics(int _this) {
             AddScriptedDialogueLine(v17->dialogue_6_evt_id, DIALOGUE_SCRIPTED_LINE_6);
 
             pDialogueWindow->_41D08F_set_keyboard_control_group(num_menu_buttons, 1, 0, 2);
-            dword_F8B1E0 = pDialogueWindow->pNumPresenceButton;
+            // TODO(Nik-RE-dev): initial number of buttons used only in non-simple houses now
+            //                   but this causes situation where dead character can talk to someone
+            //dword_F8B1E0 = pDialogueWindow->pNumPresenceButton;
         }
     }
 }

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2535,7 +2535,6 @@ int guild_membership_approved;
 PLAYER_SKILL_MASTERY dword_F8B1B0_MasteryBeingTaught;
 int gold_transaction_amount;  // F8B1B4
 std::array<const char *, 4> pShopOptions;
-int dword_F8B1E0;
 int dword_F8B1E4;
 std::string current_npc_text;                        // F8B1E8
 char dialogue_show_profession_details = false;  // F8B1EC

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -189,7 +189,6 @@ extern int guild_membership_approved;
 extern PLAYER_SKILL_MASTERY dword_F8B1B0_MasteryBeingTaught;
 extern int gold_transaction_amount;  // F8B1B4
 extern std::array<const char *, 4> pShopOptions; // TODO(Nik-RE-dev): used only for local pointers, not needed as global
-extern int dword_F8B1E0;
 extern int dword_F8B1E4;
 extern std::string current_npc_text;  // F8B1E8
 extern char dialogue_show_profession_details;

--- a/src/GUI/GUIButton.cpp
+++ b/src/GUI/GUIButton.cpp
@@ -111,11 +111,3 @@ bool GUIButton::Contains(unsigned int x, unsigned int y) {
 void CreateShopDialogueButtonAtRow(int row, DIALOGUE_TYPE type) {
     pDialogueWindow->CreateButton({480, 146 + 30 * row}, {140, 30}, 1, 0, UIMSG_SelectShopDialogueOption, type, InputAction::Invalid, "");
 }
-
-void UI_CreateEndConversationButton() {
-    pDialogueWindow->Release();
-    pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetPresentDimensions().w, 345}, 0);
-    pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
-        localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background});
-    pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0, InputAction::Invalid, "");
-}

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -122,4 +122,3 @@ extern std::array<GUIButton*, 4> pCreationUI_BtnPressLeft;
 extern std::array<GUIButton*, 4> pCreationUI_BtnPressRight;
 
 void CreateShopDialogueButtonAtRow(int row_index, DIALOGUE_TYPE type);
-void UI_CreateEndConversationButton();

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -132,7 +132,7 @@ void GUIWindow_MagicGuild::mainDialogue() {
         return;
     }
 
-    if (!HouseUI_CheckIfPlayerCanInteract()) {
+    if (!checkIfPlayerCanInteract()) {
         return;
     }
 
@@ -177,9 +177,9 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
         ++itemxind;
     }
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int itemcount = 0;
-        for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; ++i) {
+        for (int i = 0; i < itemAmountInShop[buildingType()]; ++i) {
             if (pParty->spellBooksInGuilds[houseId()][i].uItemID != ITEM_NULL)
                 ++itemcount;
         }
@@ -226,7 +226,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
 void GUIWindow_MagicGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
     if (option == DIALOGUE_GUILD_BUY_BOOKS) {
         if (pParty->PartyTimes.guildNextRefreshTime[houseId()] >= pParty->GetPlayingTime()) {
-            for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; ++i) {
+            for (int i = 0; i < itemAmountInShop[buildingType()]; ++i) {
                 if (pParty->spellBooksInGuilds[houseId()][i].uItemID != ITEM_NULL)
                     shop_ui_items_in_store[i] = assets->getImage_ColorKey(pParty->spellBooksInGuilds[houseId()][i].GetIconName());
             }
@@ -255,8 +255,7 @@ void GUIWindow_MagicGuild::houseSpecificDialogue() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions(DIALOGUE_TYPE option) {
-    // TODO(Nik-RE-dev): add buildingType() to GUIWindow_House
-    BuildingType guildType = buildingTable[wData.val - 1].uType;
+    BuildingType guildType = buildingType();
 
     switch (option) {
       case DIALOGUE_MAIN:
@@ -271,7 +270,7 @@ std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions(DIALOGUE_TY
 }
 
 void GUIWindow_MagicGuild::generateSpellBooksForGuild() {
-    BuildingType guildType = buildingTable[wData.val - 1].uType;
+    BuildingType guildType = buildingType();
 
     // Combined guilds exist only in MM6/MM8 and need to be processed separately
     assert(guildType >= BuildingType_FireGuild && guildType <= BuildingType_DarkGuild);
@@ -280,7 +279,7 @@ void GUIWindow_MagicGuild::generateSpellBooksForGuild() {
     PLAYER_SKILL_MASTERY maxMastery = guildSpellsMastery[houseId()];
     Segment<ITEM_TYPE> spellbooksForGuild = spellbooksOfSchool(schoolType, maxMastery);
 
-    for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; ++i) {
+    for (int i = 0; i < itemAmountInShop[guildType]; ++i) {
         ITEM_TYPE pItemNum = grng->randomSample(spellbooksForGuild);
 
         if (pItemNum == ITEM_SPELLBOOK_DIVINE_INTERVENTION) {

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -35,7 +35,8 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
             pDialogueWindow->pNumPresenceButton = 0;
             return;
         }
-        if (!HouseUI_CheckIfPlayerCanInteract()) return;
+        if (!checkIfPlayerCanInteract())
+            return;
         int all_text_height = 0;
         int index = 0;
         for (int i = pDialogueWindow->pStartingPosActiveItem; i < pDialogueWindow->pNumPresenceButton + pDialogueWindow->pStartingPosActiveItem; ++i) {
@@ -53,7 +54,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
         return;
     }
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         __debugbreak();  // what type of house that even is?
         // pSkillAvailabilityPerClass[8 + v58->uClass][4 + v23]
         // or

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -256,7 +256,7 @@ void GUIWindow_Shop::mainDialogue() {
     dialogwin.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     dialogwin.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         pShopOptions[0] = localization->GetString(LSTR_STANDARD);
         pShopOptions[1] = localization->GetString(LSTR_SPECIAL);
         pShopOptions[2] = localization->GetString(LSTR_DISPLAY);
@@ -301,7 +301,7 @@ void GUIWindow_Shop::displayEquipmentDialogue() {
     pShopOptions[1] = localization->GetString(LSTR_IDENTIFY);
     pShopOptions[2] = localization->GetString(LSTR_REPAIR);
 
-    int options = (buildingTable[wData.val - 1].uType == BuildingType_AlchemistShop) ? 2 : 3;
+    int options = (buildingType() == BuildingType_AlchemistShop) ? 2 : 3;
     int all_text_height = 0;
     for (int i = 0; i < options; ++i)
         all_text_height += pFontArrus->CalcTextHeight(pShopOptions[i], dialogwin.uFrameWidth, 0);
@@ -334,7 +334,7 @@ void GUIWindow_Shop::sellDialogue() {
     draw_leather();
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), Color());
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
@@ -346,7 +346,7 @@ void GUIWindow_Shop::sellDialogue() {
         int pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex);
         if (pItemID) {
             ItemGen *item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
-            MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingTable[wData.val - 1].uType, wData.val, 3);
+            MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), wData.val, 3);
             std::string str = BuildDialogueString(pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, wData.val, 3);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             dialogwin.DrawTitleText(pFontArrus, 0, vertMargin, colorTable.White, str, 3);
@@ -363,7 +363,7 @@ void GUIWindow_Shop::identifyDialogue() {
     draw_leather();
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), Color());
 
         Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
@@ -379,7 +379,7 @@ void GUIWindow_Shop::identifyDialogue() {
 
             std::string str;
             if (!item->IsIdentified()) {
-                MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingTable[wData.val - 1].uType, wData.val, 4);
+                MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), wData.val, 4);
                 str = BuildDialogueString(pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, wData.val, 4);
             } else {
                 str = BuildDialogueString("%24", pParty->activeCharacterIndex() - 1, item, wData.val, 4);
@@ -400,7 +400,7 @@ void GUIWindow_Shop::repairDialogue() {
     draw_leather();
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), Color());
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
@@ -415,7 +415,7 @@ void GUIWindow_Shop::repairDialogue() {
 
         if (pParty->activeCharacter().pOwnItems[pItemID - 1].uAttributes & ITEM_BROKEN) {
             ItemGen *item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
-            MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingTable[wData.val - 1].uType, wData.val, 5);
+            MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), wData.val, 5);
             std::string str = BuildDialogueString(pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, wData.val, 5);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             dialogwin.DrawTitleText(pFontArrus, 0, vertMargin, colorTable.White, str, 3);
@@ -429,7 +429,7 @@ void GUIWindow_Shop::learnSkillsDialogue() {
     dialogwin.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     dialogwin.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
-    if (!HouseUI_CheckIfPlayerCanInteract())
+    if (!checkIfPlayerCanInteract())
         return;
 
     int item_num = 0;
@@ -465,7 +465,7 @@ void GUIWindow_WeaponShop::shopWaresDialogue(bool isSpecial) {
         item_X += 70;
     }
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int item_num = 0;
         for (int i = 0; i < 6; ++i) {
             item_num += (isSpecial ? pParty->specialItemsInShops[houseId()][i].uItemID : pParty->standartItemsInShops[houseId()][i].uItemID) != ITEM_NULL;
@@ -537,7 +537,7 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
         item_x += 105;
     }
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int pItemCount = 0;
         for (int i = 0; i < 6; ++i) {
             pItemCount += (isSpecial ? pParty->specialItemsInShops[houseId()][i].uItemID : pParty->standartItemsInShops[houseId()][i].uItemID) != ITEM_NULL;
@@ -582,7 +582,7 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
 
                             std::string str;
                             if (!isStealingModeActive()) {
-                                MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingTable[wData.val - 1].uType, wData.val, 2);
+                                MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), wData.val, 2);
                                 str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, wData.val, 2);
                             } else {
                                 str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, item, wData.val, 2);
@@ -639,7 +639,7 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
         }
     }
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int item_num = 0;
 
         for (int i = 0; i < 12; ++i) {
@@ -685,7 +685,7 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
 
                             std::string str;
                             if (!isStealingModeActive()) {
-                                MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingTable[wData.val - 1].uType, wData.val, 2);
+                                MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), wData.val, 2);
                                 str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, wData.val, 2);
                             } else {
                                 str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, item, wData.val, 2);
@@ -706,7 +706,7 @@ void GUIWindow_WeaponShop::generateShopItems(bool isSpecial) {
     std::array<ItemGen, 12> &itemArray = isSpecial ? pParty->specialItemsInShops[houseId()] : pParty->standartItemsInShops[houseId()];
     const ITEM_VARIATION variation = isSpecial ? weaponShopVariationSpecial[houseId()] : weaponShopVariationStandart[houseId()];
 
-    for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; i++) {
+    for (int i = 0; i < itemAmountInShop[buildingType()]; i++) {
         int itemClass = variation.item_class[grng->random(4)];
         pItemTable->generateItem(variation.treasure_level, itemClass, &itemArray[i]);
         itemArray[i].SetIdentified();
@@ -720,7 +720,7 @@ void GUIWindow_ArmorShop::generateShopItems(bool isSpecial) {
     const ITEM_VARIATION variationTop = isSpecial ? armorShopTopRowVariationSpecial[houseId()] : armorShopTopRowVariationStandart[houseId()];
     const ITEM_VARIATION variationBottom = isSpecial ? armorShopBottomRowVariationSpecial[houseId()] : armorShopBottomRowVariationStandart[houseId()];
 
-    for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; i++) {
+    for (int i = 0; i < itemAmountInShop[buildingType()]; i++) {
         int itemClass;
         ITEM_TREASURE_LEVEL treasureLvl;
 
@@ -742,7 +742,7 @@ void GUIWindow_MagicShop::generateShopItems(bool isSpecial) {
     std::array<ItemGen, 12> &itemArray = isSpecial ? pParty->specialItemsInShops[houseId()] : pParty->standartItemsInShops[houseId()];
     ITEM_TREASURE_LEVEL treasureLvl = isSpecial ? magicShopVariationSpecial[houseId()] : magicShopVariationStandart[houseId()];
 
-    for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; i++) {
+    for (int i = 0; i < itemAmountInShop[buildingType()]; i++) {
         pItemTable->generateItem(treasureLvl, 22, &itemArray[i]);
         itemArray[i].SetIdentified();
     }
@@ -755,7 +755,7 @@ void GUIWindow_AlchemyShop::generateShopItems(bool isSpecial) {
     ITEM_TREASURE_LEVEL treasureLvl = isSpecial ? alchemyShopVariationSpecial[houseId()] : alchemyShopVariationStandart[houseId()];
     int bottomRowItemClass = isSpecial ? 44 : 45;
 
-    for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; i++) {
+    for (int i = 0; i < itemAmountInShop[buildingType()]; i++) {
         if (i < 6) {
             itemArray[i].Reset();
             if (isSpecial) {
@@ -843,6 +843,7 @@ void GUIWindow_Shop::houseSpecificDialogue() {
         learnSkillsDialogue();
         break;
       default:
+        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         break;
     }
 }
@@ -856,20 +857,23 @@ void GUIWindow_Shop::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
             pParty->PartyTimes.shopNextRefreshTime[houseId()] = nextGenTime;
         }
 
+        BuildingType shopType = buildingType();
         const std::array<ItemGen, 12> &itemArray = (option == DIALOGUE_SHOP_BUY_STANDARD) ? pParty->standartItemsInShops[houseId()] : pParty->specialItemsInShops[houseId()];
-        for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; ++i) {
+        for (int i = 0; i < itemAmountInShop[shopType]; ++i) {
             if (itemArray[i].uItemID != ITEM_NULL) {
                 shop_ui_items_in_store[i] = assets->getImage_ColorKey(itemArray[i].GetIconName());
             }
         }
-        if (buildingTable[wData.val - 1].uType == BuildingType_WeaponShop) {
-            for (int i = 0; i < itemAmountInShop[buildingTable[wData.val - 1].uType]; ++i) {
+        if (shopType == BuildingType_WeaponShop) {
+            for (int i = 0; i < itemAmountInShop[shopType]; ++i) {
                 if (itemArray[i].uItemID != ITEM_NULL) {
                     // Note that we're using grng here for a reason - we want recorded mouse clicks to work.
                     weaponYPos[i] = grng->random(300 - shop_ui_items_in_store[i]->height());
                 }
             }
         }
+    } else if (option == DIALOGUE_SHOP_SELL || option == DIALOGUE_SHOP_IDENTIFY || option == DIALOGUE_SHOP_REPAIR) {
+        pParty->placeHeldItemInInventoryOrDrop();
     } else if (IsSkillLearningDialogue(option)) {
         learnSelectedSkill(GetLearningDialogueSkill(option));
     }
@@ -893,6 +897,19 @@ std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listDialogueOptions(DIALOGUE_T
         return {DIALOGUE_SHOP_SELL, DIALOGUE_SHOP_IDENTIFY};
     }
     return GUIWindow_Shop::listDialogueOptions(option);
+}
+
+DIALOGUE_TYPE GUIWindow_Shop::getOptionOnEscape() {
+    if (IsSkillLearningDialogue(dialog_menu_id)) {
+        return DIALOGUE_LEARN_SKILLS;
+    }
+    if (dialog_menu_id == DIALOGUE_SHOP_SELL || dialog_menu_id == DIALOGUE_SHOP_IDENTIFY || dialog_menu_id == DIALOGUE_SHOP_REPAIR) {
+        return DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
+    }
+    if (dialog_menu_id == DIALOGUE_MAIN) {
+        return DIALOGUE_NULL;
+    }
+    return DIALOGUE_MAIN;
 }
 
 void GUIWindow_Shop::processStealingResult(int stealingResult, int fineToAdd) {  // not working properly??
@@ -950,7 +967,7 @@ void UIShop_Buy_Identify_Repair() {
         return;
     }
 
-    if (!HouseUI_CheckIfPlayerCanInteract()) {
+    if (!window_SpeakInHouse->checkIfPlayerCanInteract()) {
         pAudioPlayer->playUISound(SOUND_error);
         return;
     }

--- a/src/GUI/UI/Houses/Shops.h
+++ b/src/GUI/UI/Houses/Shops.h
@@ -15,6 +15,7 @@ class GUIWindow_Shop : public GUIWindow_House {
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual DIALOGUE_TYPE getOptionOnEscape() override;
 
     /**
      * @offset 0x4B1447

--- a/src/GUI/UI/Houses/Tavern.h
+++ b/src/GUI/UI/Houses/Tavern.h
@@ -13,6 +13,7 @@ class GUIWindow_Tavern : public GUIWindow_House {
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual DIALOGUE_TYPE getOptionOnEscape() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -146,7 +146,7 @@ void GUIWindow_Temple::learnSkillsDialogue() {
     temple_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     temple_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int allTextHeight = 0;
         int availableSkills = 0;
         int cost = PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1]);
@@ -209,6 +209,16 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions(DIALOGUE_TYPE o
       default:
         return {};
     }
+}
+
+DIALOGUE_TYPE GUIWindow_Temple::getOptionOnEscape() {
+    if (IsSkillLearningDialogue(dialog_menu_id)) {
+        return DIALOGUE_LEARN_SKILLS;
+    }
+    if (dialog_menu_id == DIALOGUE_MAIN) {
+        return DIALOGUE_NULL;
+    }
+    return DIALOGUE_MAIN;
 }
 
 bool GUIWindow_Temple::isPlayerHealableByTemple(const Player &player) const {

--- a/src/GUI/UI/Houses/Temple.h
+++ b/src/GUI/UI/Houses/Temple.h
@@ -14,6 +14,7 @@ class GUIWindow_Temple : public GUIWindow_House {
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual DIALOGUE_TYPE getOptionOnEscape() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -57,7 +57,7 @@ void GUIWindow_TownHall::mainDialogue() {
 }
 
 void GUIWindow_TownHall::bountyHuntDialogue() {
-    GUIWindow townHall_window = *window_SpeakInHouse;
+    GUIWindow townHall_window = *this;
     townHall_window.uFrameX = SIDE_TEXT_BOX_POS_X;
     townHall_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     townHall_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -31,7 +31,7 @@ void GUIWindow_Training::mainDialogue() {
     training_dialog_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     training_dialog_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1]);
         uint64_t expForNextLevel = 1000ull * pParty->activeCharacter().uLevel * (pParty->activeCharacter().uLevel + 1) / 2;
         int index = 0;
@@ -90,7 +90,7 @@ void GUIWindow_Training::trainDialogue() {
     int pPrice = PriceCalculator::trainingCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1]);
     uint64_t expForNextLevel = 1000ull * pParty->activeCharacter().uLevel * (pParty->activeCharacter().uLevel + 1) / 2;
 
-    if (!HouseUI_CheckIfPlayerCanInteract()) {
+    if (!checkIfPlayerCanInteract()) {
         int height = pFontArrus->CalcTextHeight(pNPCTopics[122].pText, training_dialog_window.uFrameWidth, 0);
         training_dialog_window.DrawTitleText(pFontArrus, 0, (212 - height) / 2 + 101, colorTable.Jonquil, pNPCTopics[122].pText, 3);
         pDialogueWindow->pNumPresenceButton = 0;
@@ -153,7 +153,7 @@ void GUIWindow_Training::learnSkillsDialogue() {
     training_dialog_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
     int all_text_height = 0;
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1]);
         int index = 0;
         for (int i = pDialogueWindow->pStartingPosActiveItem; i < pDialogueWindow->pNumPresenceButton + pDialogueWindow->pStartingPosActiveItem; ++i) {
@@ -211,4 +211,14 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions(DIALOGUE_TYPE
       default:
         return {};
     }
+}
+
+DIALOGUE_TYPE GUIWindow_Training::getOptionOnEscape() {
+    if (IsSkillLearningDialogue(dialog_menu_id)) {
+        return DIALOGUE_LEARN_SKILLS;
+    }
+    if (dialog_menu_id == DIALOGUE_MAIN) {
+        return DIALOGUE_NULL;
+    }
+    return DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/Houses/Training.h
+++ b/src/GUI/UI/Houses/Training.h
@@ -17,6 +17,7 @@ class GUIWindow_Training : public GUIWindow_House {
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual DIALOGUE_TYPE getOptionOnEscape() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -98,7 +98,7 @@ void GUIWindow_Transport::mainDialogue() {
 
     int pPrice = PriceCalculator::transportCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1]);
 
-    if (HouseUI_CheckIfPlayerCanInteract()) {
+    if (checkIfPlayerCanInteract()) {
         int index = 0;
 
         std::string travelcost = localization->FormatString(LSTR_FMT_TRAVEL_COST_D_GOLD, pPrice);
@@ -223,7 +223,7 @@ void GUIWindow_Transport::transportDialogue() {
         restAndHeal(GameTime::FromDays(getTravelTimeTransportDays(transportRoutes[houseId()][choice_id])));
         pParty->activeCharacter().playReaction(pSpeech);
         pAudioPlayer->soundDrain();
-        while (HouseDialogPressCloseBtn()) {}
+        while (houseDialogPressEscape()) {}
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 0, 0);
     } else {
         dialog_menu_id = DIALOGUE_MAIN;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -278,42 +278,28 @@ IndexedArray<int, BuildingType_WeaponShop, BuildingType_DarkGuild> itemAmountInS
     {BuildingType_BodyGuild, 12},
     {BuildingType_LightGuild, 12},
     {BuildingType_DarkGuild, 12}
-}};;
+}};
 
-static std::array<const char *, 19> _4F03B8_shop_background_names = {
-    { "", "WEPNTABL", "ARMORY", "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF",
-    "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF",
-    "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF", "MAGSHELF" } };
+IndexedArray<std::string, BuildingType_WeaponShop, BuildingType_MirroredPath> shopBackgroundNames = {{
+    {BuildingType_WeaponShop, "WEPNTABL"},
+    {BuildingType_ArmorShop, "ARMORY"},
+    {BuildingType_MagicShop, "MAGSHELF"},
+    {BuildingType_AlchemistShop, "MAGSHELF"},
+    {BuildingType_FireGuild, "MAGSHELF"},
+    {BuildingType_AirGuild, "MAGSHELF"},
+    {BuildingType_WaterGuild, "MAGSHELF"},
+    {BuildingType_EarthGuild, "MAGSHELF"},
+    {BuildingType_SpiritGuild, "MAGSHELF"},
+    {BuildingType_MindGuild, "MAGSHELF"},
+    {BuildingType_BodyGuild, "MAGSHELF"},
+    {BuildingType_LightGuild, "MAGSHELF"},
+    {BuildingType_DarkGuild, "MAGSHELF"},
+    {BuildingType_ElementalGuild, "MAGSHELF"},
+    {BuildingType_SelfGuild, "MAGSHELF"},
+    {BuildingType_MirroredPath, "MAGSHELF"}
+}};
 
 std::array<std::string, 6> portraitClickLabel;
-
-bool HouseUI_CheckIfPlayerCanInteract() {
-    if (!pParty->hasActiveCharacter()) {  // to avoid access zeroeleement
-        return false;
-    }
-
-    if (pParty->activeCharacter().CanAct()) {
-        pDialogueWindow->pNumPresenceButton = dword_F8B1E0;
-        return true;
-    } else {
-        pDialogueWindow->pNumPresenceButton = 0;
-        GUIWindow window = *pPrimaryWindow;
-        window.uFrameX = SIDE_TEXT_BOX_POS_X;
-        window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
-        window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
-
-        std::string str = localization->FormatString(
-            LSTR_FMT_S_IS_IN_NO_CODITION_TO_S,
-            pParty->activeCharacter().name.c_str(),
-            localization->GetString(LSTR_DO_ANYTHING));
-        window.DrawTitleText(
-            pFontArrus, 0,
-            (212 - pFontArrus->CalcTextHeight(str, window.uFrameWidth, 0)) / 2 +
-            101,
-            ui_house_player_cant_interact_color, str, 3);
-        return false;
-    }
-}
 
 bool enterHouse(HOUSE_ID uHouseID) {
     GameUI_StatusBar_Clear();
@@ -521,103 +507,6 @@ void GetHouseGoodbyeSpeech() {
                 }
             }
         }
-    }
-}
-
-//----- (004BCACC) --------------------------------------------------------
-void OnSelectShopDialogueOption(DIALOGUE_TYPE option) {
-    if (!pDialogueWindow->pNumPresenceButton)
-        return;
-    render->ClearZBuffer();
-
-    if (dialog_menu_id == DIALOGUE_MAIN) {
-        pDialogueWindow->Release();
-        pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetRenderDimensions().w, 345}, 0);
-        pBtn_ExitCancel = pDialogueWindow->CreateButton({526, 445}, {75, 33}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
-                                                        localization->GetString(LSTR_END_CONVERSATION), {ui_buttdesc2});
-        pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0);
-        dialog_menu_id = option;
-        if (in_current_building_type < BuildingType_TownHall_MM6) {
-            shop_ui_background = assets->getImage_ColorKey(_4F03B8_shop_background_names[(int)in_current_building_type]);
-        }
-    }
-
-    // NEW
-    // TODO(Nik-RE-dev): houseDialogueOptionSelected must be called without switch
-    switch (in_current_building_type) {
-      case BuildingType_FireGuild:
-      case BuildingType_AirGuild:
-      case BuildingType_WaterGuild:
-      case BuildingType_EarthGuild:
-      case BuildingType_SpiritGuild:
-      case BuildingType_MindGuild:
-      case BuildingType_BodyGuild:
-      case BuildingType_LightGuild:
-      case BuildingType_DarkGuild:
-      case BuildingType_ElementalGuild:
-      case BuildingType_SelfGuild:
-      case BuildingType_MirroredPath:
-      case BuildingType_Bank:
-      case BuildingType_Temple:
-      case BuildingType_Tavern:
-      case BuildingType_Training:
-      case BuildingType_Jail:
-      case BuildingType_MercenaryGuild:
-      case BuildingType_TownHall:
-      case BuildingType_WeaponShop:
-      case BuildingType_ArmorShop:
-      case BuildingType_MagicShop:
-      case BuildingType_AlchemistShop:
-        window_SpeakInHouse->houseDialogueOptionSelected(option);
-        break;
-      default:
-        return;
-    }
-
-    switch (option) {
-    case DIALOGUE_LEARN_SKILLS:
-    {
-        pDialogueWindow->eWindowType = WINDOW_MainMenu;
-        UI_CreateEndConversationButton();
-        window_SpeakInHouse->initializeDialog();
-        break;
-    }
-    case DIALOGUE_TAVERN_ARCOMAGE_MAIN:
-    {
-        pDialogueWindow->eWindowType = WINDOW_MainMenu;
-        UI_CreateEndConversationButton();
-        window_SpeakInHouse->initializeDialog();
-        break;
-    }
-    case DIALOGUE_TAVERN_ARCOMAGE_RULES:
-    case DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS:
-    {
-        dialog_menu_id = option;
-        break;
-    }
-    case DIALOGUE_TAVERN_ARCOMAGE_RESULT:
-    {
-        pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_PlayArcomage, 0, 0);
-        dialog_menu_id = DIALOGUE_TAVERN_ARCOMAGE_RESULT;
-        break;
-    }
-    case DIALOGUE_SHOP_SELL:
-    case DIALOGUE_SHOP_IDENTIFY:
-    case DIALOGUE_SHOP_REPAIR:
-    {
-        dialog_menu_id = option;
-        pParty->placeHeldItemInInventoryOrDrop();
-        break;
-    }
-    case DIALOGUE_SHOP_DISPLAY_EQUIPMENT:
-    {
-        pDialogueWindow->eWindowType = WINDOW_MainMenu;
-        UI_CreateEndConversationButton();
-        window_SpeakInHouse->initializeDialog();
-        break;
-    }
-    default:
-        break;
     }
 }
 
@@ -831,80 +720,68 @@ void SimpleHouseDialog() {
     }
 }
 
-int HouseDialogPressCloseBtn() {
+void onSelectShopDialogueOption(DIALOGUE_TYPE option) {
+    if (!pDialogueWindow || !pDialogueWindow->pNumPresenceButton) {
+        return;
+    }
+
+    render->ClearZBuffer();
+
+    dialog_menu_id = option;
+    window_SpeakInHouse->houseDialogueOptionSelected(option);
+    window_SpeakInHouse->reinitDialogueWindow();
+    window_SpeakInHouse->initializeDialog();
+}
+
+bool houseDialogPressEscape() {
     pCurrentFrameMessageQueue->Flush();
     keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_CANCELLED);
     keyboardInputHandler->ResetKeys();
     activeLevelDecoration = nullptr;
     current_npc_text.clear();
-    if (pDialogueNPCCount == 0) return 0;
 
-    if (dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL &&
-        shop_ui_background) {
-        shop_ui_background->Release();
-        shop_ui_background = nullptr;
+    if (pDialogueNPCCount == 0) {
+        return false;
     }
 
-    switch (dialog_menu_id) {
-    case -1:
+    if (dialog_menu_id == DIALOGUE_OTHER) {
         _4B4224_UpdateNPCTopics(pDialogueNPCCount - 1);
         BackToHouseMenu();
-        break;
+        return true;
+    }
 
-    case DIALOGUE_SHOP_DISPLAY_EQUIPMENT:
-    case DIALOGUE_LEARN_SKILLS:
-    case DIALOGUE_TAVERN_ARCOMAGE_MAIN:
-        BackToHouseMenu();
-        UI_CreateEndConversationButton();
-        dialog_menu_id = DIALOGUE_MAIN;
-        window_SpeakInHouse->initializeDialog();
-        break;
-
-    case DIALOGUE_SHOP_SELL:
-    case DIALOGUE_SHOP_IDENTIFY:
-    case DIALOGUE_SHOP_REPAIR:
-        UI_CreateEndConversationButton();
-        dialog_menu_id = DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
-        window_SpeakInHouse->initializeDialog();
-        break;
-
-    case DIALOGUE_TAVERN_ARCOMAGE_RULES:
-    case DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS:
-    case DIALOGUE_TAVERN_ARCOMAGE_RESULT:
-        BackToHouseMenu();
-        UI_CreateEndConversationButton();
-        dialog_menu_id = DIALOGUE_TAVERN_ARCOMAGE_MAIN;
-        window_SpeakInHouse->initializeDialog();
-        break;
-
-    case DIALOGUE_NULL:
-    case DIALOGUE_MAIN:
+    if (dialog_menu_id == DIALOGUE_NULL || dialog_menu_id == DIALOGUE_MAIN) {
         pDialogueNPCCount = 0;
-        pDialogueWindow->Release();
+        if (pDialogueWindow) {
+            pDialogueWindow->Release();
+        }
+        if (shop_ui_background) {
+            shop_ui_background->Release();
+            shop_ui_background = nullptr;
+        }
         dialog_menu_id = DIALOGUE_NULL;
-        pDialogueWindow = 0;
+        pDialogueWindow = nullptr;
 
-        if (uNumDialogueNPCPortraits == 1) return 0;
+        if (uNumDialogueNPCPortraits == 1) {
+            return false;
+        }
 
         pBtn_ExitCancel = window_SpeakInHouse->vButtons.front();
-        if (uNumDialogueNPCPortraits > 0) {
-            for (uint i = 0; i < (unsigned int)uNumDialogueNPCPortraits; ++i) {
-                HouseNPCPortraitsButtonsList[i] = window_SpeakInHouse->CreateButton(
-                    {pNPCPortraits_x[uNumDialogueNPCPortraits - 1][i], pNPCPortraits_y[uNumDialogueNPCPortraits - 1][i]}, {63, 73}, 1, 0,
-                    UIMSG_ClickHouseNPCPortrait, i, InputAction::Invalid, portraitClickLabel[i]);
-            }
+        for (int i = 0; i < uNumDialogueNPCPortraits; ++i) {
+            Pointi pos = {pNPCPortraits_x[uNumDialogueNPCPortraits - 1][i], pNPCPortraits_y[uNumDialogueNPCPortraits - 1][i]};
+            HouseNPCPortraitsButtonsList[i] = window_SpeakInHouse->CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
+                                                                                InputAction::Invalid, portraitClickLabel[i]);
         }
 
         BackToHouseMenu();
-        break;
-
-    default:
-        BackToHouseMenu();
-        dialog_menu_id = DIALOGUE_MAIN;
-        window_SpeakInHouse->initializeDialog();
-        break;
+        return true;
     }
-    return 1;
+
+    dialog_menu_id = window_SpeakInHouse->getOptionOnEscape();
+    window_SpeakInHouse->reinitDialogueWindow();
+    window_SpeakInHouse->initializeDialog();
+
+    return true;
 }
 
 void createHouseUI(HOUSE_ID houseId) {
@@ -972,6 +849,7 @@ void createHouseUI(HOUSE_ID houseId) {
     }
 }
 
+// TODO(Nik-RE-dev): looks like this function is not needed anymore
 void BackToHouseMenu() {
     auto pMouse = EngineIocContainer::ResolveMouse();
     pMouse->ClearPickedItem();
@@ -980,7 +858,7 @@ void BackToHouseMenu() {
     if (window_SpeakInHouse && window_SpeakInHouse->wData.val == 165 &&
         !pMovie_Track) {
         bGameoverLoop = true;
-        HouseDialogPressCloseBtn();
+        houseDialogPressEscape();
         window_SpeakInHouse->Release();
         pParty->uFlags &= 0xFFFFFFFD;
         if (enterHouse(HOUSE_BODY_GUILD_MASTER_ERATHIA)) {
@@ -990,6 +868,43 @@ void BackToHouseMenu() {
         bGameoverLoop = false;
     }
 #endif
+}
+
+void GUIWindow_House::reinitDialogueWindow() {
+    if (pDialogueWindow) {
+        pDialogueWindow->Release();
+    }
+
+    pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetPresentDimensions().w, 345}, 0);
+    pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
+        localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background});
+    pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0, InputAction::Invalid, "");
+}
+
+bool GUIWindow_House::checkIfPlayerCanInteract() {
+    if (!pParty->hasActiveCharacter()) {  // to avoid access zeroeleement
+        return false;
+    }
+
+    // Do nothing if no current conversation exist
+    if (!pDialogueWindow) {
+        return true;
+    }
+
+    if (pParty->activeCharacter().CanAct()) {
+        pDialogueWindow->pNumPresenceButton = _savedButtonsNum;
+        return true;
+    } else {
+        pDialogueWindow->pNumPresenceButton = 0;
+        GUIWindow window = *window_SpeakInHouse;
+        window.uFrameX = SIDE_TEXT_BOX_POS_X;
+        window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
+        window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
+
+        std::string str = localization->FormatString(LSTR_FMT_S_IS_IN_NO_CODITION_TO_S, pParty->activeCharacter().name.c_str(), localization->GetString(LSTR_DO_ANYTHING));
+        window.DrawTitleText(pFontArrus, 0, (212 - pFontArrus->CalcTextHeight(str, window.uFrameWidth, 0)) / 2 + 101, ui_house_player_cant_interact_color, str, 3);
+        return false;
+    }
 }
 
 void GUIWindow_House::houseDialogManager() {
@@ -1107,6 +1022,10 @@ void GUIWindow_House::houseDialogManager() {
 }
 
 void GUIWindow_House::initializeDialog() {
+    if (!pDialogueWindow) {
+        return;
+    }
+
     std::vector<DIALOGUE_TYPE> optionList = listDialogueOptions(dialog_menu_id);
 
     if (optionList.size()) {
@@ -1115,7 +1034,7 @@ void GUIWindow_House::initializeDialog() {
         }
         pDialogueWindow->_41D08F_set_keyboard_control_group(optionList.size(), 1, 0, 2);
     }
-    dword_F8B1E0 = pDialogueWindow->pNumPresenceButton;
+    _savedButtonsNum = pDialogueWindow->pNumPresenceButton;
 }
 
 void GUIWindow_House::learnSelectedSkill(PLAYER_SKILL_TYPE skill) {
@@ -1145,6 +1064,11 @@ GUIWindow_House::GUIWindow_House(HOUSE_ID houseId) : GUIWindow(WINDOW_HouseInter
     current_screen_type = CURRENT_SCREEN::SCREEN_HOUSE;
     pBtn_ExitCancel = CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
                                    localization->GetString(LSTR_EXIT_BUILDING), {ui_exit_cancel_button_background});
+
+    if (in_current_building_type <= BuildingType_MirroredPath) {
+        shop_ui_background = assets->getImage_ColorKey(shopBackgroundNames[in_current_building_type]);
+    }
+
     for (int curNpc = 0; curNpc < uNumDialogueNPCPortraits; curNpc++) {
         int labelFmt;
         std::string labelData;
@@ -1216,4 +1140,11 @@ void GUIWindow_House::houseSpecificDialogue() {
 
 std::vector<DIALOGUE_TYPE> GUIWindow_House::listDialogueOptions(DIALOGUE_TYPE option) {
     return {};
+}
+
+DIALOGUE_TYPE GUIWindow_House::getOptionOnEscape() {
+    if (dialog_menu_id == DIALOGUE_MAIN) {
+        return DIALOGUE_NULL;
+    }
+    return DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -16,10 +16,15 @@ constexpr int SIDE_TEXT_BOX_BODY_TEXT_HEIGHT = 174;
 constexpr int SIDE_TEXT_BOX_BODY_TEXT_OFFSET = 138;
 constexpr int SIDE_TEXT_BOX_MAX_SPACING = 32;
 
-bool HouseUI_CheckIfPlayerCanInteract();
 void PlayHouseSound(unsigned int uHouseID, HouseSoundID sound);  // idb
 void SimpleHouseDialog();
-void OnSelectShopDialogueOption(DIALOGUE_TYPE option);
+
+void BackToHouseMenu();
+
+/**
+ * @offset 0x4BCACC
+ */
+void onSelectShopDialogueOption(DIALOGUE_TYPE option);
 void PrepareHouse(HOUSE_ID house);  // idb
 
 void createHouseUI(HOUSE_ID houseId);
@@ -28,9 +33,8 @@ void createHouseUI(HOUSE_ID houseId);
  * @offset 0x44622E
  */
 bool enterHouse(HOUSE_ID uHouseID);
-void BackToHouseMenu();
 
-int HouseDialogPressCloseBtn();
+bool houseDialogPressEscape();
 
 void GetHouseGoodbyeSpeech();
 
@@ -42,6 +46,10 @@ class GUIWindow_House : public GUIWindow {
     virtual void Update();
     virtual void Release();
 
+    BuildingType buildingType() const {
+        return buildingTable[wData.val - 1].uType;
+    }
+
     HOUSE_ID houseId() const {
         return static_cast<HOUSE_ID>(wData.val); // TODO(captainurist): drop all direct accesses to wData.val.
     }
@@ -49,11 +57,17 @@ class GUIWindow_House : public GUIWindow {
     void houseDialogManager();
     void initializeDialog();
     void learnSelectedSkill(PLAYER_SKILL_TYPE skill);
+    void reinitDialogueWindow();
+    bool checkIfPlayerCanInteract();
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option);
     // TODO(Nik-RE-dev): add DIALOGUE_TYPE argument?
     virtual void houseSpecificDialogue();
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option);
+    virtual DIALOGUE_TYPE getOptionOnEscape();
+
+ protected:
+    int _savedButtonsNum{};
 };
 
 // Originally was a packed struct.


### PR DESCRIPTION
- Add `buildingType()` function to base class.
- Move `HouseUI_CheckIfPlayerCanInteract` function inside class.
- Move `dword_F8B1E0` global inside class (it saves number of dialogue buttons for the case where you switch to the character that cannot act).
- Move most of functionality from functions `OnSelectShopDialogueOption` and `HouseDialogPressCloseBtn` functions inside class.
- Move `UI_CreateEndConversationButton` function into class and rename it to `reinitDialogueWindow`.