### PR TITLE
Collision fixes, jumps now work reliably outdoors

### DIFF
--- a/src/Application/main.cpp
+++ b/src/Application/main.cpp
@@ -37,7 +37,7 @@ int runRetrace(GameOptions options) {
 
             recorder->startRecording(game, savePath, tracePath, TRACE_RECORDING_LOAD_EXISTING_SAVE);
             engine->config->graphics.FPSLimit.setValue(0);
-            player->playTrace(game, std::move(oldTrace.events), tracePath, TRACE_PLAYBACK_SKIP_RANDOM_CHECKS | TRACE_PLAYBACK_SKIP_STATE_CHECKS);
+            player->playTrace(game, std::move(oldTrace.events), tracePath, TRACE_PLAYBACK_SKIP_RANDOM_CHECKS); // Don't skip time checks.
             recorder->finishRecording(game);
         }
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -501,8 +501,12 @@ void BLVFace::Flatten(FlatFace *points, int model_idx, FaceAttributes override_p
 }
 
 bool BLVFace::Contains(const Vec3i &pos, int model_idx, int slack, FaceAttributes override_plane) const {
-    Assert(!override_plane ||
+    assert(!override_plane ||
             override_plane == FACE_XY_PLANE || override_plane == FACE_YZ_PLANE || override_plane == FACE_XZ_PLANE);
+
+    // TODO(captainurist): uncomment this
+    // float d = std::abs(this->facePlane.signedDistanceTo(pos.toFloat()));
+    // assert(d < 0.01f);
 
     if (this->uNumVertices < 3)
         return false; // This does happen.

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -144,8 +144,8 @@ void reconstruct(const TileDesc_MM7 &src, TileDesc *dst);
 struct TextureFrame_MM7 {
     std::array<char, 12> textureName;
     int16_t textureID;
-    int16_t animTime;
-    int16_t animLength;
+    int16_t animTime; // Total animation time, set only on the 1st frame, in 1/16th of a real-time second.
+    int16_t animLength; // Frame duration, in 1/16th of a real-time second.
     int16_t flags;
 };
 static_assert(sizeof(TextureFrame_MM7) == 20);

--- a/src/Utility/Geometry/Plane.h
+++ b/src/Utility/Geometry/Plane.h
@@ -15,7 +15,7 @@ struct Planei {
      *                                  means that `point` is in the half-space that the normal is pointing to,
      *                                  and this usually is "outside" the model that the face belongs to.
      */
-    int signedDistanceTo(const Vec3i &point) {
+    int signedDistanceTo(const Vec3i &point) const {
         return signedDistanceTo(point.x, point.y, point.z);
     }
 
@@ -25,28 +25,28 @@ struct Planei {
      *
      * @see signedDistanceTo(const Vec3i &)
      */
-    int signedDistanceToAsFixpoint(const Vec3i &point) {
+    int signedDistanceToAsFixpoint(const Vec3i &point) const {
         return signedDistanceToAsFixpoint(point.x, point.y, point.z);
     }
 
     /**
      * @see signedDistanceTo(const Vec3i &)
      */
-    int signedDistanceTo(const Vec3s &point) {
+    int signedDistanceTo(const Vec3s &point) const {
         return signedDistanceTo(point.x, point.y, point.z);
     }
 
     /**
      * @see signedDistanceTo(const Vec3i &)
      */
-    int signedDistanceTo(int x, int y, int z) {
+    int signedDistanceTo(int x, int y, int z) const {
         return signedDistanceToAsFixpoint(x, y, z) >> 16;
     }
 
     /**
      * @see signedDistanceToAsFixpoint(const Vec3i &)
      */
-    int signedDistanceToAsFixpoint(int x, int y, int z) {
+    int signedDistanceToAsFixpoint(int x, int y, int z) const {
         return this->dist + this->normal.x * x + this->normal.y * y + this->normal.z * z;
     }
 };
@@ -64,7 +64,7 @@ struct Planef {
      *                                  means that `point` is in the half-space that the normal is pointing to,
      *                                  and this usually is "outside" the model that the face belongs to.
      */
-    float signedDistanceTo(const Vec3f &point) {
+    float signedDistanceTo(const Vec3f &point) const {
         return this->dist + this->normal.x * point.x + this->normal.y * point.y + this->normal.z * point.z;
     }
 };

--- a/src/Utility/Geometry/Vec.h
+++ b/src/Utility/Geometry/Vec.h
@@ -164,6 +164,10 @@ struct Vec3 {
         return r * l;
     }
 
+    friend Vec3 operator-(const Vec3 &v) {
+        return Vec3(-v.x, -v.y, -v.z);
+    }
+
     Vec3 &operator+=(const Vec3 &v) {
         *this = *this + v;
         return *this;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG c4df4a9e8f54cc41ab30d6e9c5af8e6384314157
+            GIT_TAG 0f5520fd39a41f9a35702aaf2e3eeadcf39b607c
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTestMain.cpp
+++ b/test/Bin/GameTest/GameTestMain.cpp
@@ -25,7 +25,7 @@ void printGoogleTestHelp(char *app) {
 int platformMain(int argc, char **argv) {
     try {
         GameTestOptions opts = GameTestOptions::Parse(argc, argv);
-        if (opts.helpPrinted) {
+        if (opts.helpRequested) {
             fmt::print(stdout, "\n");
             printGoogleTestHelp(argv[0]);
             return 1;

--- a/test/Bin/GameTest/GameTestOptions.cpp
+++ b/test/Bin/GameTest/GameTestOptions.cpp
@@ -29,7 +29,7 @@ GameTestOptions GameTestOptions::Parse(int argc, char **argv) {
     } catch (const CLI::ParseError &e) {
         if (app->get_help_ptr()->as<bool>()) {
             app->exit(e);
-            result.helpPrinted = true;
+            result.helpRequested = true;
         } else {
             throw; // Genuine parse error => propagate.
         }

--- a/test/Bin/GameTest/GameTestOptions.h
+++ b/test/Bin/GameTest/GameTestOptions.h
@@ -8,7 +8,7 @@ class Platform;
 
 struct GameTestOptions : public GameStarterOptions {
     std::string testPath;
-    bool helpPrinted = false;
+    bool helpRequested = false;
 
     static GameTestOptions Parse(int argc, char **argv);
 };

--- a/test/Testing/Game/TestController.cpp
+++ b/test/Testing/Game/TestController.cpp
@@ -43,6 +43,9 @@ void TestController::playTraceFromTestData(const std::string &saveName, const st
 
 void TestController::prepareForNextTest() {
     engine->config->resetForTest();
+
+    // This is frame time for tests that are implemented by manually sending events from the test code.
+    // For such tests, frame time value is taken from config defaults.
     restart(engine->config->debug.TraceFrameTimeMs.value());
     ::application->get<GameKeyboardController>()->reset();
     _controller->goToMainMenu();

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -664,7 +664,7 @@ GAME_TEST(Issues, Issue506) {
     test->playTraceFromTestData("issue_506.mm7", "issue_506.json");
 }
 
-GAME_TEST(Issue, Issue518) {
+GAME_TEST(Issues, Issue518) {
     // Armageddon yeets the actors way too far into the sky & actors take stops when falling down
     test->playTraceFromTestData("issue_518.mm7", "issue_518.json");
     for (auto &actor : pActors) {
@@ -856,7 +856,7 @@ GAME_TEST(Issues, Issue626) {
     EXPECT_EQ(pSavegameList->selectedSlot, 1);
 }
 
-GAME_TEST(Issue, Issue645) {
+GAME_TEST(Issues, Issue645) {
     // Characters does not enter unconscious state
     test->playTraceFromTestData("issue_645.mm7", "issue_645.json");
     EXPECT_EQ(pParty->pCharacters[0].conditions.Has(CONDITION_UNCONSCIOUS), true);

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -1365,6 +1365,14 @@ GAME_TEST(Issues, Issue929) {
 
 // 1000
 
+GAME_TEST(Prs, Pr1005) {
+    // Testing collisions - stairs should work. In this test case the party is walking onto a wooden paving in Tatalia.
+    test->playTraceFromTestData("pr_1005.mm7", "pr_1005.json", [&] {
+        EXPECT_EQ(pParty->pos.z, 154);
+    });
+    EXPECT_EQ(pParty->pos.z, 193); // Paving is at z=192, party z should be this value +1.
+}
+
 GAME_TEST(Issues, Issue1020) {
     // Test finishing the scavenger hunt quest. The game should not crash when there is no dialogue options.
     test->playTraceFromTestData("issue_1020.mm7", "issue_1020.json"); // Should not assert

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -314,9 +314,9 @@ GAME_TEST(Issues, Issue293a) {
     EXPECT_EQ(partyItemCount(), 19); // +1
     EXPECT_TRUE(pParty->pCharacters[0].hasItem(ITEM_CHAIN_MAIL, false)); // That's the item from the trash pile.
     EXPECT_EQ(pParty->pCharacters[0].GetMajorConditionIdx(), CONDITION_DISEASE_WEAK);
-    EXPECT_EQ(pParty->pCharacters[1].GetMajorConditionIdx(), CONDITION_GOOD); // Good roll here, didn't get sick.
+    EXPECT_EQ(pParty->pCharacters[1].GetMajorConditionIdx(), CONDITION_DISEASE_WEAK);
     EXPECT_EQ(pParty->pCharacters[2].GetMajorConditionIdx(), CONDITION_DISEASE_WEAK);
-    EXPECT_EQ(pParty->pCharacters[3].GetMajorConditionIdx(), CONDITION_DISEASE_WEAK);
+    EXPECT_EQ(pParty->pCharacters[3].GetMajorConditionIdx(), CONDITION_GOOD); // Good roll here, didn't get sick.
 }
 
 GAME_TEST(Issues, Issue293b) {

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -19,6 +19,7 @@
 
 #include "Utility/DataPath.h"
 #include "Utility/ScopeGuard.h"
+#include "Utility/String.h"
 
 static int totalPartyHealth() {
     int result = 0;
@@ -1071,7 +1072,11 @@ GAME_TEST(Issues, Issue735b) {
 
 GAME_TEST(Issues, Issue735c) {
     // Trace-only test: entering the dragon cave on Emerald Isle, hugging the walls and shooting fireballs.
-    test->playTraceFromTestData("issue_735c.mm7", "issue_735c.json");
+    // Checking location names explicitly so that we'll notice if party misses cave entrance after retracing.
+    test->playTraceFromTestData("issue_735c.mm7", "issue_735c.json", [] {
+        EXPECT_EQ(toLower(pCurrentMapName), "out01.odm"); // Emerald Isle.
+    });
+    EXPECT_EQ(toLower(pCurrentMapName), "d28.blv"); // Dragon's cave.
 }
 
 GAME_TEST(Issues, Issue741) {


### PR DESCRIPTION
This breaks a lot of tests because it affects party & actor movement.

I'd appreciate if you could test this PR and see if actor / party movement looks OK to you.

Please note that #1004, #681 and #289 are not affected by this PR.