### PR TITLE
Dropped class Texture

### DIFF
--- a/src/Arcomage/Arcomage.h
+++ b/src/Arcomage/Arcomage.h
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "Engine/Graphics/Image.h"
-#include "Engine/Graphics/Texture.h"
 #include "Engine/Graphics/FrameLimiter.h"
 
 #include "Utility/Geometry/Point.h"
@@ -160,8 +159,8 @@ struct ArcomageGame {
     GUIFont *pfntArrus = nullptr;  // ptr_4C;
     int field_50 = 0;
     int field_54 = 0;  // blend mode ??
-    Texture *pGameBackground = nullptr;
-    Texture *pSprites = nullptr;
+    GraphicsImage *pGameBackground = nullptr;
+    GraphicsImage *pSprites = nullptr;
     int uGameWinner = 0;
     int Victory_type = 0;
     std::string pPlayer1Name;

--- a/src/Engine/AssetsManager.cpp
+++ b/src/Engine/AssetsManager.cpp
@@ -4,7 +4,6 @@
 
 #include "Engine/Graphics/IRender.h"
 #include "Engine/Graphics/ImageLoader.h"
-#include "Engine/Graphics/Texture.h"
 #include "GUI/GUIFont.h"
 
 #include "Utility/String.h"
@@ -42,7 +41,7 @@ bool AssetsManager::releaseImage(const std::string &name) {
     return true;
 }
 
-Texture *AssetsManager::getImage_Paletted(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_Paletted(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -56,7 +55,7 @@ Texture *AssetsManager::getImage_Paletted(const std::string &name) {
 }
 
 
-Texture *AssetsManager::getImage_ColorKey(const std::string &name, Color colorkey) {
+GraphicsImage *AssetsManager::getImage_ColorKey(const std::string &name, Color colorkey) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -71,7 +70,7 @@ Texture *AssetsManager::getImage_ColorKey(const std::string &name, Color colorke
 
 
 
-Texture *AssetsManager::getImage_Solid(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_Solid(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -84,7 +83,7 @@ Texture *AssetsManager::getImage_Solid(const std::string &name) {
     return i->second;
 }
 
-Texture *AssetsManager::getImage_Alpha(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_Alpha(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -97,7 +96,7 @@ Texture *AssetsManager::getImage_Alpha(const std::string &name) {
     return i->second;
 }
 
-Texture *AssetsManager::getImage_PCXFromIconsLOD(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_PCXFromIconsLOD(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -110,7 +109,7 @@ Texture *AssetsManager::getImage_PCXFromIconsLOD(const std::string &name) {
     return i->second;
 }
 
-Texture *AssetsManager::getImage_PCXFromNewLOD(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_PCXFromNewLOD(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -123,7 +122,7 @@ Texture *AssetsManager::getImage_PCXFromNewLOD(const std::string &name) {
     return i->second;
 }
 
-Texture *AssetsManager::getImage_PCXFromFile(const std::string &name) {
+GraphicsImage *AssetsManager::getImage_PCXFromFile(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = images.find(filename);
@@ -136,7 +135,7 @@ Texture *AssetsManager::getImage_PCXFromFile(const std::string &name) {
     return i->second;
 }
 
-Texture *AssetsManager::getBitmap(const std::string &name) {
+GraphicsImage *AssetsManager::getBitmap(const std::string &name) {
     std::string filename = toLower(name);
 
     auto i = bitmaps.find(filename);
@@ -162,7 +161,7 @@ bool AssetsManager::releaseBitmap(const std::string &name) {
     return true;
 }
 
-Texture *AssetsManager::getSprite(const std::string &name, unsigned int palette_id,
+GraphicsImage *AssetsManager::getSprite(const std::string &name, unsigned int palette_id,
                                   unsigned int lod_sprite_id) {
     std::string filename = toLower(name);
 

--- a/src/Engine/AssetsManager.h
+++ b/src/Engine/AssetsManager.h
@@ -6,7 +6,6 @@
 #include "Library/Color/ColorTable.h"
 
 class GraphicsImage;
-class Texture;
 
 class AssetsManager {
  public:
@@ -18,27 +17,27 @@ class AssetsManager {
     bool releaseSprite(const std::string &name);
     bool releaseBitmap(const std::string &name);
 
-    Texture *getImage_ColorKey(const std::string &name, Color colorkey = colorTable.TealMask);
-    Texture *getImage_Paletted(const std::string &name);
-    Texture *getImage_Solid(const std::string &name);
-    Texture *getImage_Alpha(const std::string &name);
+    GraphicsImage *getImage_ColorKey(const std::string &name, Color colorkey = colorTable.TealMask);
+    GraphicsImage *getImage_Paletted(const std::string &name);
+    GraphicsImage *getImage_Solid(const std::string &name);
+    GraphicsImage *getImage_Alpha(const std::string &name);
 
-    Texture *getImage_PCXFromFile(const std::string &name);
-    Texture *getImage_PCXFromIconsLOD(const std::string &name);
-    Texture *getImage_PCXFromNewLOD(const std::string &name);
+    GraphicsImage *getImage_PCXFromFile(const std::string &name);
+    GraphicsImage *getImage_PCXFromIconsLOD(const std::string &name);
+    GraphicsImage *getImage_PCXFromNewLOD(const std::string &name);
 
-    Texture *getBitmap(const std::string &name);
-    Texture *getSprite(const std::string &name, unsigned int palette_id,
+    GraphicsImage *getBitmap(const std::string &name);
+    GraphicsImage *getSprite(const std::string &name, unsigned int palette_id,
                        unsigned int lod_sprite_id);
 
     // TODO(pskelton): Contain better
     // TODO(pskelton): Manager should have a ref to all loose textures created throuh CreateTexture_Blank also
-    Texture *winnerCert{ nullptr };
+    GraphicsImage *winnerCert{ nullptr };
 
  protected:
-    std::unordered_map<std::string, Texture *> bitmaps;
-    std::unordered_map<std::string, Texture *> sprites;
-    std::unordered_map<std::string, Texture *> images;
+    std::unordered_map<std::string, GraphicsImage *> bitmaps;
+    std::unordered_map<std::string, GraphicsImage *> sprites;
+    std::unordered_map<std::string, GraphicsImage *> images;
 };
 
 extern AssetsManager *assets;

--- a/src/Engine/Graphics/BSPModel.cpp
+++ b/src/Engine/Graphics/BSPModel.cpp
@@ -12,12 +12,12 @@
 
 // ODMFace
 
-Texture *ODMFace::GetTexture() {
+GraphicsImage *ODMFace::GetTexture() {
     if (this->IsTextureFrameTable()) {
         return pTextureFrameTable->GetFrameTexture(
             (int64_t)this->resource, pEventTimer->uTotalTimeElapsed);
     } else {
-        return (Texture *)this->resource;
+        return static_cast<GraphicsImage *>(this->resource);
     }
 }
 

--- a/src/Engine/Graphics/BSPModel.h
+++ b/src/Engine/Graphics/BSPModel.h
@@ -8,6 +8,8 @@
 #include "Utility/Geometry/Plane.h"
 #include "Utility/Geometry/BBox.h"
 
+class GraphicsImage;
+
 enum class FaceAttribute : uint32_t {
     FACE_IsPortal          = 0x00000001,
     FACE_IsSecret          = 0x00000002,
@@ -79,7 +81,6 @@ struct BSPNode {
     int16_t uNumBSPFaces;
 };
 
-class Texture;
 
 struct ODMFace {
     bool HasEventHint();
@@ -111,7 +112,7 @@ struct ODMFace {
     }
 
     void SetTexture(const std::string &filename);
-    Texture *GetTexture();
+    GraphicsImage *GetTexture();
 
     // TODO: does this really have to be two separate functions?
     /**
@@ -131,7 +132,7 @@ struct ODMFace {
     std::array<int16_t, 20> pZInterceptDisplacements = {{}};
 
     // details store for array texture
-    void *resource = nullptr;  // int16_t uTextureID;;
+    void *resource = nullptr;  // int16_t uTextureID;
     int texunit = -1;
     int texlayer = -1;
 

--- a/src/Engine/Graphics/CMakeLists.txt
+++ b/src/Engine/Graphics/CMakeLists.txt
@@ -72,7 +72,6 @@ set(ENGINE_GRAPHICS_HEADERS
         RenderBase.h
         RendererType.h
         Sprites.h
-        Texture.h
         Texture_MM7.h
         TextureFrameTable.h
         Viewport.h

--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -6,7 +7,6 @@
 
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Nuklear.h"
-#include "Engine/Graphics/Texture.h"
 #include "Engine/OurMath.h"
 #include "Application/GameConfig.h"
 #include "Library/Color/Color.h"
@@ -126,7 +126,7 @@ struct RenderBillboardD3D {
     };
     using enum OpacityType;
 
-    Texture *texture;  // void *gapi_texture;//IDirect3DTexture2 *pTexture; for d3d
+    GraphicsImage *texture;  // void *gapi_texture;//IDirect3DTexture2 *pTexture; for d3d
     unsigned int uNumVertices;
     std::array<RenderVertexD3D3, 4> pQuads;
     float z_order;
@@ -211,22 +211,22 @@ class IRender {
     virtual struct nk_image NuklearImageLoad(GraphicsImage *img) = 0;
     virtual void NuklearImageFree(GraphicsImage *img) = 0;
 
-    virtual Texture *CreateTexture_Paletted(const std::string &name) = 0;
-    virtual Texture *CreateTexture_ColorKey(const std::string &name, Color colorkey) = 0;
-    virtual Texture *CreateTexture_Solid(const std::string &name) = 0;
-    virtual Texture *CreateTexture_Alpha(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_Paletted(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_ColorKey(const std::string &name, Color colorkey) = 0;
+    virtual GraphicsImage *CreateTexture_Solid(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_Alpha(const std::string &name) = 0;
 
-    virtual Texture *CreateTexture_PCXFromFile(const std::string &name) = 0;
-    virtual Texture *CreateTexture_PCXFromIconsLOD(const std::string &name) = 0;
-    virtual Texture *CreateTexture_PCXFromNewLOD(const std::string &name) = 0;
-    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_PCXFromFile(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_PCXFromIconsLOD(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_PCXFromNewLOD(const std::string &name) = 0;
+    virtual GraphicsImage *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) = 0;
 
-    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height) = 0;
-    virtual Texture *CreateTexture_Blank(RgbaImage image) = 0;
+    virtual GraphicsImage *CreateTexture_Blank(unsigned int width, unsigned int height) = 0;
+    virtual GraphicsImage *CreateTexture_Blank(RgbaImage image) = 0;
 
-    virtual Texture *CreateTexture(const std::string &name) = 0;
-    virtual Texture *CreateSprite(const std::string &name, unsigned int palette_id,
-                                  /*refactor*/ unsigned int lod_sprite_id) = 0;
+    virtual GraphicsImage *CreateTexture(const std::string &name) = 0;
+    virtual GraphicsImage *CreateSprite(const std::string &name, unsigned int palette_id,
+                                        /*refactor*/ unsigned int lod_sprite_id) = 0;
 
     virtual void ClearBlack() = 0;
     virtual void PresentBlackScreen() = 0;
@@ -258,9 +258,9 @@ class IRender {
                                     bool clampAtTextureBorders) = 0;
 
     virtual void MakeParticleBillboardAndPush(SoftwareBillboard *a2,
-                                                  Texture *texture,
-                                                  Color uDiffuse,
-                                                  int angle) = 0;
+                                              GraphicsImage *texture,
+                                              Color uDiffuse,
+                                              int angle) = 0;
     virtual float GetGamma() = 0;
 
     virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene() = 0;
@@ -269,12 +269,12 @@ class IRender {
 
     virtual void DrawProjectile(float srcX, float srcY, float a3, float a4,
                                 float dstX, float dstY, float a7, float a8,
-                                Texture *texture) = 0;
-    virtual void RemoveTextureFromDevice(Texture *texture) = 0;
-    virtual bool MoveTextureToDevice(Texture *texture) = 0;
+                                GraphicsImage *texture) = 0;
+    virtual void RemoveTextureFromDevice(GraphicsImage *texture) = 0;
+    virtual bool MoveTextureToDevice(GraphicsImage *texture) = 0;
 
-    virtual void Update_Texture(Texture *texture) = 0;
-    virtual void DeleteTexture(Texture *texture) = 0;
+    virtual void Update_Texture(GraphicsImage *texture) = 0;
+    virtual void DeleteTexture(GraphicsImage *texture) = 0;
 
 
     virtual void BeginScene2D() = 0;
@@ -302,7 +302,7 @@ class IRender {
     virtual void DrawTransparentGreenShade(float u, float v, GraphicsImage *pTexture) = 0;
     // virtual void DrawFansTransparent(const RenderVertexD3D3 *vertices, unsigned int num_vertices) = 0;
 
-    virtual void BeginTextNew(Texture *main, Texture *shadow) = 0;
+    virtual void BeginTextNew(GraphicsImage *main, GraphicsImage *shadow) = 0;
     virtual void EndTextNew() = 0;
     virtual void DrawTextNew(int x, int y, int w, int h, float u1, float v1, float u2, float v2, int isshadow, Color colour) = 0;
 
@@ -342,7 +342,7 @@ class IRender {
     virtual void EndDecals() = 0;
     virtual void DrawDecal(struct Decal *pDecal, float z_bias) = 0;
 
-    virtual void DrawSpecialEffectsQuad(Texture *texture, int palette) = 0;
+    virtual void DrawSpecialEffectsQuad(GraphicsImage *texture, int palette) = 0;
 
     virtual void DrawFromSpriteSheet(Recti *pSrcRect,
                                Pointi *pTargetPoint, int a3,
@@ -366,7 +366,7 @@ class IRender {
     Color uFogColor;
     unsigned int pHDWaterBitmapIDs[7];
     int hd_water_current_frame;
-    Texture *hd_water_tile_anim[7];
+    GraphicsImage *hd_water_tile_anim[7];
     RenderBillboardD3D pBillboardRenderListD3D[1000];
     unsigned int uNumBillboardsToDraw;
 

--- a/src/Engine/Graphics/Image.cpp
+++ b/src/Engine/Graphics/Image.cpp
@@ -6,7 +6,6 @@
 #include "Engine/Engine.h"
 
 #include "Engine/Graphics/ImageLoader.h"
-#include "Engine/Graphics/Texture.h"
 
 GraphicsImage::GraphicsImage(bool lazy_initialization): _lazyInitialization(lazy_initialization) {}
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -16,7 +16,6 @@
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/Overlays.h"
 #include "Engine/Graphics/ParticleEngine.h"
-#include "Engine/Graphics/Texture.h"
 #include "Engine/Graphics/TextureFrameTable.h"
 #include "Engine/Graphics/Sprites.h"
 #include "Engine/Graphics/PortalFunctions.h"
@@ -166,12 +165,12 @@ void BLVFace::FromODM(ODMFace *face) {
 }
 
 //----- (004AE5BA) --------------------------------------------------------
-Texture *BLVFace::GetTexture() {
+GraphicsImage *BLVFace::GetTexture() {
     if (this->IsTextureFrameTable())
         return pTextureFrameTable->GetFrameTexture(
             (int64_t)this->resource, pBLVRenderParams->textureFrameTableTimer);
     else
-        return (Texture *)this->resource;
+        return static_cast<GraphicsImage *>(this->resource);
 }
 
 void BLVFace::SetTexture(const std::string &filename) {
@@ -667,13 +666,13 @@ void BLV_UpdateDoors() {
             if (face->uAttributes & FACE_TexAlignLeft) {
                 extras->sTextureDeltaU -= minU;
             } else if (face->uAttributes & FACE_TexAlignRight && face->resource) {
-                extras->sTextureDeltaU -= maxU + ((Texture *) face->resource)->width();
+                extras->sTextureDeltaU -= maxU + face->GetTexture()->width();
             }
 
             if (face->uAttributes & FACE_TexAlignDown) {
                 extras->sTextureDeltaV -= minV;
             } else if (face->uAttributes & FACE_TexAlignBottom && face->resource) {
-                extras->sTextureDeltaV -= maxU + ((Texture *) face->resource)->height();
+                extras->sTextureDeltaV -= maxU + face->GetTexture()->height();
             }
 
             if (face->uAttributes & FACE_TexMoveByDoor) {

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -94,7 +94,7 @@ struct BLVFace {  // 60h
     void FromODM(struct ODMFace *face);
 
     void SetTexture(const std::string &filename);
-    Texture *GetTexture();
+    GraphicsImage *GetTexture();
 
     inline bool Invisible() const {
         return uAttributes & FACE_IsInvisible;

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -410,7 +410,7 @@ int forceperstorecnt{ 0 };
 
 void RenderOpenGL::DrawProjectile(float srcX, float srcY, float srcworldview, float srcfovoworldview,
                                   float dstX, float dstY, float dstworldview, float dstfovoworldview,
-                                  Texture *texture) {
+                                  GraphicsImage *texture) {
     // billboards projectile - lightning bolt
 
     TextureOpenGL *textured3d = (TextureOpenGL *)texture;
@@ -561,7 +561,7 @@ void RenderOpenGL::ScreenFade(Color color, float t) {
     float drawz = static_cast<float>(pViewport->uViewportBR_X);
     float draww = static_cast<float>(pViewport->uViewportBR_Y);
 
-    static Texture *effpar03 = assets->getBitmap("effpar03");
+    static GraphicsImage *effpar03 = assets->getBitmap("effpar03");
     auto texture = (TextureOpenGL *)effpar03;
     float gltexid = static_cast<float>(texture->GetOpenGlTexture());
 
@@ -780,7 +780,7 @@ void RenderOpenGL::BlendTextures(int x, int y, GraphicsImage *imgin, GraphicsIma
 
         int w = imgin->width();
         int h = imgin->height();
-        Texture *temp = render->CreateTexture_Blank(w, h);
+        GraphicsImage *temp = render->CreateTexture_Blank(w, h);
         RgbaImage &dstImage = temp->rgba();
 
         Color c = maskImage.pixels()[2700];  // guess at brightest pixel
@@ -845,7 +845,7 @@ void RenderOpenGL::BlendTextures(int x, int y, GraphicsImage *imgin, GraphicsIma
 // a6 is time, a7 is 0, a8 is 63
 void RenderOpenGL::TexturePixelRotateDraw(float u, float v, GraphicsImage *img, int time) {
     // TODO(pskelton): sort this - precalculate/ shader
-    static std::array<Texture *, 14> cachedtemp {};
+    static std::array<GraphicsImage *, 14> cachedtemp {};
     static std::array<int, 14> cachetime { -1 };
 
     if (img) {
@@ -1401,66 +1401,66 @@ void RenderOpenGL::DrawFromSpriteSheet(Recti *pSrcRect, Pointi *pTargetPoint, in
     return;
 }
 
-Texture *RenderOpenGL::CreateTexture_Paletted(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_Paletted(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<Paletted_Img_Loader>(pIcons_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_ColorKey(const std::string &name, Color colorkey) {
+GraphicsImage *RenderOpenGL::CreateTexture_ColorKey(const std::string &name, Color colorkey) {
     return TextureOpenGL::Create(std::make_unique<ColorKey_LOD_Loader>(pIcons_LOD, name, colorkey));
 }
 
-Texture *RenderOpenGL::CreateTexture_Solid(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_Solid(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<Image16bit_LOD_Loader>(pIcons_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_Alpha(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_Alpha(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<Alpha_LOD_Loader>(pIcons_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_PCXFromIconsLOD(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_PCXFromIconsLOD(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<PCX_LOD_Compressed_Loader>(pIcons_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_PCXFromNewLOD(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_PCXFromNewLOD(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<PCX_LOD_Compressed_Loader>(pSave_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_PCXFromFile(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_PCXFromFile(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<PCX_File_Loader>(name));
 }
 
-Texture *RenderOpenGL::CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<PCX_LOD_Raw_Loader>(pLOD, name));
 }
 
-Texture *RenderOpenGL::CreateTexture_Blank(unsigned int width, unsigned int height) {
+GraphicsImage *RenderOpenGL::CreateTexture_Blank(unsigned int width, unsigned int height) {
     return TextureOpenGL::Create(width, height);
 }
 
-Texture *RenderOpenGL::CreateTexture_Blank(RgbaImage image) {
+GraphicsImage *RenderOpenGL::CreateTexture_Blank(RgbaImage image) {
     return TextureOpenGL::Create(std::move(image));
 }
 
-Texture *RenderOpenGL::CreateTexture(const std::string &name) {
+GraphicsImage *RenderOpenGL::CreateTexture(const std::string &name) {
     return TextureOpenGL::Create(std::make_unique<Bitmaps_LOD_Loader>(pBitmaps_LOD, name));
 }
 
-Texture *RenderOpenGL::CreateSprite(const std::string &name, unsigned int palette_id,
-                                    /*refactor*/ unsigned int lod_sprite_id) {
+GraphicsImage *RenderOpenGL::CreateSprite(const std::string &name, unsigned int palette_id,
+                                          /*refactor*/ unsigned int lod_sprite_id) {
     return TextureOpenGL::Create(std::make_unique<Sprites_LOD_Loader>(pSprites_LOD, palette_id, name, lod_sprite_id));
 }
 
-void RenderOpenGL::Update_Texture(Texture *texture) {
-    auto t = (TextureOpenGL *)texture;
+void RenderOpenGL::Update_Texture(GraphicsImage *texture) {
+    auto t = static_cast<TextureOpenGL *>(texture);
     glBindTexture(GL_TEXTURE_2D, t->GetOpenGlTexture());
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, t->width(), t->height(), GL_RGBA, GL_UNSIGNED_BYTE, t->rgba().pixels().data());
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void RenderOpenGL::DeleteTexture(Texture *texture) {
+void RenderOpenGL::DeleteTexture(GraphicsImage *texture) {
     // crash here when assets not loaded as texture
 
-    auto t = (TextureOpenGL *)texture;
+    auto t = static_cast<TextureOpenGL *>(texture);
     GLuint texid = t->GetOpenGlTexture(false);
     if (texid != -1) {
         glDeleteTextures(1, &texid);
@@ -1468,12 +1468,12 @@ void RenderOpenGL::DeleteTexture(Texture *texture) {
     }
 }
 
-void RenderOpenGL::RemoveTextureFromDevice(Texture *texture) {
+void RenderOpenGL::RemoveTextureFromDevice(GraphicsImage *texture) {
     logger->info("RenderGL - RemoveTextureFromDevice");
 }
 
-bool RenderOpenGL::MoveTextureToDevice(Texture *texture) {
-    auto t = (TextureOpenGL *)texture;
+bool RenderOpenGL::MoveTextureToDevice(GraphicsImage *texture) {
+    auto t = static_cast<TextureOpenGL *>(texture);
     const Color *pixels = t->rgba().pixels().data();
     assert(pixels);
 
@@ -2243,7 +2243,7 @@ void RenderOpenGL::DrawOutdoorSkyPolygon(struct Polygon *pSkyPolygon) {
     auto texture = (TextureOpenGL *)pSkyPolygon->texture;
     auto texid = texture->GetOpenGlTexture();
 
-    static Texture *effpar03 = assets->getBitmap("effpar03");
+    static GraphicsImage *effpar03 = assets->getBitmap("effpar03");
     auto texturesolid = (TextureOpenGL*)effpar03;
     float texidsolid = static_cast<float>(texturesolid->GetOpenGlTexture());
 
@@ -2569,8 +2569,8 @@ void RenderOpenGL::DoRenderBillboards_D3D() {
             auto texture = (TextureOpenGL *)pBillboardRenderListD3D[i].texture;
             gltexid = texture->GetOpenGlTexture();
         } else {
-            static Texture *effpar03 = assets->getBitmap("effpar03");
-            auto texture = (TextureOpenGL *)effpar03;
+            static GraphicsImage *effpar03 = assets->getBitmap("effpar03");
+            auto texture = static_cast<TextureOpenGL *>(effpar03);
             gltexid = static_cast<float>(texture->GetOpenGlTexture());
         }
 
@@ -3075,7 +3075,7 @@ void RenderOpenGL::DrawTextureCustomHeight(float u, float v, class GraphicsImage
 twodverts textshaderstore[10000] = {};
 int textvertscnt = 0;
 
-void RenderOpenGL::BeginTextNew(Texture *main, Texture *shadow) {
+void RenderOpenGL::BeginTextNew(GraphicsImage *main, GraphicsImage *shadow) {
     // draw any images in buffer
     if (twodvertscnt) {
         DrawTwodVerts();
@@ -4765,8 +4765,8 @@ void RenderOpenGL::FillRectFast(unsigned int uX, unsigned int uY, unsigned int u
     // check for overlap
     if (!(this->clip_x < z && this->clip_z > x && this->clip_y < w && this->clip_w > y)) return;
 
-    static Texture *effpar03 = assets->getBitmap("effpar03");
-    auto texture = (TextureOpenGL*)effpar03;
+    static GraphicsImage *effpar03 = assets->getBitmap("effpar03");
+    auto texture = static_cast<TextureOpenGL *>(effpar03);
     float gltexid = static_cast<float>(texture->GetOpenGlTexture());
 
     float drawx = static_cast<float>(std::max(x, this->clip_x));

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -38,21 +38,21 @@ class RenderOpenGL : public RenderBase {
     virtual struct nk_image NuklearImageLoad(GraphicsImage *img) override;
     virtual void NuklearImageFree(GraphicsImage *img) override;
 
-    virtual Texture *CreateTexture_Paletted(const std::string &name) override;
-    virtual Texture *CreateTexture_ColorKey(const std::string &name, Color colorkey) override;
-    virtual Texture *CreateTexture_Solid(const std::string &name) override;
-    virtual Texture *CreateTexture_Alpha(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_Paletted(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_ColorKey(const std::string &name, Color colorkey) override;
+    virtual GraphicsImage *CreateTexture_Solid(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_Alpha(const std::string &name) override;
 
-    virtual Texture *CreateTexture_PCXFromFile(const std::string &name) override;
-    virtual Texture *CreateTexture_PCXFromIconsLOD(const std::string &name) override;
-    virtual Texture *CreateTexture_PCXFromNewLOD(const std::string &name) override;
-    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_PCXFromFile(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_PCXFromIconsLOD(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_PCXFromNewLOD(const std::string &name) override;
+    virtual GraphicsImage *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) override;
 
-    virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height) override;
-    virtual Texture *CreateTexture_Blank(RgbaImage image) override;
+    virtual GraphicsImage *CreateTexture_Blank(unsigned int width, unsigned int height) override;
+    virtual GraphicsImage *CreateTexture_Blank(RgbaImage image) override;
 
-    virtual Texture *CreateTexture(const std::string &name) override;
-    virtual Texture *CreateSprite(
+    virtual GraphicsImage *CreateTexture(const std::string &name) override;
+    virtual GraphicsImage *CreateSprite(
         const std::string &name, unsigned int palette_id,
         /*refactor*/ unsigned int lod_sprite_id) override;
 
@@ -86,14 +86,14 @@ class RenderOpenGL : public RenderBase {
 
     virtual void DrawProjectile(float srcX, float srcY, float a3, float a4,
                                 float dstX, float dstY, float a7, float a8,
-                                Texture *texture) override;
+                                GraphicsImage *texture) override;
 
-    virtual void RemoveTextureFromDevice(Texture *texture) override;
-    virtual bool MoveTextureToDevice(Texture *texture) override;
+    virtual void RemoveTextureFromDevice(GraphicsImage *texture) override;
+    virtual bool MoveTextureToDevice(GraphicsImage *texture) override;
 
-    virtual void Update_Texture(Texture *texture) override;
+    virtual void Update_Texture(GraphicsImage *texture) override;
 
-    virtual void DeleteTexture(Texture *texture) override;
+    virtual void DeleteTexture(GraphicsImage *texture) override;
 
     virtual void BeginScene2D() override;
     virtual void ScreenFade(Color color, float t) override;
@@ -115,7 +115,7 @@ class RenderOpenGL : public RenderBase {
                                int start_opacity, int end_opacity) override;
     virtual void TexturePixelRotateDraw(float u, float v, GraphicsImage *img, int time) override;
 
-    virtual void BeginTextNew(Texture *main, Texture *shadow) override;
+    virtual void BeginTextNew(GraphicsImage *main, GraphicsImage *shadow) override;
     virtual void EndTextNew() override;
     virtual void DrawTextNew(int x, int y, int w, int h, float u1, float v1, float u2, float v2, int isshadow, Color colour) override;
 

--- a/src/Engine/Graphics/OpenGL/TextureOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/TextureOpenGL.cpp
@@ -7,7 +7,7 @@
 #include "Engine/Graphics/ImageLoader.h"
 #include "Engine/ErrorHandling.h"
 
-Texture *TextureOpenGL::Create(RgbaImage image) {
+TextureOpenGL *TextureOpenGL::Create(RgbaImage image) {
     TextureOpenGL *tex = new TextureOpenGL(false);
 
     tex->_rgbaImage = std::move(image);
@@ -18,11 +18,11 @@ Texture *TextureOpenGL::Create(RgbaImage image) {
     return tex;
 }
 
-Texture *TextureOpenGL::Create(unsigned int width, unsigned int height) {
+TextureOpenGL *TextureOpenGL::Create(unsigned int width, unsigned int height) {
     return Create(RgbaImage::solid(width, height, Color()));
 }
 
-Texture *TextureOpenGL::Create(std::unique_ptr<ImageLoader> loader) {
+TextureOpenGL *TextureOpenGL::Create(std::unique_ptr<ImageLoader> loader) {
     auto tex = new TextureOpenGL();
     tex->_loader = std::move(loader);
     return tex;

--- a/src/Engine/Graphics/OpenGL/TextureOpenGL.h
+++ b/src/Engine/Graphics/OpenGL/TextureOpenGL.h
@@ -2,9 +2,9 @@
 
 #include <memory>
 
-#include "Engine/Graphics/Texture.h"
+#include "Engine/Graphics/Image.h"
 
-class TextureOpenGL : public Texture {
+class TextureOpenGL : public GraphicsImage {
  public:
     int GetOpenGlTexture(bool bLoad = true);
 
@@ -13,14 +13,14 @@ class TextureOpenGL : public Texture {
  protected:
     friend class RenderOpenGL;
 
-    static Texture *Create(RgbaImage image);
-    static Texture *Create(unsigned int width, unsigned int height);
-    static Texture *Create(std::unique_ptr<ImageLoader> loader);
+    static TextureOpenGL *Create(RgbaImage image);
+    static TextureOpenGL *Create(unsigned int width, unsigned int height);
+    static TextureOpenGL *Create(std::unique_ptr<ImageLoader> loader);
 
     void SetOpenGlTexture(int ogl_texture) { this->ogl_texture = ogl_texture; }
 
     explicit TextureOpenGL(bool lazy_initialization = true)
-        : Texture(lazy_initialization), ogl_texture(-1) {}
+        : GraphicsImage(lazy_initialization), ogl_texture(-1) {}
 
     int ogl_texture;
 

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -137,7 +137,7 @@ struct OutdoorLocation {
     std::vector<BSPModel> pBModels;
     std::vector<uint16_t> pFaceIDLIST;
     std::array<uint32_t, 128 * 128> pOMAP;
-    Texture *sky_texture = nullptr;        // signed int sSky_TextureID;
+    GraphicsImage *sky_texture = nullptr;        // signed int sSky_TextureID;
     int16_t field_F0;
     int16_t field_F2;
     int field_F4;

--- a/src/Engine/Graphics/ParticleEngine.h
+++ b/src/Engine/Graphics/ParticleEngine.h
@@ -32,7 +32,7 @@ struct Particle_sw {
     float b{};
     Color uDiffuse{};
     int timeToLive{};
-    Texture *texture{ nullptr };
+    GraphicsImage *texture{ nullptr };
     int paletteID{ 0 };
     float particle_size{};
     int field_2C{};
@@ -51,7 +51,7 @@ struct Particle {
     float shift_z = 0;
     Color uParticleColor;
     int timeToLive = 0;
-    Texture *texture = nullptr;  // unsigned int resource_id;// bitmap IDirect3DTexture
+    GraphicsImage *texture = nullptr;  // unsigned int resource_id;// bitmap IDirect3DTexture
                        // idx or sprite idx depending on type
     int paletteID = 0;
     float particle_size = 0;  // field_28

--- a/src/Engine/Graphics/Polygon.h
+++ b/src/Engine/Graphics/Polygon.h
@@ -2,7 +2,6 @@
 #include <array>
 
 
-class Texture;
 struct ODMFace;
 struct Span;
 struct Edge;
@@ -32,7 +31,7 @@ struct Polygon {
     int16_t field_32 = 0;
     int field_34 = 0;
     struct SkyBillboardStruct *ptr_38 = nullptr;
-    Texture *texture = nullptr;  // struct Texture_MM7 *pTexture;
+    GraphicsImage *texture = nullptr;  // struct Texture_MM7 *pTexture;
     Span *_unused_prolly_head = nullptr;
     Span *_unused_prolly_tail = nullptr;
     int **ptr_48 = nullptr;

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -521,9 +521,9 @@ double fix2double(int fix) {
 }
 
 void RenderBase::MakeParticleBillboardAndPush(SoftwareBillboard *a2,
-                                                  Texture *texture,
-                                                  Color uDiffuse,
-                                                  int angle) {
+                                              GraphicsImage *texture,
+                                              Color uDiffuse,
+                                              int angle) {
     unsigned int billboard_index = Billboard_ProbablyAddToListAndSortByZOrder(a2->screen_space_z);
     RenderBillboardD3D *billboard = &pBillboardRenderListD3D[billboard_index];
 
@@ -723,7 +723,7 @@ void RenderBase::DrawMonsterPortrait(Recti rc, SpriteFrame *Portrait, int Y_Offs
     render->ResetUIClipRect();
 }
 
-void RenderBase::DrawSpecialEffectsQuad(Texture *texture, int palette) {
+void RenderBase::DrawSpecialEffectsQuad(GraphicsImage *texture, int palette) {
     Recti targetrect{};
     targetrect.x = pViewport->uViewportTL_X;
     targetrect.y = pViewport->uViewportTL_Y;

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -626,7 +626,7 @@ Blob RenderBase::PackScreenshot(const unsigned int width, const unsigned int hei
 }
 
 GraphicsImage *RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {
-    return GraphicsImage::Create(MakeScreenshot32(width, height));
+    return CreateTexture_Blank(MakeScreenshot32(width, height));
 }
 
 void RenderBase::DrawTextureGrayShade(float a2, float a3, GraphicsImage *a4) {

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -23,9 +23,9 @@ class RenderBase : public IRender {
     virtual void DrawSpriteObjects() override;
     virtual void PrepareDecorationsRenderList_ODM() override;
     virtual void MakeParticleBillboardAndPush(SoftwareBillboard *a2,
-                                                  Texture *texture,
-                                                  Color uDiffuse,
-                                                  int angle) override;
+                                              GraphicsImage *texture,
+                                              Color uDiffuse,
+                                              int angle) override;
     virtual float GetGamma() override;
 
     virtual void SavePCXScreenshot() override;
@@ -47,7 +47,7 @@ class RenderBase : public IRender {
     virtual void ClearBlack() override;
     virtual void BillboardSphereSpellFX(struct SpellFX_Billboard *a1, Color diffuse) override;
     virtual void DrawMonsterPortrait(Recti rc, SpriteFrame *Portrait_Sprite, int Y_Offset) override;
-    virtual void DrawSpecialEffectsQuad(Texture *texture, int palette) override;
+    virtual void DrawSpecialEffectsQuad(GraphicsImage *texture, int palette) override;
     virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene() override;
     virtual void PresentBlackScreen() override;
 

--- a/src/Engine/Graphics/Sprites.h
+++ b/src/Engine/Graphics/Sprites.h
@@ -9,7 +9,7 @@
 
 #include "Utility/Memory/Blob.h"
 
-class Texture;
+class GraphicsImage;
 
 class Sprite {
  public:
@@ -29,7 +29,7 @@ class Sprite {
 
     std::string pName;
     int uPaletteID; // this is repaint palette index if it doesnt match sprite header palette
-    Texture *texture;
+    GraphicsImage *texture;
     int uAreaX;
     int uAreaY;
     int uBufferWidth;   // hardware width  (as opposed to LODSprite::Width)

--- a/src/Engine/Graphics/Texture.h
+++ b/src/Engine/Graphics/Texture.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "Engine/Graphics/Image.h"
-
-class Texture : public GraphicsImage {
- protected:
-    explicit Texture(bool lazy_initialization = true)
-        : GraphicsImage(lazy_initialization) {}
-};

--- a/src/Engine/Graphics/TextureFrameTable.cpp
+++ b/src/Engine/Graphics/TextureFrameTable.cpp
@@ -7,7 +7,7 @@
 
 struct TextureFrameTable *pTextureFrameTable;
 
-Texture *TextureFrame::GetTexture() {
+GraphicsImage *TextureFrame::GetTexture() {
     if (!this->tex) {
         this->tex = assets->getBitmap(this->name);
     }
@@ -50,7 +50,7 @@ int64_t TextureFrameTable::FindTextureByName(const std::string &Str2) {
     return -1;
 }
 
-Texture *TextureFrameTable::GetFrameTexture(int frameId, int time) {
+GraphicsImage *TextureFrameTable::GetFrameTexture(int frameId, int time) {
     int animLength = textures[frameId].uAnimLength;
 
     if (textures[frameId].uFlags & 1 && animLength != 0) {

--- a/src/Engine/Graphics/TextureFrameTable.h
+++ b/src/Engine/Graphics/TextureFrameTable.h
@@ -6,7 +6,7 @@
 
 #include "Utility/Memory/Blob.h"
 
-class Texture;
+class GraphicsImage;
 
 // TODO(captainurist): where is this used?
 enum TEXTURE_FRAME_TABLE_FLAGS {
@@ -23,16 +23,16 @@ class TextureFrame {
     int16_t uAnimLength = 0;
     int16_t uFlags = 0;  // 1 for anim
 
-    Texture *GetTexture();
+    GraphicsImage *GetTexture();
 
  protected:
-    Texture *tex;
+    GraphicsImage *tex;
 };
 
 struct TextureFrameTable {
     void FromFile(const Blob &data_mm6, const Blob &data_mm7, const Blob &data_mm8);
     void LoadAnimationSequenceAndPalettes(int uIconID);
-    Texture *GetFrameTexture(int frameId, int time);
+    GraphicsImage *GetFrameTexture(int frameId, int time);
     /**
     * @param   frameID        TextureFrameTable index
     * @return                 Total length of texture animation

--- a/src/Engine/Objects/Player.cpp
+++ b/src/Engine/Objects/Player.cpp
@@ -7538,9 +7538,7 @@ bool Player::SetBeacon(size_t index, size_t power) {
 
     LloydBeacon beacon;
 
-    std::unique_ptr<GraphicsImage> tmp(render->TakeScreenshot(92, 68));
-
-    beacon.image = render->CreateTexture_Blank(std::move(tmp->rgba()));
+    beacon.image = render->TakeScreenshot(92, 68);
     beacon.uBeaconTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power));
     beacon.PartyPos_X = pParty->vPosition.x;
     beacon.PartyPos_Y = pParty->vPosition.y;

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -15,7 +15,6 @@
 #include "Engine/Graphics/Overlays.h"
 #include "Engine/Graphics/ParticleEngine.h"
 #include "Engine/Graphics/Sprites.h"
-#include "Engine/Graphics/Texture.h"
 #include "Engine/Graphics/Viewport.h"
 
 #include "Engine/Objects/Actor.h"
@@ -204,7 +203,7 @@ void SpellFX_Billboard::_47829F_sphere_particle(
 //----- (004A71FE) --------------------------------------------------------
 void SpellFxRenderer::DoAddProjectile(float srcX, float srcY, float srcZ,
                                       float dstX, float dstY, float dstZ,
-                                      Texture *texture) {
+                                      GraphicsImage *texture) {
     // int v8; // eax@1
 
     // v8 = uNumProjectiles;
@@ -253,7 +252,7 @@ void SpellFxRenderer::DrawProjectiles() {
 
 //----- (004A73AA) --------------------------------------------------------
 void SpellFxRenderer::_4A73AA_hanging_trace_particles___like_fire_strike_ice_blast_etc(
-        SpriteObject *a2, Color uDiffuse, Texture *texture) {
+        SpriteObject *a2, Color uDiffuse, GraphicsImage *texture) {
     // check if enough time has passed to add particle into the trail
     if (a2->_lastParticleTime + a2->_ticksPerParticle < pEventTimer->uTotalTimeElapsed) {
         a2->_lastParticleTime += a2->_ticksPerParticle;
@@ -328,7 +327,7 @@ void SpellFxRenderer::_4A73AA_hanging_trace_particles___like_fire_strike_ice_bla
 
 //----- (004A75CC) --------------------------------------------------------
 void SpellFxRenderer::_4A75CC_single_spell_collision_particle(
-    SpriteObject *a1, Color uDiffuse, Texture *texture) {
+    SpriteObject *a1, Color uDiffuse, GraphicsImage *texture) {
     double v4;            // st7@1
     signed int v5;        // edi@1
     Particle_sw local_0;  // [sp+8h] [bp-68h]@1
@@ -431,7 +430,7 @@ bool SpellFxRenderer::AddMobileLight(SpriteObject *a1, Color uDiffuse,
 //----- (004A7A66) --------------------------------------------------------
 void SpellFxRenderer::
     _4A7A66_miltiple_spell_collision_partifles___like_after_sparks_or_lightning(
-        SpriteObject *a1, Color uDiffuse, Texture *texture, float a4) {
+        SpriteObject *a1, Color uDiffuse, GraphicsImage *texture, float a4) {
     int v5;               // eax@1
     double v7;            // st6@1
     double v8;            // st6@1
@@ -546,7 +545,7 @@ void SpellFxRenderer::_4A7C07_stun_spell_fx(SpriteObject *a2) {
 
 //----- (004A7E05) --------------------------------------------------------
 void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
-                                    Texture *texture) {
+                                    GraphicsImage *texture) {
     if (a2->field_54) {
         DoAddProjectile(array_4[a2->field_54 & 0x1F].flt_0_x,
                         array_4[a2->field_54 & 0x1F].flt_4_y,

--- a/src/Engine/SpellFxRenderer.h
+++ b/src/Engine/SpellFxRenderer.h
@@ -9,7 +9,7 @@
 #include "Library/Color/ColorTable.h"
 
 class Actor;
-class Texture;
+class GraphicsImage;
 class ParticleEngine;
 
 struct SpellFX_Billboard {
@@ -74,7 +74,7 @@ struct ProjectileAnim {
     float dstX;
     float dstY;
     float dstZ;
-    Texture *texture;  // int uTextureID;
+    GraphicsImage *texture;  // int uTextureID;
 };
 
 struct stru6_stru2 {
@@ -111,13 +111,13 @@ struct SpellFxRenderer {
     }
 
     void DoAddProjectile(float srcX, float srcY, float srcZ, float dstX,
-                         float dstY, float dstZ, Texture *);
+                         float dstY, float dstZ, GraphicsImage *);
     void DrawProjectiles();
     void _4A73AA_hanging_trace_particles___like_fire_strike_ice_blast_etc(
-        struct SpriteObject *a2, Color uDiffuse, Texture *texture);
+        struct SpriteObject *a2, Color uDiffuse, GraphicsImage *texture);
     void _4A75CC_single_spell_collision_particle(struct SpriteObject *a1,
                                                  Color uDiffuse,
-                                                 Texture *texture);
+                                                 GraphicsImage *texture);
     void _4A7688_fireball_collision_particle(struct SpriteObject *a2);
     void _4A77FD_implosion_particle_d3d(struct SpriteObject *a1);
     void _4A7948_mind_blast_after_effect(struct SpriteObject *a1);
@@ -125,9 +125,9 @@ struct SpellFxRenderer {
                         int uRadius);
     void
     _4A7A66_miltiple_spell_collision_partifles___like_after_sparks_or_lightning(
-        SpriteObject *a1, Color uDiffuse, Texture *texture, float a4);
+        SpriteObject *a1, Color uDiffuse, GraphicsImage *texture, float a4);
     void _4A7C07_stun_spell_fx(struct SpriteObject *a2);
-    void AddProjectile(struct SpriteObject *a2, int a3, Texture *);
+    void AddProjectile(struct SpriteObject *a2, int a3, GraphicsImage *);
     /**
      * @offset 0x4A7E89
      */
@@ -158,9 +158,9 @@ struct SpellFxRenderer {
     int uFadeTime;
     int uFadeLength;
     Color uFadeColor;
-    Texture *effpar01;  // unsigned int effpar01; // trail fire
-    Texture *effpar02;  // unsigned int effpar02;
-    Texture *effpar03;  // unsigned int effpar03; // trail particle
+    GraphicsImage *effpar01;  // unsigned int effpar01; // trail fire
+    GraphicsImage *effpar02;  // unsigned int effpar02;
+    GraphicsImage *effpar03;  // unsigned int effpar03; // trail particle
     unsigned int _unused_uSpriteID_sp57c;
     int field_5F4;
 

--- a/src/Engine/Tables/IconFrameTable.cpp
+++ b/src/Engine/Tables/IconFrameTable.cpp
@@ -7,7 +7,7 @@
 #include "../LOD.h"
 
 
-Texture *Icon::GetTexture() {
+GraphicsImage *Icon::GetTexture() {
     if (!this->img) {
         this->img = assets->getImage_ColorKey(this->pTextureName);
     }

--- a/src/Engine/Tables/IconFrameTable.h
+++ b/src/Engine/Tables/IconFrameTable.h
@@ -8,7 +8,7 @@
 
 #include "Utility/Memory/Blob.h"
 
-class Texture;
+class GraphicsImage;
 
 class Icon {
  public:
@@ -29,7 +29,7 @@ class Icon {
     }
     inline unsigned int GetAnimTime() const { return this->anim_time; }
 
-    Texture *GetTexture();
+    GraphicsImage *GetTexture();
 
     std::string pTextureName;
     int16_t uFlags = 0;
@@ -39,7 +39,7 @@ class Icon {
     std::string anim_name;
     unsigned int anim_length = 0;
     unsigned int anim_time = 0;
-    Texture *img = nullptr;
+    GraphicsImage *img = nullptr;
 };
 
 struct IconFrameTable {

--- a/src/Engine/Tables/TileFrameTable.h
+++ b/src/Engine/Tables/TileFrameTable.h
@@ -86,7 +86,6 @@ enum Tileset : int16_t {
 };
 #pragma warning(pop)
 
-class Texture;
 
 class TileDesc {
  public:
@@ -98,7 +97,7 @@ class TileDesc {
     uint16_t uSection = 0;
     uint16_t uAttributes = TILE_DESC_NULL;
 
-    inline Texture *GetTexture() {
+    inline GraphicsImage *GetTexture() {
         if (!this->texture) {
             this->texture = assets->getBitmap(this->name);
         }
@@ -114,7 +113,7 @@ class TileDesc {
     }
 
  protected:
-    Texture *texture;
+    GraphicsImage *texture;
 };
 
 struct TileTable {

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -32,7 +32,6 @@ struct FontData {
 
 class GUIWindow;
 class GraphicsImage;
-class Texture;
 struct FontData;
 
 class GUIFont {
@@ -74,8 +73,8 @@ class GUIFont {
                          GUIWindow *pWindow, int startX, int a6);
 
     int maxcharwidth = 0;
-    Texture *fonttex = nullptr;
-    Texture *fontshadow = nullptr;
+    GraphicsImage *fonttex = nullptr;
+    GraphicsImage *fontshadow = nullptr;
 
  protected:
     FontData *pData;

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -172,7 +172,7 @@ void DrawBook_Map_sub(unsigned int tl_x, unsigned int tl_y, unsigned int br_x, i
             ((double)(-pCenterY - 22528 / (viewparams->uMapBookMapZoom / 384) + 32768) / MapSizeScale) << 16;
         int scaled_posY = stepY_r >> 16;
 
-        static Texture *minimaptemp = nullptr;
+        static GraphicsImage *minimaptemp = nullptr;
         if (!minimaptemp) {
             minimaptemp = render->CreateTexture_Blank(screenWidth, screenHeight);
         }

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -1064,7 +1064,7 @@ void CharacterUI_DrawPaperdoll(Player *player) {
             item_X = pPaperdoll_BodyX + paperdoll_Weapon[pBodyComplection][1][0] - pItemTable->pItems[item->uItemID].uEquipX;
             item_Y = pPaperdoll_BodyY + paperdoll_Weapon[pBodyComplection][1][1] - pItemTable->pItems[item->uItemID].uEquipY;
 
-            Texture *texture = nullptr;
+            GraphicsImage *texture = nullptr;
             if (item->uItemID == ITEM_BLASTER)
                 texture = assets->getImage_Alpha("item64v1");
 
@@ -1088,7 +1088,7 @@ void CharacterUI_DrawPaperdoll(Player *player) {
                 item_X = pPaperdoll_BodyX + paperdoll_Cloak[pBodyComplection][index][0];
                 item_Y = pPaperdoll_BodyY + paperdoll_Cloak[pBodyComplection][index][1];
 
-                Texture *texture = (Texture *)paperdoll_cloak_texture[pBodyComplection][index];
+                GraphicsImage *texture = paperdoll_cloak_texture[pBodyComplection][index];
                 CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uCloak, texture, !bRingsShownInCharScreen);
             }
         }
@@ -1104,7 +1104,7 @@ void CharacterUI_DrawPaperdoll(Player *player) {
                 item_X = pPaperdoll_BodyX + paperdoll_Armor_Coord[pBodyComplection][index][0];
                 item_Y = pPaperdoll_BodyY + paperdoll_Armor_Coord[pBodyComplection][index][1];
 
-                Texture *texture = (Texture *)paperdoll_armor_texture[pBodyComplection][index][0];
+                GraphicsImage *texture = paperdoll_armor_texture[pBodyComplection][index][0];
                 CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uArmor, texture, !bRingsShownInCharScreen);
             }
         }
@@ -1117,11 +1117,11 @@ void CharacterUI_DrawPaperdoll(Player *player) {
                 item_X = pPaperdoll_BodyX + paperdoll_Boot[pBodyComplection][index][0];
                 item_Y = pPaperdoll_BodyY + paperdoll_Boot[pBodyComplection][index][1];
 
-                Texture *texture = nullptr;
+                GraphicsImage *texture = nullptr;
                 if (item->uItemID == ITEM_ARTIFACT_HERMES_SANDALS) {
-                    texture = (Texture *)paperdoll_flying_feet[player->uCurrentFace];
+                    texture = paperdoll_flying_feet[player->uCurrentFace];
                 } else {
-                    texture = (Texture *)paperdoll_boots_texture[pBodyComplection][index];
+                    texture = paperdoll_boots_texture[pBodyComplection][index];
                 }
 
                 CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uBoot, texture, !bRingsShownInCharScreen);
@@ -1146,11 +1146,11 @@ void CharacterUI_DrawPaperdoll(Player *player) {
             if (index != -1) {
                 item_X = pPaperdoll_BodyX + paperdoll_Belt[pBodyComplection][index][0];
                 item_Y = pPaperdoll_BodyY + paperdoll_Belt[pBodyComplection][index][1];
-                Texture *texture = nullptr;
+                GraphicsImage *texture = nullptr;
                 if (IsDwarf != 1 || index == 5)
-                    texture = (Texture *)paperdoll_belt_texture[pBodyComplection][index];
+                    texture = paperdoll_belt_texture[pBodyComplection][index];
                 else
-                    texture = (Texture *)paperdoll_belt_texture[pBodyComplection - 2][index];
+                    texture = paperdoll_belt_texture[pBodyComplection - 2][index];
 
                 CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uBelt, texture, !bRingsShownInCharScreen);
             }
@@ -1161,18 +1161,18 @@ void CharacterUI_DrawPaperdoll(Player *player) {
         if (item) {
             index = valueOr(paperdoll_armor_indexByType, item->uItemID, -1);
             if (index != -1) {
-                Texture *texture = nullptr;
+                GraphicsImage *texture = nullptr;
                 // Some armors doesn't have sleeves so use normal one for two-handed or none if it also unavailable
                 if (bTwoHandedGrip && paperdoll_shoulder_second_coord[pBodyComplection][index][0]) {
                     item_X = pPaperdoll_BodyX + paperdoll_shoulder_second_coord[pBodyComplection][index][0];
                     item_Y = pPaperdoll_BodyY + paperdoll_shoulder_second_coord[pBodyComplection][index][1];
 
-                    texture = (Texture *)paperdoll_armor_texture[pBodyComplection][index][2];
+                    texture = paperdoll_armor_texture[pBodyComplection][index][2];
                 } else if (paperdoll_shoulder_coord[pBodyComplection][index][0]) {
                     item_X = pPaperdoll_BodyX + paperdoll_shoulder_coord[pBodyComplection][index][0];
                     item_Y = pPaperdoll_BodyY + paperdoll_shoulder_coord[pBodyComplection][index][1];
 
-                    texture = (Texture *)paperdoll_armor_texture[pBodyComplection][index][1];
+                    texture = paperdoll_armor_texture[pBodyComplection][index][1];
                 }
 
                 if (texture)
@@ -1190,7 +1190,7 @@ void CharacterUI_DrawPaperdoll(Player *player) {
                     item_X = pPaperdoll_BodyX + paperdoll_CloakCollar[pBodyComplection][index][0];
                     item_Y = pPaperdoll_BodyY + paperdoll_CloakCollar[pBodyComplection][index][1];
 
-                    Texture *texture = (Texture *)paperdoll_cloak_collar_texture[pBodyComplection][index];
+                    GraphicsImage *texture = paperdoll_cloak_collar_texture[pBodyComplection][index];
                     CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uCloak, texture, !bRingsShownInCharScreen);
                 }
             }
@@ -1212,11 +1212,11 @@ void CharacterUI_DrawPaperdoll(Player *player) {
                 item_X = pPaperdoll_BodyX + paperdoll_Helm[pBodyComplection][index][0];
                 item_Y = pPaperdoll_BodyY + paperdoll_Helm[pBodyComplection][index][1];
 
-                Texture *texture = nullptr;
+                GraphicsImage *texture = nullptr;
                 if (IsDwarf != 1 || item->uItemID != ITEM_PHYNAXIAN_HELM)
-                    texture = (Texture *)paperdoll_helm_texture[player->GetSexByVoice()][index];
+                    texture = paperdoll_helm_texture[player->GetSexByVoice()][index];
                 else
-                    texture = (Texture *)paperdoll_dbrds[11];
+                    texture = paperdoll_dbrds[11];
 
                 CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment.uHelm, texture, !bRingsShownInCharScreen);
             }
@@ -1228,7 +1228,7 @@ void CharacterUI_DrawPaperdoll(Player *player) {
             item_X = pPaperdoll_BodyX + paperdoll_Weapon[pBodyComplection][1][0] - pItemTable->pItems[item->uItemID].uEquipX;
             item_Y = pPaperdoll_BodyY + paperdoll_Weapon[pBodyComplection][1][1] - pItemTable->pItems[item->uItemID].uEquipY;
 
-            Texture *texture = nullptr;
+            GraphicsImage *texture = nullptr;
             if (item->uItemID == ITEM_BLASTER)
                 texture = assets->getImage_Alpha("item64v1");
 
@@ -1328,7 +1328,7 @@ void CharacterUI_InventoryTab_Draw(Player *player, bool Cover_Strip) {
     }
 }
 
-static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, Texture *item_texture, bool doZDraw) {
+static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, GraphicsImage *item_texture, bool doZDraw) {
     if (!item_texture)
         item_texture = assets->getImage_Alpha(item->GetIconName());
 

--- a/src/GUI/UI/UICharacter.h
+++ b/src/GUI/UI/UICharacter.h
@@ -53,7 +53,7 @@ class GUIWindow_CharacterRecord : public GUIWindow {
 };
 
 bool ringscreenactive();
-static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, Texture *item_texture = nullptr, bool doZDraw = false);
+static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, GraphicsImage *item_texture = nullptr, bool doZDraw = false);
 
 class GraphicsImage;
 extern GraphicsImage *ui_character_skills_background;

--- a/src/GUI/UI/UICredits.h
+++ b/src/GUI/UI/UICredits.h
@@ -22,6 +22,6 @@ class GUICredits : public GUIWindow {
 
     int width;
     int height;
-    Texture *cred_texture;
+    GraphicsImage *cred_texture;
     float move_Y;
 };

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1440,7 +1440,7 @@ void GameUI_DrawMinimap(unsigned int uX, unsigned int uY, unsigned int uZ,
     }
 
     if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
-        static Texture *minimaptemp;
+        static GraphicsImage *minimaptemp;
         if (!minimaptemp) {
             minimaptemp = render->CreateTexture_Blank(uWidth, uHeight);
         }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -6,7 +6,6 @@
 #include "Engine/Engine.h"
 #include "Engine/Graphics/PaletteManager.h"
 #include "Engine/Graphics/Sprites.h"
-#include "Engine/Graphics/Texture.h"
 #include "Engine/Graphics/Viewport.h"
 #include "Engine/Graphics/Vis.h"
 #include "Engine/LOD.h"
@@ -35,7 +34,7 @@
 
 #include "Library/Random/Random.h"
 
-Texture *parchment = nullptr;
+GraphicsImage *parchment = nullptr;
 GraphicsImage *messagebox_corner_x = nullptr;       // 5076AC
 GraphicsImage *messagebox_corner_y = nullptr;       // 5076B4
 GraphicsImage *messagebox_corner_z = nullptr;       // 5076A8

--- a/src/GUI/UI/UIPopup.h
+++ b/src/GUI/UI/UIPopup.h
@@ -4,8 +4,8 @@
 void DrawPopupWindow(unsigned int uX, unsigned int uY, unsigned int uWidth, unsigned int uHeight);  // idb
 
 class GraphicsImage;
-class Texture;
-extern Texture *parchment;
+
+extern GraphicsImage *parchment;
 extern GraphicsImage *messagebox_corner_x;       // 5076AC
 extern GraphicsImage *messagebox_corner_y;       // 5076B4
 extern GraphicsImage *messagebox_corner_z;       // 5076A8

--- a/src/Library/Color/ColorTable.h
+++ b/src/Library/Color/ColorTable.h
@@ -2,6 +2,11 @@
 
 #include "Color.h"
 
+/**
+ * Common colors used throughout the codebase.
+ *
+ * @see https://colors.artyclick.com/color-name-finder/
+ */
 class ColorTable {
  public:
     const Color Anakiwa = Color(150, 212, 255);         // #96D4FF

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -485,7 +485,7 @@ class Movie : public IMovie {
 
 
         // create texture
-        Texture *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
+        GraphicsImage *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
 
         // holds decoded audio
         std::queue<std::shared_ptr<Blob>, std::deque<std::shared_ptr<Blob>>> buffq;
@@ -802,7 +802,7 @@ void MPlayer::HouseMovieLoop() {
 
     render->BeginScene2D();
 
-    static Texture *tex;
+    static GraphicsImage *tex;
     if (!tex) {
         tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
     }
@@ -869,7 +869,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
     Sizei scaleSize;
 
     // create texture
-    Texture *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
+    GraphicsImage *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
 
     if (pMovie->GetFormat() == "bink") {
         logger->info("bink file");

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -134,7 +134,7 @@ GAME_TEST(Issues, Issue198) {
 
     // Then can safely check everything.
     forEachInventoryItem([](const ItemGen &item, int x, int y) {
-        Texture *image = assets->getImage_ColorKey(pItemTable->pItems[item.uItemID].iconName);
+        GraphicsImage *image = assets->getImage_ColorKey(pItemTable->pItems[item.uItemID].iconName);
         int width = GetSizeInInventorySlots(image->width());
         int height = GetSizeInInventorySlots(image->height());
 


### PR DESCRIPTION
* Dropped class `Texture` as it's not really needed (and I'll be replacing it).
* Dropped the workaround in `Player::SetBeacon` caused by `RenderBase::TakeScreenshot` returning `GraphicsImage` and not `OpenGLTexture`.
* Docs for `class ColorTable`.