### PR TITLE
Cleaning up DrawText

### DIFF
--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -2962,7 +2962,7 @@ void SetStartConditions() {
 }
 
 void am_DrawText(const std::string &str, Pointi *pXY) {
-    pPrimaryWindow->DrawText(pFontComic, {pXY->x, pXY->y - ((pFontComic->GetHeight() - 3) / 2) + 3}, Color(), str, false, 0, Color());
+    pPrimaryWindow->DrawText(pFontComic, {pXY->x, pXY->y - ((pFontComic->GetHeight() - 3) / 2) + 3}, Color(), str);
 }
 
 void DrawRect(Recti *pRect, Color uColor, char bSolidFill) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -257,22 +257,22 @@ void Engine::DrawGUI() {
 
     if (engine->config->debug.ShowFPS.value()) {
         if (render_framerate) {
-            pPrimaryWindow->DrawText(pFontArrus, {494, 0}, colorTable.White, fmt::format("FPS: {: .4f}", framerate), 0, 0, Color());
+            pPrimaryWindow->DrawText(pFontArrus, {494, 0}, colorTable.White, fmt::format("FPS: {: .4f}", framerate));
         }
 
-        pPrimaryWindow->DrawText(pFontArrus, {300, 0}, colorTable.White, fmt::format("DrawCalls: {}", render->drawcalls), 0, 0, Color());
+        pPrimaryWindow->DrawText(pFontArrus, {300, 0}, colorTable.White, fmt::format("DrawCalls: {}", render->drawcalls));
         render->drawcalls = 0;
 
 
         int debug_info_offset = 0;
         pPrimaryWindow->DrawText(pFontArrus, {16, debug_info_offset + 16}, colorTable.White,
-                                 fmt::format("Party position:         {} {} {}", pParty->vPosition.x, pParty->vPosition.y, pParty->vPosition.z), 0, 0, Color());
+                                 fmt::format("Party position:         {} {} {}", pParty->vPosition.x, pParty->vPosition.y, pParty->vPosition.z));
 
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
             debug_info_offset += 16;
             int sector_id = pBLVRenderParams->uPartySectorID;
             pPrimaryWindow->DrawText(pFontArrus, { 16, debug_info_offset + 16 }, colorTable.White,
-                                     fmt::format("Party Sector ID:        {}/{}\n", sector_id, pIndoor->pSectors.size()), 0, 0, Color());
+                                     fmt::format("Party Sector ID:        {}/{}\n", sector_id, pIndoor->pSectors.size()));
         }
 
         std::string floor_level_str;
@@ -297,7 +297,7 @@ void Engine::DrawGUI() {
             );
         }
 
-        pPrimaryWindow->DrawText(pFontArrus, {16, debug_info_offset + 16 + 16}, colorTable.White, floor_level_str, 0, 0, Color());
+        pPrimaryWindow->DrawText(pFontArrus, {16, debug_info_offset + 16 + 16}, colorTable.White, floor_level_str);
     }
 }
 

--- a/src/GUI/GUIButton.cpp
+++ b/src/GUI/GUIButton.cpp
@@ -98,10 +98,10 @@ void GUIButton::Release() {
     delete this;
 }
 
-void GUIButton::DrawLabel(const std::string &label_text, GUIFont *pFont, Color color, Color uFontShadowColor) {
-    return pParent->DrawText(pFont,
-                             {this->uX + (int)(this->uWidth - pFont->GetLineWidth(label_text)) / 2, this->uY + (int)(this->uHeight - pFont->GetHeight()) / 2}, color,
-                             label_text, 0, 0, uFontShadowColor);
+void GUIButton::DrawLabel(const std::string &text, GUIFont *font, Color color, Color shadowColor) {
+    return pParent->DrawText(font,
+                             {this->uX + (int)(this->uWidth - font->GetLineWidth(text)) / 2, this->uY + (int)(this->uHeight - font->GetHeight()) / 2},
+                             color, text, 0, shadowColor);
 }
 
 bool GUIButton::Contains(unsigned int x, unsigned int y) {

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -14,7 +14,7 @@ class GUIButton {
         pParent = nullptr;
     }
 
-    void DrawLabel(const std::string &label_text, GUIFont *pFont, Color color, Color uFontShadowColor);
+    void DrawLabel(const std::string &text, GUIFont *font, Color color, Color shadowColor);
     bool Contains(unsigned int x, unsigned int y);
     void Release();
 

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -134,7 +134,7 @@ int GUIFont::GetHeight() const {
     return pData->uFontHeight;
 }
 
-void GUIFont::DrawTextLine(const std::string &text, Color uDefaultColor, Pointi position, int max_len_pix) {
+void GUIFont::DrawTextLine(const std::string &text, Color color, Pointi position, int max_len_pix) {
     if (text.empty()) {
         return;
     }
@@ -443,38 +443,37 @@ std::string GUIFont::FitTextInAWindow(const std::string &inString, unsigned int 
     return temp_string;
 }
 
-void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, const std::string &str,
-    bool present_time_transparency, int max_text_height, Color uFontShadowColor) {
+void GUIFont::DrawText(GUIWindow *window, Pointi position, Color color, const std::string &text, int maxHeight, Color shadowColor) {
     int left_margin = 0;
-    if (str.empty()) {
+    if (text.empty()) {
         return;
     }
-    if (str == "null") {
+    if (text == "null") {
         return;
     }
 
     // TODO(captainurist): just use colorTable.Black at all call sites and drop this?
-    if (uFontShadowColor == Color())
-        uFontShadowColor = colorTable.Black; // Default shadow color.
+    if (shadowColor == Color())
+        shadowColor = colorTable.Black; // Default shadow color.
 
     render->BeginTextNew(fonttex, fontshadow);
 
-    size_t v30 = str.length();
+    size_t v30 = text.length();
     if (!position.x) {
         position.x = 12;
     }
 
-    std::string string_begin = str;
-    if (max_text_height == 0) {
-        string_begin = FitTextInAWindow(str, pWindow->uFrameWidth, position.x);
+    std::string string_begin = text;
+    if (maxHeight == 0) {
+        string_begin = FitTextInAWindow(text, window->uFrameWidth, position.x);
     }
     auto string_end = string_begin;
     auto string_base = string_begin;
 
-    int out_x = position.x + pWindow->uFrameX;
-    int out_y = position.y + pWindow->uFrameY;
+    int out_x = position.x + window->uFrameX;
+    int out_y = position.y + window->uFrameY;
 
-    if (max_text_height != 0 && out_y + pData->uFontHeight > max_text_height) {
+    if (maxHeight != 0 && out_y + pData->uFontHeight > maxHeight) {
         return;
     }
 
@@ -494,14 +493,14 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
                     Dest[3] = 0;
                     v14 += 3;
                     left_margin = atoi(Dest);
-                    out_x = position.x + pWindow->uFrameX + left_margin;
+                    out_x = position.x + window->uFrameX + left_margin;
                     break;
                 case '\n':
                     position.y = position.y + pData->uFontHeight - 3;
-                    out_y = position.y + pWindow->uFrameY;
-                    out_x = position.x + pWindow->uFrameX + left_margin;
-                    if (max_text_height != 0) {
-                        if (pData->uFontHeight + out_y - 3 > max_text_height) {
+                    out_y = position.y + window->uFrameY;
+                    out_x = position.x + window->uFrameX + left_margin;
+                    if (maxHeight != 0) {
+                        if (pData->uFontHeight + out_y - 3 > maxHeight) {
                             return;
                         }
                     }
@@ -509,7 +508,7 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
                 case '\f':
                     strncpy(Dest, &string_base[v14 + 1], 5);
                     Dest[5] = 0;
-                    uFontColor = Color::fromC16(atoi(Dest));
+                    color = Color::fromC16(atoi(Dest));
                     v14 += 5;
                     break;
                 case '\r':
@@ -517,10 +516,10 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
                     Dest[3] = 0;
                     v14 += 3;
                     left_margin = atoi(Dest);
-                    out_x = pWindow->uFrameZ - this->GetLineWidth(&string_base[v14]) - left_margin;
-                    out_y = position.y + pWindow->uFrameY;
-                    if (max_text_height != 0) {
-                        if (pData->uFontHeight + out_y - 3 > max_text_height) {
+                    out_x = window->uFrameZ - this->GetLineWidth(&string_base[v14]) - left_margin;
+                    out_y = position.y + window->uFrameY;
+                    if (maxHeight != 0) {
+                        if (pData->uFontHeight + out_y - 3 > maxHeight) {
                             return;
                         }
                         break;
@@ -537,11 +536,8 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
                         out_x += pData->pMetrics[c].uLeftSpacing;
                     }
 
-                    if (present_time_transparency) __debugbreak();
-
-
                     unsigned char *letter_pixels = &pData->pFontData[pData->font_pixels_offset[c]];
-                    if (uFontColor != Color()) {
+                    if (color != Color()) {
                         int xsq = c % 16;
                         int ysq = c / 16;
                         float u1 = (xsq * 32.0f) / 512.0f;
@@ -549,8 +545,8 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
                         float v1 = (ysq * 32.0f) / 512.0f;
                         float v2 = (ysq * 32.0f + pData->uFontHeight) / 512.0f;
 
-                        render->DrawTextNew(out_x, out_y, pData->pMetrics[c].uWidth, pData->uFontHeight, u1, v1, u2, v2, 1, uFontShadowColor);
-                        render->DrawTextNew(out_x, out_y, pData->pMetrics[c].uWidth, pData->uFontHeight, u1, v1, u2, v2, 0, uFontColor);
+                        render->DrawTextNew(out_x, out_y, pData->pMetrics[c].uWidth, pData->uFontHeight, u1, v1, u2, v2, 1, shadowColor);
+                        render->DrawTextNew(out_x, out_y, pData->pMetrics[c].uWidth, pData->uFontHeight, u1, v1, u2, v2, 0, color);
                     } else {
                         // pallette24 check for colour
                         unsigned char *pix = letter_pixels;
@@ -591,17 +587,17 @@ void GUIFont::DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor, co
     // render->EndTextNew();
 }
 
-int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, const std::string &str, int rect_width, int reverse_text) {
-    char text[4096];
-    Assert(str.length() < sizeof(text));
-    strcpy(text, str.c_str());
+int GUIFont::DrawTextInRect(GUIWindow *window, Pointi position, Color color, const std::string &text, int rect_width, int reverse_text) {
+    char buf[4096];
+    Assert(text.length() < sizeof(buf));
+    strcpy(buf, text.c_str());
 
-    size_t pNumLen = strlen(text);
+    size_t pNumLen = strlen(buf);
     if (pNumLen == 0) return 0;
 
-    unsigned int pLineWidth = this->GetLineWidth(text);
+    unsigned int pLineWidth = this->GetLineWidth(buf);
     if (pLineWidth < rect_width) {
-        this->DrawText(pWindow, position, uColor, text, 0, 0, Color());
+        this->DrawText(window, position, color, buf, 0, Color());
         return pLineWidth;
     }
 
@@ -609,7 +605,7 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
 
     unsigned int text_width = 0;
     if (reverse_text)
-        std::reverse(text, text + pNumLen);
+        std::reverse(buf, buf + pNumLen);
 
     size_t Str1a = 0;
     size_t i = 0;
@@ -617,7 +613,7 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
         if (text_width >= rect_width) {
             break;
         }
-        uint8_t v12 = text[i];
+        uint8_t v12 = buf[i];
         if (this->IsCharValid(v12)) {
             switch (v12) {
             case '\t':  // Horizontal tab 09
@@ -638,22 +634,22 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
             }
         }
     }
-    text[i - 1] = 0;
+    buf[i - 1] = 0;
 
-    pNumLen = strlen(text);
-    unsigned int v28 = this->GetLineWidth(text);
+    pNumLen = strlen(buf);
+    unsigned int v28 = this->GetLineWidth(buf);
     if (reverse_text)
-        std::reverse(text, text + pNumLen);
+        std::reverse(buf, buf + pNumLen);
 
-    int text_pos_x = position.x + pWindow->uFrameX;
-    int text_pos_y = position.y + pWindow->uFrameY;
+    int text_pos_x = position.x + window->uFrameX;
+    int text_pos_y = position.y + window->uFrameY;
     for (i = 0; i < pNumLen; ++i) {
-        uint8_t v15 = text[i];
+        uint8_t v15 = buf[i];
         if (this->IsCharValid(v15)) {
             switch (v15) {
             case '\t': {  // Horizontal tab 09
                 char Str[6];
-                strncpy(Str, &text[i + 1], 3);
+                strncpy(Str, &buf[i + 1], 3);
                 Str[3] = 0;
                 //   atoi(Str);
                 i += 3;
@@ -668,19 +664,19 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
             }
             case '\r': {  // Form Feed, page eject  0C 12
                 char Str[6];
-                strncpy(Str, &text[i + 1], 5);
+                strncpy(Str, &buf[i + 1], 5);
                 Str[5] = 0;
                 i += 5;
-                uColor = Color::fromC16(atoi(Str));
+                color = Color::fromC16(atoi(Str));
                 break;
             }
             case '\f': {  // Carriage Return 0D 13
                 char Str[6];
-                strncpy(Str, &text[i + 1], 3);
+                strncpy(Str, &buf[i + 1], 3);
                 Str[3] = 0;
                 i += 3;
-                unsigned int v23 = this->GetLineWidth(&text[i]);
-                text_pos_x = pWindow->uFrameZ - v23 - atoi(Str);
+                unsigned int v23 = this->GetLineWidth(&buf[i]);
+                text_pos_x = window->uFrameZ - v23 - atoi(Str);
                 text_pos_y = position.y;
                 break;
             }
@@ -690,7 +686,7 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
                     text_pos_x += pData->pMetrics[v15].uLeftSpacing;
                 }
                 uint8_t *char_pix_ptr = &pData->pFontData[pData->font_pixels_offset[v15]];
-                if (uColor != Color()) {
+                if (color != Color()) {
                     int xsq = v15 % 16;
                     int ysq = v15 / 16;
                     float u1 = (xsq * 32.0f) / 512.0f;
@@ -699,7 +695,7 @@ int GUIFont::DrawTextInRect(GUIWindow *pWindow, Pointi position, Color uColor, c
                     float v2 = (ysq * 32.0f + pData->uFontHeight) / 512.0f;
 
                     render->DrawTextNew(text_pos_x, text_pos_y, pData->pMetrics[v15].uWidth, pData->uFontHeight, u1, v1, u2, v2, 1, Color());
-                    render->DrawTextNew(text_pos_x, text_pos_y, pData->pMetrics[v15].uWidth, pData->uFontHeight, u1, v1, u2, v2, 0, uColor);
+                    render->DrawTextNew(text_pos_x, text_pos_y, pData->pMetrics[v15].uWidth, pData->uFontHeight, u1, v1, u2, v2, 0, color);
                 } else {
                     // pallette24 check for colour
                     unsigned char *pix = char_pix_ptr;

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -54,12 +54,10 @@ class GUIFont {
 
     std::string GetPageTop(const std::string &pInString, GUIWindow *pWindow,
                       unsigned int uX, int a5);
-    void DrawTextLine(const std::string &text, Color uDefaultColor, Pointi position, int max_len_pix);
-    void DrawText(GUIWindow *pWindow, Pointi position, Color uFontColor,
-                  const std::string &str, bool present_time_transparency,
-                  int max_text_height, Color uFontShadowColor);
-    int DrawTextInRect(GUIWindow *pWindow, Pointi position,
-                       Color uColor, const std::string &str, int rect_width,
+    void DrawTextLine(const std::string &text, Color color, Pointi position, int max_len_pix);
+    void DrawText(GUIWindow *window, Pointi position, Color color, const std::string &text, int maxHeight, Color shadowColor);
+    int DrawTextInRect(GUIWindow *window, Pointi position,
+                       Color color, const std::string &text, int rect_width,
                        int reverse_text);
 
     std::string FitTextInAWindow(const std::string &inString, unsigned int width, int uX,

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -362,32 +362,31 @@ void GUIWindow::DrawShops_next_generation_time_string(GameTime time) {
 }
 
 //----- (0044D406) --------------------------------------------------------
-void GUIWindow::DrawTitleText(GUIFont *pFont, int uHorizontalMargin, int uVerticalMargin, Color uDefaultColor, const std::string &str, int uLineSpacing) {
-    int width = this->uFrameWidth - uHorizontalMargin;
-    ui_current_text_color = uDefaultColor;
-    std::string resString = pFont->FitTextInAWindow(str, this->uFrameWidth, uHorizontalMargin);
+void GUIWindow::DrawTitleText(GUIFont *pFont, int horizontalMargin, int verticalMargin, Color color, const std::string &text, int lineSpacing) {
+    int width = this->uFrameWidth - horizontalMargin;
+    ui_current_text_color = color;
+    std::string resString = pFont->FitTextInAWindow(text, this->uFrameWidth, horizontalMargin);
     std::istringstream stream(resString);
     std::string line;
-    int x = uHorizontalMargin + this->uFrameX;
-    int y = uVerticalMargin + this->uFrameY;
+    int x = horizontalMargin + this->uFrameX;
+    int y = verticalMargin + this->uFrameY;
     while (std::getline(stream, line)) {
         int x_offset = pFont->AlignText_Center(width, line);
-        pFont->DrawTextLine(line, uDefaultColor, {x + x_offset, y}, render->GetRenderDimensions().w);
-        y += pFont->GetHeight() - uLineSpacing;
+        pFont->DrawTextLine(line, color, {x + x_offset, y}, render->GetRenderDimensions().w);
+        y += pFont->GetHeight() - lineSpacing;
     }
 }
 
 //----- (0044CE08) --------------------------------------------------------
-void GUIWindow::DrawText(GUIFont *font, Pointi position, Color uFontColor, const std::string &Str,
-                         bool present_time_transparency, int max_text_height, Color uFontShadowColor) {
-    font->DrawText(this, position, uFontColor, Str, present_time_transparency, max_text_height, uFontShadowColor);
+void GUIWindow::DrawText(GUIFont *font, Pointi position, Color color, const std::string &text, int maxHeight, Color shadowColor) {
+    font->DrawText(this, position, color, text, maxHeight, shadowColor);
 }
 
 //----- (0044CB4F) --------------------------------------------------------
 int GUIWindow::DrawTextInRect(GUIFont *pFont, Pointi position,
-                              Color uColor, const std::string &str, int rect_width,
+                              Color uColor, const std::string &text, int rect_width,
                               int reverse_text) {
-    return pFont->DrawTextInRect(this, position, uColor, str, rect_width, reverse_text);
+    return pFont->DrawTextInRect(this, position, uColor, text, rect_width, reverse_text);
 }
 
 GUIButton *GUIWindow::CreateButton(Pointi position, Sizei dimensions,
@@ -443,7 +442,7 @@ void GUIWindow::InitializeGUI() {
 void GUIWindow::DrawFlashingInputCursor(int uX, int uY, GUIFont *a2) {
     // TODO(pskelton): check tickcount usage here
     if (platform->tickCount() % 1000 > 500) {
-        DrawText(a2, {uX, uY}, Color(), "_", 0, 0, Color());
+        DrawText(a2, {uX, uY}, Color(), "_");
     }
 }
 
@@ -901,7 +900,7 @@ void SetUserInterface(PartyAlignment align, bool bReplace) {
 }
 
 void DrawBuff_remaining_time_string(int uY, GUIWindow *window, GameTime remaining_time, GUIFont *Font) {
-    window->DrawText(Font, {32, uY}, Color(), "\r020" + MakeDateTimeString(remaining_time), 0, 0, Color());
+    window->DrawText(Font, {32, uY}, Color(), "\r020" + MakeDateTimeString(remaining_time));
 }
 
 void GUIMessageQueue::AddMessageImpl(UIMessageType msg, int param,

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -56,11 +56,11 @@ class GUIWindow {
     bool Contains(unsigned int x, unsigned int y);
     void DrawFlashingInputCursor(int uX, int uY, GUIFont *a2);
 
-    int DrawTextInRect(GUIFont *font, Pointi position, Color color, const std::string &str, int rect_width, int reverse_text);
+    int DrawTextInRect(GUIFont *font, Pointi position, Color color, const std::string &text, int rect_width, int reverse_text);
 
-    void DrawText(GUIFont *font, Pointi position, Color uFontColor, const std::string &str, bool present_time_transparency = false, int max_text_height = 0, Color uFontShadowColor = Color());
+    void DrawText(GUIFont *font, Pointi position, Color color, const std::string &text, int maxHeight = 0, Color shadowColor = Color());
 
-    void DrawTitleText(GUIFont *font, int horizontal_margin, int vertical_margin, Color uDefaultColor, const std::string &str, int line_spacing);
+    void DrawTitleText(GUIFont *font, int horizontalMargin, int verticalMargin, Color color, const std::string &text, int lineSpacing);
 
     void DrawShops_next_generation_time_string(GameTime time);
     void DrawMessageBox(bool inside_game_viewport);

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -245,7 +245,7 @@ void GUIWindow_AutonotesBook::Update() {
     for (int i = _startingNotesIdx; i < _activeNotesIdx.size(); ++i) {
         _currentPageNotes++;
 
-        autonotes_window.DrawText(pAutonoteFont, {1, 0}, ui_book_autonotes_text_color, pAutonoteTxt[_activeNotesIdx[i]].pText, 0, 0, Color());
+        autonotes_window.DrawText(pAutonoteFont, {1, 0}, ui_book_autonotes_text_color, pAutonoteTxt[_activeNotesIdx[i]].pText);
         pTextHeight = pAutonoteFont->CalcTextHeight(pAutonoteTxt[_activeNotesIdx[i]].pText, autonotes_window.uFrameWidth, 1);
         if ((autonotes_window.uFrameY + pTextHeight) > autonotes_window.uFrameHeight) {
             break;

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -92,21 +92,21 @@ void GUIWindow_CalendarBook::Update() {
 
     std::string str = fmt::format("{}\t100:\t110{}:{:02} {} - {}", localization->GetString(LSTR_TIME), hour,
                                   pParty->uCurrentMinute, localization->GetAmPm(am), GetDayPart());
-    calendar_window.DrawText(pBookFont, {70, 55}, ui_book_calendar_time_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 55}, ui_book_calendar_time_color, str);
 
     str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_DAY_CAPITALIZED), pParty->uCurrentDayOfMonth + 1,
                       localization->GetDayName(pParty->uCurrentDayOfMonth % 7));
-    calendar_window.DrawText(pBookFont, {70, 2 * pBookFont->GetHeight() + 49}, ui_book_calendar_day_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 2 * pBookFont->GetHeight() + 49}, ui_book_calendar_day_color, str);
 
     str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_MONTH), pParty->uCurrentMonth + 1,
                       localization->GetMonthName(pParty->uCurrentMonth));
-    calendar_window.DrawText(pBookFont, {70, 4 * pBookFont->GetHeight() + 43}, ui_book_calendar_month_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 4 * pBookFont->GetHeight() + 43}, ui_book_calendar_month_color, str);
 
     str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_YEAR), pParty->uCurrentYear);
-    calendar_window.DrawText(pBookFont, {70, 6 * pBookFont->GetHeight() + 37}, ui_book_calendar_year_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 6 * pBookFont->GetHeight() + 37}, ui_book_calendar_year_color, str);
 
     str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_MOON), localization->GetMoonPhaseName(pDayMoonPhase[pParty->uCurrentDayOfMonth]));
-    calendar_window.DrawText(pBookFont, {70, 8 * (unsigned char)pBookFont->GetHeight() + 31}, ui_book_calendar_moon_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 8 * (unsigned char)pBookFont->GetHeight() + 31}, ui_book_calendar_moon_color, str);
 
     int pMapID = pMapStats->GetMapInfo(pCurrentMapName);
     std::string pMapName;
@@ -117,5 +117,5 @@ void GUIWindow_CalendarBook::Update() {
     }
 
     str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_LOCATION), pMapName);
-    calendar_window.DrawText(pBookFont, {70, 10 * (unsigned char)pBookFont->GetHeight() + 25}, ui_book_calendar_location_color, str, 0, 0, Color());
+    calendar_window.DrawText(pBookFont, {70, 10 * (unsigned char)pBookFont->GetHeight() + 25}, ui_book_calendar_location_color, str);
 }

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -120,7 +120,7 @@ void GUIWindow_JournalBook::Update() {
         std::string str = BuildDialogueString(pStorylineText->StoreLine[_journalIdx[_currentIdx]].pText,
                                               0, 0, 0, 0, &pParty->PartyTimes.HistoryEventTimes[_journalIdx[_currentIdx] - 1]);
         std::string pStringOnPage = pAutonoteFont->GetPageTop(str, &journal_window, 1, _journalEntryPage[_currentIdx]);
-        journal_window.DrawText(pAutonoteFont, {1, 0}, ui_book_journal_text_color, pStringOnPage, 0,
+        journal_window.DrawText(pAutonoteFont, {1, 0}, ui_book_journal_text_color, pStringOnPage,
                                 journal_window.uFrameY + journal_window.uFrameHeight, ui_book_journal_text_shadow);
     }
 }

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -102,7 +102,7 @@ void GUIWindow_QuestBook::Update() {
     for (int i = _startingQuestIdx; i < _activeQuestsIdx.size(); ++i) {
         _currentPageQuests++;
 
-        questbook_window.DrawText(pAutonoteFont, {1, 0}, ui_book_quests_text_color, pQuestTable[_activeQuestsIdx[i]], 0, 0, Color());
+        questbook_window.DrawText(pAutonoteFont, {1, 0}, ui_book_quests_text_color, pQuestTable[_activeQuestsIdx[i]]);
         pTextHeight = pAutonoteFont->CalcTextHeight(pQuestTable[_activeQuestsIdx[i]], questbook_window.uFrameWidth, 1);
         if ((questbook_window.uFrameY + pTextHeight) > questbook_window.uFrameHeight) {
             break;

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -126,7 +126,7 @@ void GUIWindow_Tavern::arcomageRulesDialogue() {
     }
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);
-    DrawText(font, {12, 354 - pTextHeight}, Color(), font->FitTextInAWindow(str, dialog_window.uFrameWidth, 12), 0, 0, Color());
+    DrawText(font, {12, 354 - pTextHeight}, Color(), font->FitTextInAWindow(str, dialog_window.uFrameWidth, 12));
 }
 
 void GUIWindow_Tavern::arcomageVictoryCondDialogue() {

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -77,7 +77,7 @@ void GUIWindow_TownHall::bountyHuntDialogue() {
     }
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);
-    window.DrawText(pOutString, {13, 354 - pTextHeight}, Color(), current_npc_text, 0, 0, Color());
+    window.DrawText(pOutString, {13, 354 - pTextHeight}, Color(), current_npc_text);
 }
 
 void GUIWindow_TownHall::payFineDialogue() {

--- a/src/GUI/UI/UIArena.cpp
+++ b/src/GUI/UI/UIArena.cpp
@@ -130,7 +130,7 @@ void ArenaFight() {
     std::string v1 = pFontArrus->FitTextInAWindow(
         localization->GetString(LSTR_PLEASE_WAIT_WHILE_I_SUMMON), window.uFrameWidth,
         13);
-    pDialogueWindow->DrawText(pFontArrus, {13, 354 - v0}, Color(), v1, 0, 0, Color());
+    pDialogueWindow->DrawText(pFontArrus, {13, 354 - v0}, Color(), v1);
     render->Present();
     pParty->vPosition.x = 3849;
     pParty->vPosition.y = 5770;

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -792,7 +792,7 @@ static int CharacterUI_SkillsTab_Draw__DrawSkillTable(
     Pointi pt = mouse->GetCursorPos();
 
     auto str = fmt::format("{}\r{:03}{}", skill_group_name, right_margin, localization->GetString(LSTR_LEVEL));
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {x, y}, ui_character_header_text_color, str, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {x, y}, ui_character_header_text_color, str);
 
     int num_skills_drawn = 0;
     for (PLAYER_SKILL_TYPE skill : skill_list) {
@@ -834,7 +834,7 @@ static int CharacterUI_SkillsTab_Draw__DrawSkillTable(
                 } else {
                     Strsk = fmt::format("{}\r{:03}{}", localization->GetSkillName(skill), right_margin, skill_level);
                 }
-                pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, button->uY}, skill_color, Strsk, 0, 0, Color());
+                pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, button->uY}, skill_color, Strsk);
             } else {
                 const char *skill_level_str = skill_mastery == PLAYER_SKILL_MASTERY_NOVICE ? "" : localization->MasteryName(skill_mastery);
 
@@ -844,14 +844,14 @@ static int CharacterUI_SkillsTab_Draw__DrawSkillTable(
 
                 auto Strsk = fmt::format("{} {::}{}{::}\r{:03}{}",
                         localization->GetSkillName(skill), skill_mastery_color.tag(), skill_level_str, skill_color.tag(), right_margin, skill_level);
-                pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, button->uY}, skill_color, Strsk, 0, 0, Color());
+                pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, button->uY}, skill_color, Strsk);
             }
         }
     }
 
     if (!num_skills_drawn) {
         y_offset += pFontLucida->GetHeight() - 3;
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, y_offset}, Color(), localization->GetString(LSTR_NONE), 0, 0, Color());
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, y_offset}, Color(), localization->GetString(LSTR_NONE));
     }
 
     return y_offset;
@@ -869,7 +869,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_Draw(Player *player) {
                      player->uSkillPoints ? ui_character_bonus_text_color.tag()
                                           : ui_character_default_text_color.tag(),
                      player->uSkillPoints);
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str);
 
     int y = 2 * pFontLucida->GetHeight() + 13;
     y = CharacterUI_SkillsTab_Draw__DrawSkillTable(player, 24, y, allWeaponSkills(), 400, localization->GetString(LSTR_WEAPONS));
@@ -974,7 +974,7 @@ void GUIWindow_CharacterRecord::CharacterUI_AwardsTab_Draw(Player *player) {
     std::string str = fmt::format("{} {::}{}\f00000", localization->GetString(LSTR_AWARDS_FOR),
                                   ui_character_header_text_color.tag(), NameAndTitle(player->name, player->classType));
 
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str);
 
 
     if (_awardsCharacterId != pParty->activeCharacterIndex()) {
@@ -985,7 +985,7 @@ void GUIWindow_CharacterRecord::CharacterUI_AwardsTab_Draw(Player *player) {
     for (int i = _startAwardElem; i < _achievedAwardsList.size(); ++i) {
         std::string str = getAchievedAwardsString(i);
 
-        window.DrawText(pFontArrus, {0, 0}, ui_character_award_color[pAwards[_achievedAwardsList[i]].uPriority % 6], str, 0, 0, Color());
+        window.DrawText(pFontArrus, {0, 0}, ui_character_award_color[pAwards[_achievedAwardsList[i]].uPriority % 6], str);
         window.uFrameY = pFontArrus->CalcTextHeight(str, window.uFrameWidth, 0) + window.uFrameY + 8;
         currentlyDisplayedElems++;
         if (window.uFrameY > window.uFrameHeight) {

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -296,7 +296,7 @@ void GUIWindow_Dialogue::Update() {
 
         render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
                                     _591428_endcap);
-        pDialogueWindow->DrawText(font, {13, 354 - pTextHeight}, Color(), font->FitTextInAWindow(dialogue_string, window.uFrameWidth, 13), 0, 0, Color());
+        pDialogueWindow->DrawText(font, {13, 354 - pTextHeight}, Color(), font->FitTextInAWindow(dialogue_string, window.uFrameWidth, 13));
     }
 
     // Right panel(Правая панель)-------
@@ -488,8 +488,7 @@ void GUIWindow_GenericDialogue::Update() {
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
                                 _591428_endcap);
     pGUIWindow_BranchlessDialogue->DrawText(pFont, {12, 354 - pTextHeight}, Color(),
-        pFont->FitTextInAWindow(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12),
-        0, 0, Color());
+        pFont->FitTextInAWindow(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12));
     render->DrawTextureNew(0, 352 / 480.0f, game_ui_statusbar);
     if (pGUIWindow_BranchlessDialogue->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS) {
         if (pGUIWindow_BranchlessDialogue->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
@@ -508,7 +507,7 @@ void GUIWindow_GenericDialogue::Update() {
 
     if (pGUIWindow_BranchlessDialogue->wData.val == (int)EVENT_InputString) {
         auto str = fmt::format("{} {}", GameUI_StatusBar_GetInput(), keyboardInputHandler->GetTextInput());
-        pGUIWindow_BranchlessDialogue->DrawText(pFontLucida, {13, 357}, Color(), str, 0, 0, Color());
+        pGUIWindow_BranchlessDialogue->DrawText(pFontLucida, {13, 357}, Color(), str);
         pGUIWindow_BranchlessDialogue->DrawFlashingInputCursor(pFontLucida->GetLineWidth(str) + 13, 357, pFontLucida);
         return;
     }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -343,13 +343,13 @@ void GUIWindow_GameKeyBindings::Update() {
 
     for (int i = 0; i < 7; ++i) {
         InputAction action1 = (InputAction)(base_controls_offset + i);
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {23, 142 + i * 21}, ui_gamemenu_keys_action_name_color, GetDisplayName(action1), 0, 0, Color());
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {127, 142 + i * 21}, GameMenuUI_GetKeyBindingColor(action1), GetDisplayName(curr_key_map[action1]), 0, 0, Color());
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {23, 142 + i * 21}, ui_gamemenu_keys_action_name_color, GetDisplayName(action1));
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {127, 142 + i * 21}, GameMenuUI_GetKeyBindingColor(action1), GetDisplayName(curr_key_map[action1]));
 
         int j = i + 7;
         InputAction action2 = (InputAction)(base_controls_offset + j);
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {247, 142 + i * 21}, ui_gamemenu_keys_action_name_color, GetDisplayName(action2), 0, 0, Color());
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {350, 142 + i * 21}, GameMenuUI_GetKeyBindingColor(action2), GetDisplayName(curr_key_map[action2]), 0, 0, Color());
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {247, 142 + i * 21}, ui_gamemenu_keys_action_name_color, GetDisplayName(action2));
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {350, 142 + i * 21}, GameMenuUI_GetKeyBindingColor(action2), GetDisplayName(curr_key_map[action2]));
     }
 }
 
@@ -786,8 +786,8 @@ void GameUI_DrawFoodAndGold() {
     if (uGameState != GAME_STATE_FINAL_WINDOW) {
         text_y = _44100D_should_alter_right_panel() != 0 ? 381 : 322;
 
-        pPrimaryWindow->DrawText(pFontSmallnum, {0, text_y}, uGameUIFontMain, fmt::format("\r087{}", pParty->GetFood()), 0, 0, uGameUIFontShadow);
-        pPrimaryWindow->DrawText(pFontSmallnum, {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", pParty->GetGold()), 0, 0, uGameUIFontShadow);
+        pPrimaryWindow->DrawText(pFontSmallnum, {0, text_y}, uGameUIFontMain, fmt::format("\r087{}", pParty->GetFood()), 0, uGameUIFontShadow);
+        pPrimaryWindow->DrawText(pFontSmallnum, {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", pParty->GetGold()), 0, uGameUIFontShadow);
         // force to render all queued text now so it wont be delayed and drawn over things it isn't supposed to, like item in hand or nuklear
         render->EndTextNew();
     }
@@ -1900,7 +1900,7 @@ void GUIWindow_DebugMenu::Update() {
         pViewport->uViewportTL_Y / 480.0f,
         game_ui_menu_options);
 
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 10}, Color(), "Debug Menu", 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 10}, Color(), "Debug Menu");
 
     buttonbox(13, 140, "Town Portal", engine->config->debug.TownPortal.value());
     buttonbox(127, 140, "Give Gold", 2);
@@ -1972,5 +1972,5 @@ void buttonbox(int x, int y, const char *text, int col) {
     if (col == 1) {
         colour = ui_character_bonus_text_color;
     }
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {x+1, y+2}, colour, text, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {x+1, y+2}, colour, text);
 }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -523,7 +523,7 @@ void SimpleHouseDialog() {
                 int h = (pFontArrus->CalcTextHeight(pInString, house_window.uFrameWidth, 13) + 7);
                 render->DrawTextureNew(8 / 640.0f, (347 - h) / 480.0f, _591428_endcap);
                 pDialogueWindow->DrawText(pFontArrus, {13, 354 - h}, Color(),
-                    pFontArrus->FitTextInAWindow(pInString, house_window.uFrameWidth, 13), 0, 0, Color());
+                    pFontArrus->FitTextInAWindow(pInString, house_window.uFrameWidth, 13));
             }
         }
     }
@@ -663,7 +663,7 @@ void SimpleHouseDialog() {
             ui_leather_mm7, pTextHeight);
         render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
             _591428_endcap);
-        house_window.DrawText(pTextFont, {13, 354 - pTextHeight}, Color(), pTextFont->FitTextInAWindow(current_npc_text, w.uFrameWidth, 13), 0, 0, Color());
+        house_window.DrawText(pTextFont, {13, 354 - pTextHeight}, Color(), pTextFont->FitTextInAWindow(current_npc_text, w.uFrameWidth, 13));
     }
 }
 
@@ -936,7 +936,7 @@ void GUIWindow_House::houseDialogManager() {
             int v6 = pTextHeight + 7;
             render->DrawTextureCustomHeight(8 / 640.0f, (352 - (pTextHeight + 7)) / 480.0f, ui_leather_mm7, pTextHeight + 7);
             render->DrawTextureNew(8 / 640.0f, (347 - v6) / 480.0f, _591428_endcap);
-            DrawText(pFontArrus, {13, 354 - v6}, Color(), pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13), 0, 0, Color());
+            DrawText(pFontArrus, {13, 354 - v6}, Color(), pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13));
         }
         if (uNumDialogueNPCPortraits <= 0) {
             if (pDialogueNPCCount == uNumDialogueNPCPortraits &&

--- a/src/GUI/UI/UIInventory.cpp
+++ b/src/GUI/UI/UIInventory.cpp
@@ -16,8 +16,8 @@
 
 void GUIWindow_Inventory::Update() {
     DrawMessageBox(0);
-    DrawText(pFontLucida, {10, 20}, Color(), "Making item number", 0, 0, Color());
-    DrawText(pFontLucida, {10, 40}, Color(), keyboardInputHandler->GetTextInput(), 0, 0, Color());
+    DrawText(pFontLucida, {10, 20}, Color(), "Making item number");
+    DrawText(pFontLucida, {10, 40}, Color(), keyboardInputHandler->GetTextInput());
 
     // a hack to capture end of user input (enter) while avoiding listening to UI message handler
     // redo this in a more clean way

--- a/src/GUI/UI/UIMessageScroll.cpp
+++ b/src/GUI/UI/UIMessageScroll.cpp
@@ -38,5 +38,5 @@ void GUIWindow_MessageScroll::Update() {
     const std::string &name = pItemTable->pItems[pGUIWindow_ScrollWindow->scroll_type].name;
 
     a1.DrawTitleText(pFontCreate, 0, 0, Color(), fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), name), 3);
-    a1.DrawText(pFontSmallnum, {1, pFontCreate->GetHeight() - 3}, Color(), pMessageScrolls[pGUIWindow_ScrollWindow->scroll_type], 0, 0, Color());
+    a1.DrawText(pFontSmallnum, {1, pFontCreate->GetHeight() - 3}, Color(), pMessageScrolls[pGUIWindow_ScrollWindow->scroll_type]);
 }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -335,7 +335,7 @@ void GUIWindow_PartyCreation::Update() {
     pTextCenter = ui_partycreation_font->AlignText_Center(
         640, localization->GetString(LSTR_CREATE_PARTY_FANCY));
     pGUIWindow_CurrentMenu->DrawText(ui_partycreation_font, {pTextCenter + 1, 0}, Color(),
-        localization->GetString(LSTR_CREATE_PARTY_FANCY), 0, 0, Color());
+        localization->GetString(LSTR_CREATE_PARTY_FANCY));
 
     render->DrawTextureNew(17 / oldDims.w, 35 / oldDims.h, ui_partycreation_portraits[pParty->pPlayers[0].uCurrentFace]);
     render->DrawTextureNew(176 / oldDims.w, 35 / oldDims.h, ui_partycreation_portraits[pParty->pPlayers[1].uCurrentFace]);
@@ -363,7 +363,7 @@ void GUIWindow_PartyCreation::Update() {
 
     for (int i = 0; i < 4; ++i) {
         pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pIntervalX + 73, 100}, Color(),
-            localization->GetClassName(pParty->pPlayers[i].classType), 0, 0, Color());
+            localization->GetClassName(pParty->pPlayers[i].classType));
         render->DrawTextureNew((pIntervalX + 77) / oldDims.w, 50 / oldDims.h, ui_partycreation_class_icons[pParty->pPlayers[i].classType / 4]);
 
         if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_NONE &&
@@ -402,7 +402,7 @@ void GUIWindow_PartyCreation::Update() {
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX + 72, pIntervalY + 12}, Color(), pRaceName, 130, 0);
 
         pTextCenter = pFontCreate->AlignText_Center(150, pText);
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + uX - 24, 291}, colorTable.Tacha, pText, 0, 0, Color());  // Skills
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + uX - 24, 291}, colorTable.Tacha, pText);  // Skills
 
         int posY = 169;
 
@@ -473,72 +473,72 @@ void GUIWindow_PartyCreation::Update() {
 
     uClassType = pParty->pPlayers[uPlayerCreationUI_SelectedCharacter].classType;
     pTextCenter = pFontCreate->AlignText_Center(193, pText);
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 324, 395}, colorTable.Tacha, pText, 0, 0, Color());  // Classes
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 324, 395}, colorTable.Tacha, pText);  // Classes
 
     pColorText = colorTable.Aqua;
     if (uClassType)
         pColorText = colorTable.White;
     pTextCenter = pFontCreate->AlignText_Center(65, localization->GetClassName(0));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, 417}, pColorText, localization->GetClassName(0), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, 417}, pColorText, localization->GetClassName(0));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_PALADIN)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(12));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, pIntervalY + 417}, pColorText, localization->GetClassName(12), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, pIntervalY + 417}, pColorText, localization->GetClassName(12));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_RANGER)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(20));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(20), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 323, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(20));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_CLERIC)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(24));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, 417}, pColorText, localization->GetClassName(24), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, 417}, pColorText, localization->GetClassName(24));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_DRUID)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(28));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, pIntervalY + 417}, pColorText, localization->GetClassName(28), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, pIntervalY + 417}, pColorText, localization->GetClassName(28));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_SORCERER)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(32));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(32), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 388, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(32));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_ARCHER)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(16));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, 417}, pColorText, localization->GetClassName(16), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, 417}, pColorText, localization->GetClassName(16));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_MONK)
         pColorText = colorTable.White;
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(8));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, pIntervalY + 417}, pColorText, localization->GetClassName(8), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, pIntervalY + 417}, pColorText, localization->GetClassName(8));
 
     pColorText = colorTable.Aqua;
     if (uClassType != PLAYER_CLASS_THIEF)
         pColorText = colorTable.White;
     pTextCenter = pFontCreate->AlignText_Center(65, localization->GetClassName(4));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(4), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 453, 2 * pIntervalY + 417}, pColorText, localization->GetClassName(4));
 
     pTextCenter = pFontCreate->AlignText_Center(
         236, localization->GetString(LSTR_AVAILABLE_SKILLS));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 37, 395}, colorTable.Tacha, localization->GetString(LSTR_AVAILABLE_SKILLS), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 37, 395}, colorTable.Tacha, localization->GetString(LSTR_AVAILABLE_SKILLS));
     for (int i = 0; i < 9; ++i) {
         pSkillId = pParty->pPlayers[uPlayerCreationUI_SelectedCharacter].GetSkillIdxByOrder(i + 4);
         strcpy(pText, localization->GetSkillName(pSkillId));
@@ -573,12 +573,12 @@ void GUIWindow_PartyCreation::Update() {
             pTextCenter = 105 - pFontCreate->GetLineWidth(pText);
         }
 
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {100 * (i / 3) + pTextCenter + pCorrective + 17, pIntervalY * (i % 3) + 417}, pColorText, pText, 0, 0, Color());
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {100 * (i / 3) + pTextCenter + pCorrective + 17, pIntervalY * (i % 3) + 417}, pColorText, pText);
     }
 
     pTextCenter = pFontCreate->AlignText_Center(
         0x5C, localization->GetString(LSTR_BONUS));
-    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 533, 394}, colorTable.Tacha, localization->GetString(LSTR_BONUS), 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 533, 394}, colorTable.Tacha, localization->GetString(LSTR_BONUS));
 
     // force draw so overlays dont get muddled
     render->DrawTwodVerts();

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -114,7 +114,7 @@ void CharacterUI_DrawTooltip(const char *title, std::string &content) {
     auto colored_title = fmt::format(
         "{::}{}\f00000\n", ui_character_tooltip_header_default_color.tag(), title);
     popup_window.DrawTitleText(pFontCreate, 0, 0, Color(), colored_title, 3);
-    popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), content, 0, 0, Color());  // popup_window.uFrameY + popup_window.uFrameHeight
+    popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), content);  // popup_window.uFrameY + popup_window.uFrameHeight
 }
 
 void CharacterUI_DrawTooltip(const char *title, const char *content) {
@@ -473,12 +473,12 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
 
     for (const std::string &s : text) {
         if (!s.empty()) {
-            iteminfo_window.DrawText(pFontComic, {100, v34}, Color(), s, 0, 0, Color());
+            iteminfo_window.DrawText(pFontComic, {100, v34}, Color(), s);
             v34 += pFontComic->CalcTextHeight(s, iteminfo_window.uFrameWidth, 100, 0) + 3;
         }
     }
     if (!pItemTable->pItems[inspect_item->uItemID].pDescription.empty())
-        iteminfo_window.DrawText(pFontSmallnum, {100, v34}, Color(), pItemTable->pItems[inspect_item->uItemID].pDescription, 0, 0, Color());
+        iteminfo_window.DrawText(pFontSmallnum, {100, v34}, Color(), pItemTable->pItems[inspect_item->uItemID].pDescription);
     iteminfo_window.uFrameX += 12;
     iteminfo_window.uFrameWidth -= 24;
     iteminfo_window.DrawTitleText(pFontArrus, 0, 0xCu, colorTable.PaleCanary,
@@ -488,7 +488,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
 
     if (GoldAmount) {
         auto txt = fmt::format("{}: {}", localization->GetString(LSTR_VALUE), GoldAmount);
-        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt, 0, 0, Color());
+        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt);
         render->ResetUIClipRect();
     } else {
         if ((inspect_item->uAttributes & ITEM_TEMP_BONUS) &&
@@ -519,14 +519,14 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
             if (formatting)
                 txt4 += fmt::format(" {}:mn", v67.field_4_expire_minute);
 
-            iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - 2 * pFontComic->GetHeight()}, Color(), txt4.data(), 0, 0, Color());
+            iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - 2 * pFontComic->GetHeight()}, Color(), txt4.data());
         }
 
         auto txt2 = fmt::format(
             "{}: {}", localization->GetString(LSTR_VALUE),
             inspect_item->GetValue()
         );
-        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt2.data(), 0, 0, Color());
+        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt2.data());
 
         std::string txt3;
         if (inspect_item->uAttributes & ITEM_STOLEN) {
@@ -540,7 +540,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
         }
 
         iteminfo_window.DrawText(pFontComic,
-            {pFontComic->GetLineWidth(txt2.data()) + 132, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, colorTable.Red, txt3, 0, 0, Color());
+            {pFontComic->GetLineWidth(txt2.data()) + 132, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, colorTable.Red, txt3);
         render->ResetUIClipRect();
     }
 }
@@ -690,9 +690,9 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     int pTextHeight = 0;
     const char *pText = nullptr;
     int pTextColorID = 0;
-    pWindow->DrawText(pFontSmallnum, {12, 196}, colorTable.Jonquil, localization->GetString(LSTR_EFFECTS), 0, 0, Color());
+    pWindow->DrawText(pFontSmallnum, {12, 196}, colorTable.Jonquil, localization->GetString(LSTR_EFFECTS));
     if (!for_effects) {
-        pWindow->DrawText(pFontSmallnum, {28, pFontSmallnum->GetHeight() + 193}, colorTable.White, localization->GetString(LSTR_UNKNOWN_VALUE), 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {28, pFontSmallnum->GetHeight() + 193}, colorTable.White, localization->GetString(LSTR_UNKNOWN_VALUE));
     } else {
         pText = "";
         pTextHeight = pFontSmallnum->GetHeight() + 193;
@@ -787,13 +787,13 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
                         break;
                 }
                 if (!iequals(pText, "")) {
-                    pWindow->DrawText(pFontSmallnum, {28, pTextHeight}, GetSpellColor(pTextColorID), pText, 0, 0, Color());
+                    pWindow->DrawText(pFontSmallnum, {28, pTextHeight}, GetSpellColor(pTextColorID), pText);
                     pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
                 }
             }
         }
         if (iequals(pText, ""))
-            pWindow->DrawText(pFontSmallnum, {28, pTextHeight}, colorTable.White, localization->GetString(LSTR_NONE), 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {28, pTextHeight}, colorTable.White, localization->GetString(LSTR_NONE));
     }
 
     std::string txt2;
@@ -801,7 +801,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         auto str =
             fmt::format("{}\f00000\t100{}\n", localization->GetString(LSTR_HIT_POINTS),
                          pActors[uActorID].pMonsterInfo.uHP);
-        pWindow->DrawText(pFontSmallnum, {150, doll_rect.y}, colorTable.Jonquil, str, 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {150, doll_rect.y}, colorTable.Jonquil, str);
         pTextHeight = doll_rect.y + pFontSmallnum->GetHeight() - 3;
         txt2 = fmt::format("{}\f00000\t100{}\n", localization->GetString(LSTR_ARMOR_CLASS),
                             pActors[uActorID].pMonsterInfo.uAC);
@@ -809,13 +809,13 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         auto str = fmt::format(
             "{}\f00000\t100{}\n", localization->GetString(LSTR_HIT_POINTS),
             localization->GetString(LSTR_UNKNOWN_VALUE));
-        pWindow->DrawText(pFontSmallnum, {150, doll_rect.y}, colorTable.Jonquil, str, 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {150, doll_rect.y}, colorTable.Jonquil, str);
         pTextHeight = doll_rect.y + pFontSmallnum->GetHeight() - 3;
         txt2 = fmt::format(
             "{}\f00000\t100{}\n", localization->GetString(LSTR_ARMOR_CLASS),
             localization->GetString(LSTR_UNKNOWN_VALUE));
     }
-    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt2, 0, 0, Color());
+    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt2);
     pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 6 +
                   pFontSmallnum->GetHeight();
 
@@ -837,7 +837,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         auto txt3 = fmt::format(
             "{}\f00000\t080{}\n", localization->GetString(LSTR_ATTACK),
             content[pActors[uActorID].pMonsterInfo.uAttack1Type]);
-        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt3, 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt3);
 
         pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         if (pActors[uActorID].pMonsterInfo.uAttack1DamageBonus)
@@ -856,14 +856,14 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
             "{}\f00000\t080{}\n", localization->GetString(LSTR_ATTACK),
             localization->GetString(LSTR_UNKNOWN_VALUE)
         );
-        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt3, 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt3);
         pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         txt4 = fmt::format(
             "{}\f00000\t080{}\n", localization->GetString(LSTR_DAMAGE),
             localization->GetString(LSTR_UNKNOWN_VALUE)
         );
     }
-    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt4, 0, 0, Color());
+    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt4);
 
     pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 6 +
                   pFontSmallnum->GetHeight();
@@ -872,7 +872,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
             "{}\f00000\t080{}\n", localization->GetString(LSTR_SPELL),
             localization->GetString(LSTR_UNKNOWN_VALUE)
         );
-        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt5, 0, 0, Color());
+        pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt5);
         pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
     } else {
         pText = localization->GetString(LSTR_SPELL);
@@ -883,7 +883,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
                 "{}\f00000\t070{}\n", pText,
                 pSpellStats->pInfos[pActors[uActorID].pMonsterInfo.uSpell1ID].pShortName
             );  // "%s\f%05u\t060%s\n"
-            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6, 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6);
             pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         }
         if (pActors[uActorID].pMonsterInfo.uSpell2ID != SPELL_NONE) {
@@ -891,7 +891,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
                 "\f00000\t070{}\n",
                 pSpellStats->pInfos[pActors[uActorID].pMonsterInfo.uSpell2ID]
                     .pShortName);  // "%s\f%05u\t060%s\n"
-            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6, 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6);
             pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         }
         if (!pActors[uActorID].pMonsterInfo.uSpell1ID &&
@@ -899,13 +899,13 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
             auto txt6 = fmt::format(
                 "{}\f00000\t070{}\n", localization->GetString(LSTR_SPELL),
                 localization->GetString(LSTR_NONE));  // "%s\f%05u\t060%s\n"
-            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6, 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, txt6);
             pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         }
     }
 
     pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
-    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, localization->GetString(LSTR_RESISTANCES), 0, 0, Color());
+    pWindow->DrawText(pFontSmallnum, {150, pTextHeight}, colorTable.Jonquil, localization->GetString(LSTR_RESISTANCES));
     pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
 
     const char *string_name[10] = {0};
@@ -943,12 +943,12 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
                     pText = localization->GetString(LSTR_NONE);
             }
 
-            pWindow->DrawText(pFontSmallnum, {170, pTextHeight}, colorTable.Jonquil, fmt::format("{}\f00000\t070{}\n", string_name[i], pText), 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {170, pTextHeight}, colorTable.Jonquil, fmt::format("{}\f00000\t070{}\n", string_name[i], pText));
             pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         }
     } else {
         for (uint i = 0; i < 10; ++i) {
-            pWindow->DrawText(pFontSmallnum, {170, pTextHeight}, colorTable.Jonquil, fmt::format("{}\f00000\t070{}\n", string_name[i], localization->GetString(LSTR_UNKNOWN_VALUE)), 0, 0, Color());
+            pWindow->DrawText(pFontSmallnum, {170, pTextHeight}, colorTable.Jonquil, fmt::format("{}\f00000\t070{}\n", string_name[i], localization->GetString(LSTR_UNKNOWN_VALUE)));
             pTextHeight = pTextHeight + pFontSmallnum->GetHeight() - 3;
         }
     }
@@ -1247,7 +1247,7 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     spell_info_window.uFrameW = spell_info_window.uFrameHeight + spell_info_window.uFrameY - 1;
     spell_info_window.DrawTitleText(
         pFontArrus, 0x78u, 0xCu, colorTable.PaleCanary, spell->name, 3);
-    spell_info_window.DrawText(pFontSmallnum, {120, 44}, Color(), str, 0, 0, Color());
+    spell_info_window.DrawText(pFontSmallnum, {120, 44}, Color(), str);
     spell_info_window.uFrameWidth = 108;
     spell_info_window.uFrameZ = spell_info_window.uFrameX + 107;
     PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pParty->activeCharacter().lastOpenedSpellbookPage + 12);
@@ -1309,7 +1309,7 @@ static void drawBuffPopupWindow() {
         if (pParty->pPartyBuffs[i].Active()) {
             GameTime remaingTime = pParty->pPartyBuffs[i].GetExpireTime() - pParty->GetPlayingTime();
             int yPos = stringCount * pFontComic->GetHeight() + 40;
-            popupWindow.DrawText(pFontComic, {52, yPos}, spellTooltipColors[i], localization->GetSpellName(i), 0, 0, Color());
+            popupWindow.DrawText(pFontComic, {52, yPos}, spellTooltipColors[i], localization->GetSpellName(i));
             DrawBuff_remaining_time_string(yPos, &popupWindow, remaingTime, pFontComic);
             stringCount++;
         }
@@ -1364,7 +1364,7 @@ void showSpellbookInfo(ITEM_TYPE spellItemId) {
     popup.uFrameZ = popup.uFrameX + popup.uFrameWidth - 1;
     popup.uFrameW = popup.uFrameHeight + popup.uFrameY - 1;
     popup.DrawTitleText(pFontArrus, 0x78u, 0xCu, colorTable.PaleCanary, pSpellStats->pInfos[spellId].name, 3u);
-    popup.DrawText(pFontSmallnum, {120, 44}, Color(), str, 0, 0, Color());
+    popup.DrawText(pFontSmallnum, {120, 44}, Color(), str);
     popup.uFrameZ = popup.uFrameX + 107;
     popup.uFrameWidth = 108;
     popup.DrawTitleText(pFontComic, 0xCu, 0x4Bu, Color(), localization->GetSkillName(static_cast<PLAYER_SKILL_TYPE>(spellSchool / 4 + 12)), 3u);
@@ -1660,7 +1660,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
 
     str += fmt::format("{}: {}", localization->GetString(LSTR_QUICK_SPELL), spellName);
 
-    window->DrawText(pFontArrus, {120, 22}, Color(), str, 0, 0, Color());
+    window->DrawText(pFontArrus, {120, 22}, Color(), str);
 
     uFramesetIDa = 0;
     for (uint i = 0; i < 24; ++i) {
@@ -1669,7 +1669,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
             v36 = uFramesetIDa++ * pFontComic->GetHeight() + 134;
             window->DrawText(pFontComic, {52, v36},
                              ui_game_character_record_playerbuff_colors[i],
-                             localization->GetSpellName(20 + i), 0, 0, Color());
+                             localization->GetSpellName(20 + i));
             DrawBuff_remaining_time_string(
                 v36, window, buff->GetExpireTime() - pParty->GetPlayingTime(),
                 pFontComic);
@@ -1679,7 +1679,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
     auto active_spells = localization->FormatString(
         LSTR_FMT_ACTIVE_SPELLS_S,
         uFramesetIDa == 0 ? localization->GetString(LSTR_NONE) : "");
-    window->DrawText(pFontArrus, {14, 114}, Color(), active_spells, 0, 0, Color());
+    window->DrawText(pFontArrus, {14, 114}, Color(), active_spells);
 }
 
 void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
@@ -2055,7 +2055,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
 
                 std::string str = fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), pStr);
                 popup_window.DrawTitleText(pFontCreate, 0, 0, Color(), str, 3);
-                popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), sHint, 0, 0, Color());
+                popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), sHint);
             }
             break;
         }

--- a/src/GUI/UI/UIQuickReference.cpp
+++ b/src/GUI/UI/UIQuickReference.cpp
@@ -139,7 +139,7 @@ void GUIWindow_QuickReference::Update() {
     }
 
     std::string rep = fmt::format("{}: {::}{}\f00000", localization->GetString(LSTR_REPUTATION), pTextColor.tag(), GetReputationString(pParty->GetPartyReputation()));
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {22, 323}, Color(), rep, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {22, 323}, Color(), rep);
     std::string fame = fmt::format("\r261{}: {}", localization->GetString(LSTR_FAME), pParty->getPartyFame());
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 323}, Color(), fame, 0, 0, Color());
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 323}, Color(), fame);
 }

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -171,7 +171,7 @@ void GUIWindow_Rest::Update() {
         tmp_button.pParent = 0;
 
         auto str1 = fmt::format("\r408{}", foodRequiredToRest);
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {0, 164}, colorTable.Diesel, str1, 0, 0, colorTable.StarkWhite);
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {0, 164}, colorTable.Diesel, str1, 0, colorTable.StarkWhite);
 
         pButton_RestUI_WaitUntilDawn->DrawLabel(localization->GetString(LSTR_WAIT_UNTIL_DAWN), pFontCreate, colorTable.Diesel, colorTable.StarkWhite);
         pButton_RestUI_Wait1Hour->DrawLabel(localization->GetString(LSTR_WAIT_1_HOUR), pFontCreate, colorTable.Diesel, colorTable.StarkWhite);
@@ -190,13 +190,13 @@ void GUIWindow_Rest::Update() {
         tmp_button.DrawLabel(localization->GetString(LSTR_WAIT_WITHOUT_HEALING), pFontCreate, colorTable.Diesel, colorTable.StarkWhite);
         tmp_button.pParent = 0;
         std::string str2 = fmt::format("{}:{:02} {}", am_pm_hours, pParty->uCurrentMinute, localization->GetAmPm((pParty->uCurrentHour >= 12 && pParty->uCurrentHour < 24) ? 1 : 0));
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {368, 168}, colorTable.Diesel, str2, 0, 0, colorTable.StarkWhite);
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {368, 168}, colorTable.Diesel, str2, 0, colorTable.StarkWhite);
         std::string str3 = fmt::format("{}\r190{}", localization->GetString(LSTR_DAY_CAPITALIZED), pParty->uCurrentDayOfMonth + 1);
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 190}, colorTable.Diesel, str3, 0, 0, colorTable.StarkWhite);
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 190}, colorTable.Diesel, str3, 0, colorTable.StarkWhite);
         std::string str4 = fmt::format("{}\r190{}", localization->GetString(LSTR_MONTH), pParty->uCurrentMonth + 1);
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 222}, colorTable.Diesel, str4, 0, 0, colorTable.StarkWhite);
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 222}, colorTable.Diesel, str4, 0, colorTable.StarkWhite);
         std::string str5 = fmt::format("{}\r190{}", localization->GetString(LSTR_YEAR), pParty->uCurrentYear);
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 254}, colorTable.Diesel, str5, 0, 0, colorTable.StarkWhite);
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {350, 254}, colorTable.Diesel, str5, 0, colorTable.StarkWhite);
         if (currentRestType != REST_NONE) {
             Party::restOneFrame();
         }

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -154,7 +154,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     this->uFrameZ = uFrameX + uFrameWidth - 1;
     this->uFrameW = uFrameY + uFrameHeight - 1;
 
-    DrawText(pFontSmallnum, {25, 199}, Color(), localization->GetString(LSTR_READING), 0, 0, Color());
+    DrawText(pFontSmallnum, {25, 199}, Color(), localization->GetString(LSTR_READING));
     render->Present();
 
     pSavegameList->Initialize();
@@ -305,13 +305,13 @@ static void UI_DrawSaveLoad(bool save) {
     if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
         pGUIWindow_CurrentMenu->DrawText(pFontSmallnum,
             {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_LOADING)) + 25, 220}, Color(),
-            localization->GetString(LSTR_LOADING), 0, 0, Color());
+            localization->GetString(LSTR_LOADING));
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum,
                                                {pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name) + 25, 262}, Color(),
                                                pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name, 185, 0);
         pGUIWindow_CurrentMenu->DrawText(pFontSmallnum,
             {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_PLEASE_WAIT)) + 25, 304}, Color(),
-            localization->GetString(LSTR_PLEASE_WAIT), 0, 0, Color());
+            localization->GetString(LSTR_PLEASE_WAIT));
     } else {
         int maxSaveFiles = MAX_SAVE_SLOTS;
         int framex = 0, framey = 0;

--- a/src/GUI/UI/UIStatusBar.cpp
+++ b/src/GUI/UI/UIStatusBar.cpp
@@ -97,7 +97,7 @@ void GameUI_StatusBar_Draw() {
     }
 
     if (status.length() > 0) {
-        pPrimaryWindow->DrawText(pFontLucida, {pFontLucida->AlignText_Center(450, status) + 11, 357}, uGameUIFontMain, status, 0, 0, uGameUIFontShadow);
+        pPrimaryWindow->DrawText(pFontLucida, {pFontLucida->AlignText_Center(450, status) + 11, 357}, uGameUIFontMain, status, 0, uGameUIFontShadow);
     }
 }
 


### PR DESCRIPTION
* Dropped `present_time_transparency` parameter.
* Not passing defaulted args at call sites.
* Some renamings in arg names.