### PR TITLE
Fixing warnings

### DIFF
--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -1244,6 +1244,8 @@ char PlayerTurn(int player_num) {
                     pArcomageGame->check_exit = 1;
                 }
                 break;
+            default:
+                break;
         }
 
         // time to start the AIs turn

--- a/src/Engine/Events/EventIR.cpp
+++ b/src/Engine/Events/EventIR.cpp
@@ -333,9 +333,9 @@ static std::string getVariableSetStr(VariableType type, int value) {
             return fmt::format("ERROR: Invisible, value");
         case VAR_ItemEquipped:
             return fmt::format("ERROR: ItemEquipped, value");
+        default:
+            return fmt::format("UNPROCESSED: [{}], {}", std::to_underlying(type), value);
     }
-
-    return fmt::format("UNPROCESSED: [{}], {}", std::to_underlying(type), value);
 }
 
 static std::string getVariableCompareStr(VariableType type, int value) {
@@ -656,9 +656,9 @@ static std::string getVariableCompareStr(VariableType type, int value) {
             return fmt::format("Invisible");
         case VAR_ItemEquipped:
             return fmt::format("ItemEquipped({})", value);
+        default:
+            return fmt::format("UNPROCESSED: [{}] ? {}", std::to_underlying(type), value);
     }
-
-    return fmt::format("UNPROCESSED: [{}] ? {}", std::to_underlying(type), value);
 }
 
 std::string EventIR::toString() const {

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -14,22 +14,6 @@ const char *Localization::GetString(unsigned int index) const {
     return this->localization_strings[index];
 }
 
-std::string Localization::FormatString(unsigned int index, ...) const {
-    va_list args_ptr;
-
-    const char *format = (this->GetString(index));
-    char buf[2048];
-
-    va_start(args_ptr, index);  // ?? sometimes args_ptr has junk at start ??
-                                // args must pass as type c_str() ??
-    vsprintf(buf, format, args_ptr);
-    va_end(args_ptr);
-
-    extern int sprintfex_internal(char *str);
-    sprintfex_internal(buf);
-    return std::string(buf);
-}
-
 //----- (00452C49) --------------------------------------------------------
 bool Localization::Initialize() {
     char *tmp_pos;     // eax@3

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -8,7 +8,7 @@
 
 #include "Utility/Workaround/ToUnderlying.h"
 #include "Utility/IndexedArray.h"
-
+#include "Utility/Format.h"
 
 #define LSTR_AC                               0   // "AC"
 #define LSTR_ACCURACY                         1   // "Accuracy"
@@ -438,7 +438,13 @@ class Localization {
     bool Initialize();
 
     const char *GetString(unsigned int index) const;
-    std::string FormatString(unsigned int index, ...) const;
+
+    template<class... Args>
+    std::string FormatString(unsigned int index, Args &&... args) const {
+        // TODO(captainurist): what if fmt throws?
+        return fmt::sprintf(GetString(index), std::forward<Args>(args)...);
+        // TODO(captainurist): there was also a call to sprintfex_internal after a call to vsprintf.
+    }
 
     const char *GetDayName(unsigned int index) const {
         return this->day_names[index];

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -74,8 +74,9 @@ bool ShouldMonsterPlayAttackAnim(SPELL_TYPE spell_id) {
         case SPELL_LIGHT_HOUR_OF_POWER:
         case SPELL_DARK_PAIN_REFLECTION:
             return false;
+        default:
+            return true;
     }
-    return true;
 }
 
 //----- (0041AF52) --------------------------------------------------------
@@ -677,6 +678,10 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             actorPtr->buffs[ACTOR_BUFF_PAIN_REFLECTION].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, 0);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.MediumGrey);
             pAudioPlayer->playSound(SOUND_Sacrifice2, PID(OBJECT_Actor, uActorID));
+            break;
+
+        default:
+            assert(false);
             break;
     }
 }
@@ -3185,6 +3190,9 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
                             hit_will_paralyze = true;
                     }
                     break;
+
+                default:
+                    break;
             }
         }
         attackElement = DMGT_PHISYCAL;
@@ -3386,8 +3394,8 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
         if (engine->config->settings.ShowHits.value()) {
             GameUI_SetStatusBar(
                 LSTR_FMT_S_STUNS_S,
-                character->name.c_str(),
-                pMonster
+                character->name,
+                pMonster->name
             );
         }
     }
@@ -3399,8 +3407,8 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
         if (engine->config->settings.ShowHits.value()) {
             GameUI_SetStatusBar(
                 LSTR_FMT_S_PARALYZES_S,
-                character->name.c_str(),
-                pMonster
+                character->name,
+                pMonster->name
             );
         }
     }
@@ -4917,6 +4925,9 @@ void evaluateAoeDamage() {
                                     break;
                                 case OBJECT_Item:
                                     ItemDamageFromActor(attack.pid, actorID, &attackVector);
+                                    break;
+                                default:
+                                    assert(false);
                                     break;
                             }
                         }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -609,6 +609,9 @@ void GenerateItemsInChest() {
                                 goldAmount = grng->random(3001) + 2000;
                                 currItem->uItemID = ITEM_GOLD_LARGE;
                                 break;
+                            default:
+                                assert(false);
+                                break;
                             }
                             currItem->SetIdentified();
                             currItem->special_enchantment = (ITEM_ENCHANTMENT)goldAmount;

--- a/src/Engine/Objects/Items.h
+++ b/src/Engine/Objects/Items.h
@@ -113,7 +113,7 @@ struct ItemGen {  // 0x24
     ItemFlags uAttributes = 0;          // 14
     ITEM_SLOT uBodyAnchor = ITEM_SLOT_INVALID; // 18
     uint8_t uMaxCharges = 0;           // 19
-    uint8_t uHolderPlayer = -1;        // 1A
+    int8_t uHolderPlayer = -1;        // 1A
     bool placedInChest = false;        // 1B (was unused, repurposed)
     GameTime uExpireTime;        // uint64_t uExpireTime; //1C
 };

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -1126,6 +1126,9 @@ bool processSpellImpact(unsigned int uLayingItemID, int pid) {
                     dmgType = DMGT_DARK;
                     buffIdx = ACTOR_BUFF_SHRINK;
                     break;
+                default:
+                    assert(false);
+                    break;
             }
             if (object->uType == SPRITE_SPELL_DARK_SHRINKING_RAY) {
                 switch (skillMastery) {
@@ -1138,6 +1141,9 @@ bool processSpellImpact(unsigned int uLayingItemID, int pid) {
                     case CHARACTER_SKILL_MASTERY_MASTER:
                     case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                         shrinkPower = 4;
+                        break;
+                    default:
+                        assert(false);
                         break;
                 }
                 pActors[PID_ID(pid)].attributes |= ACTOR_AGGRESSOR;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -313,7 +313,7 @@ struct Party {
     unsigned char days_played_without_rest;
     IndexedBitset<1, 512> _questBits;
     std::array<uint8_t, 16> pArcomageWins;
-    char field_7B5_in_arena_quest; // 0, DIALOGUE_ARENA_SELECT_PAGE..DIALOGUE_ARENA_SELECT_CHAMPION, or -1 for win
+    int8_t field_7B5_in_arena_quest; // 0, DIALOGUE_ARENA_SELECT_PAGE..DIALOGUE_ARENA_SELECT_CHAMPION, or -1 for win
     std::array<char, 4> uNumArenaWins; // 0=page, 1=squire, 2=knight, 3=lord
     IndexedArray<bool, ITEM_FIRST_SPAWNABLE_ARTIFACT, ITEM_LAST_SPAWNABLE_ARTIFACT> pIsArtifactFound;  // 7ba
     IndexedBitset<1, 208> _autonoteBits;

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -828,6 +828,8 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHA
             spell_sprites.spell_caster_pid = PID(OBJECT_Item, 1000); // 8000 | OBJECT_Item;
             spell_sprites.uSoundID = 0;
             break;
+        default:
+            break;
     }
 
     GameTime spell_length;
@@ -941,6 +943,7 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHA
                     spell_length = GameTime::FromHours(skillLevel + 1);
                     break;
                 default:
+                    assert(false);
                     break;
             }
             switch (uSpellID) {
@@ -955,6 +958,9 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHA
                 case SPELL_SPIRIT_HEROISM:
                     spell_power = skillLevel + 5;
                     buff_id = PARTY_BUFF_HEROISM;
+                    break;
+                default:
+                    assert(false);
                     break;
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
@@ -1004,6 +1010,9 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHA
                     break;
                 case SPELL_BODY_PROTECTION_FROM_BODY:
                     buff_id = PARTY_BUFF_RESIST_BODY;
+                    break;
+                default:
+                    assert(false);
                     break;
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);

--- a/src/Engine/mm7text_ru.cpp
+++ b/src/Engine/mm7text_ru.cpp
@@ -659,16 +659,6 @@ const char *GetSpecialCase(const char *ansi_name, char c) {
     return nullptr;
 }
 
-int sprintfex(char *buf, const char *format, ...) {
-    va_list args_ptr;
-    va_start(args_ptr, format);
-    { vsprintf(buf, format, args_ptr); }
-    va_end(args_ptr);
-
-    extern int sprintfex_internal(char *buf);
-    return sprintfex_internal(buf);
-}
-
 int sprintfex_internal(char *str) {
     auto p = strstr(str, "^");
     if (!p) return strlen(str);

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -1133,6 +1133,10 @@ void GUIWindow_Shop::houseScreenClick() {
             }
             break;
         }
+
+        default:
+            assert(false);
+            break;
     }
 }
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -1083,7 +1083,7 @@ void GUIWindow_House::drawOptions(std::vector<std::string> &optionsText, Color s
         GUIButton *button = pDialogueWindow->GetControl(buttonIndex);
 
         if (!optionsText[i].empty()) {
-            Color textColor = (pDialogueWindow->pCurrentPosActiveItem == buttonIndex) ? selectColor : textColor = colorTable.White;
+            Color textColor = (pDialogueWindow->pCurrentPosActiveItem == buttonIndex) ? selectColor : colorTable.White;
             int textHeight = pFontArrus->CalcTextHeight(optionsText[i], window.uFrameWidth, 0);
             button->uY = spacing + offset;
             button->uHeight = textHeight;

--- a/src/GUI/UI/UIStatusBar.cpp
+++ b/src/GUI/UI/UIStatusBar.cpp
@@ -35,23 +35,6 @@ void GameUI_SetStatusBar(const std::string &str) {
     GameUI_StatusBar_OnEvent_Internal(str, 2 * 1000);
 }
 
-
-void GameUI_SetStatusBar(int localization_string_id, ...) {
-    va_list args_ptr;
-
-    const char *format = localization->GetString(localization_string_id);
-    char buf[4096];
-
-    va_start(args_ptr, localization_string_id);
-    vsprintf(buf, format, args_ptr);
-    va_end(args_ptr);
-
-    extern int sprintfex_internal(char *str);
-    sprintfex_internal(buf);
-    GameUI_SetStatusBar(buf);
-}
-
-
 void GameUI_SetStatusBarShortNotification(const std::string &str) {
     GameUI_StatusBar_OnEvent_Internal(str, 128);
 }

--- a/src/GUI/UI/UIStatusBar.h
+++ b/src/GUI/UI/UIStatusBar.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <string>
+#include <utility>
+
+#include "Engine/Localization.h"
 
 #include "Library/Color/Color.h"
 
@@ -11,7 +14,14 @@ void GameUI_StatusBar_Set(const std::string &str);
 void GameUI_StatusBar_Clear();
 
 void GameUI_SetStatusBar(const std::string &str);
-void GameUI_SetStatusBar(int localization_string_id, ...);
+
+template<class... Args>
+void GameUI_SetStatusBar(int localization_string_id, Args &&... args) {
+    // TODO(captainurist): what if fmt throws?
+    GameUI_SetStatusBar(fmt::sprintf(localization->GetString(localization_string_id), std::forward<Args>(args)...));
+    // TODO(captainurist): there was also a call to sprintfex_internal here.
+}
+
 void GameUI_SetStatusBarShortNotification(const std::string &str);
 void GameUI_StatusBar_ClearEventString();
 


### PR DESCRIPTION
As reported by clang.

Btw, `sprintfex_internal` doesn't even do anything. It prints into a stack-allocated buffer and doesn't seem to do with it afterward.