### PR TITLE
Unify globals for interactable objects in houses

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1085,7 +1085,7 @@ void Game::processQueuedMessages() {
                 playButtonSoundOnEscape = false;
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 SaveGame(1, 0);
-                pCurrentMapName = pMapStats->pInfos[uHouse_ExitPic].pFilename;
+                pCurrentMapName = pMapStats->pInfos[houseInteractionList[currentHouseInteraction].data.targetMapID].pFilename;
                 dword_6BE364_game_settings_1 |= GAME_SETTINGS_0001;
                 uGameState = GAME_STATE_CHANGE_LOCATION;
                 // v53 = buildingTable_minus1_::30[26 * (unsigned

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1085,7 +1085,7 @@ void Game::processQueuedMessages() {
                 playButtonSoundOnEscape = false;
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 SaveGame(1, 0);
-                pCurrentMapName = pMapStats->pInfos[dialogueInteractiveList[currentDialogueInteractive].data.targetMapID].pFilename;
+                pCurrentMapName = pMapStats->pInfos[houseNpcs[currentHouseNpc].targetMapID].pFilename;
                 dword_6BE364_game_settings_1 |= GAME_SETTINGS_0001;
                 uGameState = GAME_STATE_CHANGE_LOCATION;
                 // v53 = buildingTable_minus1_::30[26 * (unsigned

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1085,7 +1085,7 @@ void Game::processQueuedMessages() {
                 playButtonSoundOnEscape = false;
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 SaveGame(1, 0);
-                pCurrentMapName = pMapStats->pInfos[houseInteractionList[currentHouseInteraction].data.targetMapID].pFilename;
+                pCurrentMapName = pMapStats->pInfos[dialogueInteractiveList[currentDialogueInteractive].data.targetMapID].pFilename;
                 dword_6BE364_game_settings_1 |= GAME_SETTINGS_0001;
                 uGameState = GAME_STATE_CHANGE_LOCATION;
                 // v53 = buildingTable_minus1_::30[26 * (unsigned

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -239,7 +239,6 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                         window_SpeakInHouse = nullptr;
                         pCurrentFrameMessageQueue->Flush();
                         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
-                        pDialogueNPCCount = 0;
                         if (pDialogueWindow) {
                             pDialogueWindow->Release();
                             pDialogueWindow = 0;

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -108,7 +108,7 @@ bool CheckHiredNPCSpeciality(NPCProf prof) {
 //----- (004B40E6) --------------------------------------------------------
 void NPCHireableDialogPrepare() {
     int v0 = 0;
-    NPCData *v1 = dialogueInteractiveList[currentDialogueInteractive].data.npc;
+    NPCData *v1 = houseNpcs[currentHouseNpc].npc;
 
     pDialogueWindow->Release();
     pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetRenderDimensions().w, 350}, 0);
@@ -132,12 +132,12 @@ void NPCHireableDialogPrepare() {
 void _4B4224_UpdateNPCTopics(int _this) {
     int num_menu_buttons = 0;
 
-    currentDialogueInteractive = _this;
+    currentHouseNpc = _this;
     Sizei renDims = render->GetRenderDimensions();
-    if (dialogueInteractiveList[_this].type == HOUSE_INTERACTIVE_TRANSITION) {
+    if (houseNpcs[_this].type == HOUSE_TRANSITION) {
         pDialogueWindow->Release();
         pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, renDims, 0);
-        transition_button_label = dialogueInteractiveList[_this].label;
+        transition_button_label = houseNpcs[_this].label;
         pBtn_ExitCancel = pDialogueWindow->CreateButton({566, 445}, {75, 33}, 1, 0, UIMSG_Escape, 0, InputAction::No, localization->GetString(LSTR_CANCEL), {ui_buttdesc2});
         pBtn_YES = pDialogueWindow->CreateButton({486, 445}, {75, 33}, 1, 0, UIMSG_BF, 1, InputAction::Yes, transition_button_label, {ui_buttyes2});
         pDialogueWindow->CreateButton({pNPCPortraits_x[0][0], pNPCPortraits_y[0][0]}, {63, 73}, 1, 0, UIMSG_BF, 1, InputAction::EventTrigger, transition_button_label);
@@ -146,9 +146,9 @@ void _4B4224_UpdateNPCTopics(int _this) {
         if (dialog_menu_id == DIALOGUE_OTHER) {
             pDialogueWindow->Release();
         } else {
-            for (int i = 0; i < dialogueInteractiveList.size(); ++i) {
-                dialogueInteractiveList[i].button->Release();
-                dialogueInteractiveList[i].button = nullptr;
+            for (int i = 0; i < houseNpcs.size(); ++i) {
+                houseNpcs[i].button->Release();
+                houseNpcs[i].button = nullptr;
             }
         }
         pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {renDims.w, 345}, 0);
@@ -156,10 +156,10 @@ void _4B4224_UpdateNPCTopics(int _this) {
                                                         localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background});
         pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_HouseScreenClick, 0);
         dialog_menu_id = DIALOGUE_MAIN;
-        if (dialogueInteractiveList[_this].type == HOUSE_INTERACTIVE_PROPRIETOR) {
+        if (houseNpcs[_this].type == HOUSE_PROPRIETOR) {
             window_SpeakInHouse->initializeDialog();
         } else { // NPC
-            NPCData *npc = dialogueInteractiveList[_this].data.npc;
+            NPCData *npc = houseNpcs[_this].npc;
             if (npc->is_joinable) {
                 num_menu_buttons = 1;
                 pDialogueWindow->CreateButton({480, 160}, {140, 30}, 1, 0, UIMSG_ClickNPCTopic, DIALOGUE_13_hiring_related);

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -108,7 +108,7 @@ bool CheckHiredNPCSpeciality(NPCProf prof) {
 //----- (004B40E6) --------------------------------------------------------
 void NPCHireableDialogPrepare() {
     int v0 = 0;
-    NPCData *v1 = houseInteractionList[currentHouseInteraction].data.npc;
+    NPCData *v1 = dialogueInteractiveList[currentDialogueInteractive].data.npc;
 
     pDialogueWindow->Release();
     pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {render->GetRenderDimensions().w, 350}, 0);
@@ -132,12 +132,12 @@ void NPCHireableDialogPrepare() {
 void _4B4224_UpdateNPCTopics(int _this) {
     int num_menu_buttons = 0;
 
-    currentHouseInteraction = _this;
+    currentDialogueInteractive = _this;
     Sizei renDims = render->GetRenderDimensions();
-    if (houseInteractionList[_this].type == HOUSE_INTERACTION_TRANSITION) {
+    if (dialogueInteractiveList[_this].type == HOUSE_INTERACTIVE_TRANSITION) {
         pDialogueWindow->Release();
         pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, renDims, 0);
-        transition_button_label = houseInteractionList[_this].label;
+        transition_button_label = dialogueInteractiveList[_this].label;
         pBtn_ExitCancel = pDialogueWindow->CreateButton({566, 445}, {75, 33}, 1, 0, UIMSG_Escape, 0, InputAction::No, localization->GetString(LSTR_CANCEL), {ui_buttdesc2});
         pBtn_YES = pDialogueWindow->CreateButton({486, 445}, {75, 33}, 1, 0, UIMSG_BF, 1, InputAction::Yes, transition_button_label, {ui_buttyes2});
         pDialogueWindow->CreateButton({pNPCPortraits_x[0][0], pNPCPortraits_y[0][0]}, {63, 73}, 1, 0, UIMSG_BF, 1, InputAction::EventTrigger, transition_button_label);
@@ -146,9 +146,9 @@ void _4B4224_UpdateNPCTopics(int _this) {
         if (dialog_menu_id == DIALOGUE_OTHER) {
             pDialogueWindow->Release();
         } else {
-            for (int i = 0; i < houseInteractionList.size(); ++i) {
-                houseInteractionList[i].button->Release();
-                houseInteractionList[i].button = nullptr;
+            for (int i = 0; i < dialogueInteractiveList.size(); ++i) {
+                dialogueInteractiveList[i].button->Release();
+                dialogueInteractiveList[i].button = nullptr;
             }
         }
         pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, {renDims.w, 345}, 0);
@@ -156,10 +156,10 @@ void _4B4224_UpdateNPCTopics(int _this) {
                                                         localization->GetString(LSTR_END_CONVERSATION), {ui_exit_cancel_button_background});
         pDialogueWindow->CreateButton({8, 8}, {450, 320}, 1, 0, UIMSG_HouseScreenClick, 0);
         dialog_menu_id = DIALOGUE_MAIN;
-        if (houseInteractionList[_this].type == HOUSE_INTERACTION_PROPRIETOR) {
+        if (dialogueInteractiveList[_this].type == HOUSE_INTERACTIVE_PROPRIETOR) {
             window_SpeakInHouse->initializeDialog();
         } else { // NPC
-            NPCData *npc = houseInteractionList[_this].data.npc;
+            NPCData *npc = dialogueInteractiveList[_this].data.npc;
             if (npc->is_joinable) {
                 num_menu_buttons = 1;
                 pDialogueWindow->CreateButton({480, 160}, {140, 30}, 1, 0, UIMSG_ClickNPCTopic, DIALOGUE_13_hiring_related);

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -10,9 +10,6 @@
 #include "Engine/Tables/NPCTable.h"
 #include "Engine/Graphics/Image.h"
 
-extern int pDialogueNPCCount;
-extern std::vector<GraphicsImage *> pDialogueNPCPortraits;
-
 // TODO(Nik-RE-dev): remove
 //----- (0047730C) --------------------------------------------------------
 inline bool CheckPortretAgainstSex(int a1, int) { return true; }

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2471,8 +2471,6 @@ DIALOGUE_TYPE uDialogueType;
 int sDialogue_SpeakingActorNPC_ID;
 int uCurrentHouse_Animation;
 std::string Party_Teleport_Map_Name;
-std::array<struct NPCData *, 7> HouseNPCData;  // 0 zero element holds standart house npc
-GUIButton *HouseNPCPortraitsButtonsList[6];  // dword_5913F4
 std::string branchless_dialogue_str;
 int Party_Teleport_X_Pos;
 int Party_Teleport_Y_Pos;
@@ -2493,8 +2491,6 @@ unsigned int game_ui_status_bar_event_string_time_left; // this is platform->tic
 int bForceDrawFooter;
 int _5C35C0_force_party_death = false;
 int bDialogueUI_InitializeActor_NPC_ID;
-
-int dword_5C35D4;
 
 int64_t qword_5C6DF0;
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -105,8 +105,6 @@ extern DIALOGUE_TYPE uDialogueType;
 extern signed int sDialogue_SpeakingActorNPC_ID;
 extern int uCurrentHouse_Animation;
 
-extern std::array<struct NPCData *, 7> HouseNPCData;  // 0this array size temporarily increased to 60 from 6 to work aroud house overflow
-extern GUIButton *HouseNPCPortraitsButtonsList[6];
 extern std::string branchless_dialogue_str;
 
 extern std::string Party_Teleport_Map_Name;
@@ -127,7 +125,6 @@ extern int bForceDrawFooter;
 extern int _5C35C0_force_party_death;
 extern int bDialogueUI_InitializeActor_NPC_ID;
 
-extern int dword_5C35D4;
 extern std::array<char, 10000> pTmpBuf3;
 extern int64_t qword_5C6DF0;
 extern struct FactionTable *pFactionTable;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -940,7 +940,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     int pPrice;        // ecx@70
 
     uDialogueType = (DIALOGUE_TYPE)(topic + 1);
-    NPCData *pCurrentNPCInfo = houseInteractionList[currentHouseInteraction].data.npc;
+    NPCData *pCurrentNPCInfo = dialogueInteractiveList[currentDialogueInteractive].data.npc;
     if (topic <= DIALOGUE_SCRIPTED_LINE_6) {
         switch (topic) {
         case DIALOGUE_13_hiring_related:
@@ -1528,7 +1528,7 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
 
     pPlayer = &pParty->pCharacters[uPlayerID];
 
-    NPCData *npc = houseInteractionList[currentHouseInteraction].data.npc;
+    NPCData *npc = dialogueInteractiveList[currentDialogueInteractive].data.npc;
 
     std::string result;
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -940,7 +940,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     int pPrice;        // ecx@70
 
     uDialogueType = (DIALOGUE_TYPE)(topic + 1);
-    NPCData *pCurrentNPCInfo = dialogueInteractiveList[currentDialogueInteractive].data.npc;
+    NPCData *pCurrentNPCInfo = houseNpcs[currentHouseNpc].npc;
     if (topic <= DIALOGUE_SCRIPTED_LINE_6) {
         switch (topic) {
         case DIALOGUE_13_hiring_related:
@@ -1530,8 +1530,8 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
 
     NPCData *npc;
 
-    if (dialogueInteractiveList.size()) {
-        npc = dialogueInteractiveList[currentDialogueInteractive].data.npc;
+    if (houseNpcs.size()) {
+        npc = houseNpcs[currentHouseNpc].npc;
     } else {
         npc = GetNPCData(sDialogue_SpeakingActorNPC_ID);
     }

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -1528,7 +1528,13 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
 
     pPlayer = &pParty->pCharacters[uPlayerID];
 
-    NPCData *npc = dialogueInteractiveList[currentDialogueInteractive].data.npc;
+    NPCData *npc;
+
+    if (dialogueInteractiveList.size()) {
+        npc = dialogueInteractiveList[currentDialogueInteractive].data.npc;
+    } else {
+        npc = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    }
 
     std::string result;
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -940,7 +940,7 @@ void ClickNPCTopic(DIALOGUE_TYPE topic) {
     int pPrice;        // ecx@70
 
     uDialogueType = (DIALOGUE_TYPE)(topic + 1);
-    NPCData *pCurrentNPCInfo = HouseNPCData[pDialogueNPCCount - ((dword_591080 != 0) ? 1 : 0)];  //- 1
+    NPCData *pCurrentNPCInfo = houseInteractionList[currentHouseInteraction].data.npc;
     if (topic <= DIALOGUE_SCRIPTED_LINE_6) {
         switch (topic) {
         case DIALOGUE_13_hiring_related:
@@ -1528,11 +1528,7 @@ std::string BuildDialogueString(std::string &str, uint8_t uPlayerID, ItemGen *a3
 
     pPlayer = &pParty->pCharacters[uPlayerID];
 
-    NPCData *npc = nullptr;
-    if (dword_5C35D4)
-        npc = HouseNPCData[pDialogueNPCCount - (dword_591080 != 0)];
-    else
-        npc = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *npc = houseInteractionList[currentHouseInteraction].data.npc;
 
     std::string result;
 

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -51,15 +51,15 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     std::string filename = DialogueBackgroundResourceByAlignment[pParty->alignment];
     game_ui_dialogue_background = assets->getImage_Solid(filename);
 
-    currentHouseInteraction = 0;
+    currentDialogueInteractive = 0;
 
-    HouseInteractionDesc desc;
-    desc.type = HOUSE_INTERACTION_NPC;
+    HouseInteractiveDesc desc;
+    desc.type = HOUSE_INTERACTIVE_NPC;
     desc.label = localization->FormatString(LSTR_FMT_CONVERSE_WITH_S, pNPCInfo->pName.c_str());
     desc.icon = assets->getImage_ColorKey(fmt::format("npc{:03}", pNPCInfo->uPortraitID));
     desc.data.npc = pNPCInfo;
 
-    houseInteractionList.push_back(desc);
+    dialogueInteractiveList.push_back(desc);
 
     // TODO(Nik-RE-dev): this looks like checks for NPC that only talk if party has enough fame
     //                   which is a thing only for MM8 if I remember correctly
@@ -184,10 +184,10 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(Pointi position, Sizei dimensions, Window
 }
 
 void GUIWindow_Dialogue::Release() {
-    if (houseInteractionList[0].icon) {
-        houseInteractionList[0].icon->Release();
+    if (dialogueInteractiveList[0].icon) {
+        dialogueInteractiveList[0].icon->Release();
     }
-    houseInteractionList.clear();
+    dialogueInteractiveList.clear();
 
     if (game_ui_dialogue_background) {
         game_ui_dialogue_background->Release();
@@ -217,7 +217,7 @@ void GUIWindow_Dialogue::Update() {
                                 game_ui_evtnpc);
     render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f,
                                 pNPCPortraits_y[0][0] / 480.0f,
-                                houseInteractionList[0].icon);
+                                dialogueInteractiveList[0].icon);
 
     window.DrawTitleText(
         pFontArrus, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, ui_game_dialogue_npc_name_color, NameAndTitle(pNPC), 3

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -51,15 +51,15 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     std::string filename = DialogueBackgroundResourceByAlignment[pParty->alignment];
     game_ui_dialogue_background = assets->getImage_Solid(filename);
 
-    currentDialogueInteractive = 0;
+    currentHouseNpc = 0;
 
-    HouseInteractiveDesc desc;
-    desc.type = HOUSE_INTERACTIVE_NPC;
+    HouseNpcDesc desc;
+    desc.type = HOUSE_NPC;
     desc.label = localization->FormatString(LSTR_FMT_CONVERSE_WITH_S, pNPCInfo->pName.c_str());
     desc.icon = assets->getImage_ColorKey(fmt::format("npc{:03}", pNPCInfo->uPortraitID));
-    desc.data.npc = pNPCInfo;
+    desc.npc = pNPCInfo;
 
-    dialogueInteractiveList.push_back(desc);
+    houseNpcs.push_back(desc);
 
     // TODO(Nik-RE-dev): this looks like checks for NPC that only talk if party has enough fame
     //                   which is a thing only for MM8 if I remember correctly
@@ -184,10 +184,10 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(Pointi position, Sizei dimensions, Window
 }
 
 void GUIWindow_Dialogue::Release() {
-    if (dialogueInteractiveList[0].icon) {
-        dialogueInteractiveList[0].icon->Release();
+    if (houseNpcs[0].icon) {
+        houseNpcs[0].icon->Release();
     }
-    dialogueInteractiveList.clear();
+    houseNpcs.clear();
 
     if (game_ui_dialogue_background) {
         game_ui_dialogue_background->Release();
@@ -217,7 +217,7 @@ void GUIWindow_Dialogue::Update() {
                                 game_ui_evtnpc);
     render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f,
                                 pNPCPortraits_y[0][0] / 480.0f,
-                                dialogueInteractiveList[0].icon);
+                                houseNpcs[0].icon);
 
     window.DrawTitleText(
         pFontArrus, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, ui_game_dialogue_npc_name_color, NameAndTitle(pNPC), 3

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -51,10 +51,15 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     std::string filename = DialogueBackgroundResourceByAlignment[pParty->alignment];
     game_ui_dialogue_background = assets->getImage_Solid(filename);
 
-    pDialogueNPCCount = 0;
+    currentHouseInteraction = 0;
 
-    filename = fmt::format("npc{:03}", pNPCInfo->uPortraitID);
-    pDialogueNPCPortraits.push_back(assets->getImage_ColorKey(filename));
+    HouseInteractionDesc desc;
+    desc.type = HOUSE_INTERACTION_NPC;
+    desc.label = localization->FormatString(LSTR_FMT_CONVERSE_WITH_S, pNPCInfo->pName.c_str());
+    desc.icon = assets->getImage_ColorKey(fmt::format("npc{:03}", pNPCInfo->uPortraitID));
+    desc.data.npc = pNPCInfo;
+
+    houseInteractionList.push_back(desc);
 
     // TODO(Nik-RE-dev): this looks like checks for NPC that only talk if party has enough fame
     //                   which is a thing only for MM8 if I remember correctly
@@ -179,12 +184,10 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(Pointi position, Sizei dimensions, Window
 }
 
 void GUIWindow_Dialogue::Release() {
-    for (GraphicsImage *image : pDialogueNPCPortraits) {
-        if (image) {
-            image->Release();
-        }
+    if (houseInteractionList[0].icon) {
+        houseInteractionList[0].icon->Release();
     }
-    pDialogueNPCPortraits.clear();
+    houseInteractionList.clear();
 
     if (game_ui_dialogue_background) {
         game_ui_dialogue_background->Release();
@@ -214,7 +217,7 @@ void GUIWindow_Dialogue::Update() {
                                 game_ui_evtnpc);
     render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f,
                                 pNPCPortraits_y[0][0] / 480.0f,
-                                pDialogueNPCPortraits[0]);
+                                houseInteractionList[0].icon);
 
     window.DrawTitleText(
         pFontArrus, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, ui_game_dialogue_npc_name_color, NameAndTitle(pNPC), 3

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -986,7 +986,7 @@ void GUIWindow_House::houseDialogManager() {
         pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, nameAndTitle, 3);
         houseSpecificDialogue();
     }
-    if (dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
+    if (currentDialogueInteractive != -1 && dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
         render->DrawTextureNew(556 / 640.0f, 451 / 480.0f, dialogue_ui_x_x_u);
         render->DrawTextureNew(476 / 640.0f, 451 / 480.0f, dialogue_ui_x_ok_u);
     } else {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -911,10 +911,10 @@ void GUIWindow_House::houseDialogManager() {
     if (currentDialogueInteractive == -1 || dialogueInteractiveList[currentDialogueInteractive].type != HOUSE_INTERACTIVE_TRANSITION) {
         if (!buildingTable[wData.val - 1].pName.empty()) {
             if (current_screen_type != CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
-                int v3 = 2 * pFontCreate->GetHeight() - 6 - pFontCreate->CalcTextHeight(buildingTable[wData.val - 1].pName, 130, 0);
-                if (v3 < 0)
-                    v3 = 0;
-                pWindow.DrawTitleText(pFontCreate, 0x1EAu, v3 / 2 + 4, colorTable.White, buildingTable[wData.val - 1].pName, 3);
+                int yPos = 2 * pFontCreate->GetHeight() - 6 - pFontCreate->CalcTextHeight(buildingTable[wData.val - 1].pName, 130, 0);
+                if (yPos < 0)
+                    yPos = 0;
+                pWindow.DrawTitleText(pFontCreate, 0x1EAu, yPos / 2 + 4, colorTable.White, buildingTable[wData.val - 1].pName, 3);
             }
         }
     }
@@ -938,39 +938,37 @@ void GUIWindow_House::houseDialogManager() {
             render->DrawTextureNew(8 / 640.0f, (347 - v6) / 480.0f, _591428_endcap);
             DrawText(pFontArrus, {13, 354 - v6}, colorTable.White, pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13));
         }
-        if (dialogueInteractiveList.size() == 0) {
-            return;
-        }
 
-        for (int v8 = 0; v8 < dialogueInteractiveList.size(); ++v8) {
-            render->DrawTextureNew((pNPCPortraits_x[dialogueInteractiveList.size() - 1][v8] - 4) / 640.0f,
-                                   (pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] - 4) / 480.0f, game_ui_evtnpc);
-            render->DrawTextureNew(pNPCPortraits_x[dialogueInteractiveList.size() - 1][v8] / 640.0f,
-                                   pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] / 480.0f, dialogueInteractiveList[v8].icon);
+        for (int i = 0; i < dialogueInteractiveList.size(); ++i) {
+            render->DrawTextureNew((pNPCPortraits_x[dialogueInteractiveList.size() - 1][i] - 4) / 640.0f,
+                                   (pNPCPortraits_y[dialogueInteractiveList.size() - 1][i] - 4) / 480.0f, game_ui_evtnpc);
+            render->DrawTextureNew(pNPCPortraits_x[dialogueInteractiveList.size() - 1][i] / 640.0f,
+                                   pNPCPortraits_y[dialogueInteractiveList.size() - 1][i] / 480.0f, dialogueInteractiveList[i].icon);
             if (dialogueInteractiveList.size() < 4) {
-                std::string pTitleText;
-                int v9 = 0;
-                if (dialogueInteractiveList[v8].type == HOUSE_INTERACTIVE_TRANSITION) {
-                    pTitleText = pMapStats->pInfos[dialogueInteractiveList[v8].data.targetMapID].pName;
-                    v9 = 94 * v8 + SIDE_TEXT_BOX_POS_Y;
-                } else {
-                    if (!v8 && dialogueInteractiveList[0].type == HOUSE_INTERACTIVE_PROPRIETOR) {
-                        pTitleText = buildingTable[wData.val - 1].pProprieterTitle;
-                        pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, pTitleText, 3);
-                        continue;
-                    }
-                    pTitleText = dialogueInteractiveList[v8].data.npc->pName;
-                    v9 = pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] + dialogueInteractiveList[v8].icon->height() + 2;
+                std::string pTitleText = "";
+                int yPos = 0;
+                switch (dialogueInteractiveList[i].type) {
+                  case HOUSE_INTERACTIVE_TRANSITION:
+                    pTitleText = pMapStats->pInfos[dialogueInteractiveList[i].data.targetMapID].pName;
+                    yPos = 94 * i + SIDE_TEXT_BOX_POS_Y;
+                    break;
+                  case HOUSE_INTERACTIVE_PROPRIETOR:
+                    pTitleText = buildingTable[wData.val - 1].pProprieterTitle;
+                    yPos = SIDE_TEXT_BOX_POS_Y;
+                    break;
+                  case HOUSE_INTERACTIVE_NPC:
+                    pTitleText = dialogueInteractiveList[i].data.npc->pName;
+                    yPos = pNPCPortraits_y[dialogueInteractiveList.size() - 1][i] + dialogueInteractiveList[i].icon->height() + 2;
+                    break;
                 }
-                pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, v9, colorTable.EasternBlue, pTitleText, 3);
+                pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, yPos, colorTable.EasternBlue, pTitleText, 3);
             }
         }
         return;
     }
 
-    int v4 = currentDialogueInteractive;
     render->DrawTextureNew((pNPCPortraits_x[0][0] - 4) / 640.0f, (pNPCPortraits_y[0][0] - 4) / 480.0f, game_ui_evtnpc);
-    render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f, pNPCPortraits_y[0][0] / 480.0f, dialogueInteractiveList[v4].icon);
+    render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f, pNPCPortraits_y[0][0] / 480.0f, dialogueInteractiveList[currentDialogueInteractive].icon);
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
         CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
         if (dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
@@ -981,7 +979,7 @@ void GUIWindow_House::houseDialogManager() {
         }
         return;
     }
-    if (v4 || dialogueInteractiveList[0].type != HOUSE_INTERACTIVE_PROPRIETOR) {  // emerald isle ship before quest's done
+    if (currentDialogueInteractive || dialogueInteractiveList[0].type != HOUSE_INTERACTIVE_PROPRIETOR) {  // emerald isle ship before quest's done
         SimpleHouseDialog();
     } else {
         std::string nameAndTitle = NameAndTitle(buildingTable[wData.val - 1].pProprieterName, buildingTable[wData.val - 1].pProprieterTitle);

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -62,8 +62,8 @@ DIALOGUE_TYPE dialog_menu_id;     // 00F8B19C
 
 GraphicsImage *_591428_endcap = nullptr;
 
-std::vector<HouseInteractionDesc> houseInteractionList;
-int currentHouseInteraction;
+std::vector<HouseInteractiveDesc> dialogueInteractiveList;
+int currentDialogueInteractive;
 
 std::array<const HouseAnimDescr, 196> pAnimatedRooms = { {  // 0x4E5F70
     { "", 0x4, 0x1F4, BUILDING_INVALID, 0, 0 },
@@ -365,13 +365,13 @@ bool enterHouse(HOUSE_ID uHouseID) {
 
         std::string pContainer = DialogueBackgroundResourceByAlignment[pParty->alignment];
 
-        currentHouseInteraction = -1;
+        currentDialogueInteractive = -1;
         game_ui_dialogue_background = assets->getImage_Solid(pContainer);
 
         PrepareHouse(uHouseID);
 
-        if (houseInteractionList.size() == 1) {
-            currentHouseInteraction = 0;
+        if (dialogueInteractiveList.size() == 1) {
+            currentDialogueInteractive = 0;
         }
         pMediaPlayer->OpenHouseMovie(pAnimatedRooms[uCurrentHouse_Animation].video_name, 1u);
         if (isMagicGuild(uHouseID)) {
@@ -396,25 +396,25 @@ void PrepareHouse(HOUSE_ID house) {
     // Default proprietor of non-simple houses
     int proprietorId = pAnimatedRooms[buildingTable[house - 1].uAnimationID].house_npc_id;
     if (proprietorId) {
-        HouseInteractionDesc desc;
-        desc.type = HOUSE_INTERACTION_PROPRIETOR;
+        HouseInteractiveDesc desc;
+        desc.type = HOUSE_INTERACTIVE_PROPRIETOR;
         desc.label = localization->FormatString(LSTR_FMT_CONVERSE_WITH_S, buildingTable[house - 1].pProprieterName.c_str());
         desc.icon = assets->getImage_ColorKey(fmt::format("npc{:03}", proprietorId));
 
-        houseInteractionList.push_back(desc);
+        dialogueInteractiveList.push_back(desc);
     }
 
     // NPCs of this house
     for (int i = 1; i < pNPCStats->uNumNewNPCs; ++i) {
         if (pNPCStats->pNewNPCData[i].Location2D == house) {
             if (!(pNPCStats->pNewNPCData[i].uFlags & NPC_HIRED)) {
-                HouseInteractionDesc desc;
-                desc.type = HOUSE_INTERACTION_NPC;
+                HouseInteractiveDesc desc;
+                desc.type = HOUSE_INTERACTIVE_NPC;
                 desc.label = localization->FormatString(LSTR_FMT_CONVERSE_WITH_S, pNPCStats->pNewNPCData[i].pName.c_str());
                 desc.icon = assets->getImage_ColorKey(fmt::format("npc{:03}", pNPCStats->pNewNPCData[i].uPortraitID));
                 desc.data.npc = &pNPCStats->pNewNPCData[i];
 
-                houseInteractionList.push_back(desc);
+                dialogueInteractiveList.push_back(desc);
                 if (!(pNPCStats->pNewNPCData[i].uFlags & NPC_GREETED_SECOND)) {
                     if (pNPCStats->pNewNPCData[i].uFlags & NPC_GREETED_FIRST) {
                         pNPCStats->pNewNPCData[i].uFlags &= ~NPC_GREETED_FIRST;
@@ -432,13 +432,13 @@ void PrepareHouse(HOUSE_ID house) {
         if (!buildingTable[house - 1]._quest_bit || !pParty->_questBits[buildingTable[house - 1]._quest_bit]) {
             int id = buildingTable[house - 1].uExitMapID;
 
-            HouseInteractionDesc desc;
-            desc.type = HOUSE_INTERACTION_TRANSITION;
+            HouseInteractiveDesc desc;
+            desc.type = HOUSE_INTERACTIVE_TRANSITION;
             desc.label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[id].pName.c_str());
             desc.icon = assets->getImage_ColorKey(pHouse_ExitPictures[id]);
             desc.data.targetMapID = id;
 
-            houseInteractionList.push_back(desc);
+            dialogueInteractiveList.push_back(desc);
         }
     }
 }
@@ -459,8 +459,8 @@ void SimpleHouseDialog() {
     std::string pInString;  // [sp+114h] [bp-8h]@12
 
     GUIWindow house_window = *pDialogueWindow;
-    if (houseInteractionList[currentHouseInteraction].type == HOUSE_INTERACTION_TRANSITION) {
-        int id = houseInteractionList[currentHouseInteraction].data.targetMapID;
+    if (dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
+        int id = dialogueInteractiveList[currentDialogueInteractive].data.targetMapID;
         house_window.uFrameX = 493;
         house_window.uFrameWidth = 126;
         house_window.uFrameZ = 366;
@@ -480,11 +480,11 @@ void SimpleHouseDialog() {
     }
     house_window.uFrameWidth -= 10;
     house_window.uFrameZ -= 10;
-    NPCData *pNPC = houseInteractionList[currentHouseInteraction].data.npc;
+    NPCData *pNPC = dialogueInteractiveList[currentDialogueInteractive].data.npc;
 
     house_window.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, NameAndTitle(pNPC), 3);
 
-    if (houseInteractionList[0].type != HOUSE_INTERACTION_PROPRIETOR) {
+    if (dialogueInteractiveList[0].type != HOUSE_INTERACTIVE_PROPRIETOR) {
         if (uDialogueType == DIALOGUE_NULL) {
             if (pNPC->greet) {
                 house_window.uFrameWidth = game_viewport_width;
@@ -672,18 +672,18 @@ bool houseDialogPressEscape() {
     activeLevelDecoration = nullptr;
     current_npc_text.clear();
 
-    if (currentHouseInteraction == -1) {
+    if (currentDialogueInteractive == -1) {
         return false;
     }
 
     if (dialog_menu_id == DIALOGUE_OTHER) {
-        _4B4224_UpdateNPCTopics(currentHouseInteraction);
+        _4B4224_UpdateNPCTopics(currentDialogueInteractive);
         BackToHouseMenu();
         return true;
     }
 
     if (dialog_menu_id == DIALOGUE_NULL || dialog_menu_id == DIALOGUE_MAIN) {
-        currentHouseInteraction = -1;
+        currentDialogueInteractive = -1;
         if (pDialogueWindow) {
             pDialogueWindow->Release();
         }
@@ -694,15 +694,15 @@ bool houseDialogPressEscape() {
         dialog_menu_id = DIALOGUE_NULL;
         pDialogueWindow = nullptr;
 
-        if (houseInteractionList.size() == 1) {
+        if (dialogueInteractiveList.size() == 1) {
             return false;
         }
 
         pBtn_ExitCancel = window_SpeakInHouse->vButtons.front();
-        for (int i = 0; i < houseInteractionList.size(); ++i) {
-            Pointi pos = {pNPCPortraits_x[houseInteractionList.size() - 1][i], pNPCPortraits_y[houseInteractionList.size() - 1][i]};
-            houseInteractionList[i].button = window_SpeakInHouse->CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
-                                                                               InputAction::Invalid, houseInteractionList[i].label);
+        for (int i = 0; i < dialogueInteractiveList.size(); ++i) {
+            Pointi pos = {pNPCPortraits_x[dialogueInteractiveList.size() - 1][i], pNPCPortraits_y[dialogueInteractiveList.size() - 1][i]};
+            dialogueInteractiveList[i].button = window_SpeakInHouse->CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
+                                                                               InputAction::Invalid, dialogueInteractiveList[i].label);
         }
 
         BackToHouseMenu();
@@ -776,7 +776,7 @@ void createHouseUI(HOUSE_ID houseId) {
     window_SpeakInHouse->CreateButton({292, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 3, InputAction::SelectChar3, "");
     window_SpeakInHouse->CreateButton({407, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 4, InputAction::SelectChar4, "");
     window_SpeakInHouse->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, InputAction::CharCycle, "");
-    if (houseInteractionList.size() == 1) {
+    if (dialogueInteractiveList.size() == 1) {
         _4B4224_UpdateNPCTopics(0);
     }
 }
@@ -908,7 +908,7 @@ void GUIWindow_House::houseDialogManager() {
     render->DrawTextureNew(477 / 640.0f, 0, game_ui_dialogue_background);
     render->DrawTextureNew(468 / 640.0f, 0, game_ui_right_panel_frame);
 
-    if (currentHouseInteraction == -1 || houseInteractionList[currentHouseInteraction].type != HOUSE_INTERACTION_TRANSITION) {
+    if (currentDialogueInteractive == -1 || dialogueInteractiveList[currentDialogueInteractive].type != HOUSE_INTERACTIVE_TRANSITION) {
         if (!buildingTable[wData.val - 1].pName.empty()) {
             if (current_screen_type != CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
                 int v3 = 2 * pFontCreate->GetHeight() - 6 - pFontCreate->CalcTextHeight(buildingTable[wData.val - 1].pName, 130, 0);
@@ -921,7 +921,7 @@ void GUIWindow_House::houseDialogManager() {
 
     pWindow.uFrameWidth += 8;
     pWindow.uFrameZ += 8;
-    if (currentHouseInteraction == -1) {
+    if (currentDialogueInteractive == -1) {
         render->DrawTextureNew(471 / 640.0f, 445 / 480.0f, ui_exit_cancel_button_background);
 
         if (in_current_building_type == BUILDING_JAIL) {
@@ -938,29 +938,29 @@ void GUIWindow_House::houseDialogManager() {
             render->DrawTextureNew(8 / 640.0f, (347 - v6) / 480.0f, _591428_endcap);
             DrawText(pFontArrus, {13, 354 - v6}, colorTable.White, pFontArrus->FitTextInAWindow(current_npc_text, pDialogWindow.uFrameWidth, 13));
         }
-        if (houseInteractionList.size() == 0) {
+        if (dialogueInteractiveList.size() == 0) {
             return;
         }
 
-        for (int v8 = 0; v8 < houseInteractionList.size(); ++v8) {
-            render->DrawTextureNew((pNPCPortraits_x[houseInteractionList.size() - 1][v8] - 4) / 640.0f,
-                                   (pNPCPortraits_y[houseInteractionList.size() - 1][v8] - 4) / 480.0f, game_ui_evtnpc);
-            render->DrawTextureNew(pNPCPortraits_x[houseInteractionList.size() - 1][v8] / 640.0f,
-                                   pNPCPortraits_y[houseInteractionList.size() - 1][v8] / 480.0f, houseInteractionList[v8].icon);
-            if (houseInteractionList.size() < 4) {
+        for (int v8 = 0; v8 < dialogueInteractiveList.size(); ++v8) {
+            render->DrawTextureNew((pNPCPortraits_x[dialogueInteractiveList.size() - 1][v8] - 4) / 640.0f,
+                                   (pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] - 4) / 480.0f, game_ui_evtnpc);
+            render->DrawTextureNew(pNPCPortraits_x[dialogueInteractiveList.size() - 1][v8] / 640.0f,
+                                   pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] / 480.0f, dialogueInteractiveList[v8].icon);
+            if (dialogueInteractiveList.size() < 4) {
                 std::string pTitleText;
                 int v9 = 0;
-                if (houseInteractionList[v8].type == HOUSE_INTERACTION_TRANSITION) {
-                    pTitleText = pMapStats->pInfos[houseInteractionList[v8].data.targetMapID].pName;
+                if (dialogueInteractiveList[v8].type == HOUSE_INTERACTIVE_TRANSITION) {
+                    pTitleText = pMapStats->pInfos[dialogueInteractiveList[v8].data.targetMapID].pName;
                     v9 = 94 * v8 + SIDE_TEXT_BOX_POS_Y;
                 } else {
-                    if (!v8 && houseInteractionList[0].type == HOUSE_INTERACTION_PROPRIETOR) {
+                    if (!v8 && dialogueInteractiveList[0].type == HOUSE_INTERACTIVE_PROPRIETOR) {
                         pTitleText = buildingTable[wData.val - 1].pProprieterTitle;
                         pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, pTitleText, 3);
                         continue;
                     }
-                    pTitleText = houseInteractionList[v8].data.npc->pName;
-                    v9 = pNPCPortraits_y[houseInteractionList.size() - 1][v8] + houseInteractionList[v8].icon->height() + 2;
+                    pTitleText = dialogueInteractiveList[v8].data.npc->pName;
+                    v9 = pNPCPortraits_y[dialogueInteractiveList.size() - 1][v8] + dialogueInteractiveList[v8].icon->height() + 2;
                 }
                 pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, v9, colorTable.EasternBlue, pTitleText, 3);
             }
@@ -968,12 +968,12 @@ void GUIWindow_House::houseDialogManager() {
         return;
     }
 
-    int v4 = currentHouseInteraction;
+    int v4 = currentDialogueInteractive;
     render->DrawTextureNew((pNPCPortraits_x[0][0] - 4) / 640.0f, (pNPCPortraits_y[0][0] - 4) / 480.0f, game_ui_evtnpc);
-    render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f, pNPCPortraits_y[0][0] / 480.0f, houseInteractionList[v4].icon);
+    render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f, pNPCPortraits_y[0][0] / 480.0f, dialogueInteractiveList[v4].icon);
     if (current_screen_type == CURRENT_SCREEN::SCREEN_SHOP_INVENTORY) {
         CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
-        if (houseInteractionList[currentHouseInteraction].type == HOUSE_INTERACTION_TRANSITION) {
+        if (dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
             render->DrawTextureNew(556 / 640.0f, 451 / 480.0f, dialogue_ui_x_x_u);
             render->DrawTextureNew(476 / 640.0f, 451 / 480.0f, dialogue_ui_x_ok_u);
         } else {
@@ -981,14 +981,14 @@ void GUIWindow_House::houseDialogManager() {
         }
         return;
     }
-    if (v4 || houseInteractionList[0].type != HOUSE_INTERACTION_PROPRIETOR) {  // emerald isle ship before quest's done
+    if (v4 || dialogueInteractiveList[0].type != HOUSE_INTERACTIVE_PROPRIETOR) {  // emerald isle ship before quest's done
         SimpleHouseDialog();
     } else {
         std::string nameAndTitle = NameAndTitle(buildingTable[wData.val - 1].pProprieterName, buildingTable[wData.val - 1].pProprieterTitle);
         pWindow.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, nameAndTitle, 3);
         houseSpecificDialogue();
     }
-    if (houseInteractionList[currentHouseInteraction].type == HOUSE_INTERACTION_TRANSITION) {
+    if (dialogueInteractiveList[currentDialogueInteractive].type == HOUSE_INTERACTIVE_TRANSITION) {
         render->DrawTextureNew(556 / 640.0f, 451 / 480.0f, dialogue_ui_x_x_u);
         render->DrawTextureNew(476 / 640.0f, 451 / 480.0f, dialogue_ui_x_ok_u);
     } else {
@@ -1087,10 +1087,10 @@ GUIWindow_House::GUIWindow_House(HOUSE_ID houseId) : GUIWindow(WINDOW_HouseInter
         shop_ui_background = assets->getImage_ColorKey(shopBackgroundNames[in_current_building_type]);
     }
 
-    for (int i = 0; i < houseInteractionList.size(); ++i) {
-        Pointi pos = {pNPCPortraits_x[houseInteractionList.size() - 1][i], pNPCPortraits_y[houseInteractionList.size() - 1][i]};
-        houseInteractionList[i].button = CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
-                                                      InputAction::Invalid, houseInteractionList[i].label);
+    for (int i = 0; i < dialogueInteractiveList.size(); ++i) {
+        Pointi pos = {pNPCPortraits_x[dialogueInteractiveList.size() - 1][i], pNPCPortraits_y[dialogueInteractiveList.size() - 1][i]};
+        dialogueInteractiveList[i].button = CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
+                                                      InputAction::Invalid, dialogueInteractiveList[i].label);
     }
 }
 
@@ -1111,12 +1111,12 @@ void GUIWindow_House::Update() {
 }
 
 void GUIWindow_House::Release() {
-    for (HouseInteractionDesc &desc : houseInteractionList) {
+    for (HouseInteractiveDesc &desc : dialogueInteractiveList) {
         if (desc.icon) {
             desc.icon->Release();
         }
     }
-    houseInteractionList.clear();
+    dialogueInteractiveList.clear();
 
     if (game_ui_dialogue_background) {
         game_ui_dialogue_background->Release();

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -38,22 +38,23 @@ bool houseDialogPressEscape();
  */
 void playHouseSound(HOUSE_ID houseID, HouseSoundType type);
 
-enum class HouseInteractiveType {
-    HOUSE_INTERACTIVE_PROPRIETOR,
-    HOUSE_INTERACTIVE_NPC,
-    HOUSE_INTERACTIVE_TRANSITION
+/**
+ * Type of NPC you can have dialogue with inside house.
+ */
+enum class HouseNpcType {
+    HOUSE_PROPRIETOR, // default resident in non-simple houses (shop owner, temple priest etc.).
+    HOUSE_NPC,        // regular NPC, have description in NPCs table, @npc field is points to it.
+    HOUSE_TRANSITION  // transition point to different map, @targetMapID contains ID of target map.
 };
-using enum HouseInteractiveType;
+using enum HouseNpcType;
 
-struct HouseInteractiveDesc {
-    HouseInteractiveType type;
+struct HouseNpcDesc {
+    HouseNpcType type;
     std::string label = "";
     GraphicsImage *icon = nullptr;
     GUIButton *button = nullptr;
-    union {
-        int targetMapID;
-        NPCData *npc;
-    } data{};
+    int targetMapID = 0;
+    NPCData *npc = nullptr;
 };
 
 class GUIWindow_House : public GUIWindow {
@@ -115,5 +116,5 @@ extern std::array<const HouseAnimDescr, 196> pAnimatedRooms;
 
 extern IndexedArray<int, BUILDING_WEAPON_SHOP, BUILDING_DARK_GUILD> itemAmountInShop;
 
-extern std::vector<HouseInteractiveDesc> dialogueInteractiveList;
-extern int currentDialogueInteractive;
+extern std::vector<HouseNpcDesc> houseNpcs;
+extern int currentHouseNpc;

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -16,8 +16,6 @@ constexpr int SIDE_TEXT_BOX_BODY_TEXT_HEIGHT = 174;
 constexpr int SIDE_TEXT_BOX_BODY_TEXT_OFFSET = 138;
 constexpr int SIDE_TEXT_BOX_MAX_SPACING = 32;
 
-void SimpleHouseDialog();
-
 void BackToHouseMenu();
 
 /**
@@ -39,6 +37,24 @@ bool houseDialogPressEscape();
  * @offset 0x4B1E92
  */
 void playHouseSound(HOUSE_ID houseID, HouseSoundType type);
+
+enum class HouseInteractionType {
+    HOUSE_INTERACTION_PROPRIETOR,
+    HOUSE_INTERACTION_NPC,
+    HOUSE_INTERACTION_TRANSITION
+};
+using enum HouseInteractionType;
+
+struct HouseInteractionDesc {
+    HouseInteractionType type;
+    std::string label = "";
+    GraphicsImage *icon = nullptr;
+    GUIButton *button = nullptr;
+    union {
+        int targetMapID;
+        NPCData *npc;
+    } data{};
+};
 
 class GUIWindow_House : public GUIWindow {
  public:
@@ -90,8 +106,6 @@ struct HouseAnimDescr {
     uint16_t padding_e;
 };
 
-extern int uHouse_ExitPic;
-extern int dword_591080;
 extern BuildingType in_current_building_type;  // 00F8B198
 extern DIALOGUE_TYPE dialog_menu_id;     // 00F8B19C
 
@@ -100,3 +114,6 @@ extern class GraphicsImage *_591428_endcap;
 extern std::array<const HouseAnimDescr, 196> pAnimatedRooms;
 
 extern IndexedArray<int, BUILDING_WEAPON_SHOP, BUILDING_DARK_GUILD> itemAmountInShop;
+
+extern std::vector<HouseInteractionDesc> houseInteractionList;
+extern int currentHouseInteraction;

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -38,15 +38,15 @@ bool houseDialogPressEscape();
  */
 void playHouseSound(HOUSE_ID houseID, HouseSoundType type);
 
-enum class HouseInteractionType {
-    HOUSE_INTERACTION_PROPRIETOR,
-    HOUSE_INTERACTION_NPC,
-    HOUSE_INTERACTION_TRANSITION
+enum class HouseInteractiveType {
+    HOUSE_INTERACTIVE_PROPRIETOR,
+    HOUSE_INTERACTIVE_NPC,
+    HOUSE_INTERACTIVE_TRANSITION
 };
-using enum HouseInteractionType;
+using enum HouseInteractiveType;
 
-struct HouseInteractionDesc {
-    HouseInteractionType type;
+struct HouseInteractiveDesc {
+    HouseInteractiveType type;
     std::string label = "";
     GraphicsImage *icon = nullptr;
     GUIButton *button = nullptr;
@@ -115,5 +115,5 @@ extern std::array<const HouseAnimDescr, 196> pAnimatedRooms;
 
 extern IndexedArray<int, BUILDING_WEAPON_SHOP, BUILDING_DARK_GUILD> itemAmountInShop;
 
-extern std::vector<HouseInteractionDesc> houseInteractionList;
-extern int currentHouseInteraction;
+extern std::vector<HouseInteractiveDesc> dialogueInteractiveList;
+extern int currentDialogueInteractive;


### PR DESCRIPTION
Unify some dialogue globals into 2 global objects:
- List of interactable objects of different 3 types: default proprietor, npc, transition point.
- Currently picked object.

Unified globals:
- `uHouse_ExitPic` - contains ID of map that you can transfer from house (practically unused in MM7)
- `pDialogueNPCPortraits` - list of objects icons.
- `pDialogueNPCCount` - currently picked object + 1.
- `HouseNPCData` - list of pointers to house NPC datas.
- `HouseNPCPortraitsButtonsList` - list of pointers to buttons on screen when objects are being picked.
- `dword_5C35D4` - flag, if true means that current dialogue is inside house.
- `dword_591080` - flag, if true means that current house have proprietor (actually ID of proprietor NPC, but used only as zero/non-zero value).
- `portraitClickLabel` - list of labels for buttons.