### PR TITLE
Refactor house sound functions

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -777,7 +777,7 @@ void Game::processQueuedMessages() {
                                         if (houseDialogPressEscape())
                                             continue;
                                     }
-                                    GetHouseGoodbyeSpeech();
+                                    window_SpeakInHouse->playHouseGoodbyeSpeech();
                                     pAudioPlayer->playHouseSound(SOUND_WoodDoorClosing, false);
                                     pMediaPlayer->Unload();
                                     pGUIWindow_CurrentMenu = window_SpeakInHouse;
@@ -786,7 +786,7 @@ void Game::processQueuedMessages() {
                                     continue;
                                 case CURRENT_SCREEN::SCREEN_INPUT_BLV:  // click escape
                                     if (uCurrentHouse_Animation == 153)
-                                        PlayHouseSound(0x99u, HouseSound_Greeting_2);
+                                        playHouseSound((HOUSE_ID)0x99u, HouseSoundType(3)); // TODO(Nik-RE-dev): what is this?
                                     pMediaPlayer->Unload();
                                     if (npcIdToDismissAfterDialogue) {
                                         pParty->hirelingScrollPosition = 0;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2535,7 +2535,6 @@ int guild_membership_approved;
 PLAYER_SKILL_MASTERY dword_F8B1B0_MasteryBeingTaught;
 int gold_transaction_amount;  // F8B1B4
 std::array<const char *, 4> pShopOptions;
-int dword_F8B1E4;
 std::string current_npc_text;                        // F8B1E8
 char dialogue_show_profession_details = false;  // F8B1EC
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -189,7 +189,6 @@ extern int guild_membership_approved;
 extern PLAYER_SKILL_MASTERY dword_F8B1B0_MasteryBeingTaught;
 extern int gold_transaction_amount;  // F8B1B4
 extern std::array<const char *, 4> pShopOptions; // TODO(Nik-RE-dev): used only for local pointers, not needed as global
-extern int dword_F8B1E4;
 extern std::string current_npc_text;  // F8B1E8
 extern char dialogue_show_profession_details;
 

--- a/src/GUI/UI/Houses/Bank.cpp
+++ b/src/GUI/UI/Houses/Bank.cpp
@@ -54,13 +54,14 @@ void GUIWindow_Bank::putGoldDialogue() {
 
         int party_gold = pParty->GetGold();
         if (sum > party_gold) {
-            PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+            playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
             sum = party_gold;
         }
 
         if (sum > 0) {
             pParty->TakeGold(sum);
             pParty->AddBankGold(sum);
+            _transactionPerformed = true;
             if (pParty->hasActiveCharacter()) {
                 pParty->activeCharacter().playReaction(SPEECH_BankDeposit);
             }
@@ -94,11 +95,12 @@ void GUIWindow_Bank::getGoldDialogue() {
 
         int bank_gold = pParty->GetBankGold();
         if (sum > bank_gold) {
-            PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+            playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
             sum = bank_gold;
         }
 
         if (sum > 0) {
+            _transactionPerformed = true;
             pParty->TakeBankGold(sum);
             pParty->AddGold(sum);
         }

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -345,7 +345,7 @@ void GUIWindow_MagicGuild::houseScreenClick() {
                     int uPriceItemService = PriceCalculator::itemBuyingPriceForPlayer(&pParty->activeCharacter(), boughtItem.GetValue(), fPriceMultiplier);
 
                     if (pParty->GetGold() < uPriceItemService) {
-                        PlayHouseSound(wData.val, (HouseSoundID)2);
+                        playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
                         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                         return;
                     }
@@ -354,7 +354,7 @@ void GUIWindow_MagicGuild::houseScreenClick() {
                     if (itemSlot) {
                         boughtItem.SetIdentified();
                         pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = boughtItem;
-                        dword_F8B1E4 = 1;
+                        _transactionPerformed = true;
                         pParty->TakeGold(uPriceItemService);
                         boughtItem.Reset();
                         render->ClearZBuffer();

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -64,7 +64,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
                 *(short *)v6 = 1;
                 v27 = 2;
             }
-            PlayHouseSound(window_SpeakInHouse->wData.val, (HouseSoundID)v27);
+            playHouseSound(houseId(), HouseSoundType(v27));
         }
     }
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -920,7 +920,7 @@ void GUIWindow_Shop::houseScreenClick() {
             }
 
             if (pParty->activeCharacter().pInventoryItemList[pItemID - 1].MerchandiseTest(wData.val)) {
-                dword_F8B1E4 = 1;
+                _transactionPerformed = true;
                 pParty->activeCharacter().SalesProcess(invindex, pItemID - 1, wData.val);
                 render->ClearZBuffer();
                 pParty->activeCharacter().playReaction(SPEECH_ItemSold);
@@ -950,7 +950,7 @@ void GUIWindow_Shop::houseScreenClick() {
             if (!(item.uAttributes & ITEM_IDENTIFIED)) {
                 if (item.MerchandiseTest(wData.val)) {
                     if (pParty->GetGold() >= uPriceItemService) {
-                        dword_F8B1E4 = 1;
+                        _transactionPerformed = true;
                         pParty->TakeGold(uPriceItemService);
                         item.uAttributes |= ITEM_IDENTIFIED;
                         pParty->activeCharacter().playReaction(SPEECH_ShopIdentify);
@@ -958,7 +958,8 @@ void GUIWindow_Shop::houseScreenClick() {
                         return;
                     }
 
-                    PlayHouseSound(wData.val, (HouseSoundID)2);
+                    playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
+                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                     return;
                 }
 
@@ -989,7 +990,7 @@ void GUIWindow_Shop::houseScreenClick() {
             if (item.uAttributes & ITEM_BROKEN) {
                 if (item.MerchandiseTest(wData.val)) {
                     if (pParty->GetGold() >= uPriceItemService) {
-                        dword_F8B1E4 = 1;
+                        _transactionPerformed = true;
                         pParty->TakeGold(uPriceItemService);
                         item.uAttributes = (item.uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
                         pParty->activeCharacter().playReaction(SPEECH_ShopRepair);
@@ -997,7 +998,8 @@ void GUIWindow_Shop::houseScreenClick() {
                         return;
                     }
 
-                    PlayHouseSound(wData.val, (HouseSoundID)2);
+                    playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
+                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                     return;
                 }
 
@@ -1117,7 +1119,7 @@ void GUIWindow_Shop::houseScreenClick() {
                     return;
                 }
             } else if (pParty->GetGold() < uPriceItemService) {
-                PlayHouseSound(wData.val, (HouseSoundID)2);
+                playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
                 GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
                 return;
             }
@@ -1130,7 +1132,7 @@ void GUIWindow_Shop::houseScreenClick() {
                     pParty->activeCharacter().pInventoryItemList[itemSlot - 1].SetStolen();
                     processStealingResult(stealResult, fine);
                 } else {
-                    dword_F8B1E4 = 1;
+                    _transactionPerformed = true;
                     pParty->TakeGold(uPriceItemService);
                 }
                 boughtItem->Reset();

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -170,10 +170,10 @@ void GUIWindow_Tavern::restDialogue() {
 
     if (pParty->GetGold() >= pPriceRoom) {
         pParty->TakeGold(pPriceRoom);
-        PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+        playHouseSound(houseId(), HOUSE_SOUND_TAVERN_RENT_ROOM);
         dialog_menu_id = DIALOGUE_NULL;
         houseDialogPressEscape();
-        GetHouseGoodbyeSpeech();
+        playHouseGoodbyeSpeech();
         pMediaPlayer->Unload();
 
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_RentRoom, wData.val, 1);
@@ -182,7 +182,7 @@ void GUIWindow_Tavern::restDialogue() {
         return;
     }
     GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-    PlayHouseSound(wData.val, HouseSound_Goodbye);
+    playHouseSound(houseId(), HOUSE_SOUND_TAVERN_NOT_ENOUGH_GOLD);
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
 }
 
@@ -200,12 +200,12 @@ void GUIWindow_Tavern::buyFoodDialogue() {
     if (pParty->GetGold() >= pPriceFood) {
         pParty->TakeGold(pPriceFood);
         pParty->SetFood(buildingTable[wData.val - 1].fPriceMultiplier);
-        PlayHouseSound(wData.val, HouseSound_Greeting_2);
+        playHouseSound(houseId(), HOUSE_SOUND_TAVERN_BUY_FOOD);
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
     GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-    PlayHouseSound(wData.val, HouseSound_Goodbye);
+    playHouseSound(houseId(), HOUSE_SOUND_TAVERN_NOT_ENOUGH_GOLD);
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
 }
 

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -65,7 +65,7 @@ void GUIWindow_Temple::healDialogue() {
     int price = PriceCalculator::templeHealingCostForPlayer(&pParty->activeCharacter(), buildingTable[wData.val - 1].fPriceMultiplier);
     if (pParty->GetGold() < price) {
         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-        PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+        playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -100,7 +100,7 @@ void GUIWindow_TownHall::payFineDialogue() {
         if (sum > 0) {
             int party_gold = pParty->GetGold();
             if (sum > party_gold) {
-                PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+                playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
                 sum = party_gold;
             }
 

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -100,7 +100,7 @@ void GUIWindow_Training::trainDialogue() {
         if (pParty->activeCharacter().experience >= expForNextLevel) {
             if (pParty->GetGold() >= pPrice) {
                 pParty->TakeGold(pPrice);
-                PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+                playHouseSound(houseId(), HOUSE_SOUND_TRAINING_TRAIN);
                 pParty->activeCharacter().uLevel++;
                 pParty->activeCharacter().uSkillPoints += pParty->activeCharacter().uLevel / 10 + 5;
                 pParty->activeCharacter().health = pParty->activeCharacter().GetMaxHealth();
@@ -128,7 +128,7 @@ void GUIWindow_Training::trainDialogue() {
             }
 
             GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-            PlayHouseSound(wData.val, HouseSound_Goodbye);
+            playHouseSound(houseId(), HOUSE_SOUND_TRAINING_NOT_ENOUGH_GOLD);
             pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
             return;
         }
@@ -141,7 +141,7 @@ void GUIWindow_Training::trainDialogue() {
     }
     training_dialog_window.DrawTitleText(pFontArrus, 0, textHeight, colorTable.Jonquil, label, 3);
 
-    PlayHouseSound(wData.val, HouseSound_Greeting_2);
+    playHouseSound(houseId(), HOUSE_SOUND_TRAINING_CANT_TRAIN);
     pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
     return;
 }

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -173,8 +173,7 @@ void GUIWindow_Transport::transportDialogue() {
 
     if (pParty->GetGold() < pPrice) {
         GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
-        // TODO(pskelton): correct sound but wrong label - travel house sounds might need different enum
-        PlayHouseSound(wData.val, HouseSound_Greeting_2);
+        playHouseSound(houseId(), HOUSE_SOUND_TRANSPORT_NOT_ENOUGH_GOLD);
         pCurrentFrameMessageQueue->AddGUIMessage(UIMSG_Escape, 1, 0);
         return;
     }
@@ -210,8 +209,7 @@ void GUIWindow_Transport::transportDialogue() {
         }
 
         pParty->TakeGold(pPrice);
-        // TODO(pskelton): correct sound but wrong label - travel house sounds might need different enum
-        PlayHouseSound(wData.val, HouseSound_NotEnoughMoney);
+        playHouseSound(houseId(), HOUSE_SOUND_TRANSPORT_TRAVEL);
 
         PlayerSpeech pSpeech;
         if (isBoat(houseId())) {

--- a/src/GUI/UI/UIHouseEnums.h
+++ b/src/GUI/UI/UIHouseEnums.h
@@ -243,9 +243,22 @@ inline bool isBoat(HOUSE_ID houseId) {
     return houseId >= HOUSE_FIRST_BOAT && houseId <= HOUSE_LAST_BOAT;
 }
 
-enum HouseSoundID : uint32_t {
-    HouseSound_Greeting = 1,  // General greeting
-    HouseSound_NotEnoughMoney = 2,
-    HouseSound_Greeting_2 = 3,  // Polite Greeting when you're guild member
-    HouseSound_Goodbye = 4      // farewells when bought something
+enum class HouseSoundType : uint32_t {
+    HOUSE_SOUND_GENERAL_GREETING = 1,
+    HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD = 2,
+
+    HOUSE_SOUND_MAGIC_GUILD_MEMBERS_ONLY = 3,
+    HOUSE_SOUND_SHOP_GOODBYE_RUDE = 3,
+    HOUSE_SOUND_SHOP_GOODBYE_POLITE = 4,
+    HOUSE_SOUND_TEMPLE_GOODBYE = 3,
+    HOUSE_SOUND_BANK_GOODBYE = 3,
+    HOUSE_SOUND_TAVERN_RENT_ROOM = 2,
+    HOUSE_SOUND_TAVERN_BUY_FOOD = 3,
+    HOUSE_SOUND_TAVERN_NOT_ENOUGH_GOLD = 4,
+    HOUSE_SOUND_TRAINING_TRAIN = 2,
+    HOUSE_SOUND_TRAINING_CANT_TRAIN = 3,
+    HOUSE_SOUND_TRAINING_NOT_ENOUGH_GOLD = 4,
+    HOUSE_SOUND_TRANSPORT_TRAVEL = 2,
+    HOUSE_SOUND_TRANSPORT_NOT_ENOUGH_GOLD = 3
 };
+using enum HouseSoundType;

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -16,7 +16,6 @@ constexpr int SIDE_TEXT_BOX_BODY_TEXT_HEIGHT = 174;
 constexpr int SIDE_TEXT_BOX_BODY_TEXT_OFFSET = 138;
 constexpr int SIDE_TEXT_BOX_MAX_SPACING = 32;
 
-void PlayHouseSound(unsigned int uHouseID, HouseSoundID sound);  // idb
 void SimpleHouseDialog();
 
 void BackToHouseMenu();
@@ -36,7 +35,10 @@ bool enterHouse(HOUSE_ID uHouseID);
 
 bool houseDialogPressEscape();
 
-void GetHouseGoodbyeSpeech();
+/**
+ * @offset 0x4B1E92
+ */
+void playHouseSound(HOUSE_ID houseID, HouseSoundType type);
 
 class GUIWindow_House : public GUIWindow {
  public:
@@ -60,6 +62,11 @@ class GUIWindow_House : public GUIWindow {
     void reinitDialogueWindow();
     bool checkIfPlayerCanInteract();
 
+    /**
+     * @offset 0x4B1D27
+     */
+    void playHouseGoodbyeSpeech();
+
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option);
     // TODO(Nik-RE-dev): add DIALOGUE_TYPE argument?
     virtual void houseSpecificDialogue();
@@ -71,6 +78,7 @@ class GUIWindow_House : public GUIWindow {
     void learnSkillsDialogue();
 
     int _savedButtonsNum{};
+    bool _transactionPerformed = false;
 };
 
 // Originally was a packed struct.

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -105,7 +105,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
         } else {
             transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].pName.c_str());
             if (pAnimatedRooms[buildingTable[anim_id].uAnimationID].uRoomSoundId)
-                PlayHouseSound(anim_id, HouseSound_Greeting);
+                playHouseSound((HOUSE_ID)anim_id, HOUSE_SOUND_GENERAL_GREETING);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
                 pParty->activeCharacter().playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(locationName))
@@ -115,7 +115,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
         if (pMapStats->GetMapInfo(pCurrentMapName)) {
             transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].pName.c_str());
             if (pAnimatedRooms[buildingTable[anim_id].uAnimationID].uRoomSoundId)
-                PlayHouseSound(anim_id, HouseSound_Greeting);
+                playHouseSound((HOUSE_ID)anim_id, HOUSE_SOUND_GENERAL_GREETING);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
                 pParty->activeCharacter().playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(locationName))
@@ -123,7 +123,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
         } else {
             transition_button_label = localization->GetString(LSTR_DIALOGUE_EXIT);
             if ( pAnimatedRooms[buildingTable[anim_id].uAnimationID].uRoomSoundId)
-                PlayHouseSound(anim_id, HouseSound_Greeting);
+                playHouseSound((HOUSE_ID)anim_id, HOUSE_SOUND_GENERAL_GREETING);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
                 pParty->activeCharacter().playReaction(SPEECH_LeaveDungeon);
             if (IndoorLocation::GetLocationIndex(locationName))


### PR DESCRIPTION
- Move playHouseGoodbyeSpeech into class.
- Leave playHouseSound outside of it as it's used externally.
- Move global dword_F8B1E4 into class - it's marker of performed transaction.
- Correctly enumerate sound type of particular houses.
- Add transaction marker to bank - it's used in goodbye speech.
- Add "not enough money" status where it's missing.

P.S. While "not enough money" sound used when paying fine in town hall - such sound is missing from the game resources for any type of town hall.
P.P.S. Human town hall sound id is incorrect in game resources.