### PR TITLE
Remove flush method from message queue in favor of clear

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -355,7 +355,7 @@ GraphicsImage *gamma_preview_image = nullptr;  // 506E40
 
 void Game_StartDialogue(unsigned int actor_id) {
     if (pParty->hasActiveCharacter()) {
-        engine->_messageQueue->flush();
+        engine->_messageQueue->clear();
 
         GameUI_InitializeDialogue(&pActors[actor_id], true);
     }
@@ -364,7 +364,7 @@ void Game_StartDialogue(unsigned int actor_id) {
 void Game_StartHirelingDialogue(unsigned int hireling_id) {
     if (bNoNPCHiring || current_screen_type != CURRENT_SCREEN::SCREEN_GAME) return;
 
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
 
     FlatHirelings buf;
     buf.Prepare();
@@ -512,7 +512,7 @@ void Game::processQueuedMessages() {
                 new OnCancel({350, 302}, {106, 42}, pBtnCancel);
                 continue;
             case UIMSG_OpenQuestBook:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_QuestBook) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -531,7 +531,7 @@ void Game::processQueuedMessages() {
                 pGUIWindow_CurrentMenu = new GUIWindow_QuestBook();
                 continue;
             case UIMSG_OpenAutonotes:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_AutonotesBook) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -550,7 +550,7 @@ void Game::processQueuedMessages() {
                 pGUIWindow_CurrentMenu = new GUIWindow_AutonotesBook();
                 continue;
             case UIMSG_OpenMapBook:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_MapsBook) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -569,7 +569,7 @@ void Game::processQueuedMessages() {
                 pGUIWindow_CurrentMenu = new GUIWindow_MapBook();
                 continue;
             case UIMSG_OpenCalendar:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_CalendarBook) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -588,7 +588,7 @@ void Game::processQueuedMessages() {
                 pGUIWindow_CurrentMenu = new GUIWindow_CalendarBook();
                 continue;
             case UIMSG_OpenHistoryBook:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_BOOKS && pGUIWindow_CurrentMenu->eWindowType == WindowType::WINDOW_JournalBook) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -607,7 +607,7 @@ void Game::processQueuedMessages() {
                 pGUIWindow_CurrentMenu = new GUIWindow_JournalBook();
                 continue;
             case UIMSG_OpenDebugMenu:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_DEBUG) {
                     back_to_game();
                     onEscape();
@@ -621,7 +621,7 @@ void Game::processQueuedMessages() {
                 continue;
             case UIMSG_Escape:  // нажатие Escape and return to game
                 back_to_game();
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 switch (current_screen_type) {
                     case CURRENT_SCREEN::SCREEN_SHOP_INVENTORY:
                     case CURRENT_SCREEN::SCREEN_NPC_DIALOGUE:
@@ -660,7 +660,7 @@ void Game::processQueuedMessages() {
                     if (!pGUIWindow_CastTargetedSpell) {  // Draw Menu
                         new OnButtonClick2({602, 450}, {0, 0}, pBtn_GameSettings, std::string(), false);
 
-                        engine->_messageQueue->flush();
+                        engine->_messageQueue->clear();
                         _menu->MenuLoop();
                     } else {
                         pGUIWindow_CastTargetedSpell->Release();
@@ -876,7 +876,7 @@ void Game::processQueuedMessages() {
                 continue;
 
             case UIMSG_TransitionUI_Confirm:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 playButtonSoundOnEscape = false;
                 // PID_INVALID was used (exclusive sound)
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
@@ -948,7 +948,7 @@ void Game::processQueuedMessages() {
                 }
                 continue;
             case UIMSG_OnTravelByFoot:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 playButtonSoundOnEscape = false;
 
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
@@ -1063,7 +1063,7 @@ void Game::processQueuedMessages() {
             }
             case UIMSG_CastSpell_TargetCharacter:
             case UIMSG_CastSpell_Hireling:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 if (IsEnchantingInProgress) {
                     // Change character while enchanting is active
                     // TODO(Nik-RE-dev): need separate message type
@@ -1478,7 +1478,7 @@ void Game::processQueuedMessages() {
                 }
                 continue;
             case UIMSG_RestWindow:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 //if (current_screen_type == CURRENT_SCREEN::SCREEN_REST) {
                 //    engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -1731,7 +1731,7 @@ void Game::processQueuedMessages() {
                     GameUI_SetStatusBar(LSTR_CANT_DO_UNDERWATER);
                     pAudioPlayer->playUISound(SOUND_error);
                 } else {
-                    engine->_messageQueue->flush();
+                    engine->_messageQueue->clear();
                     if (pParty->hasActiveCharacter()) {
                         if (!pParty->activeCharacter().timeToRecovery) {
                             // toggle
@@ -1757,7 +1757,7 @@ void Game::processQueuedMessages() {
                 }
                 continue;
             case UIMSG_QuickReference:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // toggle
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_QUICK_REFERENCE) {
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
@@ -1886,7 +1886,7 @@ void Game::processQueuedMessages() {
                 ((GUIWindow_Book *)pGUIWindow_CurrentMenu)->bookButtonClicked(BookButtonAction(uMessageParam));
                 continue;
             case UIMSG_SelectCharacter:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 GameUI_OnPlayerPortraitLeftClick(uMessageParam);
                 continue;
             case UIMSG_ShowStatus_Funds: {
@@ -1953,13 +1953,13 @@ void Game::processQueuedMessages() {
                 pParty->activeCharacter().OnInventoryLeftClick();
                 continue;
             case UIMSG_MouseLeftClickInGame:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 engine->_messageQueue->addMessageCurrentFrame(UIMSG_MouseLeftClickInScreen, 0, 0);
                 continue;
             case UIMSG_MouseLeftClickInScreen:  // срабатывает при нажатии на
                                                 // правую кнопку мыши после
                                                 // UIMSG_MouseLeftClickInGame
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 _engine->onGameViewportClick();
                 continue;
             case UIMSG_F:  // what event?
@@ -1973,7 +1973,7 @@ void Game::processQueuedMessages() {
                 __debugbreak();  // GUIWindow::Create(0, 0, 0, 0, WINDOW_22, (int)pButton2, 0);
                 continue;
             case UIMSG_Game_Action:
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 // if currently in a chest
                 if (current_screen_type == CURRENT_SCREEN::SCREEN_CHEST) {
                     Chest::GrabItem(keyboardInputHandler->IsTakeAllToggled());
@@ -2242,7 +2242,7 @@ void Game::gameLoop() {
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
 
     while (true) {
-        engine->_messageQueue->flush();
+        engine->_messageQueue->clear();
 
         pPartyActionQueue->uNumActions = 0;
 
@@ -2414,7 +2414,7 @@ void Game::gameLoop() {
                 GameUI_SetStatusBar(LSTR_CHEATED_THE_DEATH);
                 uGameState = GAME_STATE_PLAYING;
 
-                // need to flush messages here??
+                // need to clear messages here??
             }
         } while (!game_finished);
 

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -52,7 +52,7 @@ std::map<InputAction, PlatformKey> curr_key_map;
 
 void Game_StartNewGameWhilePlaying(bool force_start) {
     if (confirmationState == CONFIRM_NEW_GAME || force_start) {
-        engine->_messageQueue->flush();
+        engine->_messageQueue->clear();
         // pGUIWindow_CurrentMenu->Release();
         uGameState = GAME_STATE_NEWGAME_OUT_GAMEMENU;
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
@@ -65,7 +65,7 @@ void Game_StartNewGameWhilePlaying(bool force_start) {
 
 void Game_QuitGameWhilePlaying(bool force_quit) {
     if (confirmationState == CONFIRM_QUIT || force_quit) {
-        engine->_messageQueue->flush();
+        engine->_messageQueue->clear();
         // pGUIWindow_CurrentMenu->Release();
         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
         pAudioPlayer->stopSounds();
@@ -79,7 +79,7 @@ void Game_QuitGameWhilePlaying(bool force_quit) {
 }
 
 void Game_OpenLoadGameDialog() {
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
     pGUIWindow_CurrentMenu->Release();
     pGUIWindow_CurrentMenu = nullptr;
     game_ui_status_bar_event_string_time_left = 0;
@@ -198,7 +198,7 @@ void Menu::EventLoop() {
             }
             case UIMSG_Game_OpenOptionsDialog:  // Open
             {
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameOptions();  // GameMenuUI_Options_Load();
@@ -210,7 +210,7 @@ void Menu::EventLoop() {
 
             case UIMSG_OpenKeyMappingOptions:  // Open
             {
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameKeyBindings();  // GameMenuUI_OptionsKeymapping_Load();
@@ -253,7 +253,7 @@ void Menu::EventLoop() {
                 continue;
 
             case UIMSG_OpenVideoOptions: {
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
 
                 pGUIWindow_CurrentMenu->Release();
                 pGUIWindow_CurrentMenu = new GUIWindow_GameVideoOptions();

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -235,7 +235,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                         pMediaPlayer->Unload();
                         window_SpeakInHouse->Release();
                         window_SpeakInHouse = nullptr;
-                        engine->_messageQueue->flush();
+                        engine->_messageQueue->clear();
                         current_screen_type = CURRENT_SCREEN::SCREEN_GAME;
                         if (pDialogueWindow) {
                             pDialogueWindow->Release();

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6771,7 +6771,7 @@ void Character::OnInventoryLeftClick() {
                     ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
                     IsEnchantingInProgress = false;
 
-                    engine->_messageQueue->flush();
+                    engine->_messageQueue->clear();
 
                     mouse->SetCursorImage("MICON1");
                     AfterEnchClickEventId = UIMSG_Escape;

--- a/src/GUI/GUIMessageQueue.cpp
+++ b/src/GUI/GUIMessageQueue.cpp
@@ -2,26 +2,22 @@
 
 #include <utility>
 
-void GUIFrameMessageQueue::Flush() {
-    if (messageQueue.size()) {
-        GUIMessage message = messageQueue.front();
-        Clear();
-        if (message.field_8 != 0) { // TODO(Nik-RE-dev): what's the semantics here?
-            messageQueue.push(message);
-        }
-    }
-}
-
-void GUIFrameMessageQueue::Clear() {
+void GUIFrameMessageQueue::clear() {
     std::queue<GUIMessage> empty;
 
     messageQueue.swap(empty);
 }
 
-void GUIFrameMessageQueue::PopMessage(UIMessageType *pType, int *pParam, int *a4) {
-    *pType = UIMSG_Invalid;
-    *pParam = 0;
-    *a4 = 0;
+void GUIFrameMessageQueue::popMessage(UIMessageType *msg, int *param, int *param2) {
+    assert(msg != nullptr);
+
+    *msg = UIMSG_Invalid;
+    if (param) {
+        *param = 0;
+    }
+    if (param2) {
+        *param2 = 0;
+    }
 
     if (messageQueue.empty()) {
         return;
@@ -30,15 +26,19 @@ void GUIFrameMessageQueue::PopMessage(UIMessageType *pType, int *pParam, int *a4
     GUIMessage message = messageQueue.front();
     messageQueue.pop();
 
-    *pType = message.eType;
-    *pParam = message.param;
-    *a4 = message.field_8;
+    *msg = message.type;
+    if (param) {
+        *param = message.param;
+    }
+    if (param2) {
+        *param2 = message.param2;
+    }
 }
 
-void GUIFrameMessageQueue::AddGUIMessage(UIMessageType msg, int param, int a4) {
+void GUIFrameMessageQueue::addGUIMessage(UIMessageType msg, int param, int param2) {
     GUIMessage message;
-    message.eType = msg;
+    message.type = msg;
     message.param = param;
-    message.field_8 = a4;
+    message.param2 = param2;
     messageQueue.push(message);
 }

--- a/src/GUI/GUIMessageQueue.h
+++ b/src/GUI/GUIMessageQueue.h
@@ -7,19 +7,18 @@
 #include "GUI/GUIEnums.h"
 
 struct GUIMessage {
-    enum UIMessageType eType;
+    UIMessageType type;
     int param;
-    int field_8;
+    int param2;
 };
 
 struct GUIFrameMessageQueue {
     GUIFrameMessageQueue() {}
 
-    void Flush();
-    void Clear();
-    bool Empty() { return messageQueue.empty(); }
-    void PopMessage(UIMessageType *pMsg, int *pParam, int *a4);
-    void AddGUIMessage(UIMessageType msg, int param, int a4);
+    void clear();
+    bool empty() { return messageQueue.empty(); }
+    void popMessage(UIMessageType *msg, int *param, int *param2);
+    void addGUIMessage(UIMessageType msg, int param, int param2);
 
     std::queue<GUIMessage> messageQueue;
 };
@@ -29,37 +28,33 @@ class GUIMessageQueue {
     GUIMessageQueue() {}
 
     bool haveMessages() {
-        return !_currentFrameQueue.Empty();
-    }
-
-    void flush() {
-        _currentFrameQueue.Flush();
+        return !_currentFrameQueue.empty();
     }
 
     void clear() {
-        _currentFrameQueue.Clear();
+        _currentFrameQueue.clear();
     }
 
     void clearAll() {
-        _currentFrameQueue.Clear();
-        _nextFrameQueue.Clear();
+        _currentFrameQueue.clear();
+        _nextFrameQueue.clear();
     }
 
     void swapFrames() {
         _nextFrameQueue.messageQueue.swap(_currentFrameQueue.messageQueue);
-        assert(_nextFrameQueue.Empty());
+        assert(_nextFrameQueue.empty());
     }
 
-    void addMessageCurrentFrame(UIMessageType msg, int param, int a4) {
-        _currentFrameQueue.AddGUIMessage(msg, param, a4);
+    void addMessageCurrentFrame(UIMessageType msg, int param = 0, int param2 = 0) {
+        _currentFrameQueue.addGUIMessage(msg, param, param2);
     }
 
-    void addMessageNextFrame(UIMessageType msg, int param, int a4) {
-        _nextFrameQueue.AddGUIMessage(msg, param, a4);
+    void addMessageNextFrame(UIMessageType msg, int param = 0, int param2 = 0) {
+        _nextFrameQueue.addGUIMessage(msg, param, param2);
     }
 
-    void popMessage(UIMessageType *msg, int *param, int *a4) {
-        _currentFrameQueue.PopMessage(msg, param, a4);
+    void popMessage(UIMessageType *msg, int *param, int *param2) {
+        _currentFrameQueue.popMessage(msg, param, param2);
     }
 
  private:

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -2182,7 +2182,7 @@ void OnPaperdollLeftClick() {
 
             ptr_50C9A4_ItemToEnchant = pitem;
             IsEnchantingInProgress = false;
-            engine->_messageQueue->flush();
+            engine->_messageQueue->clear();
             mouse->SetCursorImage("MICON1");
             AfterEnchClickEventId = UIMSG_Escape;
             AfterEnchClickEventSecondParam = 0;
@@ -2255,7 +2255,7 @@ void OnPaperdollLeftClick() {
                 ptr_50C9A4_ItemToEnchant =
                     &pParty->activeCharacter().pInventoryItemList[v34 - 1];
                 IsEnchantingInProgress = false;
-                engine->_messageQueue->flush();
+                engine->_messageQueue->clear();
                 mouse->SetCursorImage("MICON1");
                 AfterEnchClickEventId = UIMSG_Escape;
                 AfterEnchClickEventSecondParam = 0;

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -88,7 +88,7 @@ void GUICredits::EventLoop() {
 }
 
 void GUICredits::ExecuteCredits() {
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
 
     pAudioPlayer->MusicPlayTrack(MUSIC_Credits);
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -294,7 +294,7 @@ IndexedArray<std::string, BUILDING_WEAPON_SHOP, BUILDING_MIRRORED_PATH_GUILD> sh
 bool enterHouse(HOUSE_ID uHouseID) {
     GameUI_StatusBar_Clear();
     GameUI_SetStatusBar("");
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
     uDialogueType = DIALOGUE_NULL;
     keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_CANCELLED);
     keyboardInputHandler->ResetKeys();
@@ -460,7 +460,7 @@ void onSelectShopDialogueOption(DIALOGUE_TYPE option) {
 }
 
 bool houseDialogPressEscape() {
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
     keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_CANCELLED);
     keyboardInputHandler->ResetKeys();
     activeLevelDecoration = nullptr;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -608,7 +608,7 @@ void GUIWindow_PartyCreation::Update() {
 //----- (0049695A) --------------------------------------------------------
 GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     GUIWindow(WINDOW_CharacterCreation, {0, 0}, render->GetRenderDimensions(), 0) {
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
 
     main_menu_background = assets->getImage_PCXFromIconsLOD("makeme.pcx");
 

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -284,7 +284,7 @@ void Mouse::UI_OnMouseLeftClick() {
                     if (control->uButtonType == 1) {
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
-                            engine->_messageQueue->flush();
+                            engine->_messageQueue->clear();
                             engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);
                             return;
                         }
@@ -295,7 +295,7 @@ void Mouse::UI_OnMouseLeftClick() {
                                 (double)((x - control->uX) * (x - control->uX) +
                                          (y - control->uY) * (y - control->uY))) < (double)control->uWidth) {
                             control->field_2C_is_pushed = true;
-                            engine->_messageQueue->flush();
+                            engine->_messageQueue->clear();
                             engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);
                             return;
                         }
@@ -304,7 +304,7 @@ void Mouse::UI_OnMouseLeftClick() {
                     if (control->uButtonType == 3) {  // clicking skills
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
-                            engine->_messageQueue->flush();
+                            engine->_messageQueue->clear();
                             engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);
                             return;
                         }

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -906,7 +906,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
     pMovie_Track = nullptr;
 
     // prevent passing UIMSG_Escape event if video stopped by ESC key
-    engine->_messageQueue->flush();
+    engine->_messageQueue->clear();
 
     platform->setCursorShown(true);
 }


### PR DESCRIPTION
Remove `flush` method because it is a copy of `clear` but with additional semantics that is quite dubious.
Flush method clears current frame queue but may retain front (and only front) message if it have non-zero second parameter.
I found that messages that have non-zero second parameter are:
- Rent room (parameter is not zero but unused)
- Cast spell from book (second parameter is character ID so can be zero already)
- Use scroll (second parameter is character ID so can be zero already)

I don't see any logic why we (or vanilla that is) need such semantics.
