### PR TITLE
Set colors explicitry, drop special processing of Color()

### DIFF
--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -2962,7 +2962,7 @@ void SetStartConditions() {
 }
 
 void am_DrawText(const std::string &str, Pointi *pXY) {
-    pPrimaryWindow->DrawText(pFontComic, {pXY->x, pXY->y - ((pFontComic->GetHeight() - 3) / 2) + 3}, Color(), str);
+    pPrimaryWindow->DrawText(pFontComic, {pXY->x, pXY->y - ((pFontComic->GetHeight() - 3) / 2) + 3}, colorTable.White, str);
 }
 
 void DrawRect(Recti *pRect, Color uColor, char bSolidFill) {

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2496,7 +2496,6 @@ int bDialogueUI_InitializeActor_NPC_ID;
 
 int dword_5C35D4;
 
-Color ui_current_text_color;
 int64_t qword_5C6DF0;
 
 struct FactionTable *pFactionTable;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -129,7 +129,6 @@ extern int bDialogueUI_InitializeActor_NPC_ID;
 
 extern int dword_5C35D4;
 extern std::array<char, 10000> pTmpBuf3;
-extern Color ui_current_text_color;
 extern int64_t qword_5C6DF0;
 extern struct FactionTable *pFactionTable;
 

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -80,7 +80,7 @@ class GUIFont {
     std::string FitTwoFontStringINWindow(const std::string &pString, GUIFont *pFontSecond,
                                     GUIWindow *pWindow, int startPixlOff,
                                     int a6);
-    void DrawTextLineToBuff(Color uColor, Color *uX_buff_pos,
+    void DrawTextLineToBuff(Color color, Color *uX_buff_pos,
                             const std::string &text, int line_width);
 };
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -313,7 +313,7 @@ void GUIWindow::DrawMessageBox(bool inside_game_viewport) {
         current_window.DrawTitleText(
             pFontLucida,
             0, (int)(uBoxHeight - pFontLucida->CalcTextHeight(this->sHint, current_window.uFrameWidth, 0)) / 2 - 14,
-            Color(), this->sHint, 3);
+            colorTable.White, this->sHint, 3);
     }
 }
 
@@ -364,7 +364,6 @@ void GUIWindow::DrawShops_next_generation_time_string(GameTime time) {
 //----- (0044D406) --------------------------------------------------------
 void GUIWindow::DrawTitleText(GUIFont *pFont, int horizontalMargin, int verticalMargin, Color color, const std::string &text, int lineSpacing) {
     int width = this->uFrameWidth - horizontalMargin;
-    ui_current_text_color = color;
     std::string resString = pFont->FitTextInAWindow(text, this->uFrameWidth, horizontalMargin);
     std::istringstream stream(resString);
     std::string line;
@@ -442,7 +441,7 @@ void GUIWindow::InitializeGUI() {
 void GUIWindow::DrawFlashingInputCursor(int uX, int uY, GUIFont *a2) {
     // TODO(pskelton): check tickcount usage here
     if (platform->tickCount() % 1000 > 500) {
-        DrawText(a2, {uX, uY}, Color(), "_");
+        DrawText(a2, {uX, uY}, colorTable.White, "_");
     }
 }
 
@@ -900,7 +899,7 @@ void SetUserInterface(PartyAlignment align, bool bReplace) {
 }
 
 void DrawBuff_remaining_time_string(int uY, GUIWindow *window, GameTime remaining_time, GUIFont *Font) {
-    window->DrawText(Font, {32, uY}, Color(), "\r020" + MakeDateTimeString(remaining_time));
+    window->DrawText(Font, {32, uY}, colorTable.White, "\r020" + MakeDateTimeString(remaining_time));
 }
 
 void GUIMessageQueue::AddMessageImpl(UIMessageType msg, int param,

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -504,7 +504,7 @@ void OnButtonClick::Update() {
     GUIButton *pButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pButton->vTextures[0]);
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 }
@@ -521,7 +521,7 @@ void OnButtonClick2::Update() {
         }
     }
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 }
@@ -532,7 +532,7 @@ void OnButtonClick3::Update() {
     GUIButton *pButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pButton->vTextures[1]);
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 }
@@ -554,7 +554,7 @@ void OnSaveLoad::Update() {
     GUIButton *pButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pButton->vTextures[0]);
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 
@@ -572,7 +572,7 @@ void OnCancel::Update() {
     GUIButton *pGUIButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pGUIButton->vTextures[0]);
     if (!sHint.empty()) {
-        pGUIButton->DrawLabel(sHint, pFontCreate, Color());
+        pGUIButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 
@@ -586,7 +586,7 @@ void OnCancel2::Update() {
     GUIButton *pButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pButton->vTextures[1]);
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 
@@ -601,7 +601,7 @@ void OnCancel3::Update() {
     GUIButton *pButton = static_cast<GUIButton *>(wData.ptr);
     render->DrawTextureNew(uFrameX / 640.0f, uFrameY / 480.0f, pButton->vTextures[0]);
     if (!sHint.empty()) {
-        pButton->DrawLabel(sHint, pFontCreate, Color());
+        pButton->DrawLabel(sHint, pFontCreate, colorTable.White);
     }
     Release();
 

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -80,7 +80,7 @@ void GUIWindow_LloydsBook::Update() {
         pText = localization->GetString(LSTR_SET_BEACON);
     }
 
-    pWindow.DrawTitleText(pBook2Font, 0, 22, Color(), pText, 3);
+    pWindow.DrawTitleText(pBook2Font, 0, 22, colorTable.White, pText, 3);
     if (bRecallingBeacon) {
         render->DrawTextureNew(pBtn_Book_1->uX / 640.0f, pBtn_Book_1->uY / 480.0f, ui_book_button1_on);
         render->DrawTextureNew(pBtn_Book_2->uX / 640.0f, pBtn_Book_2->uY / 480.0f, ui_book_button1_off);

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -82,5 +82,5 @@ void GUIWindow_TownPortalBook::Update() {
         }
     }
 
-    townPortalWindow.DrawTitleText(pBook2Font, 0, 22, Color(), localization->GetString(LSTR_TOWN_PORTAL), 3);
+    townPortalWindow.DrawTitleText(pBook2Font, 0, 22, colorTable.White, localization->GetString(LSTR_TOWN_PORTAL), 3);
 }

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -192,7 +192,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
                 ++itemcount;
         }
 
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), Color());
+        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
 
         if (!itemcount) {  // shop empty
             GameTime nextGenTime = pParty->PartyTimes.guildNextRefreshTime[houseId()];

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -159,7 +159,7 @@ void GUIWindow_MagicGuild::mainDialogue() {
 
     if (haveLearnableSkills) {
         std::string skill_price_label = localization->FormatString(LSTR_FMT_SKILL_COST_D, pPrice);
-        working_window.DrawTitleText(pFontArrus, 0, 146, Color(), skill_price_label, 3);
+        working_window.DrawTitleText(pFontArrus, 0, 146, colorTable.White, skill_price_label, 3);
     }
 
     drawOptions(optionsText, colorTable.Sunflower, 24);

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -284,7 +284,7 @@ void GUIWindow_Shop::sellDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), Color());
+        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), colorTable.White);
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
 
@@ -313,7 +313,7 @@ void GUIWindow_Shop::identifyDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), Color());
+        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), colorTable.White);
 
         Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
 
@@ -350,7 +350,7 @@ void GUIWindow_Shop::repairDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), Color());
+        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), colorTable.White);
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
 
@@ -397,9 +397,9 @@ void GUIWindow_WeaponShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (item_num) {
@@ -469,9 +469,9 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (pItemCount) {
@@ -572,9 +572,9 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), Color());
+            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (item_num) {

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -62,7 +62,7 @@ void GUIWindow_Tavern::arcomageRulesDialogue() {
     }
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);
-    DrawText(font, {12, 354 - pTextHeight}, Color(), font->FitTextInAWindow(str, dialog_window.uFrameWidth, 12));
+    DrawText(font, {12, 354 - pTextHeight}, colorTable.White, font->FitTextInAWindow(str, dialog_window.uFrameWidth, 12));
 }
 
 void GUIWindow_Tavern::arcomageVictoryCondDialogue() {
@@ -77,7 +77,7 @@ void GUIWindow_Tavern::arcomageVictoryCondDialogue() {
     int pTextHeight = pFontArrus->CalcTextHeight(label, dialog_window.uFrameWidth, 12) + 7;
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);
-    DrawText(pFontArrus, {12, 354 - pTextHeight}, Color(), pFontArrus->FitTextInAWindow(label, dialog_window.uFrameWidth, 12));
+    DrawText(pFontArrus, {12, 354 - pTextHeight}, colorTable.White, pFontArrus->FitTextInAWindow(label, dialog_window.uFrameWidth, 12));
 }
 
 void GUIWindow_Tavern::arcomageResultDialogue() {

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -54,7 +54,7 @@ void GUIWindow_TownHall::bountyHuntDialogue() {
     }
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);
-    window.DrawText(pOutString, {13, 354 - pTextHeight}, Color(), current_npc_text);
+    window.DrawText(pOutString, {13, 354 - pTextHeight}, colorTable.White, current_npc_text);
 }
 
 void GUIWindow_TownHall::payFineDialogue() {

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -127,7 +127,7 @@ void GUIWindow_Transport::mainDialogue() {
     }
 
     if (hasActiveRoute) {
-        travel_window.DrawTitleText(pFontArrus, 0, 146, Color(), travelCost, 3);
+        travel_window.DrawTitleText(pFontArrus, 0, 146, colorTable.White, travelCost, 3);
         drawOptions(optionsText, colorTable.PaleCanary, startingOffset, true);
     } else {
         int textHeight = pFontArrus->CalcTextHeight(localization->GetString(LSTR_COME_BACK_ANOTHER_DAY), travel_window.uFrameWidth, 0);

--- a/src/GUI/UI/UIArena.cpp
+++ b/src/GUI/UI/UIArena.cpp
@@ -130,7 +130,7 @@ void ArenaFight() {
     std::string v1 = pFontArrus->FitTextInAWindow(
         localization->GetString(LSTR_PLEASE_WAIT_WHILE_I_SUMMON), window.uFrameWidth,
         13);
-    pDialogueWindow->DrawText(pFontArrus, {13, 354 - v0}, Color(), v1);
+    pDialogueWindow->DrawText(pFontArrus, {13, 354 - v0}, colorTable.White, v1);
     render->Present();
     pParty->vPosition.x = 3849;
     pParty->vPosition.y = 5770;

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -851,7 +851,7 @@ static int CharacterUI_SkillsTab_Draw__DrawSkillTable(
 
     if (!num_skills_drawn) {
         y_offset += pFontLucida->GetHeight() - 3;
-        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, y_offset}, Color(), localization->GetString(LSTR_NONE));
+        pGUIWindow_CurrentMenu->DrawText(pFontLucida, {x, y_offset}, colorTable.White, localization->GetString(LSTR_NONE));
     }
 
     return y_offset;
@@ -869,7 +869,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_Draw(Player *player) {
                      player->uSkillPoints ? ui_character_bonus_text_color.tag()
                                           : ui_character_default_text_color.tag(),
                      player->uSkillPoints);
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, colorTable.White, str);
 
     int y = 2 * pFontLucida->GetHeight() + 13;
     y = CharacterUI_SkillsTab_Draw__DrawSkillTable(player, 24, y, allWeaponSkills(), 400, localization->GetString(LSTR_WEAPONS));
@@ -974,7 +974,7 @@ void GUIWindow_CharacterRecord::CharacterUI_AwardsTab_Draw(Player *player) {
     std::string str = fmt::format("{} {::}{}\f00000", localization->GetString(LSTR_AWARDS_FOR),
                                   ui_character_header_text_color.tag(), NameAndTitle(player->name, player->classType));
 
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, Color(), str);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {24, 18}, colorTable.White, str);
 
 
     if (_awardsCharacterId != pParty->activeCharacterIndex()) {
@@ -1543,7 +1543,7 @@ void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Player *player) {
                     localization->GetString(LSTR_SKILL_POINTS),
                     player->uSkillPoints ? ui_character_bonus_text_color.tag() : ui_character_default_text_color.tag(),
                     player->uSkillPoints);
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, 18}, Color(), str1);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, 18}, colorTable.White, str1);
 
     // Left column
     auto formatLeftCol = [] (int lstr, int current, int max) {
@@ -1557,43 +1557,43 @@ void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Player *player) {
     };
 
     int pY = 53;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_MIGHT, player->GetActualMight(), player->GetBaseMight()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_INTELLECT, player->GetActualIntelligence(), player->GetBaseIntelligence()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_PERSONALITY, player->GetActualPersonality(), player->GetBasePersonality()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_ENDURANCE, player->GetActualEndurance(), player->GetBaseEndurance()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_ACCURACY, player->GetActualAccuracy(), player->GetBaseAccuracy()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_SPEED, player->GetActualSpeed(), player->GetBaseSpeed()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_LUCK, player->GetActualLuck(), player->GetBaseLuck()));
 
     pY += 2 * pFontArrus->GetHeight() + 5;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_HIT_POINTS, player->health, player->GetMaxHealth()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_SPELL_POINTS, player->mana, player->GetMaxMana()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {26, pY}, colorTable.White,
                                      formatLeftCol(LSTR_ARMOR_CLASS, player->GetActualAC(), player->GetBaseAC()));
 
     pY += 2 * pFontArrus->GetHeight() - 2;
@@ -1602,14 +1602,14 @@ void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Player *player) {
                      localization->GetString(LSTR_CONDITION),
                      GetConditionDrawColor(player->GetMajorConditionIdx()).tag(),
                      localization->GetCharacterConditionName(player->GetMajorConditionIdx()));
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {26, pY}, Color(), str12, 226, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {26, pY}, colorTable.White, str12, 226, 0);
 
     pY += pFontArrus->GetHeight() + -1;
     std::string spellName = localization->GetString(LSTR_NONE);
     if (player->uQuickSpell != SPELL_NONE)
         spellName = pSpellStats->pInfos[player->uQuickSpell].pShortName;
     auto str13 = fmt::format("{}: {}", localization->GetString(LSTR_QUICK_SPELL), spellName);
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {26, pY}, Color(), str13, 226, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {26, pY}, colorTable.White, str13, 226, 0);
 
     // Right column
     auto formatRightCol = [] (int lstr, int current, int max, bool immune = false) {
@@ -1627,11 +1627,11 @@ void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Player *player) {
     };
 
     pY = 50;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_AGE, player->GetActualAge(), player->GetBaseAge()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_LEVEL, player->GetActualLevel(), player->GetBaseLevel()));
 
     pY += pFontArrus->GetHeight() - 2;
@@ -1639,53 +1639,53 @@ void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Player *player) {
         fmt::format("{}\r180{::}{}\f00000\n\n",
                     localization->GetString(player->experience <= 9999999 ? LSTR_EXPERIENCE : LSTR_EXP),
                     player->GetExperienceDisplayColor().tag(), player->experience);
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(), str16);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White, str16);
 
     pY += 2 * pFontArrus->GetHeight();
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      fmt::format("{}\t100{:+}\n", localization->GetString(LSTR_ATTACK), player->GetActualAttack(false)));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      fmt::format("{}\t100 {}\n", localization->GetString(LSTR_DAMAGE), player->GetMeleeDamageString()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      fmt::format("{}\t100{:+}\n", localization->GetString(LSTR_SHOOT), player->GetRangedAttack()));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      fmt::format("{}\t100 {}\n\n", localization->GetString(LSTR_DAMAGE), player->GetRangedDamageString()));
 
     pY += 2 * pFontArrus->GetHeight() - 4;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_FIRE, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_FIRE),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_FIRE)));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_AIR, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_AIR),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_AIR)));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_WATER, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_WATER),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_WATER)));
 
     pY += pFontArrus->GetHeight() - 2;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_EARTH, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_EARTH),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_EARTH)));
 
     pY += pFontArrus->GetHeight() - 2;
     bool immuneToMind = player->classType == PLAYER_CLASS_LICH && player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_MIND) == 200;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_MIND, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_MIND),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_MIND), immuneToMind));
 
     pY += pFontArrus->GetHeight() - 2;
     bool immuneToBody = player->classType == PLAYER_CLASS_LICH && player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_BODY) == 200;
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {266, pY}, colorTable.White,
                                      formatRightCol(LSTR_BODY, player->GetActualResistance(CHARACTER_ATTRIBUTE_RESIST_BODY),
                                                     player->GetBaseResistance(CHARACTER_ATTRIBUTE_RESIST_BODY), immuneToBody));
 }

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -296,7 +296,7 @@ void GUIWindow_Dialogue::Update() {
 
         render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
                                     _591428_endcap);
-        pDialogueWindow->DrawText(font, {13, 354 - pTextHeight}, Color(), font->FitTextInAWindow(dialogue_string, window.uFrameWidth, 13));
+        pDialogueWindow->DrawText(font, {13, 354 - pTextHeight}, colorTable.White, font->FitTextInAWindow(dialogue_string, window.uFrameWidth, 13));
     }
 
     // Right panel(Правая панель)-------
@@ -487,7 +487,7 @@ void GUIWindow_GenericDialogue::Update() {
                                     ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
                                 _591428_endcap);
-    pGUIWindow_BranchlessDialogue->DrawText(pFont, {12, 354 - pTextHeight}, Color(),
+    pGUIWindow_BranchlessDialogue->DrawText(pFont, {12, 354 - pTextHeight}, colorTable.White,
         pFont->FitTextInAWindow(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12));
     render->DrawTextureNew(0, 352 / 480.0f, game_ui_statusbar);
     if (pGUIWindow_BranchlessDialogue->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS) {
@@ -507,7 +507,7 @@ void GUIWindow_GenericDialogue::Update() {
 
     if (pGUIWindow_BranchlessDialogue->wData.val == (int)EVENT_InputString) {
         auto str = fmt::format("{} {}", GameUI_StatusBar_GetInput(), keyboardInputHandler->GetTextInput());
-        pGUIWindow_BranchlessDialogue->DrawText(pFontLucida, {13, 357}, Color(), str);
+        pGUIWindow_BranchlessDialogue->DrawText(pFontLucida, {13, 357}, colorTable.White, str);
         pGUIWindow_BranchlessDialogue->DrawFlashingInputCursor(pFontLucida->GetLineWidth(str) + 13, 357, pFontLucida);
         return;
     }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1777,7 +1777,7 @@ Color UI_GetHealthManaAndOtherQualitiesStringColor(int actual_value,
     uint16_t R, G, B;
 
     if (actual_value == base_value) {
-        return Color(); // Default - white.
+        return colorTable.White; // Default - white.
     } else if (actual_value < base_value) {
         if (100 * actual_value / base_value >=
             25)  // Yellow( current_pos > 1/4 )
@@ -1900,7 +1900,7 @@ void GUIWindow_DebugMenu::Update() {
         pViewport->uViewportTL_Y / 480.0f,
         game_ui_menu_options);
 
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 10}, Color(), "Debug Menu");
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 10}, colorTable.White, "Debug Menu");
 
     buttonbox(13, 140, "Town Portal", engine->config->debug.TownPortal.value());
     buttonbox(127, 140, "Give Gold", 2);
@@ -1967,7 +1967,7 @@ void buttonbox(int x, int y, const char *text, int col) {
 
     Color colour = ui_character_condition_severe_color;
     if (col == 2) {
-        colour = Color();
+        colour = colorTable.White;
     }
     if (col == 1) {
         colour = ui_character_bonus_text_color;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -478,19 +478,19 @@ void SimpleHouseDialog() {
         house_window.uFrameX = 493;
         house_window.uFrameWidth = 126;
         house_window.uFrameZ = 366;
-        house_window.DrawTitleText(pFontCreate, 0, 2, Color(),
+        house_window.DrawTitleText(pFontCreate, 0, 2, colorTable.White,
             pMapStats->pInfos[uHouse_ExitPic].pName, 3);
         house_window.uFrameX = SIDE_TEXT_BOX_POS_X;
         house_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
         house_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
         if (pTransitionStrings[uHouse_ExitPic].empty()) {
             auto str = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[uHouse_ExitPic].pName.c_str());
-            house_window.DrawTitleText(pFontCreate, 0, (212 - pFontCreate->CalcTextHeight(str, house_window.uFrameWidth, 0)) / 2 + 101, Color(), str, 3);
+            house_window.DrawTitleText(pFontCreate, 0, (212 - pFontCreate->CalcTextHeight(str, house_window.uFrameWidth, 0)) / 2 + 101, colorTable.White, str, 3);
             return;
         }
 
         int vertMargin = (212 - pFontCreate->CalcTextHeight(pTransitionStrings[uHouse_ExitPic], house_window.uFrameWidth, 0)) / 2 + 101;
-        house_window.DrawTitleText(pFontCreate, 0, vertMargin, Color(), pTransitionStrings[uHouse_ExitPic], 3);
+        house_window.DrawTitleText(pFontCreate, 0, vertMargin, colorTable.White, pTransitionStrings[uHouse_ExitPic], 3);
         return;
     }
     house_window.uFrameWidth -= 10;
@@ -522,7 +522,7 @@ void SimpleHouseDialog() {
 
                 int h = (pFontArrus->CalcTextHeight(pInString, house_window.uFrameWidth, 13) + 7);
                 render->DrawTextureNew(8 / 640.0f, (347 - h) / 480.0f, _591428_endcap);
-                pDialogueWindow->DrawText(pFontArrus, {13, 354 - h}, Color(),
+                pDialogueWindow->DrawText(pFontArrus, {13, 354 - h}, colorTable.White,
                     pFontArrus->FitTextInAWindow(pInString, house_window.uFrameWidth, 13));
             }
         }
@@ -663,7 +663,7 @@ void SimpleHouseDialog() {
             ui_leather_mm7, pTextHeight);
         render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f,
             _591428_endcap);
-        house_window.DrawText(pTextFont, {13, 354 - pTextHeight}, Color(), pTextFont->FitTextInAWindow(current_npc_text, w.uFrameWidth, 13));
+        house_window.DrawText(pTextFont, {13, 354 - pTextHeight}, colorTable.White, pTextFont->FitTextInAWindow(current_npc_text, w.uFrameWidth, 13));
     }
 }
 
@@ -955,7 +955,7 @@ void GUIWindow_House::houseDialogManager() {
             int v6 = pTextHeight + 7;
             render->DrawTextureCustomHeight(8 / 640.0f, (352 - (pTextHeight + 7)) / 480.0f, ui_leather_mm7, pTextHeight + 7);
             render->DrawTextureNew(8 / 640.0f, (347 - v6) / 480.0f, _591428_endcap);
-            DrawText(pFontArrus, {13, 354 - v6}, Color(), pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13));
+            DrawText(pFontArrus, {13, 354 - v6}, colorTable.White, pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13));
         }
         if (uNumDialogueNPCPortraits <= 0) {
             if (pDialogueNPCCount == uNumDialogueNPCPortraits &&
@@ -1080,7 +1080,7 @@ void GUIWindow_House::learnSkillsDialogue() {
     }
 
     std::string skill_price_label = localization->FormatString(LSTR_FMT_SKILL_COST_D, cost);
-    dialogue.DrawTitleText(pFontArrus, 0, 146, Color(), skill_price_label, 3);
+    dialogue.DrawTitleText(pFontArrus, 0, 146, colorTable.White, skill_price_label, 3);
 
     drawOptions(optionsText, colorTable.Sunflower, 18);
 }

--- a/src/GUI/UI/UIInventory.cpp
+++ b/src/GUI/UI/UIInventory.cpp
@@ -16,8 +16,8 @@
 
 void GUIWindow_Inventory::Update() {
     DrawMessageBox(0);
-    DrawText(pFontLucida, {10, 20}, Color(), "Making item number");
-    DrawText(pFontLucida, {10, 40}, Color(), keyboardInputHandler->GetTextInput());
+    DrawText(pFontLucida, {10, 20}, colorTable.White, "Making item number");
+    DrawText(pFontLucida, {10, 40}, colorTable.White, keyboardInputHandler->GetTextInput());
 
     // a hack to capture end of user input (enter) while avoiding listening to UI message handler
     // redo this in a more clean way

--- a/src/GUI/UI/UIMessageScroll.cpp
+++ b/src/GUI/UI/UIMessageScroll.cpp
@@ -37,6 +37,6 @@ void GUIWindow_MessageScroll::Update() {
 
     const std::string &name = pItemTable->pItems[pGUIWindow_ScrollWindow->scroll_type].name;
 
-    a1.DrawTitleText(pFontCreate, 0, 0, Color(), fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), name), 3);
+    a1.DrawTitleText(pFontCreate, 0, 0, colorTable.White, fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), name), 3);
     a1.DrawText(pFontSmallnum, {1, pFontCreate->GetHeight() - 3}, Color(), pMessageScrolls[pGUIWindow_ScrollWindow->scroll_type]);
 }

--- a/src/GUI/UI/UIMessageScroll.cpp
+++ b/src/GUI/UI/UIMessageScroll.cpp
@@ -38,5 +38,5 @@ void GUIWindow_MessageScroll::Update() {
     const std::string &name = pItemTable->pItems[pGUIWindow_ScrollWindow->scroll_type].name;
 
     a1.DrawTitleText(pFontCreate, 0, 0, colorTable.White, fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), name), 3);
-    a1.DrawText(pFontSmallnum, {1, pFontCreate->GetHeight() - 3}, Color(), pMessageScrolls[pGUIWindow_ScrollWindow->scroll_type]);
+    a1.DrawText(pFontSmallnum, {1, pFontCreate->GetHeight() - 3}, colorTable.White, pMessageScrolls[pGUIWindow_ScrollWindow->scroll_type]);
 }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -334,7 +334,7 @@ void GUIWindow_PartyCreation::Update() {
 
     pTextCenter = ui_partycreation_font->AlignText_Center(
         640, localization->GetString(LSTR_CREATE_PARTY_FANCY));
-    pGUIWindow_CurrentMenu->DrawText(ui_partycreation_font, {pTextCenter + 1, 0}, Color(),
+    pGUIWindow_CurrentMenu->DrawText(ui_partycreation_font, {pTextCenter + 1, 0}, colorTable.White,
         localization->GetString(LSTR_CREATE_PARTY_FANCY));
 
     render->DrawTextureNew(17 / oldDims.w, 35 / oldDims.h, ui_partycreation_portraits[pParty->pPlayers[0].uCurrentFace]);
@@ -362,7 +362,7 @@ void GUIWindow_PartyCreation::Update() {
     pX_Numbers = oldDims.w - 147;  // 493;
 
     for (int i = 0; i < 4; ++i) {
-        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pIntervalX + 73, 100}, Color(),
+        pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pIntervalX + 73, 100}, colorTable.White,
             localization->GetClassName(pParty->pPlayers[i].classType));
         render->DrawTextureNew((pIntervalX + 77) / oldDims.w, 50 / oldDims.h, ui_partycreation_class_icons[pParty->pPlayers[i].classType / 4]);
 
@@ -370,7 +370,7 @@ void GUIWindow_PartyCreation::Update() {
             pGUIWindow_CurrentMenu->wData.val == i) {
             switch (pGUIWindow_CurrentMenu->keyboard_input_status) {
             case WINDOW_INPUT_IN_PROGRESS:  // press name panel
-                v17 = pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {159 * pGUIWindow_CurrentMenu->wData.val + 18, 124}, Color(),
+                v17 = pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {159 * pGUIWindow_CurrentMenu->wData.val + 18, 124}, colorTable.White,
                     keyboardInputHandler->GetTextInput(), 120, 1);
                 pGUIWindow_CurrentMenu->DrawFlashingInputCursor(159 * pGUIWindow_CurrentMenu->wData.val + v17 + 20, 124, pFontCreate);
                 break;
@@ -383,23 +383,23 @@ void GUIWindow_PartyCreation::Update() {
                 }
                 if (keyboardInputHandler->GetTextInput().size() > 0 && v126 != keyboardInputHandler->GetTextInput().size())
                     pParty->pPlayers[i].name = keyboardInputHandler->GetTextInput();
-                pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, Color(), pParty->pPlayers[i].name, 130, 0);
+                pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, colorTable.White, pParty->pPlayers[i].name, 130, 0);
                 pParty->pPlayers[i].field_1988[27] = 1;
                 break;
             case WINDOW_INPUT_CANCELLED:  // press escape
                 pGUIWindow_CurrentMenu->keyboard_input_status = WINDOW_INPUT_NONE;
-                pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, Color(), pParty->pPlayers[i].name, 130, 0);
+                pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, colorTable.White, pParty->pPlayers[i].name, 130, 0);
                 SetCurrentMenuID(MENU_NAMEPANELESC);
                 break;
             default:
                 break;
             }
         } else {
-            pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, Color(), pParty->pPlayers[i].name, 130, 0);
+            pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX, 124}, colorTable.White, pParty->pPlayers[i].name, 130, 0);
         }
 
         std::string pRaceName = pParty->pPlayers[i].GetRaceName();
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX + 72, pIntervalY + 12}, Color(), pRaceName, 130, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontCreate, {pIntervalX + 72, pIntervalY + 12}, colorTable.White, pRaceName, 130, 0);
 
         pTextCenter = pFontCreate->AlignText_Center(150, pText);
         pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + uX - 24, 291}, colorTable.Tacha, pText);  // Skills

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -112,8 +112,8 @@ void CharacterUI_DrawTooltip(const char *title, std::string &content) {
 
     auto colored_title = fmt::format(
         "{::}{}\f00000\n", ui_character_tooltip_header_default_color.tag(), title);
-    popup_window.DrawTitleText(pFontCreate, 0, 0, Color(), colored_title, 3);
-    popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), content);  // popup_window.uFrameY + popup_window.uFrameHeight
+    popup_window.DrawTitleText(pFontCreate, 0, 0, colorTable.White, colored_title, 3);
+    popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, colorTable.White, content);  // popup_window.uFrameY + popup_window.uFrameHeight
 }
 
 void CharacterUI_DrawTooltip(const char *title, const char *content) {
@@ -472,12 +472,12 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
 
     for (const std::string &s : text) {
         if (!s.empty()) {
-            iteminfo_window.DrawText(pFontComic, {100, v34}, Color(), s);
+            iteminfo_window.DrawText(pFontComic, {100, v34}, colorTable.White, s);
             v34 += pFontComic->CalcTextHeight(s, iteminfo_window.uFrameWidth, 100, 0) + 3;
         }
     }
     if (!pItemTable->pItems[inspect_item->uItemID].pDescription.empty())
-        iteminfo_window.DrawText(pFontSmallnum, {100, v34}, Color(), pItemTable->pItems[inspect_item->uItemID].pDescription);
+        iteminfo_window.DrawText(pFontSmallnum, {100, v34}, colorTable.White, pItemTable->pItems[inspect_item->uItemID].pDescription);
     iteminfo_window.uFrameX += 12;
     iteminfo_window.uFrameWidth -= 24;
     iteminfo_window.DrawTitleText(pFontArrus, 0, 0xCu, colorTable.PaleCanary,
@@ -487,7 +487,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
 
     if (GoldAmount) {
         auto txt = fmt::format("{}: {}", localization->GetString(LSTR_VALUE), GoldAmount);
-        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt);
+        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, colorTable.White, txt);
         render->ResetUIClipRect();
     } else {
         if ((inspect_item->uAttributes & ITEM_TEMP_BONUS) &&
@@ -518,14 +518,14 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
             if (formatting)
                 txt4 += fmt::format(" {}:mn", v67.field_4_expire_minute);
 
-            iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - 2 * pFontComic->GetHeight()}, Color(), txt4);
+            iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - 2 * pFontComic->GetHeight()}, colorTable.White, txt4);
         }
 
         auto txt2 = fmt::format(
             "{}: {}", localization->GetString(LSTR_VALUE),
             inspect_item->GetValue()
         );
-        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, Color(), txt2);
+        iteminfo_window.DrawText(pFontComic, {100, iteminfo_window.uFrameHeight - pFontComic->GetHeight()}, colorTable.White, txt2);
 
         std::string txt3;
         if (inspect_item->uAttributes & ITEM_STOLEN) {
@@ -956,14 +956,14 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     if (pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Active()) {
         std::string str = fmt::format("{}: {}", localization->GetString(LSTR_CURRENT_HIT_POINTS), pActors[uActorID].sCurrentHP);
         pFontSmallnum->GetLineWidth(str);
-        pWindow->DrawTitleText(pFontSmallnum, 0, pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, Color(), str, 3);
+        pWindow->DrawTitleText(pFontSmallnum, 0, pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, colorTable.White, str, 3);
     }
 
     // Debug - show actor AI state with full information
     if (monster_full_informations) {
         std::string str = fmt::format("AI State: {}", std::to_underlying(pActors[uActorID].uAIState));
         pFontSmallnum->GetLineWidth(str);
-        pWindow->DrawTitleText(pFontSmallnum, 0, pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, Color(), str, 3);
+        pWindow->DrawTitleText(pFontSmallnum, 0, pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, colorTable.White, str, 3);
     }
 }
 
@@ -1246,19 +1246,19 @@ void DrawSpellDescriptionPopup(int spell_index_in_book) {
     spell_info_window.uFrameW = spell_info_window.uFrameHeight + spell_info_window.uFrameY - 1;
     spell_info_window.DrawTitleText(
         pFontArrus, 0x78u, 0xCu, colorTable.PaleCanary, spell->name, 3);
-    spell_info_window.DrawText(pFontSmallnum, {120, 44}, Color(), str);
+    spell_info_window.DrawText(pFontSmallnum, {120, 44}, colorTable.White, str);
     spell_info_window.uFrameWidth = 108;
     spell_info_window.uFrameZ = spell_info_window.uFrameX + 107;
     PLAYER_SKILL_TYPE skill = static_cast<PLAYER_SKILL_TYPE>(pParty->activeCharacter().lastOpenedSpellbookPage + 12);
     PLAYER_SKILL_MASTERY skill_mastery = pParty->activeCharacter().getSkillValue(skill).mastery();
-    spell_info_window.DrawTitleText(pFontComic, 12, 75, Color(), localization->GetSkillName(skill), 3);
+    spell_info_window.DrawTitleText(pFontComic, 12, 75, colorTable.White, localization->GetSkillName(skill), 3);
 
     auto str2 = fmt::format(
         "{}\n{}", localization->GetString(LSTR_SP_COST),
         pSpellDatas[spell_id].mana_per_skill[std::to_underlying(skill_mastery) - 1]);
     spell_info_window.DrawTitleText(
         pFontComic, 12,
-        spell_info_window.uFrameHeight - pFontComic->GetHeight() - 16, Color(), str2,
+        spell_info_window.uFrameHeight - pFontComic->GetHeight() - 16, colorTable.White, str2,
         3);
     dword_507B00_spell_info_to_draw_in_popup = 0;
 }
@@ -1298,9 +1298,9 @@ static void drawBuffPopupWindow() {
     popupWindow.uFrameZ = popupWindow.uFrameWidth + popupWindow.uFrameX - 1;
     popupWindow.uFrameW = popupWindow.uFrameY + popupWindow.uFrameHeight - 1;
     popupWindow.DrawMessageBox(0);
-    popupWindow.DrawTitleText(pFontArrus, 0, 12, Color(), localization->GetString(LSTR_ACTIVE_PARTY_SPELLS), 3);
+    popupWindow.DrawTitleText(pFontArrus, 0, 12, colorTable.White, localization->GetString(LSTR_ACTIVE_PARTY_SPELLS), 3);
     if (!stringCount) {
-        popupWindow.DrawTitleText(pFontComic, 0, 40, Color(), localization->GetString(LSTR_NONE), 3);
+        popupWindow.DrawTitleText(pFontComic, 0, 40, colorTable.White, localization->GetString(LSTR_NONE), 3);
     }
 
     stringCount = 0;
@@ -1363,13 +1363,13 @@ void showSpellbookInfo(ITEM_TYPE spellItemId) {
     popup.uFrameZ = popup.uFrameX + popup.uFrameWidth - 1;
     popup.uFrameW = popup.uFrameHeight + popup.uFrameY - 1;
     popup.DrawTitleText(pFontArrus, 0x78u, 0xCu, colorTable.PaleCanary, pSpellStats->pInfos[spellId].name, 3u);
-    popup.DrawText(pFontSmallnum, {120, 44}, Color(), str);
+    popup.DrawText(pFontSmallnum, {120, 44}, colorTable.White, str);
     popup.uFrameZ = popup.uFrameX + 107;
     popup.uFrameWidth = 108;
-    popup.DrawTitleText(pFontComic, 0xCu, 0x4Bu, Color(), localization->GetSkillName(static_cast<PLAYER_SKILL_TYPE>(spellSchool / 4 + 12)), 3u);
+    popup.DrawTitleText(pFontComic, 0xCu, 0x4Bu, colorTable.White, localization->GetSkillName(static_cast<PLAYER_SKILL_TYPE>(spellSchool / 4 + 12)), 3u);
 
     str = fmt::format("{}\n{}", localization->GetString(LSTR_SP_COST), pSpellDatas[spellId].uNormalLevelMana);
-    popup.DrawTitleText(pFontComic, 0xCu, popup.uFrameHeight - pFontComic->GetHeight() - 16, Color(), str, 3);
+    popup.DrawTitleText(pFontComic, 0xCu, popup.uFrameHeight - pFontComic->GetHeight() - 16, colorTable.White, str, 3);
 }
 
 //----- new function
@@ -1659,7 +1659,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
 
     str += fmt::format("{}: {}", localization->GetString(LSTR_QUICK_SPELL), spellName);
 
-    window->DrawText(pFontArrus, {120, 22}, Color(), str);
+    window->DrawText(pFontArrus, {120, 22}, colorTable.White, str);
 
     uFramesetIDa = 0;
     for (uint i = 0; i < 24; ++i) {
@@ -1678,7 +1678,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Player *player) {
     auto active_spells = localization->FormatString(
         LSTR_FMT_ACTIVE_SPELLS_S,
         uFramesetIDa == 0 ? localization->GetString(LSTR_NONE) : "");
-    window->DrawText(pFontArrus, {14, 114}, Color(), active_spells);
+    window->DrawText(pFontArrus, {14, 114}, colorTable.White, active_spells);
 }
 
 void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
@@ -1724,7 +1724,7 @@ void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
                 popup_window.DrawTitleText(pFontArrus, 0, 12, colorTable.PaleCanary, NameAndTitle(pNPC), 3);
                 popup_window.uFrameWidth -= 24;
                 popup_window.uFrameZ = popup_window.uFrameX + popup_window.uFrameWidth - 1;
-                popup_window.DrawText(pFontArrus, {100, 36}, Color(), BuildDialogueString(pText, pParty->activeCharacterIndex() - 1, 0, 0, 0));
+                popup_window.DrawText(pFontArrus, {100, 36}, colorTable.White, BuildDialogueString(pText, pParty->activeCharacterIndex() - 1, 0, 0, 0));
             }
         }
     }
@@ -2053,8 +2053,8 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                     popup_window.uFrameY + popup_window.uFrameHeight - 1;
 
                 std::string str = fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), pStr);
-                popup_window.DrawTitleText(pFontCreate, 0, 0, Color(), str, 3);
-                popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, Color(), sHint);
+                popup_window.DrawTitleText(pFontCreate, 0, 0, colorTable.White, str, 3);
+                popup_window.DrawText(pFontSmallnum, {1, pFontLucida->GetHeight()}, colorTable.White, sHint);
             }
             break;
         }
@@ -2411,7 +2411,7 @@ void Inventory_ItemPopupAndAlchemy() {
 
 //----- (0045828B) --------------------------------------------------------
 Color GetSpellColor(signed int a1) {
-    if (a1 == 0) return Color();
+    if (a1 == 0) return colorTable.White;
     if (a1 < 12) return colorTable.DarkOrange;
     if (a1 < 23) return colorTable.Anakiwa;
     if (a1 < 34) return colorTable.AzureRadiance;
@@ -2426,7 +2426,7 @@ Color GetSpellColor(signed int a1) {
         __debugbreak();
 
     logger->warning("No color returned - GetSpellColor!");
-    return Color();
+    return colorTable.White;
 }
 
 //----- (004B46F8) --------------------------------------------------------

--- a/src/GUI/UI/UIQuickReference.cpp
+++ b/src/GUI/UI/UIQuickReference.cpp
@@ -47,32 +47,32 @@ void GUIWindow_QuickReference::Update() {
 
     render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, ui_game_quickref_background);
 
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, 18}, Color(), localization->GetString(LSTR_NAME), 60, 0);
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, 47}, Color(), localization->GetString(LSTR_LEVEL), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, 18}, colorTable.White, localization->GetString(LSTR_NAME), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, 47}, colorTable.White, localization->GetString(LSTR_LEVEL), 60, 0);
     int pY = pFontHeight + 47;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_CLASS), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_CLASS), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_HP), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_HP), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_SP), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_SP), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_AC), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_AC), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_ATTACK), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_ATTACK), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_DMG), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_DMG), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_SHOOT), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_SHOOT), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_DMG), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_DMG), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_SKILLS), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_SKILLS), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_POINTS), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_POINTS), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_COND), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_COND), 60, 0);
     pY += pFontHeight;
-    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, Color(), localization->GetString(LSTR_QSPELL), 60, 0);
+    pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {22, pY}, colorTable.White, localization->GetString(LSTR_QSPELL), 60, 0);
 
     int pX = 89;
     for (Player &player : pParty->pPlayers) {
@@ -82,7 +82,7 @@ void GUIWindow_QuickReference::Update() {
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, 47}, pTextColor, fmt::format("{}", player.GetActualLevel()), 84, 0);
 
         pY = pFontHeight + 47;
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), localization->GetClassName(player.classType), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, localization->GetClassName(player.classType), 84, 0);
         pY += pFontHeight;
 
         pTextColor = UI_GetHealthManaAndOtherQualitiesStringColor(player.health, player.GetMaxHealth());
@@ -97,16 +97,16 @@ void GUIWindow_QuickReference::Update() {
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, pTextColor, fmt::format("{}", player.GetActualAC()), 84, 0);
         pY += pFontHeight;
 
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), fmt::format("{:+}", player.GetActualAttack(false)), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, fmt::format("{:+}", player.GetActualAttack(false)), 84, 0);
         pY += pFontHeight;
 
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), player.GetMeleeDamageString(), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, player.GetMeleeDamageString(), 84, 0);
         pY += pFontHeight;
 
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), fmt::format("{:+}", player.GetRangedAttack()), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, fmt::format("{:+}", player.GetRangedAttack()), 84, 0);
         pY += pFontHeight;
 
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), player.GetRangedDamageString(), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, player.GetRangedDamageString(), 84, 0);
         pY += pFontHeight;
 
         int pSkillsCount = 0;
@@ -115,7 +115,7 @@ void GUIWindow_QuickReference::Update() {
                 ++pSkillsCount;
             }
         }
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), fmt::format("{}", pSkillsCount), 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, fmt::format("{}", pSkillsCount), 84, 0);
         pY += pFontHeight;
 
         pTextColor = player.uSkillPoints ? ui_character_bonus_text_color : ui_character_default_text_color;
@@ -127,7 +127,7 @@ void GUIWindow_QuickReference::Update() {
         pY += pFontHeight;
 
         std::string pText = (player.uQuickSpell != SPELL_NONE) ? pSpellStats->pInfos[player.uQuickSpell].pShortName : localization->GetString(LSTR_NONE);
-        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, Color(), pText, 84, 0);
+        pGUIWindow_CurrentMenu->DrawTextInRect(pFontArrus, {pX, pY}, colorTable.White, pText, 84, 0);
 
         pX += 94;
     }
@@ -139,7 +139,7 @@ void GUIWindow_QuickReference::Update() {
     }
 
     std::string rep = fmt::format("{}: {::}{}\f00000", localization->GetString(LSTR_REPUTATION), pTextColor.tag(), GetReputationString(pParty->GetPartyReputation()));
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {22, 323}, Color(), rep);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {22, 323}, colorTable.White, rep);
     std::string fame = fmt::format("\r261{}: {}", localization->GetString(LSTR_FAME), pParty->getPartyFame());
-    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 323}, Color(), fame);
+    pGUIWindow_CurrentMenu->DrawText(pFontArrus, {0, 323}, colorTable.White, fame);
 }

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -154,7 +154,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     this->uFrameZ = uFrameX + uFrameWidth - 1;
     this->uFrameW = uFrameY + uFrameHeight - 1;
 
-    DrawText(pFontSmallnum, {25, 199}, Color(), localization->GetString(LSTR_READING));
+    DrawText(pFontSmallnum, {25, 199}, colorTable.White, localization->GetString(LSTR_READING));
     render->Present();
 
     pSavegameList->Initialize();
@@ -261,7 +261,7 @@ static void UI_DrawSaveLoad(bool save) {
                                    pSavegameList->pSavegameThumbnails[pSavegameList->selectedSlot]);
         }
         // Draw map name
-        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, Color(),
+        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, colorTable.White,
                                        pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].locationName)].pName, 3);
 
         // Draw date
@@ -290,7 +290,7 @@ static void UI_DrawSaveLoad(bool save) {
             localization->GetMonthName(savegame_time.GetMonthsOfYear()),
             savegame_time.GetYears() + game_starting_year
         );
-        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, Color(), str, 3);
+        save_load_window.DrawTitleText(pFontSmallnum, 0, 0, colorTable.White, str, 3);
     }
 
     if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
@@ -304,13 +304,13 @@ static void UI_DrawSaveLoad(bool save) {
 
     if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
         pGUIWindow_CurrentMenu->DrawText(pFontSmallnum,
-            {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_LOADING)) + 25, 220}, Color(),
+            {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_LOADING)) + 25, 220}, colorTable.White,
             localization->GetString(LSTR_LOADING));
         pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum,
-                                               {pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name) + 25, 262}, Color(),
+                                               {pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name) + 25, 262}, colorTable.White,
                                                pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name, 185, 0);
         pGUIWindow_CurrentMenu->DrawText(pFontSmallnum,
-            {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_PLEASE_WAIT)) + 25, 304}, Color(),
+            {pFontSmallnum->AlignText_Center(186, localization->GetString(LSTR_PLEASE_WAIT)) + 25, 304}, colorTable.White,
             localization->GetString(LSTR_PLEASE_WAIT));
     } else {
         int maxSaveFiles = MAX_SAVE_SLOTS;
@@ -337,11 +337,11 @@ static void UI_DrawSaveLoad(bool save) {
                 break;
             }
             if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || i != pSavegameList->selectedSlot) {
-                pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y}, i == pSavegameList->selectedSlot ? colorTable.LaserLemon : Color(),
+                pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y}, i == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White,
                                                        pSavegameList->pSavegameHeader[i].name, 185, 0);
             } else {
                 pGUIWindow_CurrentMenu->DrawFlashingInputCursor(pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, {27, slot_Y},
-                    i == pSavegameList->selectedSlot ? colorTable.LaserLemon : Color(), keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, pFontSmallnum);
+                    i == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, pFontSmallnum);
             }
             slot_Y += 21;
         }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -179,7 +179,7 @@ void GUIWindow_Travel::Update() {
         travel_window.uFrameX = 493;
         travel_window.uFrameWidth = 126;
         travel_window.uFrameZ = 366;
-        travel_window.DrawTitleText(pFontCreate, 0, 4, Color(), pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].pName, 3);
+        travel_window.DrawTitleText(pFontCreate, 0, 4, colorTable.White, pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].pName, 3);
         travel_window.uFrameX = SIDE_TEXT_BOX_POS_X;
         travel_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
         travel_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
@@ -193,7 +193,7 @@ void GUIWindow_Travel::Update() {
         str += "\n \n";
         str += localization->FormatString(LSTR_FMT_DO_YOU_WISH_TO_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].pName.c_str());
 
-        travel_window.DrawTitleText(pFontCreate, 0, (212 - pFontCreate->CalcTextHeight(str, travel_window.uFrameWidth, 0)) / 2 + 101, Color(), str, 3);
+        travel_window.DrawTitleText(pFontCreate, 0, (212 - pFontCreate->CalcTextHeight(str, travel_window.uFrameWidth, 0)) / 2 + 101, colorTable.White, str, 3);
     }
 }
 
@@ -214,18 +214,18 @@ void GUIWindow_Transition::Update() {
     transition_window.uFrameX = 493;
     transition_window.uFrameWidth = 126;
     transition_window.uFrameZ = 366;
-    transition_window.DrawTitleText(pFontCreate, 0, 5, Color(), pMapStats->pInfos[map_id].pName, 3);
+    transition_window.DrawTitleText(pFontCreate, 0, 5, colorTable.White, pMapStats->pInfos[map_id].pName, 3);
     transition_window.uFrameX = SIDE_TEXT_BOX_POS_X;
     transition_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     transition_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
     if (uCurrentHouse_Animation) {
         unsigned int vertMargin = (212 - pFontCreate->CalcTextHeight(pTransitionStrings[uCurrentHouse_Animation], transition_window.uFrameWidth, 0)) / 2 + 101;
-        transition_window.DrawTitleText(pFontCreate, 0, vertMargin, Color(), pTransitionStrings[uCurrentHouse_Animation], 3);
+        transition_window.DrawTitleText(pFontCreate, 0, vertMargin, colorTable.White, pTransitionStrings[uCurrentHouse_Animation], 3);
     } else if (map_id) {
         std::string str = localization->FormatString(LSTR_FMT_DO_YOU_WISH_TO_LEAVE_S_2, pMapStats->pInfos[map_id].pName.c_str());
         unsigned int vertMargin = (212 - pFontCreate->CalcTextHeight(str, transition_window.uFrameWidth, 0)) / 2 + 101;
-        transition_window.DrawTitleText(pFontCreate, 0, vertMargin, Color(), str, 3);
+        transition_window.DrawTitleText(pFontCreate, 0, vertMargin, colorTable.White, str, 3);
     } else {
         Error("Troubles in da house");
     }

--- a/src/Library/Color/Color.h
+++ b/src/Library/Color/Color.h
@@ -31,11 +31,6 @@ struct Color {
     constexpr Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255): r(r), g(g), b(b), a(a) {}
 
     [[nodiscard]] static constexpr Color fromC16(uint16_t color) {
-        // 16-bit zero was used as a marker for 'default color', but in new code that marker is Color(), so we have
-        // to special-case the old behavior.
-        if (color == 0)
-            return Color();
-
         Color result;
         result.b = (color & 31) * 8;
         result.g = ((color >> 5) & 63) * 4;


### PR DESCRIPTION
* Dropped special processing of `Color()` in font code.
* Passing `colorTable.White` explicitly everywhere.
* Font functions now assert if passed a transparent text color.
* Dropped `ui_current_text_color`.
* Dropped special processing of `0` in `Color::fromC16`.
* Tag `\f00000` now resets the text color to what was passed into the `Draw*Text` function (it used to set the color to white before).