### PR TITLE
Refactor shop screen click

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -483,8 +483,10 @@ void Game::processQueuedMessages() {
             case UIMSG_StartHireling2Dialogue:
                 Game_StartHirelingDialogue(uMessage - UIMSG_StartHireling1Dialogue);
                 continue;
-            case UIMSG_BuyInShop_Identify_Repair:
-                UIShop_Buy_Identify_Repair();
+            case UIMSG_HouseScreenClick:
+                if (window_SpeakInHouse) {
+                    window_SpeakInHouse->houseScreenClick();
+                }
                 continue;
             case UIMSG_ClickNPCTopic:
                 ClickNPCTopic((DIALOGUE_TYPE)uMessageParam);

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -121,7 +121,7 @@ void NPCHireableDialogPrepare() {
     pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0,
         UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_CANCEL), {ui_exit_cancel_button_background}
     );
-    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0);
+    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_HouseScreenClick, 0);
     if (!pNPCStats->pProfessions[v1->profession].pBenefits.empty()) {
         pDialogueWindow->CreateButton({480, 160}, {140, 30}, 1, 0,
             UIMSG_ClickNPCTopic, DIALOGUE_PROFESSION_DETAILS, InputAction::Invalid, localization->GetString(LSTR_MORE_INFORMATION)
@@ -170,7 +170,7 @@ void _4B4224_UpdateNPCTopics(int _this) {
         pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0,
             UIMSG_Escape, 0, InputAction::Invalid, localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background}
         );
-        pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0);
+        pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_HouseScreenClick, 0);
         dialog_menu_id = DIALOGUE_MAIN;
         if (pDialogueNPCCount == 1 && dword_591080) {
             window_SpeakInHouse->initializeDialog();

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -59,7 +59,7 @@ enum UIMessageType : uint32_t {
     UIMSG_HintSelectRemoveQuickSpellBtn = 78,
     UIMSG_Spellbook_ShowHightlightedSpellInfo = 79,
 
-    UIMSG_BuyInShop_Identify_Repair = 81,
+    UIMSG_HouseScreenClick = 81,
     UIMSG_LoadGame = 82,
     UIMSG_SaveGame = 83,
     UIMSG_54 = 84,

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -482,7 +482,7 @@ void DrawJoinGuildWindow(GUILD_ID guild_id) {
     pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
         localization->GetString(LSTR_CANCEL), { ui_exit_cancel_button_background }
     );
-    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0, InputAction::Invalid, "");
+    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_HouseScreenClick, 0, InputAction::Invalid, "");
     pDialogueWindow->CreateButton({480, 160}, {140, 30}, 1, 0, UIMSG_ClickNPCTopic, DIALOGUE_82_join_guild, InputAction::Invalid,
         localization->GetString(LSTR_JOIN));
     pDialogueWindow->_41D08F_set_keyboard_control_group(1, 1, 0, 2);
@@ -1155,7 +1155,7 @@ void _4B3FE5_training_dialogue(int eventId) {
     pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
         localization->GetString(LSTR_CANCEL), { ui_exit_cancel_button_background }
     );
-    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0, InputAction::Invalid, "");
+    pDialogueWindow->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_HouseScreenClick, 0, InputAction::Invalid, "");
     pDialogueWindow->CreateButton({480, 160}, {0x8Cu, 0x1Eu}, 1, 0, UIMSG_ClickNPCTopic, DIALOGUE_79_mastery_teacher, InputAction::Invalid,
         guild_membership_approved ? localization->GetString(LSTR_LEARN) : "");
     pDialogueWindow->_41D08F_set_keyboard_control_group(1, 1, 0, 2);

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -269,6 +269,61 @@ std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions(DIALOGUE_TY
     }
 }
 
+void GUIWindow_MagicGuild::houseScreenClick() {
+    if (!checkIfPlayerCanInteract()) {
+        pAudioPlayer->playUISound(SOUND_error);
+        return;
+    }
+
+    Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
+
+    int testx = (pt.x - 32) / 70;
+    if (testx >= 0 && testx < 6) {
+        if (pt.y >= 250) {
+            testx += 6;
+        }
+
+        ItemGen &boughtItem = pParty->spellBooksInGuilds[houseId()][testx];
+        if (boughtItem.uItemID != ITEM_NULL) {
+            int testpos;
+            if (pt.y >= 250) {
+                testpos = 32 + 70 * testx - 420;
+            } else {
+                testpos = 32 + 70 * testx;
+            }
+
+            if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->height())) ||
+                    (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->height()))) {
+                    float fPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
+                    int uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), boughtItem.GetValue(), fPriceMultiplier);
+
+                    if (pParty->GetGold() < uPriceItemService) {
+                        PlayHouseSound(wData.val, (HouseSoundID)2);
+                        GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                        return;
+                    }
+
+                    int itemSlot = pParty->activeCharacter().AddItem(-1, boughtItem. uItemID);
+                    if (itemSlot) {
+                        boughtItem.SetIdentified();
+                        pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = boughtItem;
+                        dword_F8B1E4 = 1;
+                        pParty->TakeGold(uPriceItemService);
+                        boughtItem.Reset();
+                        render->ClearZBuffer();
+                        pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
+                        return;
+                    }
+
+                    pParty->activeCharacter().playReaction(SPEECH_NoRoom);
+                    GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
+                }
+            }
+        }
+    }
+}
+
 void GUIWindow_MagicGuild::generateSpellBooksForGuild() {
     BuildingType guildType = buildingType();
 

--- a/src/GUI/UI/Houses/MagicGuild.h
+++ b/src/GUI/UI/Houses/MagicGuild.h
@@ -15,6 +15,7 @@ class GUIWindow_MagicGuild : public GUIWindow_House {
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual void houseScreenClick() override;
 
  protected:
     /**

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -932,55 +932,6 @@ void GUIWindow_Shop::houseScreenClick() {
             break;
         }
 
-        case DIALOGUE_GUILD_BUY_BOOKS: {
-            int testx = (pt.x - 32) / 70;
-            if (testx >= 0 && testx < 6) {
-                if (pt.y >= 250) {
-                    testx += 6;
-                }
-
-                ItemGen &boughtItem = pParty->spellBooksInGuilds[houseId()][testx];
-                if (boughtItem.uItemID != ITEM_NULL) {
-                    int testpos;
-                    if (pt.y >= 250) {
-                        testpos = 32 + 70 * testx - 420;
-                    } else {
-                        testpos = 32 + 70 * testx;
-                    }
-
-                    if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
-                        if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->height())) ||
-                            (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->height()))) {
-                            int pPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
-                            int uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), boughtItem.GetValue(), pPriceMultiplier);
-
-                            if (pParty->GetGold() < uPriceItemService) {
-                                PlayHouseSound(wData.val, (HouseSoundID)2);
-                                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-                                return;
-                            }
-
-                            int itemSlot = pParty->activeCharacter().AddItem(-1, boughtItem.uItemID);
-                            if (itemSlot) {
-                                boughtItem.SetIdentified();
-                                pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = boughtItem;
-                                dword_F8B1E4 = 1;
-                                pParty->TakeGold(uPriceItemService);
-                                boughtItem.Reset();
-                                render->ClearZBuffer();
-                                pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
-                                return;
-                            }
-
-                            pParty->activeCharacter().playReaction(SPEECH_NoRoom);
-                            GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
-                        }
-                    }
-                }
-            }
-            break;
-        }
-
         case DIALOGUE_SHOP_SELL: {
             int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
             if (pt.x <= 13 || pt.x >= 462) {

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -912,6 +912,314 @@ DIALOGUE_TYPE GUIWindow_Shop::getOptionOnEscape() {
     return DIALOGUE_MAIN;
 }
 
+void GUIWindow_Shop::houseScreenClick() {
+    if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
+        pParty->activeCharacter().OnInventoryLeftClick();
+        return;
+    }
+
+    if (!checkIfPlayerCanInteract()) {
+        pAudioPlayer->playUISound(SOUND_error);
+        return;
+    }
+
+    Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
+
+    switch (dialog_menu_id) {
+        case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
+            current_character_screen_window = WINDOW_CharacterWindow_Inventory;
+            pParty->activeCharacter().OnInventoryLeftClick();
+            break;
+        }
+
+        case DIALOGUE_GUILD_BUY_BOOKS: {
+            int testx = (pt.x - 32) / 70;
+            if (testx >= 0 && testx < 6) {
+                if (pt.y >= 250) {
+                    testx += 6;
+                }
+
+                ItemGen &boughtItem = pParty->spellBooksInGuilds[houseId()][testx];
+                if (boughtItem.uItemID != ITEM_NULL) {
+                    int testpos;
+                    if (pt.y >= 250) {
+                        testpos = 32 + 70 * testx - 420;
+                    } else {
+                        testpos = 32 + 70 * testx;
+                    }
+
+                    if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                        if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->height())) ||
+                            (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->height()))) {
+                            int pPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
+                            int uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), boughtItem.GetValue(), pPriceMultiplier);
+
+                            if (pParty->GetGold() < uPriceItemService) {
+                                PlayHouseSound(wData.val, (HouseSoundID)2);
+                                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                                return;
+                            }
+
+                            int itemSlot = pParty->activeCharacter().AddItem(-1, boughtItem.uItemID);
+                            if (itemSlot) {
+                                boughtItem.SetIdentified();
+                                pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = boughtItem;
+                                dword_F8B1E4 = 1;
+                                pParty->TakeGold(uPriceItemService);
+                                boughtItem.Reset();
+                                render->ClearZBuffer();
+                                pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
+                                return;
+                            }
+
+                            pParty->activeCharacter().playReaction(SPEECH_NoRoom);
+                            GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
+                        }
+                    }
+                }
+            }
+            break;
+        }
+
+        case DIALOGUE_SHOP_SELL: {
+            int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
+            if (pt.x <= 13 || pt.x >= 462) {
+                return;
+            }
+
+            int pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex);
+            if (!pItemID) {
+                return;
+            }
+
+            if (pParty->activeCharacter().pInventoryItemList[pItemID - 1].MerchandiseTest(wData.val)) {
+                dword_F8B1E4 = 1;
+                pParty->activeCharacter().SalesProcess(invindex, pItemID - 1, wData.val);
+                render->ClearZBuffer();
+                pParty->activeCharacter().playReaction(SPEECH_ItemSold);
+                return;
+            }
+
+            pParty->activeCharacter().playReaction(SPEECH_WrongShop);
+            pAudioPlayer->playUISound(SOUND_error);
+            break;
+        }
+
+        case DIALOGUE_SHOP_IDENTIFY: {
+            int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
+            if (pt.x <= 13 || pt.x >= 462) {
+                return;
+            }
+
+            int pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex);
+            if (!pItemID) {
+                return;
+            }
+
+            float fPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
+            int uPriceItemService = PriceCalculator::itemIdentificationPriceForPlayer(&pParty->activeCharacter(), fPriceMultiplier);
+            ItemGen &item = pParty->activeCharacter().pInventoryItemList[pItemID - 1];
+
+            if (!(item.uAttributes & ITEM_IDENTIFIED)) {
+                if (item.MerchandiseTest(wData.val)) {
+                    if (pParty->GetGold() >= uPriceItemService) {
+                        dword_F8B1E4 = 1;
+                        pParty->TakeGold(uPriceItemService);
+                        item.uAttributes |= ITEM_IDENTIFIED;
+                        pParty->activeCharacter().playReaction(SPEECH_ShopIdentify);
+                        GameUI_SetStatusBar(LSTR_DONE);
+                        return;
+                    }
+
+                    PlayHouseSound(wData.val, (HouseSoundID)2);
+                    return;
+                }
+
+                pAudioPlayer->playUISound(SOUND_error);
+                pParty->activeCharacter().playReaction(SPEECH_WrongShop);
+                return;
+            }
+
+            pParty->activeCharacter().playReaction(SPEECH_AlreadyIdentified);
+            break;
+        }
+
+        case DIALOGUE_SHOP_REPAIR: {
+            int invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
+            if (pt.x <= 13 || pt.x >= 462) {
+                return;
+            }
+
+            int pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex);
+            if (!pItemID) {
+                return;
+            }
+
+            ItemGen &item = pParty->activeCharacter().pInventoryItemList[pItemID - 1];
+            float fPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
+            int uPriceItemService = PriceCalculator::itemRepairPriceForPlayer(&pParty->activeCharacter(), item.GetValue(), fPriceMultiplier);
+
+            if (item.uAttributes & ITEM_BROKEN) {
+                if (item.MerchandiseTest(wData.val)) {
+                    if (pParty->GetGold() >= uPriceItemService) {
+                        dword_F8B1E4 = 1;
+                        pParty->TakeGold(uPriceItemService);
+                        item.uAttributes = (item.uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
+                        pParty->activeCharacter().playReaction(SPEECH_ShopRepair);
+                        GameUI_SetStatusBar(LSTR_GOOD_AS_NEW);
+                        return;
+                    }
+
+                    PlayHouseSound(wData.val, (HouseSoundID)2);
+                    return;
+                }
+
+                pAudioPlayer->playUISound(SOUND_error);
+                pParty->activeCharacter().playReaction(SPEECH_WrongShop);
+                return;
+            }
+
+            pParty->activeCharacter().playReaction(SPEECH_AlreadyIdentified);
+            break;
+        }
+
+        case DIALOGUE_SHOP_BUY_STANDARD:
+        case DIALOGUE_SHOP_BUY_SPECIAL: {
+            int testx;
+            int testpos;
+            ItemGen *boughtItem = nullptr;
+
+            switch (buildingType()) {
+              case BuildingType_WeaponShop:
+                testx = (pt.x - 30) / 70;
+                if (testx >= 0 && testx < 6) {
+                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        boughtItem = &pParty->standartItemsInShops[houseId()][testx];
+                    else
+                        boughtItem = &pParty->specialItemsInShops[houseId()][testx];
+
+                    if (boughtItem->uItemID != ITEM_NULL) {
+                        testpos = ((60 - (shop_ui_items_in_store[testx]->width() / 2)) + testx * 70);
+                        if (pt.x >= testpos && pt.x < (testpos + shop_ui_items_in_store[testx]->width())) {
+                            if (pt.y >= weaponYPos[testx] + 30 && pt.y < (weaponYPos[testx] + 30 + shop_ui_items_in_store[testx]->height())) {
+                                break;  // good
+                            }
+                        }
+                    }
+                }
+                return;
+
+              case BuildingType_ArmorShop:
+                testx = (pt.x - 40) / 105;
+                if (testx >= 0 && testx < 4) {
+                    if (pt.y >= 126) {
+                        testx += 4;
+                    }
+
+                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        boughtItem = &pParty->standartItemsInShops[houseId()][testx];
+                    else
+                        boughtItem = &pParty->specialItemsInShops[houseId()][testx];
+
+                    if (boughtItem->uItemID != ITEM_NULL) {
+                        if (testx >= 4) {
+                            testpos = ((90 - (shop_ui_items_in_store[testx]->width() / 2)) + (testx * 105) - 420);  // low row
+                        } else {
+                            testpos = ((86 - (shop_ui_items_in_store[testx]->width() / 2)) + testx * 105);
+                        }
+
+                        if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                            if ((pt.y >= 126 && pt.y < (126 + shop_ui_items_in_store[testx]->height())) ||
+                                (pt.y <= 98 && pt.y >= (98 - shop_ui_items_in_store[testx]->height()))) {
+                                break;  // good
+                            }
+                        }
+                    }
+                }
+                return;
+
+              case BuildingType_AlchemistShop:
+              case BuildingType_MagicShop:
+                testx = (pt.x) / 75;
+                if (testx >= 0 && testx < 6) {
+                    if (pt.y > 152) {
+                        testx += 6;
+                    }
+
+                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        boughtItem = &pParty->standartItemsInShops[houseId()][testx];
+                    else
+                        boughtItem = &pParty->specialItemsInShops[houseId()][testx];
+
+                    if (boughtItem->uItemID != ITEM_NULL) {
+                        if (pt.y > 152) {
+                            testpos = 75 * testx - shop_ui_items_in_store[testx]->width() / 2 + 40 - 450;
+                        } else {
+                            testpos = 75 * testx - shop_ui_items_in_store[testx]->width() / 2 + 40;
+                        }
+
+                        if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                            if ((pt.y <= 308 && pt.y >= (308 - shop_ui_items_in_store[testx]->height())) ||
+                                (pt.y <= 152 && pt.y >= (152 - shop_ui_items_in_store[testx]->height()))) {
+                                // y is 152-h to 152 or 308-height to 308
+                                break;  // good
+                            }
+                        }
+                    }
+                }
+                return;
+
+              default:
+                return;
+            }
+
+            float fPriceMultiplier = buildingTable[wData.val - 1].fPriceMultiplier;
+            int uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), boughtItem->GetValue(), fPriceMultiplier);
+            int stealResult = 0;
+            int stealDifficulty = 0;
+            int fine;
+            if (pMapStats->GetMapInfo(pCurrentMapName)) {
+                stealDifficulty = pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)]._steal_perm;
+            }
+            int partyReputation = pParty->GetPartyReputation();
+            if (isStealingModeActive()) {
+                stealResult = pParty->activeCharacter().StealFromShop(boughtItem, stealDifficulty, partyReputation, 0, &fine);
+                if (!stealResult) {
+                    // caught stealing no item
+                    processStealingResult(0, fine);
+                    return;
+                }
+            } else if (pParty->GetGold() < uPriceItemService) {
+                PlayHouseSound(wData.val, (HouseSoundID)2);
+                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                return;
+            }
+
+            int itemSlot = pParty->activeCharacter().AddItem(-1, boughtItem->uItemID);
+            if (itemSlot) {
+                boughtItem->SetIdentified();
+                pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = *boughtItem;
+                if (stealResult != 0) {  // stolen
+                    pParty->activeCharacter().pInventoryItemList[itemSlot - 1].SetStolen();
+                    processStealingResult(stealResult, fine);
+                } else {
+                    dword_F8B1E4 = 1;
+                    pParty->TakeGold(uPriceItemService);
+                }
+                boughtItem->Reset();
+                render->ClearZBuffer();
+                pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
+                return;
+            } else {
+                pParty->activeCharacter().playReaction(SPEECH_NoRoom);
+                GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
+                return;
+            }
+            break;
+        }
+    }
+}
+
 void GUIWindow_Shop::processStealingResult(int stealingResult, int fineToAdd) {  // not working properly??
     int reputationDelta = 0;
 
@@ -941,408 +1249,4 @@ void GUIWindow_Shop::processStealingResult(int stealingResult, int fineToAdd) { 
     loc.reputation += reputationDelta;
     if (loc.reputation > 10000)
         loc.reputation = 10000;
-}
-
-//----- (004BDB56) --------------------------------------------------------
-void UIShop_Buy_Identify_Repair() {
-    unsigned int pItemID;  // esi@20
-    ItemGen *item;         // esi@21
-
-    // int v18;                   // ecx@37
-    float pPriceMultiplier;    // ST1C_4@38
-    int taken_item;            // eax@40
-    ItemGen *bought_item = nullptr;      // esi@51
-    int party_reputation;      // eax@55
-    int v39;                   // eax@63
-    uint16_t *pSkill;  // esi@77
-    int v55;                   // [sp+0h] [bp-B4h]@26
-    int a6;                    // [sp+98h] [bp-1Ch]@57
-    int a3;                    // [sp+9Ch] [bp-18h]@53
-    unsigned int uNumSeconds;  // [sp+A4h] [bp-10h]@53
-    unsigned int invindex;     // [sp+A8h] [bp-Ch]@9
-    int uPriceItemService;     // [sp+ACh] [bp-8h]@12
-
-    if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-        pParty->activeCharacter().OnInventoryLeftClick();
-        return;
-    }
-
-    if (!window_SpeakInHouse->checkIfPlayerCanInteract()) {
-        pAudioPlayer->playUISound(SOUND_error);
-        return;
-    }
-
-    Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
-
-    switch (dialog_menu_id) {
-        case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
-            current_character_screen_window = WINDOW_CharacterWindow_Inventory;
-            pParty->activeCharacter().OnInventoryLeftClick();
-            break;
-        }
-
-        case DIALOGUE_GUILD_BUY_BOOKS: {
-            int testx = (pt.x - 32) / 70;
-            if (testx >= 0 && testx < 6) {
-                if (pt.y >= 250) {
-                    testx += 6;
-                }
-
-                bought_item = &pParty->spellBooksInGuilds[window_SpeakInHouse->houseId()][testx];
-                if (bought_item->uItemID != ITEM_NULL) {
-                    int testpos;
-                    if (pt.y >= 250) {
-                        testpos = 32 + 70 * testx - 420;
-                    } else {
-                        testpos = 32 + 70 * testx;
-                    }
-
-                    if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
-                        if ((pt.y >= 90 && pt.y <= (90 + shop_ui_items_in_store[testx]->height())) ||
-                            (pt.y >= 250 && pt.y <= (250 + shop_ui_items_in_store[testx]->height()))) {
-                            pPriceMultiplier = buildingTable[window_SpeakInHouse->wData.val - 1].fPriceMultiplier;
-                            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(),
-                                                                                          bought_item->GetValue(), pPriceMultiplier);
-
-                            if (pParty->GetGold() < uPriceItemService) {
-                                PlayHouseSound(window_SpeakInHouse->wData.val, (HouseSoundID)2);
-                                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-                                return;
-                            }
-
-                            taken_item = pParty->activeCharacter().AddItem(-1, bought_item->uItemID);
-                            if (taken_item) {
-                                bought_item->SetIdentified();
-                                pParty->activeCharacter().pInventoryItemList[taken_item - 1] = *bought_item;
-                                dword_F8B1E4 = 1;
-                                pParty->TakeGold(uPriceItemService);
-                                bought_item->Reset();
-                                render->ClearZBuffer();
-                                pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
-                                return;
-                            }
-
-                            pParty->activeCharacter().playReaction(SPEECH_NoRoom);
-                            GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return;  // no item
-            break;
-        }
-
-        case DIALOGUE_SHOP_SELL: {
-            invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
-            if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex),
-                 !pItemID))
-                return;
-
-            if (pParty->activeCharacter()
-                    .pInventoryItemList[pItemID - 1]
-                    .MerchandiseTest(window_SpeakInHouse->wData.val)) {
-                dword_F8B1E4 = 1;
-                pParty->activeCharacter().SalesProcess(
-                    invindex, pItemID - 1, window_SpeakInHouse->wData.val);
-                render->ClearZBuffer();
-                pParty->activeCharacter().playReaction(SPEECH_ItemSold);
-                return;
-            }
-
-            pParty->activeCharacter().playReaction(SPEECH_WrongShop);
-            pAudioPlayer->playUISound(SOUND_error);
-            break;
-        }
-
-        case DIALOGUE_SHOP_IDENTIFY: {
-            invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
-            if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(invindex),
-                 !pItemID))
-                return;
-
-            uPriceItemService = PriceCalculator::itemIdentificationPriceForPlayer(
-                &pParty->activeCharacter(), buildingTable[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-            item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
-
-            if (!(item->uAttributes & ITEM_IDENTIFIED)) {
-                if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
-                    if (pParty->GetGold() >= uPriceItemService) {
-                        dword_F8B1E4 = 1;
-                        pParty->TakeGold(uPriceItemService);
-                        item->uAttributes |= ITEM_IDENTIFIED;
-                        pParty->activeCharacter().playReaction(SPEECH_ShopIdentify);
-                        GameUI_SetStatusBar(LSTR_DONE);
-                        return;
-                    }
-
-                    PlayHouseSound(window_SpeakInHouse->wData.val,
-                                   (HouseSoundID)2);
-                    return;
-                }
-
-                pAudioPlayer->playUISound(SOUND_error);
-                pParty->activeCharacter().playReaction(SPEECH_WrongShop);
-                return;
-            }
-
-            pParty->activeCharacter().playReaction(SPEECH_AlreadyIdentified);
-            break;
-        }
-
-        case DIALOGUE_SHOP_REPAIR: {
-            invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
-            if (pt.x <= 13 || pt.x >= 462 ||
-                (pItemID = pParty->activeCharacter().GetItemListAtInventoryIndex(
-                         invindex),
-                 !pItemID))
-                return;
-
-            item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
-            pPriceMultiplier =
-                buildingTable[window_SpeakInHouse->wData.val - 1]
-                    .fPriceMultiplier;
-            uPriceItemService = PriceCalculator::itemRepairPriceForPlayer(&pParty->activeCharacter(), item->GetValue(), pPriceMultiplier);
-
-            if (item->uAttributes & ITEM_BROKEN) {
-                if (item->MerchandiseTest(window_SpeakInHouse->wData.val)) {
-                    if (pParty->GetGold() >= uPriceItemService) {
-                        dword_F8B1E4 = 1;
-                        pParty->TakeGold(uPriceItemService);
-                        item->uAttributes =
-                            (item->uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
-                        pParty->activeCharacter().playReaction(SPEECH_ShopRepair);
-                        GameUI_SetStatusBar(LSTR_GOOD_AS_NEW);
-                        return;
-                    }
-
-                    PlayHouseSound(window_SpeakInHouse->wData.val,
-                                   (HouseSoundID)2);
-                    return;
-                }
-
-                pAudioPlayer->playUISound(SOUND_error);
-                pParty->activeCharacter().playReaction(SPEECH_WrongShop);
-                return;
-            }
-
-            pParty->activeCharacter().playReaction(SPEECH_AlreadyIdentified);
-            break;
-        }
-
-        case DIALOGUE_SHOP_BUY_STANDARD:
-        case DIALOGUE_SHOP_BUY_SPECIAL: {
-            int testx;
-            int testpos;
-
-            switch (in_current_building_type) {
-                case BuildingType_WeaponShop:
-
-                    testx = (pt.x - 30) / 70;
-                    if (testx >= 0 && testx < 6) {
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
-                            bought_item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
-                        else
-                            bought_item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
-
-                        if (bought_item->uItemID != ITEM_NULL) {
-                            testpos =
-                                ((60 -
-                                  ((signed int) shop_ui_items_in_store[testx]->width() /
-                                   2)) +
-                                 testx * 70);
-                            if (pt.x >= testpos &&
-                                pt.x <
-                                    (testpos +
-                                     (signed int) shop_ui_items_in_store[testx]->width())) {
-                                if (pt.y >= weaponYPos[testx] + 30 &&
-                                    pt.y < (weaponYPos[testx] + 30 + shop_ui_items_in_store[testx]->height())) {
-                                    break;  // good
-                                }
-                            } else {
-                                bought_item = nullptr;
-                                return;
-                            }
-                        } else {
-                            return;
-                        }
-                    }
-                    break;
-
-                case BuildingType_ArmorShop:
-
-                    testx = (pt.x - 40) / 105;
-                    if (testx >= 0 && testx < 4) {
-                        if (pt.y >= 126) {
-                            testx += 4;
-                        }
-
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
-                            bought_item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
-                        else
-                            bought_item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
-
-                        if (bought_item->uItemID != ITEM_NULL) {
-                            if (testx >= 4) {
-                                testpos = ((90 - (shop_ui_items_in_store[testx]->width() /
-                                                  2)) +
-                                           (testx * 105) - 420);  // low row
-                            } else {
-                                testpos = ((86 - (shop_ui_items_in_store[testx]->width() /
-                                                  2)) +
-                                           testx * 105);
-                            }
-
-                            if (pt.x >= testpos &&
-                                pt.x <=
-                                    testpos + shop_ui_items_in_store[testx]->width()) {
-                                if ((pt.y >= 126 &&
-                                    pt.y <
-                                         (126 + shop_ui_items_in_store[testx]->height())) ||
-                                    (pt.y <= 98 &&
-                                        pt.y >=
-                                         (98 - shop_ui_items_in_store[testx]->height()))) {
-                                    break;  // good
-                                }
-                            } else {
-                                bought_item = nullptr;
-                                return;
-                            }
-                        } else {
-                            return;
-                        }
-                    }
-                    break;
-
-                case BuildingType_AlchemistShop:
-                case BuildingType_MagicShop:
-
-                    testx = (pt.x) / 75;
-                    if (testx >= 0 && testx < 6) {
-                        if (pt.y > 152) {
-                            testx += 6;
-                        }
-
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
-                            bought_item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
-                        else
-                            bought_item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
-
-                        if (bought_item->uItemID != ITEM_NULL) {
-                            if (pt.y > 152) {
-                                testpos =
-                                    75 * testx - shop_ui_items_in_store[testx]->width() /
-                                        2 +
-                                    40 - 450;
-                            } else {
-                                testpos =
-                                    75 * testx - shop_ui_items_in_store[testx]->width() /
-                                        2 +
-                                    40;
-                            }
-
-                            if (pt.x >= testpos &&
-                                pt.x <=
-                                    testpos + shop_ui_items_in_store[testx]->width()) {
-                                if ((pt.y <= 308 &&
-                                    pt.y >=
-                                         (308 - shop_ui_items_in_store[testx]->height())) ||
-                                    (pt.y <= 152 &&
-                                        pt.y >=
-                                         (152 - shop_ui_items_in_store[testx]->height()))) {
-                                    // y is 152-h to 152 or 308-height to 308
-                                    break;  // good
-                                }
-                            } else {
-                                bought_item = nullptr;
-                                return;
-                            }
-                        } else {
-                            return;
-                        }
-                    }
-                    break;
-
-                default:
-                    return;
-            }
-
-            uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), bought_item->GetValue(),
-                                                                          buildingTable[window_SpeakInHouse->wData.val - 1].fPriceMultiplier);
-            uNumSeconds = 0;
-            a3 = 0;
-            if (pMapStats->GetMapInfo(pCurrentMapName))
-                a3 = pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)]
-                         ._steal_perm;
-            party_reputation = pParty->GetPartyReputation();
-            if (isStealingModeActive()) {
-                uNumSeconds = pParty->activeCharacter().StealFromShop(bought_item, a3, party_reputation, 0, &a6);
-                if (!uNumSeconds) {
-                    // caught stealing no item
-                    ((GUIWindow_Shop*)window_SpeakInHouse)->processStealingResult(0, a6);
-                    return;
-                }
-            } else if (pParty->GetGold() < uPriceItemService) {
-                PlayHouseSound(window_SpeakInHouse->wData.val, (HouseSoundID)2);
-                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-                return;
-            }
-
-            v39 = pParty->activeCharacter().AddItem(-1, bought_item->uItemID);
-            if (v39) {
-                bought_item->SetIdentified();
-                pParty->activeCharacter().pInventoryItemList[v39 - 1] = *bought_item;
-                if (uNumSeconds != 0) {  // stolen
-                    pParty->activeCharacter().pInventoryItemList[v39 - 1].SetStolen();
-                    ((GUIWindow_Shop*)window_SpeakInHouse)->processStealingResult(uNumSeconds, a6);
-                } else {
-                    dword_F8B1E4 = 1;
-                    pParty->TakeGold(uPriceItemService);
-                }
-                bought_item->Reset();
-                render->ClearZBuffer();
-                pParty->activeCharacter().playReaction(SPEECH_ItemBuy);
-                return;
-            } else {
-                pParty->activeCharacter().playReaction(SPEECH_NoRoom);
-                GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
-                return;
-            }
-            break;
-        }
-        default:  // if click video screen in shop
-        {
-            if (IsSkillLearningDialogue(dialog_menu_id)) {
-                PLAYER_SKILL_TYPE skill = GetLearningDialogueSkill(dialog_menu_id);
-                uPriceItemService =
-                    PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(),
-                                                                                buildingTable[window_SpeakInHouse->wData.val - 1]);
-                if (skillMaxMasteryPerClass[pParty->activeCharacter().classType][skill] != PLAYER_SKILL_MASTERY_NONE) {
-                    pSkill = &pParty->activeCharacter().pActiveSkills[skill];
-                    if (!*pSkill) {
-                        if (pParty->GetGold() < uPriceItemService) {
-                            GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-                            if (in_current_building_type == BuildingType_Training)
-                                v55 = HouseSound_Goodbye;
-                            else
-                                v55 = HouseSound_NotEnoughMoney;
-                            PlayHouseSound(
-                                window_SpeakInHouse->wData.val,
-                                (HouseSoundID)v55);
-                            return;
-                        }
-                        pParty->TakeGold(uPriceItemService);
-                        dword_F8B1E4 = 1;
-                        *pSkill = 1;
-                        pParty->activeCharacter().playReaction(SPEECH_SkillLearned);
-                        return;
-                    }
-                }
-            }
-            break;
-        }
-    }
 }

--- a/src/GUI/UI/Houses/Shops.h
+++ b/src/GUI/UI/Houses/Shops.h
@@ -16,6 +16,7 @@ class GUIWindow_Shop : public GUIWindow_House {
     virtual void houseSpecificDialogue() override;
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
     virtual DIALOGUE_TYPE getOptionOnEscape() override;
+    virtual void houseScreenClick() override;
 
     /**
      * @offset 0x4B1447

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -878,7 +878,7 @@ void GUIWindow_House::reinitDialogueWindow() {
     pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetPresentDimensions().w, 345}, 0);
     pBtn_ExitCancel = pDialogueWindow->CreateButton({471, 445}, {169, 35}, 1, 0, UIMSG_Escape, 0, InputAction::Invalid,
         localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background});
-    pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_BuyInShop_Identify_Repair, 0, InputAction::Invalid, "");
+    pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_HouseScreenClick, 0, InputAction::Invalid, "");
 }
 
 bool GUIWindow_House::checkIfPlayerCanInteract() {
@@ -1147,4 +1147,8 @@ DIALOGUE_TYPE GUIWindow_House::getOptionOnEscape() {
         return DIALOGUE_NULL;
     }
     return DIALOGUE_MAIN;
+}
+
+void GUIWindow_House::houseScreenClick() {
+    // Nothing to do by default
 }

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -65,6 +65,7 @@ class GUIWindow_House : public GUIWindow {
     virtual void houseSpecificDialogue();
     virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option);
     virtual DIALOGUE_TYPE getOptionOnEscape();
+    virtual void houseScreenClick();
 
  protected:
     int _savedButtonsNum{};


### PR DESCRIPTION
Rename, split and move into class function UIShop_Buy_Identify_Repair (also rename related message).
Split it between magic guild (buy books option) and shops.
In other houses this functions doing nothing.

P.S. Button with this message is created by default for any dialogue. In case of simple dialogue this button is "virtual" - it is placed in the corner of screen with zero dimensions. As I understand such things has been done to keep starting index of real dialogue options at 2 (0 is cancel button, 1 is screen click).