### PR TITLE
LegacyImages functions naming: snapshot/reconstruct

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -251,7 +251,7 @@ void IndoorLocation::Load(const std::string &filename, int num_days_played, int 
 
     IndoorLocation_MM7 location;
     deserialize(pGames_LOD->LoadCompressed(blv_filename), &location);
-    deserialize(location, this);
+    reconstruct(location, this);
 
     std::string dlv_filename = filename;
     dlv_filename.replace(dlv_filename.length() - 4, 4, ".dlv");
@@ -299,7 +299,7 @@ void IndoorLocation::Load(const std::string &filename, int num_days_played, int 
         *indoor_was_respawned = false;
     }
 
-    deserialize(delta, this);
+    reconstruct(delta, this);
 
     if (respawnTimed || respawnInitial)
         dlv.lastRespawnDay = num_days_played;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -856,7 +856,7 @@ void OutdoorLocation::Load(const std::string &filename, int days_played, int res
 
     OutdoorLocation_MM7 location;
     deserialize(pGames_LOD->LoadCompressed(odm_filename), &location);
-    deserialize(location, this);
+    reconstruct(location, this);
 
     // ****************.ddm file*********************//
 
@@ -912,7 +912,7 @@ void OutdoorLocation::Load(const std::string &filename, int days_played, int res
         *outdoors_was_respawned = false;
     }
 
-    deserialize(delta, this);
+    reconstruct(delta, this);
 
     if (respawnTimed || respawnInitial)
         ddm.lastRespawnDay = days_played;

--- a/src/Engine/Graphics/Sprites.cpp
+++ b/src/Engine/Graphics/Sprites.cpp
@@ -278,7 +278,7 @@ void SpriteFrameTable::FromFile(const Blob &data_mm6, const Blob &data_mm7, cons
 
     std::vector<SpriteFrame_MM7> tmp;
     deserialize(src, &tmp, presized(frameCount));
-    deserialize(tmp, &pSpriteSFrames);
+    reconstruct(tmp, &pSpriteSFrames);
     deserialize(src, &pSpriteEFrames, presized(eframeCount));
 
     pSpritePFrames.clear();

--- a/src/Engine/Serialization/CompositeImages.cpp
+++ b/src/Engine/Serialization/CompositeImages.cpp
@@ -14,10 +14,10 @@
 
 #include "CommonImages.h"
 
-void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
-    deserialize(src.vertices, &dst->pVertices);
-    deserialize(src.faces, &dst->pFaces);
-    deserialize(src.faceData, &dst->pLFaces);
+void reconstruct(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
+    reconstruct(src.vertices, &dst->pVertices);
+    reconstruct(src.faces, &dst->pFaces);
+    reconstruct(src.faceData, &dst->pLFaces);
 
     for (size_t i = 0, j = 0; i < dst->pFaces.size(); ++i) {
         BLVFace *pFace = &dst->pFaces[i];
@@ -47,15 +47,15 @@ void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
         BLVFace *pFace = &dst->pFaces[i];
 
         std::string texName;
-        deserialize(src.faceTextures[i], &texName);
+        reconstruct(src.faceTextures[i], &texName);
         pFace->SetTexture(texName);
     }
 
-    deserialize(src.faceExtras, &dst->pFaceExtras);
+    reconstruct(src.faceExtras, &dst->pFaceExtras);
 
     std::string textureName;
     for (uint i = 0; i < dst->pFaceExtras.size(); ++i) {
-        deserialize(src.faceExtraTextures[i], &textureName);
+        reconstruct(src.faceExtraTextures[i], &textureName);
 
         if (textureName.empty())
             dst->pFaceExtras[i].uAdditionalBitmapID = -1;
@@ -75,8 +75,8 @@ void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
         }
     }
 
-    deserialize(src.sectors, &dst->pSectors);
-    deserialize(src.sectorData, &dst->ptr_0002B0_sector_rdata);
+    reconstruct(src.sectors, &dst->pSectors);
+    reconstruct(src.sectorData, &dst->ptr_0002B0_sector_rdata);
 
     for (size_t i = 0, j = 0; i < dst->pSectors.size(); ++i) {
         BLVSector *pSector = &dst->pSectors[i];
@@ -111,7 +111,7 @@ void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
         assert(j <= dst->ptr_0002B0_sector_rdata.size());
     }
 
-    deserialize(src.sectorLightData, &dst->ptr_0002B8_sector_lrdata);
+    reconstruct(src.sectorLightData, &dst->ptr_0002B8_sector_lrdata);
 
     for (uint i = 0, j = 0; i < dst->pSectors.size(); ++i) {
         BLVSector *pSector = &dst->pSectors[i];
@@ -122,18 +122,18 @@ void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst) {
         assert(j <= dst->ptr_0002B8_sector_lrdata.size());
     }
 
-    deserialize(src.decorations, &pLevelDecorations);
+    reconstruct(src.decorations, &pLevelDecorations);
 
     std::string decorationName;
     for (size_t i = 0; i < pLevelDecorations.size(); ++i) {
-        deserialize(src.decorationNames[i], &decorationName);
+        reconstruct(src.decorationNames[i], &decorationName);
         pLevelDecorations[i].uDecorationDescID = pDecorationList->GetDecorIdByName(decorationName);
     }
 
-    deserialize(src.lights, &dst->pLights);
-    deserialize(src.bspNodes, &dst->pNodes);
-    deserialize(src.spawnPoints, &dst->pSpawnPoints);
-    deserialize(src.mapOutlines, &dst->pMapOutlines);
+    reconstruct(src.lights, &dst->pLights);
+    reconstruct(src.bspNodes, &dst->pNodes);
+    reconstruct(src.spawnPoints, &dst->pSpawnPoints);
+    reconstruct(src.mapOutlines, &dst->pMapOutlines);
 }
 
 void deserialize(InputStream &src, IndoorLocation_MM7 *dst) {
@@ -156,13 +156,13 @@ void deserialize(InputStream &src, IndoorLocation_MM7 *dst) {
     deserialize(src, &dst->mapOutlines);
 }
 
-void serialize(const IndoorLocation &src, IndoorDelta_MM7 *dst) {
-    serialize(src.dlv, &dst->header.info);
+void snapshot(const IndoorLocation &src, IndoorDelta_MM7 *dst) {
+    snapshot(src.dlv, &dst->header.info);
     dst->header.totalFacesCount = src.pFaces.size();
     dst->header.bmodelCount = 0;
     dst->header.decorationCount = pLevelDecorations.size();
 
-    serialize(src._visible_outlines, &dst->visibleOutlines);
+    snapshot(src._visible_outlines, &dst->visibleOutlines);
 
     dst->faceAttributes.clear();
     for (const BLVFace &pFace : pIndoor->pFaces)
@@ -172,18 +172,18 @@ void serialize(const IndoorLocation &src, IndoorDelta_MM7 *dst) {
     for (const LevelDecoration &decoration : pLevelDecorations)
         dst->decorationFlags.push_back(std::to_underlying(decoration.uFlags));
 
-    serialize(pActors, &dst->actors);
-    serialize(pSpriteObjects, &dst->spriteObjects);
-    serialize(vChests, &dst->chests);
-    serialize(src.pDoors, &dst->doors);
-    serialize(src.ptr_0002B4_doors_ddata, &dst->doorsData);
-    serialize(engine->_persistentVariables, &dst->eventVariables);
-    serialize(src.stru1, &dst->locationTime);
+    snapshot(pActors, &dst->actors);
+    snapshot(pSpriteObjects, &dst->spriteObjects);
+    snapshot(vChests, &dst->chests);
+    snapshot(src.pDoors, &dst->doors);
+    snapshot(src.ptr_0002B4_doors_ddata, &dst->doorsData);
+    snapshot(engine->_persistentVariables, &dst->eventVariables);
+    snapshot(src.stru1, &dst->locationTime);
 }
 
-void deserialize(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
-    deserialize(src.header.info, &dst->dlv); // XXX
-    deserialize(src.visibleOutlines, &dst->_visible_outlines);
+void reconstruct(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
+    reconstruct(src.header.info, &dst->dlv); // XXX
+    reconstruct(src.visibleOutlines, &dst->_visible_outlines);
 
     for (size_t i = 0; i < dst->pMapOutlines.size(); ++i) {
         BLVMapOutline *pVertex = &dst->pMapOutlines[i];
@@ -208,11 +208,11 @@ void deserialize(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
     for (size_t i = 0; i < pLevelDecorations.size(); ++i)
         pLevelDecorations[i].uFlags = LevelDecorationFlags(src.decorationFlags[i]);
 
-    deserialize(src.actors, &pActors);
+    reconstruct(src.actors, &pActors);
     for(size_t i = 0; i < pActors.size(); i++)
         pActors[i].id = i;
 
-    deserialize(src.spriteObjects, &pSpriteObjects);
+    reconstruct(src.spriteObjects, &pSpriteObjects);
 
     for (size_t i = 0; i < pSpriteObjects.size(); ++i) {
         if (pSpriteObjects[i].containing_item.uItemID != ITEM_NULL && !(pSpriteObjects[i].uAttributes & SPRITE_MISSILE)) {
@@ -221,9 +221,9 @@ void deserialize(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
         }
     }
 
-    deserialize(src.chests, &vChests);
-    deserialize(src.doors, &dst->pDoors);
-    deserialize(src.doorsData, &dst->ptr_0002B4_doors_ddata);
+    reconstruct(src.chests, &vChests);
+    reconstruct(src.doors, &dst->pDoors);
+    reconstruct(src.doorsData, &dst->ptr_0002B4_doors_ddata);
 
     for (uint i = 0, j = 0; i < dst->pDoors.size(); ++i) {
         BLVDoor *pDoor = &dst->pDoors[i];
@@ -267,8 +267,8 @@ void deserialize(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
         }
     }
 
-    deserialize(src.eventVariables, &engine->_persistentVariables);
-    deserialize(src.locationTime, &dst->stru1);
+    reconstruct(src.eventVariables, &engine->_persistentVariables);
+    reconstruct(src.locationTime, &dst->stru1);
 }
 
 void serialize(const IndoorDelta_MM7 &src, OutputStream *dst) {
@@ -299,12 +299,12 @@ void deserialize(InputStream &src, IndoorDelta_MM7 *dst, const IndoorLocation_MM
     deserialize(src, &dst->locationTime);
 }
 
-void deserialize(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &> src, BSPModel *dst) {
+void reconstruct(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &> src, BSPModel *dst) {
     const auto &[srcData, srcExtras] = src;
 
     // dst->index is set externally.
-    deserialize(srcData.pModelName, &dst->pModelName);
-    deserialize(srcData.pModelName2, &dst->pModelName2);
+    reconstruct(srcData.pModelName, &dst->pModelName);
+    reconstruct(srcData.pModelName2, &dst->pModelName2);
     dst->field_40 = srcData.field_40;
     dst->sCenterX = srcData.sCenterX;
     dst->sCenterY = srcData.sCenterY;
@@ -325,18 +325,18 @@ void deserialize(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &
     dst->sBoundingRadius = srcData.sBoundingRadius;
 
     dst->pVertices = srcExtras.vertices;
-    deserialize(srcExtras.faces, &dst->pFaces);
+    reconstruct(srcExtras.faces, &dst->pFaces);
 
     for (size_t i = 0; i < dst->pFaces.size(); i++)
         dst->pFaces[i].index = i;
 
     dst->pFacesOrdering = srcExtras.faceOrdering;
 
-    deserialize(srcExtras.bspNodes, &dst->pNodes);
+    reconstruct(srcExtras.bspNodes, &dst->pNodes);
 
     std::string textureName;
     for (size_t i = 0; i < dst->pFaces.size(); ++i) {
-        deserialize(srcExtras.faceTextures[i], &textureName);
+        reconstruct(srcExtras.faceTextures[i], &textureName);
         dst->pFaces[i].SetTexture(textureName);
 
         if (dst->pFaces[i].sCogTriggeredID) {
@@ -348,45 +348,45 @@ void deserialize(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &
     }
 }
 
-void deserialize(const OutdoorLocation_MM7 &src, OutdoorLocation *dst) {
-    deserialize(src.name, &dst->level_filename);
-    deserialize(src.fileName, &dst->location_filename);
-    deserialize(src.desciption, &dst->location_file_description);
-    deserialize(src.skyTexture, &dst->sky_texture_filename);
+void reconstruct(const OutdoorLocation_MM7 &src, OutdoorLocation *dst) {
+    reconstruct(src.name, &dst->level_filename);
+    reconstruct(src.fileName, &dst->location_filename);
+    reconstruct(src.desciption, &dst->location_file_description);
+    reconstruct(src.skyTexture, &dst->sky_texture_filename);
     // src.groundTileset is just dropped
-    deserialize(src.tileTypes, &dst->pTileTypes);
+    reconstruct(src.tileTypes, &dst->pTileTypes);
 
     dst->LoadTileGroupIds();
     dst->LoadRoadTileset();
 
-    deserialize(src.heightMap, &dst->pTerrain.pHeightmap);
-    deserialize(src.tileMap, &dst->pTerrain.pTilemap);
-    deserialize(src.attributeMap, &dst->pTerrain.pAttributemap);
+    reconstruct(src.heightMap, &dst->pTerrain.pHeightmap);
+    reconstruct(src.tileMap, &dst->pTerrain.pTilemap);
+    reconstruct(src.attributeMap, &dst->pTerrain.pAttributemap);
 
     dst->pTerrain.FillDMap(0, 0, 128, 128);
 
-    deserialize(src.someOtherMap, &pTerrainSomeOtherData);
-    deserialize(src.normalMap, &pTerrainNormalIndices);
-    deserialize(src.normals, &pTerrainNormals);
+    reconstruct(src.someOtherMap, &pTerrainSomeOtherData);
+    reconstruct(src.normalMap, &pTerrainNormalIndices);
+    reconstruct(src.normals, &pTerrainNormals);
 
     dst->pBModels.clear();
     for (size_t i = 0; i < src.models.size(); i++) {
         BSPModel &dstModel = dst->pBModels.emplace_back();
         dstModel.index = i;
-        deserialize(std::forward_as_tuple(src.models[i], src.modelExtras[i]), &dstModel);
+        reconstruct(std::forward_as_tuple(src.models[i], src.modelExtras[i]), &dstModel);
     }
 
-    deserialize(src.decorations, &pLevelDecorations);
+    reconstruct(src.decorations, &pLevelDecorations);
 
     std::string decorationName;
     for (size_t i = 0; i < pLevelDecorations.size(); ++i) {
-        deserialize(src.decorationNames[i], &decorationName);
+        reconstruct(src.decorationNames[i], &decorationName);
         pLevelDecorations[i].uDecorationDescID = pDecorationList->GetDecorIdByName(decorationName);
     }
 
-    deserialize(src.decorationPidList, &dst->pFaceIDLIST);
-    deserialize(src.decorationMap, &dst->pOMAP);
-    deserialize(src.spawnPoints, &dst->pSpawnPoints);
+    reconstruct(src.decorationPidList, &dst->pFaceIDLIST);
+    reconstruct(src.decorationMap, &dst->pOMAP);
+    reconstruct(src.spawnPoints, &dst->pSpawnPoints);
 }
 
 void deserialize(InputStream &src, OutdoorLocation_MM7 *dst) {
@@ -422,16 +422,16 @@ void deserialize(InputStream &src, OutdoorLocation_MM7 *dst) {
     deserialize(src, &dst->spawnPoints);
 }
 
-void serialize(const OutdoorLocation &src, OutdoorDelta_MM7 *dst) {
-    serialize(src.ddm, &dst->header.info);
+void snapshot(const OutdoorLocation &src, OutdoorDelta_MM7 *dst) {
+    snapshot(src.ddm, &dst->header.info);
     dst->header.totalFacesCount = 0;
     for (const BSPModel &model : src.pBModels)
         dst->header.totalFacesCount += model.pFaces.size();
     dst->header.bmodelCount = src.pBModels.size();
     dst->header.decorationCount = pLevelDecorations.size();
 
-    serialize(src.uFullyRevealedCellOnMap, &dst->fullyRevealedCells);
-    serialize(src.uPartiallyRevealedCellOnMap, &dst->partiallyRevealedCells);
+    snapshot(src.uFullyRevealedCellOnMap, &dst->fullyRevealedCells);
+    snapshot(src.uPartiallyRevealedCellOnMap, &dst->partiallyRevealedCells);
 
     dst->faceAttributes.clear();
     for (const BSPModel &model : src.pBModels)
@@ -442,17 +442,17 @@ void serialize(const OutdoorLocation &src, OutdoorDelta_MM7 *dst) {
     for (const LevelDecoration &decoration : pLevelDecorations)
         dst->decorationFlags.push_back(std::to_underlying(decoration.uFlags));
 
-    serialize(pActors, &dst->actors);
-    serialize(pSpriteObjects, &dst->spriteObjects);
-    serialize(vChests, &dst->chests);
-    serialize(engine->_persistentVariables, &dst->eventVariables);
-    serialize(src.loc_time, &dst->locationTime);
+    snapshot(pActors, &dst->actors);
+    snapshot(pSpriteObjects, &dst->spriteObjects);
+    snapshot(vChests, &dst->chests);
+    snapshot(engine->_persistentVariables, &dst->eventVariables);
+    snapshot(src.loc_time, &dst->locationTime);
 }
 
-void deserialize(const OutdoorDelta_MM7 &src, OutdoorLocation *dst) {
-    deserialize(src.header.info, &dst->ddm);
-    deserialize(src.fullyRevealedCells, &dst->uFullyRevealedCellOnMap);
-    deserialize(src.partiallyRevealedCells, &dst->uPartiallyRevealedCellOnMap);
+void reconstruct(const OutdoorDelta_MM7 &src, OutdoorLocation *dst) {
+    reconstruct(src.header.info, &dst->ddm);
+    reconstruct(src.fullyRevealedCells, &dst->uFullyRevealedCellOnMap);
+    reconstruct(src.partiallyRevealedCells, &dst->uPartiallyRevealedCellOnMap);
 
     size_t attributeIndex = 0;
     for (BSPModel &model : dst->pBModels) {
@@ -480,14 +480,14 @@ void deserialize(const OutdoorDelta_MM7 &src, OutdoorLocation *dst) {
     for (size_t i = 0; i < pLevelDecorations.size(); ++i)
         pLevelDecorations[i].uFlags = LevelDecorationFlags(src.decorationFlags[i]);
 
-    deserialize(src.actors, &pActors);
+    reconstruct(src.actors, &pActors);
     for(size_t i = 0; i < pActors.size(); i++)
         pActors[i].id = i;
 
-    deserialize(src.spriteObjects, &pSpriteObjects);
-    deserialize(src.chests, &vChests);
-    deserialize(src.eventVariables, &engine->_persistentVariables);
-    deserialize(src.locationTime, &dst->loc_time);
+    reconstruct(src.spriteObjects, &pSpriteObjects);
+    reconstruct(src.chests, &vChests);
+    reconstruct(src.eventVariables, &engine->_persistentVariables);
+    reconstruct(src.locationTime, &dst->loc_time);
 }
 
 void serialize(const OutdoorDelta_MM7 &src, OutputStream *dst) {
@@ -520,22 +520,22 @@ void deserialize(InputStream &src, OutdoorDelta_MM7 *dst, const OutdoorLocation_
     deserialize(src, &dst->locationTime);
 }
 
-void serialize(const SaveGameHeader &src, SaveGame_MM7 *dst) {
-    serialize(src, &dst->header);
-    serialize(*pParty, &dst->party);
-    serialize(*pEventTimer, &dst->eventTimer);
-    serialize(*pActiveOverlayList, &dst->overlays);
-    serialize(pNPCStats->pNewNPCData, &dst->npcData);
-    serialize(pNPCStats->pGroups_copy, &dst->npcGroup);
+void snapshot(const SaveGameHeader &src, SaveGame_MM7 *dst) {
+    snapshot(src, &dst->header);
+    snapshot(*pParty, &dst->party);
+    snapshot(*pEventTimer, &dst->eventTimer);
+    snapshot(*pActiveOverlayList, &dst->overlays);
+    snapshot(pNPCStats->pNewNPCData, &dst->npcData);
+    snapshot(pNPCStats->pGroups_copy, &dst->npcGroup);
 }
 
-void deserialize(const SaveGame_MM7 &src, SaveGameHeader *dst) {
-    deserialize(src.header, dst);
-    deserialize(src.party, pParty);
-    deserialize(src.eventTimer, pEventTimer);
-    deserialize(src.overlays, pActiveOverlayList);
-    deserialize(src.npcData, &pNPCStats->pNewNPCData);
-    deserialize(src.npcGroup, &pNPCStats->pGroups_copy);
+void reconstruct(const SaveGame_MM7 &src, SaveGameHeader *dst) {
+    reconstruct(src.header, dst);
+    reconstruct(src.party, pParty);
+    reconstruct(src.eventTimer, pEventTimer);
+    reconstruct(src.overlays, pActiveOverlayList);
+    reconstruct(src.npcData, &pNPCStats->pNewNPCData);
+    reconstruct(src.npcGroup, &pNPCStats->pGroups_copy);
 }
 
 void serialize(const SaveGame_MM7 &src, LOD::WriteableFile *dst) {

--- a/src/Engine/Serialization/CompositeImages.h
+++ b/src/Engine/Serialization/CompositeImages.h
@@ -35,7 +35,7 @@ struct IndoorLocation_MM7 {
     std::vector<BLVMapOutline_MM7> mapOutlines;
 };
 
-void deserialize(const IndoorLocation_MM7 &src, IndoorLocation *dst);
+void reconstruct(const IndoorLocation_MM7 &src, IndoorLocation *dst);
 void deserialize(InputStream &src, IndoorLocation_MM7 *dst);
 
 
@@ -53,8 +53,8 @@ struct IndoorDelta_MM7 {
     LocationTime_MM7 locationTime;
 };
 
-void serialize(const IndoorLocation &src, IndoorDelta_MM7 *dst);
-void deserialize(const IndoorDelta_MM7 &src, IndoorLocation *dst);
+void snapshot(const IndoorLocation &src, IndoorDelta_MM7 *dst);
+void reconstruct(const IndoorDelta_MM7 &src, IndoorLocation *dst);
 void serialize(const IndoorDelta_MM7 &src, OutputStream *dst);
 void deserialize(InputStream &src, IndoorDelta_MM7 *dst, const IndoorLocation_MM7 &ctx);
 
@@ -67,7 +67,7 @@ struct BSPModelExtras_MM7 {
     std::vector<std::array<char, 10>> faceTextures;
 };
 
-void deserialize(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &> src, BSPModel *dst);
+void reconstruct(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &> src, BSPModel *dst);
 
 
 struct OutdoorLocation_MM7 {
@@ -93,7 +93,7 @@ struct OutdoorLocation_MM7 {
     std::vector<SpawnPoint_MM7> spawnPoints;
 };
 
-void deserialize(const OutdoorLocation_MM7 &src, OutdoorLocation *dst);
+void reconstruct(const OutdoorLocation_MM7 &src, OutdoorLocation *dst);
 void deserialize(InputStream &src, OutdoorLocation_MM7 *dst);
 
 struct OutdoorDelta_MM7 {
@@ -109,8 +109,8 @@ struct OutdoorDelta_MM7 {
     LocationTime_MM7 locationTime;
 };
 
-void serialize(const OutdoorLocation &src, OutdoorDelta_MM7 *dst);
-void deserialize(const OutdoorDelta_MM7 &src, OutdoorLocation *dst);
+void snapshot(const OutdoorLocation &src, OutdoorDelta_MM7 *dst);
+void reconstruct(const OutdoorDelta_MM7 &src, OutdoorLocation *dst);
 void serialize(const OutdoorDelta_MM7 &src, OutputStream *dst);
 void deserialize(InputStream &src, OutdoorDelta_MM7 *dst, const OutdoorLocation_MM7 &ctx);
 
@@ -125,7 +125,7 @@ struct SaveGame_MM7 {
 };
 
 // TODO(captainurist): header here is essentially the whole savegame. Redo properly.
-void serialize(const SaveGameHeader &src, SaveGame_MM7 *dst);
-void deserialize(const SaveGame_MM7 &src, SaveGameHeader *dst);
+void snapshot(const SaveGameHeader &src, SaveGame_MM7 *dst);
+void reconstruct(const SaveGame_MM7 &src, SaveGameHeader *dst);
 void serialize(const SaveGame_MM7 &src, LOD::WriteableFile *dst);
 void deserialize(const LOD::File &src, SaveGame_MM7 *dst);

--- a/src/Engine/Serialization/LegacyImages.cpp
+++ b/src/Engine/Serialization/LegacyImages.cpp
@@ -32,19 +32,19 @@
 
 #include "CommonImages.h"
 
-static void serialize(const GameTime &src, int64_t *dst) {
+static void snapshot(const GameTime &src, int64_t *dst) {
     *dst = src.value;
 }
 
-static void deserialize(int64_t src, GameTime *dst) {
+static void reconstruct(int64_t src, GameTime *dst) {
     dst->value = src;
 }
 
-void deserialize(const SpriteFrame_MM7 &src, SpriteFrame *dst) {
-    deserialize(src.iconName, &dst->icon_name);
+void reconstruct(const SpriteFrame_MM7 &src, SpriteFrame *dst) {
+    reconstruct(src.iconName, &dst->icon_name);
     dst->icon_name = toLower(dst->icon_name);
 
-    deserialize(src.textureName, &dst->texture_name);
+    reconstruct(src.textureName, &dst->texture_name);
     dst->texture_name = toLower(dst->texture_name);
 
     for (unsigned int i = 0; i < 8; ++i)
@@ -60,7 +60,7 @@ void deserialize(const SpriteFrame_MM7 &src, SpriteFrame *dst) {
     dst->uAnimLength = src.animLength;
 }
 
-void deserialize(const BLVFace_MM7 &src, BLVFace *dst) {
+void reconstruct(const BLVFace_MM7 &src, BLVFace *dst) {
     dst->facePlane = src.facePlane;
     dst->zCalc.init(dst->facePlane);
     dst->uAttributes = static_cast<FaceAttributes>(src.attributes);
@@ -79,8 +79,8 @@ void deserialize(const BLVFace_MM7 &src, BLVFace *dst) {
     dst->uNumVertices = src.numVertices;
 }
 
-void deserialize(const TileDesc_MM7 &src, TileDesc *dst) {
-    deserialize(src.tileName, &dst->name);
+void reconstruct(const TileDesc_MM7 &src, TileDesc *dst) {
+    reconstruct(src.tileName, &dst->name);
     dst->name = toLower(dst->name);
 
     if (istarts_with(dst->name, "wtrdr"))
@@ -92,8 +92,8 @@ void deserialize(const TileDesc_MM7 &src, TileDesc *dst) {
     dst->uAttributes = src.attributes;
 }
 
-void deserialize(const TextureFrame_MM7 &src, TextureFrame *dst) {
-    deserialize(src.textureName, &dst->name);
+void reconstruct(const TextureFrame_MM7 &src, TextureFrame *dst) {
+    reconstruct(src.textureName, &dst->name);
     dst->name = toLower(dst->name);
 
     dst->uAnimLength = src.animLength;
@@ -101,7 +101,7 @@ void deserialize(const TextureFrame_MM7 &src, TextureFrame *dst) {
     dst->uFlags = src.flags;
 }
 
-void serialize(const Timer &src, Timer_MM7 *dst) {
+void snapshot(const Timer &src, Timer_MM7 *dst) {
     memzero(dst);
 
     dst->ready = src.bReady;
@@ -116,7 +116,7 @@ void serialize(const Timer &src, Timer_MM7 *dst) {
     dst->totalGameTimeElapsed = src.uTotalTimeElapsed;
 }
 
-void deserialize(const Timer_MM7 &src, Timer *dst) {
+void reconstruct(const Timer_MM7 &src, Timer *dst) {
     dst->bReady = src.ready;
     dst->bPaused = src.paused;
     dst->bTackGameTime = src.tackGameTime;
@@ -129,7 +129,7 @@ void deserialize(const Timer_MM7 &src, Timer *dst) {
     dst->uTotalTimeElapsed = src.totalGameTimeElapsed;
 }
 
-void serialize(const NPCData &src, NPCData_MM7 *dst) {
+void snapshot(const NPCData &src, NPCData_MM7 *dst) {
     memzero(dst);
 
     // dst->pName = src.pName;
@@ -154,7 +154,7 @@ void serialize(const NPCData &src, NPCData_MM7 *dst) {
     dst->newsTopic = src.news_topic;
 }
 
-void deserialize(const NPCData_MM7 &src, NPCData *dst) {
+void reconstruct(const NPCData_MM7 &src, NPCData *dst) {
     // dst->pName = src.pName;
     dst->pName = src.name ? "Dummy" : "";
     dst->uPortraitID = src.portraitId;
@@ -177,7 +177,7 @@ void deserialize(const NPCData_MM7 &src, NPCData *dst) {
     dst->news_topic = src.newsTopic;
 }
 
-void serialize(const ActiveOverlay &src, ActiveOverlay_MM7 *dst) {
+void snapshot(const ActiveOverlay &src, ActiveOverlay_MM7 *dst) {
     memzero(dst);
 
     dst->field_0 = src.field_0;
@@ -191,7 +191,7 @@ void serialize(const ActiveOverlay &src, ActiveOverlay_MM7 *dst) {
     dst->fpDamageMod = src.fpDamageMod;
 }
 
-void deserialize(const ActiveOverlay_MM7 &src, ActiveOverlay *dst) {
+void reconstruct(const ActiveOverlay_MM7 &src, ActiveOverlay *dst) {
     memzero(dst);
 
     dst->field_0 = src.field_0;
@@ -205,20 +205,20 @@ void deserialize(const ActiveOverlay_MM7 &src, ActiveOverlay *dst) {
     dst->fpDamageMod = src.fpDamageMod;
 }
 
-void serialize(const ActiveOverlayList &src, ActiveOverlayList_MM7 *dst) {
+void snapshot(const ActiveOverlayList &src, ActiveOverlayList_MM7 *dst) {
     memzero(dst);
 
     dst->redraw = true;
     dst->field_3E8 = src.field_3E8;
-    serialize(src.pOverlays, &dst->overlays);
+    snapshot(src.pOverlays, &dst->overlays);
 }
 
-void deserialize(const ActiveOverlayList_MM7 &src, ActiveOverlayList *dst) {
+void reconstruct(const ActiveOverlayList_MM7 &src, ActiveOverlayList *dst) {
     dst->field_3E8 = src.field_3E8;
-    deserialize(src.overlays, &dst->pOverlays);
+    reconstruct(src.overlays, &dst->pOverlays);
 }
 
-void serialize(const SpellBuff &src, SpellBuff_MM7 *dst) {
+void snapshot(const SpellBuff &src, SpellBuff_MM7 *dst) {
     memzero(dst);
 
     dst->expireTime = src.expireTime.value;
@@ -229,7 +229,7 @@ void serialize(const SpellBuff &src, SpellBuff_MM7 *dst) {
     dst->flags = src.isGMBuff;
 }
 
-void deserialize(const SpellBuff_MM7 &src, SpellBuff *dst) {
+void reconstruct(const SpellBuff_MM7 &src, SpellBuff *dst) {
     dst->expireTime.value = src.expireTime;
     dst->power = src.power;
     dst->skillMastery = static_cast<PLAYER_SKILL_MASTERY>(src.skillMastery);
@@ -238,7 +238,7 @@ void deserialize(const SpellBuff_MM7 &src, SpellBuff *dst) {
     dst->isGMBuff = src.flags;
 }
 
-void serialize(const ItemGen &src, ItemGen_MM7 *dst) {
+void snapshot(const ItemGen &src, ItemGen_MM7 *dst) {
     memzero(dst);
 
     dst->itemID = std::to_underlying(src.uItemID);
@@ -254,7 +254,7 @@ void serialize(const ItemGen &src, ItemGen_MM7 *dst) {
     dst->expireTime = src.uExpireTime.value;
 }
 
-void deserialize(const ItemGen_MM7 &src, ItemGen *dst) {
+void reconstruct(const ItemGen_MM7 &src, ItemGen *dst) {
     dst->uItemID = static_cast<ITEM_TYPE>(src.itemID);
     dst->uEnchantmentType = src.enchantmentType;
     dst->m_enchantmentStrength = src.enchantmentStrength;
@@ -268,7 +268,7 @@ void deserialize(const ItemGen_MM7 &src, ItemGen *dst) {
     dst->uExpireTime.value = src.expireTime;
 }
 
-void serialize(const Party &src, Party_MM7 *dst) {
+void snapshot(const Party &src, Party_MM7 *dst) {
     memzero(dst);
 
     dst->field_0 = src.field_0_set25_unused;
@@ -285,20 +285,20 @@ void serialize(const Party &src, Party_MM7 *dst) {
     dst->timePlayed = src.playing_time.value;
     dst->lastRegenerationTime = src.last_regenerated.value;
 
-    serialize(src.PartyTimes.bountyHuntNextGenTime, &dst->partyTimes.bountyHuntingNextGenerationTime);
+    snapshot(src.PartyTimes.bountyHuntNextGenTime, &dst->partyTimes.bountyHuntingNextGenerationTime);
     dst->partyTimes.bountyHuntingNextGenerationTimeUnused.fill(0);
 
     // Initially was one array but was splitted in two to simplify access with first element as zero
     // because it is corresponding to invalid house ID
     dst->partyTimes.shopsNextGenerationTime0 = 0;
-    serialize(src.PartyTimes.shopNextRefreshTime, &dst->partyTimes.shopsNextGenerationTime);
-    serialize(src.PartyTimes.guildNextRefreshTime, &dst->partyTimes.guildsNextGenerationTime);
+    snapshot(src.PartyTimes.shopNextRefreshTime, &dst->partyTimes.shopsNextGenerationTime);
+    snapshot(src.PartyTimes.guildNextRefreshTime, &dst->partyTimes.guildsNextGenerationTime);
 
     dst->partyTimes.shopBanTime0 = 0;
-    serialize(src.PartyTimes.shopBanTimes, &dst->partyTimes.shopBanTimes);
-    serialize(src.PartyTimes.CounterEventValues, &dst->partyTimes.counterEventValues);
-    serialize(src.PartyTimes.HistoryEventTimes, &dst->partyTimes.historyEventTimes);
-    serialize(src.PartyTimes._s_times, &dst->partyTimes.someOtherTimes);
+    snapshot(src.PartyTimes.shopBanTimes, &dst->partyTimes.shopBanTimes);
+    snapshot(src.PartyTimes.CounterEventValues, &dst->partyTimes.counterEventValues);
+    snapshot(src.PartyTimes.HistoryEventTimes, &dst->partyTimes.historyEventTimes);
+    snapshot(src.PartyTimes._s_times, &dst->partyTimes.someOtherTimes);
 
     dst->position.x = src.vPosition.x;
     dst->position.y = src.vPosition.y;
@@ -343,22 +343,22 @@ void serialize(const Party &src, Party_MM7 *dst) {
     dst->numBountiesCollected = src.uNumBountiesCollected;
     dst->field_74C = src.field_74C_set0_unused;
 
-    serialize(src.monster_id_for_hunting, &dst->monsterIdForHunting);
-    serialize(src.monster_for_hunting_killed, &dst->monsterForHuntingKilled, convert<bool, int16_t>());
+    snapshot(src.monster_id_for_hunting, &dst->monsterIdForHunting);
+    snapshot(src.monster_for_hunting_killed, &dst->monsterForHuntingKilled, convert<bool, int16_t>());
 
     dst->daysPlayedWithoutRest = src.days_played_without_rest;
 
-    serialize(src._questBits, &dst->questBits);
-    serialize(src.pArcomageWins, &dst->arcomageWins);
+    snapshot(src._questBits, &dst->questBits);
+    snapshot(src.pArcomageWins, &dst->arcomageWins);
 
     dst->field_7B5_in_arena_quest = src.field_7B5_in_arena_quest;
     dst->numArenaWins = src.uNumArenaWins;
 
-    serialize(src.pIsArtifactFound, &dst->isArtifactFound);
-    serialize(src.field_7d7_set0_unused, &dst->field_7d7);
-    serialize(src._autonoteBits, &dst->autonoteBits);
-    serialize(src.field_818_set0_unused, &dst->field_818);
-    serialize(src.random_order_num_unused, &dst->field_854);
+    snapshot(src.pIsArtifactFound, &dst->isArtifactFound);
+    snapshot(src.field_7d7_set0_unused, &dst->field_7d7);
+    snapshot(src._autonoteBits, &dst->autonoteBits);
+    snapshot(src.field_818_set0_unused, &dst->field_818);
+    snapshot(src.random_order_num_unused, &dst->field_854);
 
     dst->numArcomageWins = src.uNumArcomageWins;
     dst->numArcomageLoses = src.uNumArcomageLoses;
@@ -371,29 +371,29 @@ void serialize(const Party &src, Party_MM7 *dst) {
     if (src.alignment == PartyAlignment::PartyAlignment_Neutral) align = 1;
     dst->alignment = align;
 
-    serialize(src.pPartyBuffs, &dst->partyBuffs);
-    serialize(src.pPlayers, &dst->players);
-    serialize(src.pHirelings, &dst->hirelings);
+    snapshot(src.pPartyBuffs, &dst->partyBuffs);
+    snapshot(src.pPlayers, &dst->players);
+    snapshot(src.pHirelings, &dst->hirelings);
 
-    serialize(src.pPickedItem, &dst->pickedItem);
+    snapshot(src.pPickedItem, &dst->pickedItem);
 
     dst->flags = src.uFlags;
 
     dst->standartItemsInShop0.fill({});
-    serialize(src.standartItemsInShops, &dst->standartItemsInShops);
+    snapshot(src.standartItemsInShops, &dst->standartItemsInShops);
     dst->specialItemsInShop0.fill({});
-    serialize(src.specialItemsInShops, &dst->specialItemsInShops);
-    serialize(src.spellBooksInGuilds, &dst->spellBooksInGuilds);
-    serialize(src.field_1605C_set0_unused, &dst->field_1605C);
+    snapshot(src.specialItemsInShops, &dst->specialItemsInShops);
+    snapshot(src.spellBooksInGuilds, &dst->spellBooksInGuilds);
+    snapshot(src.field_1605C_set0_unused, &dst->field_1605C);
 
-    serialize(src.pHireling1Name, &dst->hireling1Name);
-    serialize(src.pHireling2Name, &dst->hireling2Name);
+    snapshot(src.pHireling1Name, &dst->hireling1Name);
+    snapshot(src.pHireling2Name, &dst->hireling2Name);
 
     dst->armageddonTimer = src.armageddon_timer;
     dst->armageddonDamage = src.armageddonDamage;
 
-    serialize(src.pTurnBasedPlayerRecoveryTimes, &dst->turnBasedPlayerRecoveryTimes);
-    serialize(src.InTheShopFlags, &dst->inTheShopFlags);
+    snapshot(src.pTurnBasedPlayerRecoveryTimes, &dst->turnBasedPlayerRecoveryTimes);
+    snapshot(src.InTheShopFlags, &dst->inTheShopFlags);
 
     dst->fine = src.uFine;
     dst->torchlightColorR = src.torchLightColor.r;
@@ -401,7 +401,7 @@ void serialize(const Party &src, Party_MM7 *dst) {
     dst->torchlightColorB = src.torchLightColor.b;
 }
 
-void deserialize(const Party_MM7 &src, Party *dst) {
+void reconstruct(const Party_MM7 &src, Party *dst) {
     dst->field_0_set25_unused = src.field_0;
     dst->uPartyHeight = src.partyHeight;
     dst->uDefaultPartyHeight = src.defaultPartyHeight;
@@ -416,13 +416,13 @@ void deserialize(const Party_MM7 &src, Party *dst) {
     dst->playing_time.value = src.timePlayed;
     dst->last_regenerated.value = src.lastRegenerationTime;
 
-    deserialize(src.partyTimes.bountyHuntingNextGenerationTime, &dst->PartyTimes.bountyHuntNextGenTime);
-    deserialize(src.partyTimes.shopsNextGenerationTime, &dst->PartyTimes.shopNextRefreshTime);
-    deserialize(src.partyTimes.guildsNextGenerationTime, &dst->PartyTimes.guildNextRefreshTime);
-    deserialize(src.partyTimes.shopBanTimes, &dst->PartyTimes.shopBanTimes);
-    deserialize(src.partyTimes.counterEventValues, &dst->PartyTimes.CounterEventValues);
-    deserialize(src.partyTimes.historyEventTimes, &dst->PartyTimes.HistoryEventTimes);
-    deserialize(src.partyTimes.someOtherTimes, &dst->PartyTimes._s_times);
+    reconstruct(src.partyTimes.bountyHuntingNextGenerationTime, &dst->PartyTimes.bountyHuntNextGenTime);
+    reconstruct(src.partyTimes.shopsNextGenerationTime, &dst->PartyTimes.shopNextRefreshTime);
+    reconstruct(src.partyTimes.guildsNextGenerationTime, &dst->PartyTimes.guildNextRefreshTime);
+    reconstruct(src.partyTimes.shopBanTimes, &dst->PartyTimes.shopBanTimes);
+    reconstruct(src.partyTimes.counterEventValues, &dst->PartyTimes.CounterEventValues);
+    reconstruct(src.partyTimes.historyEventTimes, &dst->PartyTimes.HistoryEventTimes);
+    reconstruct(src.partyTimes.someOtherTimes, &dst->PartyTimes._s_times);
 
     dst->vPosition.x = src.position.x;
     dst->vPosition.y = src.position.y;
@@ -468,22 +468,22 @@ void deserialize(const Party_MM7 &src, Party *dst) {
     dst->uNumBountiesCollected = src.numBountiesCollected;
     dst->field_74C_set0_unused = src.field_74C;
 
-    deserialize(src.monsterIdForHunting, &dst->monster_id_for_hunting);
-    deserialize(src.monsterForHuntingKilled, &dst->monster_for_hunting_killed, convert<int16_t, bool>());
+    reconstruct(src.monsterIdForHunting, &dst->monster_id_for_hunting);
+    reconstruct(src.monsterForHuntingKilled, &dst->monster_for_hunting_killed, convert<int16_t, bool>());
 
     dst->days_played_without_rest = src.daysPlayedWithoutRest;
 
-    deserialize(src.questBits, &dst->_questBits);
-    deserialize(src.arcomageWins, &dst->pArcomageWins);
+    reconstruct(src.questBits, &dst->_questBits);
+    reconstruct(src.arcomageWins, &dst->pArcomageWins);
 
     dst->field_7B5_in_arena_quest = src.field_7B5_in_arena_quest;
     dst->uNumArenaWins = src.numArenaWins;
 
-    deserialize(src.isArtifactFound, &dst->pIsArtifactFound);
-    deserialize(src.field_7d7, &dst->field_7d7_set0_unused);
-    deserialize(src.autonoteBits, &dst->_autonoteBits);
-    deserialize(src.field_818, &dst->field_818_set0_unused);
-    deserialize(src.field_854, &dst->random_order_num_unused);
+    reconstruct(src.isArtifactFound, &dst->pIsArtifactFound);
+    reconstruct(src.field_7d7, &dst->field_7d7_set0_unused);
+    reconstruct(src.autonoteBits, &dst->_autonoteBits);
+    reconstruct(src.field_818, &dst->field_818_set0_unused);
+    reconstruct(src.field_854, &dst->random_order_num_unused);
 
     dst->uNumArcomageWins = src.numArcomageWins;
     dst->uNumArcomageLoses = src.numArcomageLoses;
@@ -505,28 +505,28 @@ void deserialize(const Party_MM7 &src, Party *dst) {
             Assert(false);
     }
 
-    deserialize(src.partyBuffs, &dst->pPartyBuffs);
-    deserialize(src.players, &dst->pPlayers);
-    deserialize(src.hirelings, &dst->pHirelings);
+    reconstruct(src.partyBuffs, &dst->pPartyBuffs);
+    reconstruct(src.players, &dst->pPlayers);
+    reconstruct(src.hirelings, &dst->pHirelings);
 
-    deserialize(src.pickedItem, &dst->pPickedItem);
+    reconstruct(src.pickedItem, &dst->pPickedItem);
 
     dst->uFlags = src.flags;
 
-    deserialize(src.standartItemsInShops, &dst->standartItemsInShops);
-    deserialize(src.specialItemsInShops, &dst->specialItemsInShops);
-    deserialize(src.spellBooksInGuilds, &dst->spellBooksInGuilds);
+    reconstruct(src.standartItemsInShops, &dst->standartItemsInShops);
+    reconstruct(src.specialItemsInShops, &dst->specialItemsInShops);
+    reconstruct(src.spellBooksInGuilds, &dst->spellBooksInGuilds);
 
-    deserialize(src.field_1605C, &dst->field_1605C_set0_unused);
+    reconstruct(src.field_1605C, &dst->field_1605C_set0_unused);
 
-    deserialize(src.hireling1Name, &dst->pHireling1Name);
-    deserialize(src.hireling2Name, &dst->pHireling2Name);
+    reconstruct(src.hireling1Name, &dst->pHireling1Name);
+    reconstruct(src.hireling2Name, &dst->pHireling2Name);
 
     dst->armageddon_timer = src.armageddonTimer;
     dst->armageddonDamage = src.armageddonDamage;
 
-    deserialize(src.turnBasedPlayerRecoveryTimes, &dst->pTurnBasedPlayerRecoveryTimes);
-    deserialize(src.inTheShopFlags, &dst->InTheShopFlags);
+    reconstruct(src.turnBasedPlayerRecoveryTimes, &dst->pTurnBasedPlayerRecoveryTimes);
+    reconstruct(src.inTheShopFlags, &dst->InTheShopFlags);
 
     dst->uFine = src.fine;
 
@@ -537,7 +537,7 @@ void deserialize(const Party_MM7 &src, Party *dst) {
     dst->torchLightColor.a = 255;
 }
 
-void serialize(const Player &src, Player_MM7 *dst) {
+void snapshot(const Player &src, Player_MM7 *dst) {
     memzero(dst);
 
     for (unsigned int i = 0; i < 20; ++i)
@@ -545,7 +545,7 @@ void serialize(const Player &src, Player_MM7 *dst) {
 
     dst->experience = src.experience;
 
-    serialize(src.name, &dst->name);
+    snapshot(src.name, &dst->name);
 
     dst->sex = src.uSex;
     dst->classType = src.classType;
@@ -579,9 +579,9 @@ void serialize(const Player &src, Player_MM7 *dst) {
     dst->field_100 = src.field_100;
     dst->field_104 = src.field_104;
 
-    serialize(src.pActiveSkills, &dst->activeSkills, segment<PLAYER_SKILL_FIRST_VISIBLE, PLAYER_SKILL_LAST_VISIBLE>());
-    serialize(src._achievedAwardsBits, &dst->achievedAwardsBits);
-    serialize(src.spellbook.bHaveSpell, &dst->spellbook.haveSpell);
+    snapshot(src.pActiveSkills, &dst->activeSkills, segment<PLAYER_SKILL_FIRST_VISIBLE, PLAYER_SKILL_LAST_VISIBLE>());
+    snapshot(src._achievedAwardsBits, &dst->achievedAwardsBits);
+    snapshot(src.spellbook.bHaveSpell, &dst->spellbook.haveSpell);
 
     dst->pureLuckUsed = src.pure_luck_used;
     dst->pureSpeedUsed = src.pure_speed_used;
@@ -591,8 +591,8 @@ void serialize(const Player &src, Player_MM7 *dst) {
     dst->pureAccuracyUsed = src.pure_accuracy_used;
     dst->pureMightUsed = src.pure_might_used;
 
-    serialize(src.pOwnItems, &dst->ownItems);
-    serialize(src.pInventoryMatrix, &dst->inventoryMatrix);
+    snapshot(src.pOwnItems, &dst->ownItems);
+    snapshot(src.pInventoryMatrix, &dst->inventoryMatrix);
 
     dst->resFireBase = src.sResFireBase;
     dst->resAirBase = src.sResAirBase;
@@ -617,7 +617,7 @@ void serialize(const Player &src, Player_MM7 *dst) {
     dst->resLightBonus = src.sResLightBonus;
     dst->resDarkBonus = src.sResDarkBonus;
 
-    serialize(src.pPlayerBuffs, &dst->playerBuffs);
+    snapshot(src.pPlayerBuffs, &dst->playerBuffs);
 
     dst->voiceId = src.uVoiceID;
     dst->prevVoiceId = src.uPrevVoiceID;
@@ -632,16 +632,16 @@ void serialize(const Player &src, Player_MM7 *dst) {
     dst->mana = src.mana;
     dst->birthYear = src.uBirthYear;
 
-    serialize(src.pEquipment.pIndices, &dst->equipment.indices);
+    snapshot(src.pEquipment.pIndices, &dst->equipment.indices);
 
-    serialize(src.field_1988, &dst->field_1988);
+    snapshot(src.field_1988, &dst->field_1988);
 
     dst->field_1A4C = src.field_1A4C;
     dst->field_1A4D = src.field_1A4D;
     dst->lastOpenedSpellbookPage = src.lastOpenedSpellbookPage;
     dst->quickSpell = std::to_underlying(src.uQuickSpell);
 
-    serialize(src._playerEventBits, &dst->playerEventBits);
+    snapshot(src._playerEventBits, &dst->playerEventBits);
 
     dst->someAttackBonus = src._some_attack_bonus;
     dst->field_1A91 = src.field_1A91;
@@ -681,13 +681,13 @@ void serialize(const Player &src, Player_MM7 *dst) {
     dst->field_1B3B = src.field_1B3B_set0_unused;
 }
 
-void deserialize(const Player_MM7 &src, Player *dst) {
+void reconstruct(const Player_MM7 &src, Player *dst) {
     for (unsigned int i = 0; i < 20; ++i)
         dst->conditions.Set(static_cast<Condition>(i), GameTime(src.conditions[i]));
 
     dst->experience = src.experience;
 
-    deserialize(src.name, &dst->name);
+    reconstruct(src.name, &dst->name);
 
     switch (src.sex) {
     case 0:
@@ -843,9 +843,9 @@ void deserialize(const Player_MM7 &src, Player *dst) {
     dst->field_100 = src.field_100;
     dst->field_104 = src.field_104;
 
-    deserialize(src.activeSkills, &dst->pActiveSkills, segment<PLAYER_SKILL_FIRST_VISIBLE, PLAYER_SKILL_LAST_VISIBLE>());
-    deserialize(src.achievedAwardsBits, &dst->_achievedAwardsBits);
-    deserialize(src.spellbook.haveSpell, &dst->spellbook.bHaveSpell);
+    reconstruct(src.activeSkills, &dst->pActiveSkills, segment<PLAYER_SKILL_FIRST_VISIBLE, PLAYER_SKILL_LAST_VISIBLE>());
+    reconstruct(src.achievedAwardsBits, &dst->_achievedAwardsBits);
+    reconstruct(src.spellbook.haveSpell, &dst->spellbook.bHaveSpell);
 
     dst->pure_luck_used = src.pureLuckUsed;
     dst->pure_speed_used = src.pureSpeedUsed;
@@ -855,8 +855,8 @@ void deserialize(const Player_MM7 &src, Player *dst) {
     dst->pure_accuracy_used = src.pureAccuracyUsed;
     dst->pure_might_used = src.pureMightUsed;
 
-    deserialize(src.ownItems, &dst->pOwnItems);
-    deserialize(src.inventoryMatrix, &dst->pInventoryMatrix);
+    reconstruct(src.ownItems, &dst->pOwnItems);
+    reconstruct(src.inventoryMatrix, &dst->pInventoryMatrix);
 
     dst->sResFireBase = src.resFireBase;
     dst->sResAirBase = src.resAirBase;
@@ -881,7 +881,7 @@ void deserialize(const Player_MM7 &src, Player *dst) {
     dst->sResLightBonus = src.resLightBonus;
     dst->sResDarkBonus = src.resDarkBonus;
 
-    deserialize(src.playerBuffs, &dst->pPlayerBuffs);
+    reconstruct(src.playerBuffs, &dst->pPlayerBuffs);
 
     dst->uVoiceID = src.voiceId;
     dst->uPrevVoiceID = src.prevVoiceId;
@@ -896,16 +896,16 @@ void deserialize(const Player_MM7 &src, Player *dst) {
     dst->mana = src.mana;
     dst->uBirthYear = src.birthYear;
 
-    deserialize(src.equipment.indices, &dst->pEquipment.pIndices);
+    reconstruct(src.equipment.indices, &dst->pEquipment.pIndices);
 
-    deserialize(src.field_1988, &dst->field_1988);
+    reconstruct(src.field_1988, &dst->field_1988);
 
     dst->field_1A4C = src.field_1A4C;
     dst->field_1A4D = src.field_1A4D;
     dst->lastOpenedSpellbookPage = src.lastOpenedSpellbookPage;
     dst->uQuickSpell = static_cast<SPELL_TYPE>(src.quickSpell);
 
-    deserialize(src.playerEventBits, &dst->_playerEventBits);
+    reconstruct(src.playerEventBits, &dst->_playerEventBits);
 
     dst->_some_attack_bonus = src.someAttackBonus;
     dst->field_1A91 = src.field_1A91;
@@ -950,29 +950,29 @@ void deserialize(const Player_MM7 &src, Player *dst) {
     dst->field_1B3B_set0_unused = src.field_1B3B;
 }
 
-void serialize(const Icon &src, IconFrame_MM7 *dst) {
+void snapshot(const Icon &src, IconFrame_MM7 *dst) {
     memzero(dst);
 
-    serialize(src.GetAnimationName(), &dst->animationName);
+    snapshot(src.GetAnimationName(), &dst->animationName);
     dst->animLength = src.GetAnimLength();
 
-    serialize(src.pTextureName, &dst->textureName);
+    snapshot(src.pTextureName, &dst->textureName);
     dst->animTime = src.GetAnimTime();
     dst->flags = src.uFlags;
 }
 
-void deserialize(const IconFrame_MM7 &src, Icon *dst) {
+void reconstruct(const IconFrame_MM7 &src, Icon *dst) {
     std::string name;
-    deserialize(src.animationName, &name);
+    reconstruct(src.animationName, &name);
     dst->SetAnimationName(name);
     dst->SetAnimLength(8 * src.animLength);
 
-    deserialize(src.textureName, &dst->pTextureName);
+    reconstruct(src.textureName, &dst->pTextureName);
     dst->SetAnimTime(src.animTime);
     dst->uFlags = src.flags;
 }
 
-void serialize(const UIAnimation &src, UIAnimation_MM7 *dst) {
+void snapshot(const UIAnimation &src, UIAnimation_MM7 *dst) {
     memzero(dst);
 
     /* 000 */ dst->iconId = src.icon->id;
@@ -984,7 +984,7 @@ void serialize(const UIAnimation &src, UIAnimation_MM7 *dst) {
     /* 00C */ dst->field_C = src.field_C;
 }
 
-void deserialize(const UIAnimation_MM7 &src, UIAnimation *dst) {
+void reconstruct(const UIAnimation_MM7 &src, UIAnimation *dst) {
     dst->icon = pIconsFrameTable->GetIcon(src.iconId);
     ///* 000 */ anim->uIconID = src.uIconID;
     /* 002 */ dst->field_2 = src.field_2;
@@ -995,18 +995,18 @@ void deserialize(const UIAnimation_MM7 &src, UIAnimation *dst) {
     /* 00C */ dst->field_C = src.field_C;
 }
 
-void deserialize(const MonsterDesc_MM6 &src, MonsterDesc *dst) {
+void reconstruct(const MonsterDesc_MM6 &src, MonsterDesc *dst) {
     dst->uMonsterHeight = src.monsterHeight;
     dst->uMonsterRadius = src.monsterRadius;
     dst->uMovementSpeed = src.movementSpeed;
     dst->uToHitRadius = src.toHitRadius;
     dst->sTintColor = colorTable.White;
     dst->pSoundSampleIDs = src.soundSampleIds;
-    deserialize(src.monsterName, &dst->pMonsterName);
-    deserialize(src.spriteNames, &dst->pSpriteNames);
+    reconstruct(src.monsterName, &dst->pMonsterName);
+    reconstruct(src.spriteNames, &dst->pSpriteNames);
 }
 
-void serialize(const MonsterDesc &src, MonsterDesc_MM7 *dst) {
+void snapshot(const MonsterDesc &src, MonsterDesc_MM7 *dst) {
     memzero(dst);
 
     dst->monsterHeight = src.uMonsterHeight;
@@ -1015,24 +1015,24 @@ void serialize(const MonsterDesc &src, MonsterDesc_MM7 *dst) {
     dst->toHitRadius = src.uToHitRadius;
     dst->tintColor = src.sTintColor.c32();
     dst->soundSampleIds = src.pSoundSampleIDs;
-    serialize(src.pMonsterName, &dst->monsterName);
-    serialize(src.pSpriteNames, &dst->spriteNames);
+    snapshot(src.pMonsterName, &dst->monsterName);
+    snapshot(src.pSpriteNames, &dst->spriteNames);
     dst->spriteNamesUnused[0].fill('\0');
     dst->spriteNamesUnused[1].fill('\0');
 }
 
-void deserialize(const MonsterDesc_MM7 &src, MonsterDesc *dst) {
+void reconstruct(const MonsterDesc_MM7 &src, MonsterDesc *dst) {
     dst->uMonsterHeight = src.monsterHeight;
     dst->uMonsterRadius = src.monsterRadius;
     dst->uMovementSpeed = src.movementSpeed;
     dst->uToHitRadius = src.toHitRadius;
     dst->sTintColor = Color::fromC32(src.tintColor);
     dst->pSoundSampleIDs = src.soundSampleIds;
-    deserialize(src.monsterName, &dst->pMonsterName);
-    deserialize(src.spriteNames, &dst->pSpriteNames);
+    reconstruct(src.monsterName, &dst->pMonsterName);
+    reconstruct(src.spriteNames, &dst->pSpriteNames);
 }
 
-void serialize(const ActorJob &src, ActorJob_MM7 *dst) {
+void snapshot(const ActorJob &src, ActorJob_MM7 *dst) {
     memzero(dst);
     dst->pos = src.vPos;
     dst->attributes = src.uAttributes;
@@ -1042,7 +1042,7 @@ void serialize(const ActorJob &src, ActorJob_MM7 *dst) {
     dst->month = src.uMonth;
 }
 
-void deserialize(const ActorJob_MM7 &src, ActorJob *dst) {
+void reconstruct(const ActorJob_MM7 &src, ActorJob *dst) {
     dst->vPos = src.pos;
     dst->uAttributes = src.attributes;
     dst->uAction = src.action;
@@ -1051,10 +1051,10 @@ void deserialize(const ActorJob_MM7 &src, ActorJob *dst) {
     dst->uMonth = src.month;
 }
 
-void serialize(const Actor &src, Actor_MM7 *dst) {
+void snapshot(const Actor &src, Actor_MM7 *dst) {
     memzero(dst);
 
-    serialize(src.pActorName, &dst->pActorName);
+    snapshot(src.pActorName, &dst->pActorName);
 
     dst->sNPC_ID = src.sNPC_ID;
     dst->field_22 = src.field_22;
@@ -1138,25 +1138,25 @@ void serialize(const Actor &src, Actor_MM7 *dst) {
     dst->field_B7 = src.field_B7;
     dst->uCurrentActionTime = src.uCurrentActionTime;
 
-    serialize(src.pSpriteIDs, &dst->pSpriteIDs);
-    serialize(src.pSoundSampleIDs, &dst->pSoundSampleIDs);
-    serialize(src.pActorBuffs, &dst->pActorBuffs);
-    serialize(src.ActorHasItems, &dst->ActorHasItems);
+    snapshot(src.pSpriteIDs, &dst->pSpriteIDs);
+    snapshot(src.pSoundSampleIDs, &dst->pSoundSampleIDs);
+    snapshot(src.pActorBuffs, &dst->pActorBuffs);
+    snapshot(src.ActorHasItems, &dst->ActorHasItems);
 
     dst->uGroup = src.uGroup;
     dst->uAlly = src.uAlly;
 
-    serialize(src.pScheduledJobs, &dst->pScheduledJobs);
+    snapshot(src.pScheduledJobs, &dst->pScheduledJobs);
 
     dst->uSummonerID = src.uSummonerID;
     dst->uLastCharacterIDToHit = src.uLastCharacterIDToHit;
     dst->dword_000334_unique_name = src.dword_000334_unique_name;
 
-    serialize(src.field_338, &dst->field_338);
+    snapshot(src.field_338, &dst->field_338);
 }
 
-void deserialize(const Actor_MM7 &src, Actor *dst) {
-    deserialize(src.pActorName, &dst->pActorName);
+void reconstruct(const Actor_MM7 &src, Actor *dst) {
+    reconstruct(src.pActorName, &dst->pActorName);
     dst->sNPC_ID = src.sNPC_ID;
     dst->field_22 = src.field_22;
     dst->uAttributes = ActorAttributes(src.uAttributes);
@@ -1239,24 +1239,24 @@ void deserialize(const Actor_MM7 &src, Actor *dst) {
     dst->field_B7 = src.field_B7;
     dst->uCurrentActionTime = src.uCurrentActionTime;
 
-    deserialize(src.pSpriteIDs, &dst->pSpriteIDs);
-    deserialize(src.pSoundSampleIDs, &dst->pSoundSampleIDs);
-    deserialize(src.pActorBuffs, &dst->pActorBuffs);
-    deserialize(src.ActorHasItems, &dst->ActorHasItems);
+    reconstruct(src.pSpriteIDs, &dst->pSpriteIDs);
+    reconstruct(src.pSoundSampleIDs, &dst->pSoundSampleIDs);
+    reconstruct(src.pActorBuffs, &dst->pActorBuffs);
+    reconstruct(src.ActorHasItems, &dst->ActorHasItems);
 
     dst->uGroup = src.uGroup;
     dst->uAlly = src.uAlly;
 
-    deserialize(src.pScheduledJobs, &dst->pScheduledJobs);
+    reconstruct(src.pScheduledJobs, &dst->pScheduledJobs);
 
     dst->uSummonerID = src.uSummonerID;
     dst->uLastCharacterIDToHit = src.uLastCharacterIDToHit;
     dst->dword_000334_unique_name = src.dword_000334_unique_name;
 
-    deserialize(src.field_338, &dst->field_338);
+    reconstruct(src.field_338, &dst->field_338);
 }
 
-void serialize(const BLVDoor &src, BLVDoor_MM7 *dst) {
+void snapshot(const BLVDoor &src, BLVDoor_MM7 *dst) {
     memzero(dst);
 
     dst->uAttributes = std::to_underlying(src.uAttributes);
@@ -1274,7 +1274,7 @@ void serialize(const BLVDoor &src, BLVDoor_MM7 *dst) {
     dst->field_4E = src.field_4E;
 }
 
-void deserialize(const BLVDoor_MM7 &src, BLVDoor *dst) {
+void reconstruct(const BLVDoor_MM7 &src, BLVDoor *dst) {
     dst->uAttributes = static_cast<DoorAttributes>(src.uAttributes);
     dst->uDoorID = src.uDoorID;
     dst->uTimeSinceTriggered = src.uTimeSinceTriggered;
@@ -1290,7 +1290,7 @@ void deserialize(const BLVDoor_MM7 &src, BLVDoor *dst) {
     dst->field_4E = src.field_4E;
 }
 
-void serialize(const BLVSector &src, BLVSector_MM7 *dst) {
+void snapshot(const BLVSector &src, BLVSector_MM7 *dst) {
     memzero(dst);
 
     dst->field_0 = src.field_0;
@@ -1326,7 +1326,7 @@ void serialize(const BLVSector &src, BLVSector_MM7 *dst) {
     dst->pBounding = src.pBounding;
 }
 
-void deserialize(const BLVSector_MM7 &src, BLVSector *dst) {
+void reconstruct(const BLVSector_MM7 &src, BLVSector *dst) {
     dst->field_0 = src.field_0;
     dst->uNumFloors = src.uNumFloors;
     dst->field_6 = src.field_6;
@@ -1360,7 +1360,7 @@ void deserialize(const BLVSector_MM7 &src, BLVSector *dst) {
     dst->pBounding = src.pBounding;
 }
 
-void serialize(const GUICharMetric &src, GUICharMetric_MM7 *dst) {
+void snapshot(const GUICharMetric &src, GUICharMetric_MM7 *dst) {
     memzero(dst);
 
     dst->uLeftSpacing = src.uLeftSpacing;
@@ -1368,13 +1368,13 @@ void serialize(const GUICharMetric &src, GUICharMetric_MM7 *dst) {
     dst->uRightSpacing = src.uRightSpacing;
 }
 
-void deserialize(const GUICharMetric_MM7 &src, GUICharMetric *dst) {
+void reconstruct(const GUICharMetric_MM7 &src, GUICharMetric *dst) {
     dst->uLeftSpacing = src.uLeftSpacing;
     dst->uWidth = src.uWidth;
     dst->uRightSpacing = src.uRightSpacing;
 }
 
-void serialize(const FontData &src, FontData_MM7 *dst) {
+void snapshot(const FontData &src, FontData_MM7 *dst) {
     memzero(dst);
 
     dst->cFirstChar = src.cFirstChar;
@@ -1386,13 +1386,13 @@ void serialize(const FontData &src, FontData_MM7 *dst) {
     dst->field_7 = src.field_7;
     dst->palletes_count = src.palletes_count;
 
-    serialize(src.pMetrics, &dst->pMetrics);
-    serialize(src.font_pixels_offset, &dst->font_pixels_offset);
+    snapshot(src.pMetrics, &dst->pMetrics);
+    snapshot(src.font_pixels_offset, &dst->font_pixels_offset);
 
     std::copy(src.pFontData.begin(), src.pFontData.end(), dst->pFontData);
 }
 
-void deserialize(const FontData_MM7 &src, size_t size, FontData *dst) {
+void reconstruct(const FontData_MM7 &src, size_t size, FontData *dst) {
     dst->cFirstChar = src.cFirstChar;
     dst->cLastChar = src.cLastChar;
     dst->field_2 = src.field_2;
@@ -1402,13 +1402,13 @@ void deserialize(const FontData_MM7 &src, size_t size, FontData *dst) {
     dst->field_7 = src.field_7;
     dst->palletes_count = src.palletes_count;
 
-    deserialize(src.pMetrics, &dst->pMetrics);
-    deserialize(src.font_pixels_offset, &dst->font_pixels_offset);
+    reconstruct(src.pMetrics, &dst->pMetrics);
+    reconstruct(src.font_pixels_offset, &dst->font_pixels_offset);
 
     dst->pFontData.assign(src.pFontData, &src.pFontData[size - 4128]);
 }
 
-void deserialize(const ODMFace_MM7 &src, ODMFace *dst) {
+void reconstruct(const ODMFace_MM7 &src, ODMFace *dst) {
     dst->facePlane.normal.x = src.facePlane.normal.x / 65536.0;
     dst->facePlane.normal.y = src.facePlane.normal.y / 65536.0;
     dst->facePlane.normal.z = src.facePlane.normal.z / 65536.0;
@@ -1443,7 +1443,7 @@ void deserialize(const ODMFace_MM7 &src, ODMFace *dst) {
     dst->field_133 = src.field_133;
 }
 
-void deserialize(const SpawnPoint_MM7 &src, SpawnPoint *dst) {
+void reconstruct(const SpawnPoint_MM7 &src, SpawnPoint *dst) {
     dst->vPosition = src.vPosition;
     dst->uRadius = src.uRadius;
     dst->uKind = static_cast<ObjectType>(src.uKind);
@@ -1459,7 +1459,7 @@ void deserialize(const SpawnPoint_MM7 &src, SpawnPoint *dst) {
     dst->uGroup = src.uGroup;
 }
 
-void serialize(const SpriteObject &src, SpriteObject_MM7 *dst) {
+void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst) {
     memzero(dst);
 
     dst->uType = src.uType;
@@ -1473,7 +1473,7 @@ void serialize(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->uSpriteFrameID = src.uSpriteFrameID;
     dst->tempLifetime = src.tempLifetime;
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
-    serialize(src.containing_item, &dst->containing_item);
+    snapshot(src.containing_item, &dst->containing_item);
     dst->uSpellID = std::to_underlying(src.uSpellID);
     dst->spell_level = src.spell_level;
     dst->spell_skill = std::to_underlying(src.spell_skill);
@@ -1487,7 +1487,7 @@ void serialize(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->initialPosition = src.initialPosition;
 }
 
-void deserialize(const SpriteObject_MM7 &src, SpriteObject *dst) {
+void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->uType = static_cast<SPRITE_OBJECT_TYPE>(src.uType);
     dst->uObjectDescID = src.uObjectDescID;
     dst->vPosition = src.vPosition;
@@ -1499,7 +1499,7 @@ void deserialize(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->uSpriteFrameID = src.uSpriteFrameID;
     dst->tempLifetime = src.tempLifetime;
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
-    deserialize(src.containing_item, &dst->containing_item);
+    reconstruct(src.containing_item, &dst->containing_item);
     dst->uSpellID = static_cast<SPELL_TYPE>(src.uSpellID);
     dst->spell_level = src.spell_level;
     dst->spell_skill = static_cast<PLAYER_SKILL_MASTERY>(src.spell_skill);
@@ -1513,16 +1513,16 @@ void deserialize(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->initialPosition = src.initialPosition;
 }
 
-void deserialize(const ChestDesc_MM7 &src, ChestDesc *dst) {
-    deserialize(src.pName, &dst->sName);
+void reconstruct(const ChestDesc_MM7 &src, ChestDesc *dst) {
+    reconstruct(src.pName, &dst->sName);
     dst->uWidth = src.uWidth;
     dst->uHeight = src.uHeight;
     dst->uTextureID = src.uTextureID;
 }
 
-void deserialize(const DecorationDesc_MM6 &src, DecorationDesc *dst) {
-    deserialize(src.pName, &dst->pName);
-    deserialize(src.field_20, &dst->field_20);
+void reconstruct(const DecorationDesc_MM6 &src, DecorationDesc *dst) {
+    reconstruct(src.pName, &dst->pName);
+    reconstruct(src.field_20, &dst->field_20);
     dst->uType = src.uType;
     dst->uDecorationHeight = src.uDecorationHeight;
     dst->uRadius = src.uRadius;
@@ -1537,8 +1537,8 @@ void deserialize(const DecorationDesc_MM6 &src, DecorationDesc *dst) {
     dst->uColoredLight.a = 255;
 }
 
-void deserialize(const DecorationDesc_MM7 &src, DecorationDesc *dst) {
-    deserialize(static_cast<const DecorationDesc_MM6 &>(src), dst);
+void reconstruct(const DecorationDesc_MM7 &src, DecorationDesc *dst) {
+    reconstruct(static_cast<const DecorationDesc_MM6 &>(src), dst);
 
     dst->uColoredLight.r = src.uColoredLightRed;
     dst->uColoredLight.g = src.uColoredLightGreen;
@@ -1546,23 +1546,23 @@ void deserialize(const DecorationDesc_MM7 &src, DecorationDesc *dst) {
     dst->uColoredLight.a = 255;
 }
 
-void serialize(const Chest &src, Chest_MM7 *dst) {
+void snapshot(const Chest &src, Chest_MM7 *dst) {
     memzero(dst);
 
     dst->uChestBitmapID = src.uChestBitmapID;
     dst->uFlags = std::to_underlying(src.uFlags);
-    serialize(src.igChestItems, &dst->igChestItems);
-    serialize(src.pInventoryIndices, &dst->pInventoryIndices);
+    snapshot(src.igChestItems, &dst->igChestItems);
+    snapshot(src.pInventoryIndices, &dst->pInventoryIndices);
 }
 
-void deserialize(const Chest_MM7 &src, Chest *dst) {
+void reconstruct(const Chest_MM7 &src, Chest *dst) {
     dst->uChestBitmapID = src.uChestBitmapID;
     dst->uFlags = ChestFlags(src.uFlags);
-    deserialize(src.igChestItems, &dst->igChestItems);
-    deserialize(src.pInventoryIndices, &dst->pInventoryIndices);
+    reconstruct(src.igChestItems, &dst->igChestItems);
+    reconstruct(src.pInventoryIndices, &dst->pInventoryIndices);
 }
 
-void deserialize(const BLVLight_MM7 &src, BLVLight *dst) {
+void reconstruct(const BLVLight_MM7 &src, BLVLight *dst) {
     dst->vPosition = src.vPosition;
     dst->uRadius = src.uRadius;
     dst->uRed = src.uRed;
@@ -1573,14 +1573,14 @@ void deserialize(const BLVLight_MM7 &src, BLVLight *dst) {
     dst->uBrightness = src.uBrightness;
 }
 
-void deserialize(const OverlayDesc_MM7 &src, OverlayDesc *dst) {
+void reconstruct(const OverlayDesc_MM7 &src, OverlayDesc *dst) {
     dst->uOverlayID = src.uOverlayID;
     dst->uOverlayType = src.uOverlayType;
     dst->uSpriteFramesetID = src.uSpriteFramesetID;
     dst->spriteFramesetGroup = src.spriteFramesetGroup;
 }
 
-void deserialize(const PlayerFrame_MM7 &src, PlayerFrame *dst) {
+void reconstruct(const PlayerFrame_MM7 &src, PlayerFrame *dst) {
     dst->expression = static_cast<CHARACTER_EXPRESSION_ID>(src.expression);
     dst->uTextureID = src.uTextureID;
     dst->uAnimTime = src.uAnimTime;
@@ -1588,7 +1588,7 @@ void deserialize(const PlayerFrame_MM7 &src, PlayerFrame *dst) {
     dst->uFlags = src.uFlags;
 }
 
-void deserialize(const LevelDecoration_MM7 &src, LevelDecoration *dst) {
+void reconstruct(const LevelDecoration_MM7 &src, LevelDecoration *dst) {
     dst->uDecorationDescID = src.uDecorationDescID;
     dst->uFlags = LevelDecorationFlags(src.uFlags);
     dst->vPosition = src.vPosition;
@@ -1601,7 +1601,7 @@ void deserialize(const LevelDecoration_MM7 &src, LevelDecoration *dst) {
     dst->field_1E = src.field_1E;
 }
 
-void deserialize(const BLVFaceExtra_MM7 &src, BLVFaceExtra *dst) {
+void reconstruct(const BLVFaceExtra_MM7 &src, BLVFaceExtra *dst) {
     dst->field_0 = src.field_0;
     dst->field_2 = src.field_2;
     dst->field_4 = src.field_4;
@@ -1622,14 +1622,14 @@ void deserialize(const BLVFaceExtra_MM7 &src, BLVFaceExtra *dst) {
     dst->field_22 = src.field_22;
 }
 
-void deserialize(const BSPNode_MM7 &src, BSPNode *dst) {
+void reconstruct(const BSPNode_MM7 &src, BSPNode *dst) {
     dst->uFront = src.uFront;
     dst->uBack = src.uBack;
     dst->uBSPFaceIDOffset = src.uBSPFaceIDOffset;
     dst->uNumBSPFaces = src.uNumBSPFaces;
 }
 
-void deserialize(const BLVMapOutline_MM7 &src, BLVMapOutline *dst) {
+void reconstruct(const BLVMapOutline_MM7 &src, BLVMapOutline *dst) {
     dst->uVertex1ID = src.uVertex1ID;
     dst->uVertex2ID = src.uVertex2ID;
     dst->uFace1ID = src.uFace1ID;
@@ -1638,7 +1638,7 @@ void deserialize(const BLVMapOutline_MM7 &src, BLVMapOutline *dst) {
     dst->uFlags = src.uFlags;
 }
 
-void deserialize(const ObjectDesc_MM6 &src, ObjectDesc *dst) {
+void reconstruct(const ObjectDesc_MM6 &src, ObjectDesc *dst) {
     dst->field_0 =  src.field_0;
     dst->uObjectID = src.uObjectID;
     dst->uRadius = src.uRadius;
@@ -1651,7 +1651,7 @@ void deserialize(const ObjectDesc_MM6 &src, ObjectDesc *dst) {
     dst->uSpeed = src.uSpeed;
 }
 
-void deserialize(const ObjectDesc_MM7 &src, ObjectDesc *dst) {
+void reconstruct(const ObjectDesc_MM7 &src, ObjectDesc *dst) {
     dst->field_0 = src.field_0;
     dst->uObjectID = src.uObjectID;
     dst->uRadius = src.uRadius;
@@ -1664,77 +1664,77 @@ void deserialize(const ObjectDesc_MM7 &src, ObjectDesc *dst) {
     dst->uSpeed = src.uSpeed;
 }
 
-void serialize(const LocationTime &src, LocationTime_MM7 *dst) {
+void snapshot(const LocationTime &src, LocationTime_MM7 *dst) {
     memzero(dst);
 
-    serialize(src.last_visit, &dst->last_visit);
-    serialize(src.sky_texture_name, &dst->sky_texture_name);
+    snapshot(src.last_visit, &dst->last_visit);
+    snapshot(src.sky_texture_name, &dst->sky_texture_name);
     dst->day_attrib = src.day_attrib;
     dst->day_fogrange_1 = src.day_fogrange_1;
     dst->day_fogrange_2 = src.day_fogrange_2;
 }
 
-void deserialize(const LocationTime_MM7 &src, LocationTime *dst) {
-    deserialize(src.last_visit, &dst->last_visit);
-    deserialize(src.sky_texture_name, &dst->sky_texture_name);
+void reconstruct(const LocationTime_MM7 &src, LocationTime *dst) {
+    reconstruct(src.last_visit, &dst->last_visit);
+    reconstruct(src.sky_texture_name, &dst->sky_texture_name);
     dst->day_attrib = src.day_attrib;
     dst->day_fogrange_1 = src.day_fogrange_1;
     dst->day_fogrange_2 = src.day_fogrange_2;
 }
 
-void deserialize(const SoundInfo_MM6 &src, SoundInfo *dst) {
-    deserialize(src.pSoundName, &dst->sName);
+void reconstruct(const SoundInfo_MM6 &src, SoundInfo *dst) {
+    reconstruct(src.pSoundName, &dst->sName);
     dst->uSoundID = src.uSoundID;
     dst->eType = static_cast<SOUND_TYPE>(src.eType);
     dst->uFlags = src.uFlags;
 }
 
-void deserialize(const SoundInfo_MM7 &src, SoundInfo *dst) {
-    deserialize(static_cast<const SoundInfo_MM6 &>(src), dst);
+void reconstruct(const SoundInfo_MM7 &src, SoundInfo *dst) {
+    reconstruct(static_cast<const SoundInfo_MM6 &>(src), dst);
 }
 
-void serialize(const LocationInfo &src, LocationInfo_MM7 *dst) {
+void snapshot(const LocationInfo &src, LocationInfo_MM7 *dst) {
     dst->respawnCount = src.respawnCount;
     dst->lastRespawnDay = src.lastRespawnDay;
     dst->reputation = src.reputation;
     dst->alertStatus = src.alertStatus;
 }
 
-void deserialize(const LocationInfo_MM7 &src, LocationInfo *dst) {
+void reconstruct(const LocationInfo_MM7 &src, LocationInfo *dst) {
     dst->respawnCount = src.respawnCount;
     dst->lastRespawnDay = src.lastRespawnDay;
     dst->reputation = src.reputation;
     dst->alertStatus = src.alertStatus;
 }
 
-void serialize(const PersistentVariables &src, MapEventVariables_MM7 *dst) {
+void snapshot(const PersistentVariables &src, MapEventVariables_MM7 *dst) {
     memzero(dst);
 
     dst->mapVars = src.mapVars;
     dst->decorVars = src.decorVars;
 }
 
-void deserialize(const MapEventVariables_MM7 &src, PersistentVariables *dst) {
+void reconstruct(const MapEventVariables_MM7 &src, PersistentVariables *dst) {
     dst->mapVars = src.mapVars;
     dst->decorVars = src.decorVars;
 }
 
-void deserialize(const OutdoorLocationTileType_MM7 &src, OutdoorLocationTileType *dst) {
+void reconstruct(const OutdoorLocationTileType_MM7 &src, OutdoorLocationTileType *dst) {
     dst->tileset = static_cast<Tileset>(src.tileset);
     dst->uTileID = src.tileId;
 }
 
-void serialize(const SaveGameHeader &src, SaveGameHeader_MM7 *dst) {
+void snapshot(const SaveGameHeader &src, SaveGameHeader_MM7 *dst) {
     memzero(dst);
 
-    serialize(src.name, &dst->name);
-    serialize(src.locationName, &dst->locationName);
-    serialize(src.playingTime, &dst->playingTime);
+    snapshot(src.name, &dst->name);
+    snapshot(src.locationName, &dst->locationName);
+    snapshot(src.playingTime, &dst->playingTime);
 }
 
-void deserialize(const SaveGameHeader_MM7 &src, SaveGameHeader *dst) {
-    deserialize(src.name, &dst->name);
-    deserialize(src.locationName, &dst->locationName);
-    deserialize(src.playingTime, &dst->playingTime);
+void reconstruct(const SaveGameHeader_MM7 &src, SaveGameHeader *dst) {
+    reconstruct(src.name, &dst->name);
+    reconstruct(src.locationName, &dst->locationName);
+    reconstruct(src.playingTime, &dst->playingTime);
     // field_30 is ignored.
 }

--- a/src/Engine/Serialization/LegacyImages.h
+++ b/src/Engine/Serialization/LegacyImages.h
@@ -97,7 +97,7 @@ struct SpriteFrame_MM7 : public SpriteFrame_MM6 {
 static_assert(sizeof(SpriteFrame_MM7) == 60);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SpriteFrame_MM7)
 
-void deserialize(const SpriteFrame_MM7 &src, SpriteFrame *dst);
+void reconstruct(const SpriteFrame_MM7 &src, SpriteFrame *dst);
 
 
 struct BLVFace_MM7 {
@@ -125,7 +125,7 @@ struct BLVFace_MM7 {
 static_assert(sizeof(BLVFace_MM7) == 0x60);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVFace_MM7)
 
-void deserialize(const BLVFace_MM7 &src, BLVFace *dst);
+void reconstruct(const BLVFace_MM7 &src, BLVFace *dst);
 
 
 struct TileDesc_MM7 {
@@ -139,7 +139,7 @@ struct TileDesc_MM7 {
 static_assert(sizeof(TileDesc_MM7) == 26);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(TileDesc_MM7)
 
-void deserialize(const TileDesc_MM7 &src, TileDesc *dst);
+void reconstruct(const TileDesc_MM7 &src, TileDesc *dst);
 
 
 struct TextureFrame_MM7 {
@@ -152,7 +152,7 @@ struct TextureFrame_MM7 {
 static_assert(sizeof(TextureFrame_MM7) == 20);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(TextureFrame_MM7)
 
-void deserialize(const TextureFrame_MM7 &src, TextureFrame *dst);
+void reconstruct(const TextureFrame_MM7 &src, TextureFrame *dst);
 
 
 struct NPCData_MM7 {
@@ -180,8 +180,8 @@ struct NPCData_MM7 {
 static_assert(sizeof(NPCData_MM7) == 0x4C);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(NPCData_MM7)
 
-void serialize(const NPCData &src, NPCData_MM7 *dst);
-void deserialize(const NPCData_MM7 &src, NPCData *dst);
+void snapshot(const NPCData &src, NPCData_MM7 *dst);
+void reconstruct(const NPCData_MM7 &src, NPCData *dst);
 
 
 struct ItemGen_MM7 {
@@ -200,8 +200,8 @@ struct ItemGen_MM7 {
 static_assert(sizeof(ItemGen_MM7) == 0x24);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ItemGen_MM7)
 
-void serialize(const ItemGen &src, ItemGen_MM7 *dst);
-void deserialize(const ItemGen_MM7 &src, ItemGen *dst);
+void snapshot(const ItemGen &src, ItemGen_MM7 *dst);
+void reconstruct(const ItemGen_MM7 &src, ItemGen *dst);
 
 
 struct SpellBuff_MM7 {
@@ -216,8 +216,8 @@ struct SpellBuff_MM7 {
 static_assert(sizeof(SpellBuff_MM7) == 0x10);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SpellBuff_MM7)
 
-void serialize(const SpellBuff &src, SpellBuff_MM7 *dst);
-void deserialize(const SpellBuff_MM7 &src, SpellBuff *dst);
+void snapshot(const SpellBuff &src, SpellBuff_MM7 *dst);
+void reconstruct(const SpellBuff_MM7 &src, SpellBuff *dst);
 
 
 struct PlayerSpellbookChapter_MM7 {
@@ -387,8 +387,8 @@ struct Player_MM7 {
 static_assert(sizeof(Player_MM7) == 0x1B3C);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Player_MM7)
 
-void serialize(const Player &src, Player_MM7 *dst);
-void deserialize(const Player_MM7 &src, Player *dst);
+void snapshot(const Player &src, Player_MM7 *dst);
+void reconstruct(const Player_MM7 &src, Player *dst);
 
 
 struct PartyTimeStruct_MM7 {
@@ -506,8 +506,8 @@ struct Party_MM7 {
 static_assert(sizeof(Party_MM7) == 0x16238);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Party_MM7)
 
-void serialize(const Party &src, Party_MM7 *dst);
-void deserialize(const Party_MM7 &src, Party *dst);
+void snapshot(const Party &src, Party_MM7 *dst);
+void reconstruct(const Party_MM7 &src, Party *dst);
 
 struct Timer_MM7 {
     /* 00 */ uint32_t ready;
@@ -525,8 +525,8 @@ struct Timer_MM7 {
 static_assert(sizeof(Timer_MM7) == 0x28);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Timer_MM7)
 
-void serialize(const Timer &src, Timer_MM7 *dst);
-void deserialize(const Timer_MM7 &src, Timer *dst);
+void snapshot(const Timer &src, Timer_MM7 *dst);
+void reconstruct(const Timer_MM7 &src, Timer *dst);
 
 
 struct ActiveOverlay_MM7 {
@@ -544,8 +544,8 @@ struct ActiveOverlay_MM7 {
 static_assert(sizeof(ActiveOverlay_MM7) == 0x14);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ActiveOverlay_MM7)
 
-void serialize(const ActiveOverlay &src, ActiveOverlay_MM7 *dst);
-void deserialize(const ActiveOverlay_MM7 &src, ActiveOverlay *dst);
+void snapshot(const ActiveOverlay &src, ActiveOverlay_MM7 *dst);
+void reconstruct(const ActiveOverlay_MM7 &src, ActiveOverlay *dst);
 
 
 struct ActiveOverlayList_MM7 {
@@ -557,8 +557,8 @@ struct ActiveOverlayList_MM7 {
 static_assert(sizeof(ActiveOverlayList_MM7) == 0x3F0);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ActiveOverlayList_MM7)
 
-void serialize(const ActiveOverlayList &src, ActiveOverlayList_MM7 *dst);
-void deserialize(const ActiveOverlayList_MM7 &src, ActiveOverlayList *dst);
+void snapshot(const ActiveOverlayList &src, ActiveOverlayList_MM7 *dst);
+void reconstruct(const ActiveOverlayList_MM7 &src, ActiveOverlayList *dst);
 
 
 struct IconFrame_MM7 {
@@ -572,8 +572,8 @@ struct IconFrame_MM7 {
 static_assert(sizeof(IconFrame_MM7) == 0x20);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(IconFrame_MM7)
 
-void serialize(const Icon &src, IconFrame_MM7 *dst);
-void deserialize(const IconFrame_MM7 &src, Icon *dst);
+void snapshot(const Icon &src, IconFrame_MM7 *dst);
+void reconstruct(const IconFrame_MM7 &src, Icon *dst);
 
 
 struct UIAnimation_MM7 {
@@ -588,8 +588,8 @@ struct UIAnimation_MM7 {
 static_assert(sizeof(UIAnimation_MM7) == 0xD);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(UIAnimation_MM7)
 
-void serialize(const UIAnimation &src, UIAnimation_MM7 *dst);
-void deserialize(const UIAnimation_MM7 &src, UIAnimation *dst);
+void snapshot(const UIAnimation &src, UIAnimation_MM7 *dst);
+void reconstruct(const UIAnimation_MM7 &src, UIAnimation *dst);
 
 
 struct MonsterInfo_MM7 {
@@ -669,7 +669,7 @@ struct MonsterDesc_MM6 {
 static_assert(sizeof(MonsterDesc_MM6) == 148);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(MonsterDesc_MM6)
 
-void deserialize(const MonsterDesc_MM6 &src, MonsterDesc *dst);
+void reconstruct(const MonsterDesc_MM6 &src, MonsterDesc *dst);
 
 
 struct MonsterDesc_MM7 {
@@ -686,8 +686,8 @@ struct MonsterDesc_MM7 {
 static_assert(sizeof(MonsterDesc_MM7) == 152);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(MonsterDesc_MM7)
 
-void serialize(const MonsterDesc &src, MonsterDesc_MM7 *dst);
-void deserialize(const MonsterDesc_MM7 &src, MonsterDesc *dst);
+void snapshot(const MonsterDesc &src, MonsterDesc_MM7 *dst);
+void reconstruct(const MonsterDesc_MM7 &src, MonsterDesc *dst);
 
 
 struct ActorJob_MM7 {
@@ -701,8 +701,8 @@ struct ActorJob_MM7 {
 static_assert(sizeof(ActorJob_MM7) == 12);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ActorJob_MM7)
 
-void serialize(const ActorJob &src, ActorJob_MM7 *dst);
-void deserialize(const ActorJob_MM7 &src, ActorJob *dst);
+void snapshot(const ActorJob &src, ActorJob_MM7 *dst);
+void reconstruct(const ActorJob_MM7 &src, ActorJob *dst);
 
 
 struct Actor_MM7 {
@@ -748,8 +748,8 @@ struct Actor_MM7 {
 static_assert(sizeof(Actor_MM7) == 0x344);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Actor_MM7)
 
-void serialize(const Actor &src, Actor_MM7 *dst);
-void deserialize(const Actor_MM7 &src, Actor *dst);
+void snapshot(const Actor &src, Actor_MM7 *dst);
+void reconstruct(const Actor_MM7 &src, Actor *dst);
 
 
 struct BLVDoor_MM7 {
@@ -778,8 +778,8 @@ struct BLVDoor_MM7 {
 static_assert(sizeof(BLVDoor_MM7) == 0x50);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVDoor_MM7)
 
-void serialize(const BLVDoor &src, BLVDoor_MM7 *dst);
-void deserialize(const BLVDoor_MM7 &src, BLVDoor *dst);
+void snapshot(const BLVDoor &src, BLVDoor_MM7 *dst);
+void reconstruct(const BLVDoor_MM7 &src, BLVDoor *dst);
 
 
 struct BLVSector_MM7 {
@@ -828,8 +828,8 @@ struct BLVSector_MM7 {
 static_assert(sizeof(BLVSector_MM7) == 0x74);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVSector_MM7)
 
-void serialize(const BLVSector &src, BLVSector_MM7 *dst);
-void deserialize(const BLVSector_MM7 &src, BLVSector *dst);
+void snapshot(const BLVSector &src, BLVSector_MM7 *dst);
+void reconstruct(const BLVSector_MM7 &src, BLVSector *dst);
 
 
 struct GUICharMetric_MM7 {
@@ -840,8 +840,8 @@ struct GUICharMetric_MM7 {
 static_assert(sizeof(GUICharMetric_MM7) == 12);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(GUICharMetric_MM7)
 
-void serialize(const GUICharMetric &src, GUICharMetric_MM7 *dst);
-void deserialize(const GUICharMetric_MM7 &src, GUICharMetric *dst);
+void snapshot(const GUICharMetric &src, GUICharMetric_MM7 *dst);
+void reconstruct(const GUICharMetric_MM7 &src, GUICharMetric *dst);
 
 
 struct FontData_MM7 {
@@ -861,8 +861,8 @@ struct FontData_MM7 {
 static_assert(sizeof(FontData_MM7) == 0x1020);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(FontData_MM7)
 
-void serialize(const FontData &src, FontData_MM7 *dst);
-void deserialize(const FontData_MM7 &src, size_t size, FontData *dst);
+void snapshot(const FontData &src, FontData_MM7 *dst);
+void reconstruct(const FontData_MM7 &src, size_t size, FontData *dst);
 
 
 struct ODMFace_MM7 {
@@ -900,7 +900,7 @@ struct ODMFace_MM7 {
 static_assert(sizeof(ODMFace_MM7) == 308);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ODMFace_MM7)
 
-void deserialize(const ODMFace_MM7 &src, ODMFace *dst);
+void reconstruct(const ODMFace_MM7 &src, ODMFace *dst);
 
 
 struct SpawnPoint_MM6 {
@@ -924,7 +924,7 @@ struct SpawnPoint_MM7 {
 static_assert(sizeof(SpawnPoint_MM7) == 24);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SpawnPoint_MM7)
 
-void deserialize(const SpawnPoint_MM7 &src, SpawnPoint *dst);
+void reconstruct(const SpawnPoint_MM7 &src, SpawnPoint *dst);
 
 
 struct SpriteObject_MM7 {
@@ -955,8 +955,8 @@ struct SpriteObject_MM7 {
 static_assert(sizeof(SpriteObject_MM7) == 0x70);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SpriteObject_MM7)
 
-void serialize(const SpriteObject &src, SpriteObject_MM7 *dst);
-void deserialize(const SpriteObject_MM7 &src, SpriteObject *dst);
+void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst);
+void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst);
 
 
 struct ChestDesc_MM7 {
@@ -968,7 +968,7 @@ struct ChestDesc_MM7 {
 static_assert(sizeof(ChestDesc_MM7) == 36);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ChestDesc_MM7)
 
-void deserialize(const ChestDesc_MM7 &src, ChestDesc *dst);
+void reconstruct(const ChestDesc_MM7 &src, ChestDesc *dst);
 
 
 struct DecorationDesc_MM6 {
@@ -995,8 +995,8 @@ struct DecorationDesc_MM7 : public DecorationDesc_MM6 {
 static_assert(sizeof(DecorationDesc_MM7) == 84);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(DecorationDesc_MM7)
 
-void deserialize(const DecorationDesc_MM6 &src, DecorationDesc *dst);
-void deserialize(const DecorationDesc_MM7 &src, DecorationDesc *dst);
+void reconstruct(const DecorationDesc_MM6 &src, DecorationDesc *dst);
+void reconstruct(const DecorationDesc_MM7 &src, DecorationDesc *dst);
 
 
 struct Chest_MM7 {
@@ -1008,8 +1008,8 @@ struct Chest_MM7 {
 static_assert(sizeof(Chest_MM7) == 5324);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Chest_MM7)
 
-void serialize(const Chest &src, Chest_MM7 *dst);
-void deserialize(const Chest_MM7 &src, Chest *dst);
+void snapshot(const Chest &src, Chest_MM7 *dst);
+void reconstruct(const Chest_MM7 &src, Chest *dst);
 
 
 struct BLVLight_MM6 {
@@ -1034,7 +1034,7 @@ struct BLVLight_MM7 {
 static_assert(sizeof(BLVLight_MM7) == 16);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVLight_MM7)
 
-void deserialize(const BLVLight_MM7 &src, BLVLight *dst);
+void reconstruct(const BLVLight_MM7 &src, BLVLight *dst);
 
 
 struct OverlayDesc_MM7 {
@@ -1046,7 +1046,7 @@ struct OverlayDesc_MM7 {
 static_assert(sizeof(OverlayDesc_MM7) == 8);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(OverlayDesc_MM7)
 
-void deserialize(const OverlayDesc_MM7 &src, OverlayDesc *dst);
+void reconstruct(const OverlayDesc_MM7 &src, OverlayDesc *dst);
 
 
 struct PlayerFrame_MM7 {
@@ -1059,7 +1059,7 @@ struct PlayerFrame_MM7 {
 static_assert(sizeof(PlayerFrame_MM7) == 10);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(PlayerFrame_MM7)
 
-void deserialize(const PlayerFrame_MM7 &src, PlayerFrame *dst);
+void reconstruct(const PlayerFrame_MM7 &src, PlayerFrame *dst);
 
 
 struct LevelDecoration_MM7 {
@@ -1077,7 +1077,7 @@ struct LevelDecoration_MM7 {
 static_assert(sizeof(LevelDecoration_MM7) == 32);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(LevelDecoration_MM7)
 
-void deserialize(const LevelDecoration_MM7 &src, LevelDecoration *dst);
+void reconstruct(const LevelDecoration_MM7 &src, LevelDecoration *dst);
 
 
 struct BLVFaceExtra_MM7 {
@@ -1103,7 +1103,7 @@ struct BLVFaceExtra_MM7 {
 static_assert(sizeof(BLVFaceExtra_MM7) == 36);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVFaceExtra_MM7)
 
-void deserialize(const BLVFaceExtra_MM7 &src, BLVFaceExtra *dst);
+void reconstruct(const BLVFaceExtra_MM7 &src, BLVFaceExtra *dst);
 
 
 struct BSPNode_MM7 {
@@ -1115,7 +1115,7 @@ struct BSPNode_MM7 {
 static_assert(sizeof(BSPNode_MM7) == 8);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BSPNode_MM7)
 
-void deserialize(const BSPNode_MM7 &src, BSPNode *dst);
+void reconstruct(const BSPNode_MM7 &src, BSPNode *dst);
 
 
 struct BLVMapOutline_MM7 {
@@ -1129,7 +1129,7 @@ struct BLVMapOutline_MM7 {
 static_assert(sizeof(BLVMapOutline_MM7) == 12);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVMapOutline_MM7)
 
-void deserialize(const BLVMapOutline_MM7 &src, BLVMapOutline *dst);
+void reconstruct(const BLVMapOutline_MM7 &src, BLVMapOutline *dst);
 
 
 struct ObjectDesc_MM6 {
@@ -1168,8 +1168,8 @@ struct ObjectDesc_MM7 {
 static_assert(sizeof(ObjectDesc_MM7) == 56);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(ObjectDesc_MM7)
 
-void deserialize(const ObjectDesc_MM6 &src, ObjectDesc *dst);
-void deserialize(const ObjectDesc_MM7 &src, ObjectDesc *dst);
+void reconstruct(const ObjectDesc_MM6 &src, ObjectDesc *dst);
+void reconstruct(const ObjectDesc_MM7 &src, ObjectDesc *dst);
 
 
 struct BSPModelData_MM7 {
@@ -1218,8 +1218,8 @@ struct LocationTime_MM7 {
 static_assert(sizeof(LocationTime_MM7) == 0x38);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(LocationTime_MM7)
 
-void serialize(const LocationTime &src, LocationTime_MM7 *dst);
-void deserialize(const LocationTime_MM7 &src, LocationTime *dst);
+void snapshot(const LocationTime &src, LocationTime_MM7 *dst);
+void reconstruct(const LocationTime_MM7 &src, LocationTime *dst);
 
 
 struct SoundInfo_MM6 {
@@ -1239,8 +1239,8 @@ struct SoundInfo_MM7 : public SoundInfo_MM6 {
 static_assert(sizeof(SoundInfo_MM7) == 120);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SoundInfo_MM7)
 
-void deserialize(const SoundInfo_MM6 &src, SoundInfo *dst);
-void deserialize(const SoundInfo_MM7 &src, SoundInfo *dst);
+void reconstruct(const SoundInfo_MM6 &src, SoundInfo *dst);
+void reconstruct(const SoundInfo_MM7 &src, SoundInfo *dst);
 
 
 struct LocationInfo_MM7 {
@@ -1252,8 +1252,8 @@ struct LocationInfo_MM7 {
 static_assert(sizeof(LocationInfo_MM7) == 16);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(LocationInfo_MM7)
 
-void serialize(const LocationInfo &src, LocationInfo_MM7 *dst);
-void deserialize(const LocationInfo_MM7 &src, LocationInfo *dst);
+void snapshot(const LocationInfo &src, LocationInfo_MM7 *dst);
+void reconstruct(const LocationInfo_MM7 &src, LocationInfo *dst);
 
 
 struct LocationHeader_MM7 {
@@ -1268,7 +1268,7 @@ struct LocationHeader_MM7 {
 static_assert(sizeof(LocationHeader_MM7) == 40);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(LocationHeader_MM7)
 // LocationHeader_MM7 is only used during deserialization and doesn't have a runtime equivalent,
-// so no deserialize() overloads for it.
+// so no reconstruct() overloads for it.
 
 
 // TODO(captainurist): PersistentVariables_MM7
@@ -1279,8 +1279,8 @@ struct MapEventVariables_MM7 {
 static_assert(sizeof(MapEventVariables_MM7) == 0xC8);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(MapEventVariables_MM7)
 
-void serialize(const PersistentVariables &src, MapEventVariables_MM7 *dst);
-void deserialize(const MapEventVariables_MM7 &src, PersistentVariables *dst);
+void snapshot(const PersistentVariables &src, MapEventVariables_MM7 *dst);
+void reconstruct(const MapEventVariables_MM7 &src, PersistentVariables *dst);
 
 
 struct BLVHeader_MM7 {
@@ -1294,7 +1294,7 @@ struct BLVHeader_MM7 {
 static_assert(sizeof(BLVHeader_MM7) == 136);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVHeader_MM7)
 // BLVHeader_MM7 is only used during deserialization and doesn't have a runtime equivalent,
-// so no deserialize() overloads for it.
+// so no reconstruct() overloads for it.
 
 
 struct OutdoorLocationTileType_MM7 {
@@ -1304,7 +1304,7 @@ struct OutdoorLocationTileType_MM7 {
 static_assert(sizeof(OutdoorLocationTileType_MM7) == 4);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(OutdoorLocationTileType_MM7)
 
-void deserialize(const OutdoorLocationTileType_MM7 &src, OutdoorLocationTileType *dst);
+void reconstruct(const OutdoorLocationTileType_MM7 &src, OutdoorLocationTileType *dst);
 
 
 struct SaveGameHeader_MM7 {
@@ -1316,8 +1316,8 @@ struct SaveGameHeader_MM7 {
 static_assert(sizeof(SaveGameHeader_MM7) == 0x64);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SaveGameHeader_MM7)
 
-void serialize(const SaveGameHeader &src, SaveGameHeader_MM7 *dst);
-void deserialize(const SaveGameHeader_MM7 &src, SaveGameHeader *dst);
+void snapshot(const SaveGameHeader &src, SaveGameHeader_MM7 *dst);
+void reconstruct(const SaveGameHeader_MM7 &src, SaveGameHeader *dst);
 
 
 #pragma pack(pop)

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -62,7 +62,7 @@ GUIFont *GUIFont::LoadFont(const char *pFontFile, const char *pFontPalette) {
 
     // pFont->pData = (FontData*)pIcons_LOD->LoadCompressedTexture(pFontFile);
     Blob tmp_font = pIcons_LOD->LoadCompressedTexture(pFontFile);
-    deserialize(*static_cast<const FontData_MM7 *>(tmp_font.data()), tmp_font.size(), pFont->pData);
+    reconstruct(*static_cast<const FontData_MM7 *>(tmp_font.data()), tmp_font.size(), pFont->pData);
 
     int pallete_index = pIcons_LOD->LoadTexture(pFontPalette, TEXTURE_24BIT_PALETTE);
     if (pallete_index == -1)

--- a/src/Library/Binary/BlobSerialization.h
+++ b/src/Library/Binary/BlobSerialization.h
@@ -7,16 +7,16 @@
 #include "Utility/Streams/StringOutputStream.h"
 #include "Utility/Memory/Blob.h"
 
-template<class T, class... Tag> requires (sizeof...(Tag) <= 1)
-void serialize(const T &src, Blob *dst, const Tag &... tag) {
+template<class Src, class... Tag> requires (sizeof...(Tag) <= 1)
+void serialize(const Src &src, Blob *dst, const Tag &... tag) {
     std::string tmp;
     StringOutputStream stream(&tmp);
     serialize(src, &stream, tag...);
     *dst = Blob::fromString(std::move(tmp));
 }
 
-template<class T, class... Tag> requires (sizeof...(Tag) <= 1)
-void deserialize(const Blob &src, T &&dst, const Tag &... tag) {
+template<class Dst, class... Tag> requires (sizeof...(Tag) <= 1)
+void deserialize(const Blob &src, Dst *dst, const Tag &... tag) {
     MemoryInputStream stream(src.data(), src.size());
-    deserialize(stream, std::forward<T>(dst), tag...);
+    deserialize(stream, dst, tag...);
 }


### PR DESCRIPTION
* Conversion functions to/from legacy image classes (the ones with `_MM*` suffix) are now called `snapshot` / `reconstruct` instead of `serialize` / `deserialize`.
* Minor changes in associated serialization tags.