### PR TITLE
test for starting quests for custom party, issue #742

### DIFF
--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -379,6 +379,14 @@ GAME_TEST(Prs, Pr314) {
     EXPECT_EQ(pParty->pCharacters[1].GetRace(), CHARACTER_RACE_ELF);
     EXPECT_EQ(pParty->pCharacters[2].GetRace(), CHARACTER_RACE_GOBLIN);
     EXPECT_EQ(pParty->pCharacters[3].GetRace(), CHARACTER_RACE_ELF);
+
+    // Check that party qbits are set even if we press Clear when creating a party. Related to #742
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_RED_POTION_ACTIVE));
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_SEASHELL_ACTIVE));
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_LONGBOW_ACTIVE));
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_PLATE_ACTIVE));
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_LUTE_ACTIVE));
+    EXPECT_TRUE(pParty->_questBits.test(QBIT_EMERALD_ISLAND_HAT_ACTIVE));
 }
 
 GAME_TEST(Issues, Issue315) {


### PR DESCRIPTION
There is test already for starting a game with custom party.
And there is no starting quests.

I added a check there.

See issue https://github.com/OpenEnroth/OpenEnroth/issues/742#issuecomment-1612581023

<details>
<summary>(On a first attempt I tried to add new test data, but it is not required any more)</summary>
Test code for "new game with custom party" trace.

A bit unusual because it requires skipping RNG check.

Test data is here https://github.com/OpenEnroth/OpenEnroth_TestData/pull/32 (I will update the tag if it changes)
</details>