### PR TITLE
Propagate CombinedSkillValue & fix #1045

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1239,7 +1239,8 @@ void Game::processQueuedMessages() {
                 if (!pParty->hasActiveCharacter() || pParty->activeCharacter().timeToRecovery) {
                     continue;
                 }
-                pushSpellOrRangedAttack(pParty->activeCharacter().uQuickSpell, pParty->activeCharacterIndex() - 1, 0, 0, pParty->activeCharacterIndex());
+                pushSpellOrRangedAttack(pParty->activeCharacter().uQuickSpell, pParty->activeCharacterIndex() - 1,
+                                        CombinedSkillValue::none(), 0, pParty->activeCharacterIndex());
                 continue;
             }
 
@@ -1570,7 +1571,7 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpellFromBook:
                 if (pTurnEngine->turn_stage != TE_MOVEMENT) {
-                    pushSpellOrRangedAttack(static_cast<SPELL_TYPE>(uMessageParam), uMessageParam2, 0, 0, 0);
+                    pushSpellOrRangedAttack(static_cast<SPELL_TYPE>(uMessageParam), uMessageParam2, CombinedSkillValue::none(), 0, 0);
                 }
                 continue;
 

--- a/src/Engine/Events/EventIR.cpp
+++ b/src/Engine/Events/EventIR.cpp
@@ -1042,7 +1042,7 @@ EventIR EventIR::parse(const void *data, size_t maxSize) {
         case EVENT_CheckSkill:
             ir.data.check_skill_descr.skill_type = (CharacterSkillType)_evt->v5;
             ir.data.check_skill_descr.skill_mastery = (CharacterSkillMastery)_evt->v6;
-            ir.data.check_skill_descr.skill_level = (CHARACTER_SKILL_LEVEL)EVT_DWORD(_evt->v7);
+            ir.data.check_skill_descr.skill_level = EVT_DWORD(_evt->v7);
             ir.target_step = _evt->v11;
             break;
         case EVENT_OnCanShowDialogItemCmp:

--- a/src/Engine/Events/EventIR.h
+++ b/src/Engine/Events/EventIR.h
@@ -73,7 +73,7 @@ class EventIR {
         struct {
             SPELL_TYPE spell_id;
             CharacterSkillMastery spell_mastery;
-            CHARACTER_SKILL_LEVEL spell_level;
+            int spell_level;
             int fromx;
             int fromy;
             int fromz;
@@ -166,7 +166,7 @@ class EventIR {
         struct {
             CharacterSkillType skill_type;
             CharacterSkillMastery skill_mastery;
-            CHARACTER_SKILL_LEVEL skill_level;
+            int skill_level;
         } check_skill_descr;
     } data;
 };

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -209,13 +209,13 @@ void Actor::SetRandomGoldIfTheresNoItem() {
 
 //----- (00404AC7) --------------------------------------------------------
 void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
-                           SPELL_TYPE uSpellID, ABILITY_INDEX a4, CHARACTER_SKILL uSkillMastery) {
+                           SPELL_TYPE uSpellID, ABILITY_INDEX a4, CombinedSkillValue uSkillMastery) {
     GameTime spellLength = GameTime(0);
 
     SpriteObject sprite;
     Actor *actorPtr = &pActors[uActorID];
-    CHARACTER_SKILL_LEVEL realPoints = GetSkillLevel(uSkillMastery);
-    CharacterSkillMastery masteryLevel = GetSkillMastery(uSkillMastery);
+    int realPoints = uSkillMastery.level();
+    CharacterSkillMastery masteryLevel = uSkillMastery.mastery();
     int distancemod = 3;
     int spriteId;
 
@@ -248,8 +248,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uObjectDescID = GetObjDescId(uSpellID);
             sprite.containing_item.Reset();
             sprite.uSpellID = uSpellID;
-            sprite.spell_level = uSkillMastery;
-            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE;
+            sprite.spell_level = uSkillMastery.level();
+            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3i(0, 0, actorPtr->height / 2);
             sprite.uFacing = (short)pDir->uYawAngle;
             sprite.uSoundID = 0;
@@ -329,10 +329,10 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 sprite.containing_item.Reset();
                 sprite.uType = SpellSpriteMapping[uSpellID];
                 sprite.uObjectDescID = GetObjDescId(uSpellID);
-                sprite.spell_level = uSkillMastery;
+                sprite.spell_level = uSkillMastery.level();
+                sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
                 sprite.vPosition = pParty->pos + Vec3i(0, 0, originHeight + 2500);
                 sprite.uSpellID = SPELL_FIRE_METEOR_SHOWER;
-                sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE;
                 sprite.uAttributes = 0;
                 sprite.uSectorID = 0;
                 sprite.uSpriteFrameID = 0;
@@ -378,8 +378,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uObjectDescID = GetObjDescId(uSpellID);
             sprite.containing_item.Reset();
             sprite.uSpellID = SPELL_AIR_SPARKS;
-            sprite.spell_level = uSkillMastery;
-            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE;
+            sprite.spell_level = uSkillMastery.level();
+            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3i(0, 0, actorPtr->height / 2);
             sprite.uFacing = pDir->uYawAngle;
             sprite.uSoundID = 0;
@@ -633,8 +633,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uObjectDescID = GetObjDescId(uSpellID);
             sprite.containing_item.Reset();
             sprite.uSpellID = uSpellID;
-            sprite.spell_level = uSkillMastery;
-            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE;
+            sprite.spell_level = uSkillMastery.level();
+            sprite.spell_skill = CHARACTER_SKILL_MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3i(0, 0, actorPtr->height / 2);
             sprite.uFacing = pDir->uYawAngle;
             sprite.uSoundID = 0;
@@ -1279,8 +1279,8 @@ int Actor::_43B3E0_CalcDamage(ABILITY_INDEX dmgSource) {
     int damageBonus;
     SPELL_TYPE spellID;
     int spellPower = 0;
-    CHARACTER_SKILL skill;
-    CHARACTER_SKILL_LEVEL skillLevel = 0;
+    CombinedSkillValue skill;
+    int skillLevel = 0;
     CharacterSkillMastery skillMastery = CHARACTER_SKILL_MASTERY_NONE;
 
     switch (dmgSource) {
@@ -1303,15 +1303,15 @@ int Actor::_43B3E0_CalcDamage(ABILITY_INDEX dmgSource) {
         case ABILITY_SPELL1:
             spellID = this->monsterInfo.uSpell1ID;
             skill = this->monsterInfo.uSpellSkillAndMastery2;
-            skillLevel = GetSkillLevel(skill);
-            skillMastery = GetSkillMastery(skill);
+            skillLevel = skill.level();
+            skillMastery = skill.mastery();
             return CalcSpellDamage(spellID, skillLevel, skillMastery, 0);
             break;
         case ABILITY_SPELL2:
             spellID = this->monsterInfo.uSpell2ID;
             skill = this->monsterInfo.uSpellSkillAndMastery2;
-            skillLevel = GetSkillLevel(skill);
-            skillMastery = GetSkillMastery(skill);
+            skillLevel = skill.level();
+            skillMastery = skill.mastery();
             return CalcSpellDamage(spellID, skillLevel, skillMastery, 0);
             break;
         case ABILITY_SPECIAL:
@@ -3139,7 +3139,7 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
     uint16_t v43{};            // ax@132
     uint16_t v45{};            // ax@132
     // uint64_t v46; // [sp+Ch] [bp-60h]@6
-    CHARACTER_SKILL_LEVEL skillLevel = 0;                    // [sp+44h] [bp-28h]@1
+    int skillLevel = 0;                    // [sp+44h] [bp-28h]@1
     bool IsAdditionalDamagePossible;  // [sp+50h] [bp-1Ch]@1
     int v61;                          // [sp+58h] [bp-14h]@1
     bool isLifeStealing;              // [sp+5Ch] [bp-10h]@1

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -6,6 +6,7 @@
 #include "Engine/Spells/SpellBuff.h"
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/Monsters.h"
+#include "Engine/Objects/CombinedSkillValue.h"
 
 #include "Utility/Geometry/Vec.h"
 #include "Utility/IndexedArray.h"
@@ -133,7 +134,7 @@ class Actor {
     static void AI_RangedAttack(unsigned int uActorID, struct AIDirection *a2,
                                 int type, ABILITY_INDEX a4);
     static void AI_SpellAttack(unsigned int uActorID, struct AIDirection *pDir,
-                               SPELL_TYPE uSpellID, ABILITY_INDEX a4, CHARACTER_SKILL uSkill);
+                               SPELL_TYPE uSpellID, ABILITY_INDEX a4, CombinedSkillValue uSkill);
     static void ActorDamageFromMonster(int attacker_id, unsigned int actor_id,
                                        Vec3i *pVelocity, ABILITY_INDEX a4);
 

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -827,7 +827,7 @@ int Character::GetDisarmTrap() const {
 }
 
 char Character::getLearningPercent() const {
-    CHARACTER_SKILL_LEVEL skill = getActualSkillValue(CHARACTER_SKILL_LEARNING).level();
+    int skill = getActualSkillValue(CHARACTER_SKILL_LEARNING).level();
 
     if (skill) {
         int multiplier = GetMultiplierForSkillLevel(CHARACTER_SKILL_LEARNING, 1, 2, 3, 5);
@@ -2748,7 +2748,7 @@ int Character::GetMagicalBonus(CharacterAttributeType a2) const {
 }
 
 //----- (0048F882) --------------------------------------------------------
-CHARACTER_SKILL_LEVEL Character::GetActualSkillLevel(CharacterSkillType uSkillType) const {
+int Character::GetActualSkillLevel(CharacterSkillType uSkillType) const {
     int bonus_value = 0;
     int result;
 
@@ -4073,12 +4073,12 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
     }
 }
 
-bool CmpSkillValue(CHARACTER_SKILL valToCompare, CHARACTER_SKILL skillValue) {
-    CHARACTER_SKILL val;
+bool CmpSkillValue(int valToCompare, CombinedSkillValue skillValue) {
+    int val;
     if (valToCompare <= 63)
-        val = skillValue & 0x3F;
+        val = skillValue.level();
     else
-        val = skillValue & skillValue;
+        val = skillValue.joined();
     return val >= valToCompare;
 }
 
@@ -4243,81 +4243,81 @@ bool Character::CompareVariable(VariableType VarNum, int pValue) {
         case VAR_MagicResistanceBonus:
             return this->sResMagicBonus >= pValue;
         case VAR_StaffSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_STAFF].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_STAFF]);
         case VAR_SwordSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SWORD].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SWORD]);
         case VAR_DaggerSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DAGGER].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DAGGER]);
         case VAR_AxeSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_AXE].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_AXE]);
         case VAR_SpearSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SPEAR].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SPEAR]);
         case VAR_BowSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BOW].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BOW]);
         case VAR_MaceSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MACE].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MACE]);
         case VAR_BlasterSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BLASTER].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BLASTER]);
         case VAR_ShieldSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SHIELD].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SHIELD]);
         case VAR_LeatherSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LEATHER].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LEATHER]);
         case VAR_SkillChain:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_CHAIN].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_CHAIN]);
         case VAR_PlateSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_PLATE].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_PLATE]);
         case VAR_FireSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_FIRE].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_FIRE]);
         case VAR_AirSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_AIR].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_AIR]);
         case VAR_WaterSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_WATER].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_WATER]);
         case VAR_EarthSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_EARTH].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_EARTH]);
         case VAR_SpiritSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SPIRIT].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_SPIRIT]);
         case VAR_MindSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MIND].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MIND]);
         case VAR_BodySkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BODY].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BODY]);
         case VAR_LightSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LIGHT].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LIGHT]);
         case VAR_DarkSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DARK].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DARK]);
         case VAR_IdentifyItemSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ITEM_ID].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ITEM_ID]);
         case VAR_MerchantSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MERCHANT].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MERCHANT]);
         case VAR_RepairSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_REPAIR].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_REPAIR]);
         case VAR_BodybuildingSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BODYBUILDING].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_BODYBUILDING]);
         case VAR_MeditationSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MEDITATION].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MEDITATION]);
         case VAR_PerceptionSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_PERCEPTION].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_PERCEPTION]);
         case VAR_DiplomacySkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DIPLOMACY].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DIPLOMACY]);
         case VAR_ThieverySkill:
             //Error("Thievery isn't used in events");
             //return false;
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_THIEVERY].join());  // wasn't in the original
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_THIEVERY]);  // wasn't in the original
         case VAR_DisarmTrapSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_TRAP_DISARM].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_TRAP_DISARM]);
         case VAR_DodgeSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DODGE].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_DODGE]);
         case VAR_UnarmedSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_UNARMED].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_UNARMED]);
         case VAR_IdentifyMonsterSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MONSTER_ID].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_MONSTER_ID]);
         case VAR_ArmsmasterSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ARMSMASTER].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ARMSMASTER]);
         case VAR_StealingSkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_STEALING].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_STEALING]);
         case VAR_AlchemySkill:  // wasn't in the original
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ALCHEMY].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_ALCHEMY]);
         case VAR_LearningSkill:
-            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LEARNING].join());
+            return CmpSkillValue(pValue, this->pActiveSkills[CHARACTER_SKILL_LEARNING]);
         case VAR_Cursed:
             return conditions.Has(CONDITION_CURSED);
         case VAR_Weak:
@@ -5672,9 +5672,12 @@ void Character::PlayAwardSound_Anim97_Face(CharacterSpeech speech) {
 
 //----- (new function) --------------------------------------------------------
 void Character::AddSkillByEvent(CharacterSkillType skill, uint16_t addSkillValue) {
-    uint16_t newlevel = pActiveSkills[skill].level() + ::GetSkillLevel(addSkillValue);
-    CharacterSkillMastery newmast = std::max(pActiveSkills[skill].mastery(), ::GetSkillMastery(addSkillValue));
-    pActiveSkills[skill] = CombinedSkillValue(newlevel, newmast);
+    auto [addLevel, addMastery] = CombinedSkillValue::fromJoinedUnchecked(addSkillValue);
+
+    int newLevel = pActiveSkills[skill].level() + addLevel;
+    CharacterSkillMastery newMastery = std::max(pActiveSkills[skill].mastery(), addMastery);
+
+    pActiveSkills[skill] = CombinedSkillValue(newLevel, newMastery);
 }
 
 //----- (0044B9C4) --------------------------------------------------------
@@ -6235,9 +6238,13 @@ void Character::PlayAwardSound_Anim98_Face(CharacterSpeech speech) {
 
 //----- (new function) --------------------------------------------------------
 void Character::SubtractSkillByEvent(CharacterSkillType skill, uint16_t subSkillValue) {
-    uint16_t newlevel = pActiveSkills[skill].level() - ::GetSkillLevel(subSkillValue);
-    newlevel = std::max(uint16_t(0), newlevel);
-    pActiveSkills[skill] = CombinedSkillValue(newlevel, pActiveSkills[skill].mastery());
+    auto [subLevel, subMastery] = CombinedSkillValue::fromJoinedUnchecked(subSkillValue);
+
+    if (pActiveSkills[skill] == CombinedSkillValue::none())
+        return; // Already at zero!
+
+    int newLevel = std::max(1, pActiveSkills[skill].level() - subLevel);
+    pActiveSkills[skill] = CombinedSkillValue(newLevel, pActiveSkills[skill].mastery());
     // TODO(pskelton): check - should this be able to forget a skill '0' or min of '1'
     // TODO(pskelton): check - should this modify mastery as well
 }
@@ -7039,7 +7046,7 @@ int Character::getCharacterIndex() {
 }
 
 //----- (004272F5) --------------------------------------------------------
-bool Character::characterHitOrMiss(Actor *pActor, int distancemod, CHARACTER_SKILL_LEVEL skillmod) {  // PS - RETURN IF ATTACK WILL HIT
+bool Character::characterHitOrMiss(Actor *pActor, int distancemod, int skillmod) {  // PS - RETURN IF ATTACK WILL HIT
     int naturalArmor = pActor->monsterInfo.uAC;  // actor usual armour
     int armorBuff = 0;
 
@@ -7163,14 +7170,14 @@ void Character::_42ECB5_CharacterAttacksActor() {
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
         pushSpellOrRangedAttack(SPELL_LASER_PROJECTILE,
-                                pParty->activeCharacterIndex() - 1, 0, 0,
+                                pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0,
                                 pParty->activeCharacterIndex() + 8);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         int main_hand_idx = character->pEquipment.uMainHand;
         pushSpellOrRangedAttack(wandSpellIds[character->pInventoryItemList[main_hand_idx - 1].uItemID],
-                                pParty->activeCharacterIndex() - 1, 8, 0, pParty->activeCharacterIndex() + 8);
+                                pParty->activeCharacterIndex() - 1, CombinedSkillValue::novice(8), 0, pParty->activeCharacterIndex() + 8);
 
         if (!--character->pInventoryItemList[main_hand_idx - 1].uNumCharges)
             character->pEquipment.uMainHand = 0;
@@ -7190,7 +7197,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
                 pParty->activeCharacterIndex());
     } else if (bow_idx) {
         shooting_bow = true;
-        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, 0, 0, 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0, 0);
     } else {
         melee_attack = true;
         // ; // actor out of range or no actor; no ranged weapon so melee

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3296,7 +3296,7 @@ void Character::Reset(CharacterClassType cls) {
         if (pSkillAvailabilityPerClass[classType / 4][i] != 2)
             continue;
 
-        SetSkillLevel(i, 1);
+        setSkillValue(i, CombinedSkillValue::novice());
     }
 
     memset(&pEquipment, 0, sizeof(CharacterEquipment));
@@ -7286,24 +7286,8 @@ void Character::_42FA66_do_explosive_impact(int xpos, int ypos, int zpos, int a4
     }
 }
 
-CHARACTER_SKILL_LEVEL Character::GetSkillLevel(CharacterSkillType skill) const {
-    return pActiveSkills[skill].level();
-}
-
-CharacterSkillMastery Character::GetSkillMastery(CharacterSkillType skill) const {
-    return pActiveSkills[skill].mastery();
-}
-
 CombinedSkillValue Character::getSkillValue(CharacterSkillType skill) const {
     return pActiveSkills[skill];
-}
-
-void Character::SetSkillLevel(CharacterSkillType skill, CHARACTER_SKILL_LEVEL level) {
-    pActiveSkills[skill].setLevel(level);
-}
-
-void Character::SetSkillMastery(CharacterSkillType skill, CharacterSkillMastery mastery) {
-    pActiveSkills[skill].setMastery(mastery);
 }
 
 void Character::setSkillValue(CharacterSkillType skill, const CombinedSkillValue &value) {

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -259,7 +259,7 @@ class Character {
     int GetSpecialItemBonus(ITEM_ENCHANTMENT enchantment) const;
     int GetItemsBonus(CharacterAttributeType attr, bool getOnlyMainHandDmg = false) const;
     int GetMagicalBonus(CharacterAttributeType a2) const;
-    CHARACTER_SKILL_LEVEL GetActualSkillLevel(CharacterSkillType uSkillType) const;
+    int GetActualSkillLevel(CharacterSkillType uSkillType) const;
     CharacterSkillMastery GetActualSkillMastery(CharacterSkillType uSkillType) const;
     CombinedSkillValue getActualSkillValue(CharacterSkillType skillType) const;
     int GetSkillBonus(CharacterAttributeType a2) const;
@@ -350,7 +350,7 @@ class Character {
     bool hasItem(ITEM_TYPE uItemID, bool checkHeldItem);
     void OnInventoryLeftClick();
 
-    bool characterHitOrMiss(Actor *pActor, int distancemod, CHARACTER_SKILL_LEVEL skillmod);
+    bool characterHitOrMiss(Actor *pActor, int distancemod, int skillmod);
 
     unsigned int GetMultiplierForSkillLevel(CharacterSkillType uSkillType, int mult1, int mult2, int mult3, int mult4) const;
     int CalculateMeleeDmgToEnemyWithWeapon(ItemGen *weapon,

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -449,12 +449,7 @@ class Character {
     void cleanupBeacons();
     bool setBeacon(int index, GameTime duration);
 
-    CHARACTER_SKILL_LEVEL GetSkillLevel(CharacterSkillType skill) const;
-    CharacterSkillMastery GetSkillMastery(CharacterSkillType skill) const;
     CombinedSkillValue getSkillValue(CharacterSkillType skill) const;
-
-    void SetSkillLevel(CharacterSkillType skill, CHARACTER_SKILL_LEVEL level);
-    void SetSkillMastery(CharacterSkillType skill, CharacterSkillMastery mastery);
     void setSkillValue(CharacterSkillType skill, const CombinedSkillValue &value);
 
     CharacterConditions conditions;

--- a/src/Engine/Objects/CharacterEnums.h
+++ b/src/Engine/Objects/CharacterEnums.h
@@ -4,10 +4,6 @@
 
 #include "Utility/Segment.h"
 
-// TODO(pskelton): reduce or drop in favour of combined value
-typedef uint16_t CHARACTER_SKILL;
-typedef uint8_t CHARACTER_SKILL_LEVEL;
-
 enum class Condition : uint32_t {
     CONDITION_CURSED = 0,
     CONDITION_WEAK = 1,
@@ -43,6 +39,10 @@ enum class CharacterSkillMastery {
     CHARACTER_SKILL_MASTERY_LAST = CHARACTER_SKILL_MASTERY_GRANDMASTER
 };
 using enum CharacterSkillMastery;
+
+inline Segment<CharacterSkillMastery> SkillMasteries() {
+    return Segment(CHARACTER_SKILL_MASTERY_FIRST, CHARACTER_SKILL_MASTERY_LAST);
+}
 
 // TODO(pskelton): drop CHARACTER_ at start?
 enum CharacterBuffs {

--- a/src/Engine/Objects/CharacterEnums.h
+++ b/src/Engine/Objects/CharacterEnums.h
@@ -32,8 +32,7 @@ enum class Condition : uint32_t {
 using enum Condition;
 
 // TODO(pskelton): drop CHARACTER_ at start?
-enum class CharacterSkillMastery : int32_t {  // TODO: type could be changed to something else when SpriteObject_MM7 implemented in
-    // LegacyImages
+enum class CharacterSkillMastery {
     CHARACTER_SKILL_MASTERY_NONE = 0,
     CHARACTER_SKILL_MASTERY_NOVICE = 1,
     CHARACTER_SKILL_MASTERY_EXPERT = 2,

--- a/src/Engine/Objects/CombinedSkillValue.cpp
+++ b/src/Engine/Objects/CombinedSkillValue.cpp
@@ -1,10 +1,11 @@
-#include <algorithm>
-
 #include "CombinedSkillValue.h"
 
+#include <cassert>
+
 CombinedSkillValue::CombinedSkillValue(int level, CharacterSkillMastery mastery) {
-    assert(isLevelValid(level));
-    assert(isMasteryValid(mastery));
+    assert(level >= 0 && level <= 63);
+    assert((level == 0) ^ (mastery != CHARACTER_SKILL_MASTERY_NONE));
+
     _level = level;
     _mastery = mastery;
 }
@@ -12,6 +13,31 @@ CombinedSkillValue::CombinedSkillValue(int level, CharacterSkillMastery mastery)
 CombinedSkillValue::CombinedSkillValue() {
     _level = 0;
     _mastery = CHARACTER_SKILL_MASTERY_NONE;
+}
+
+CombinedSkillValue CombinedSkillValue::none() {
+    return CombinedSkillValue();
+}
+
+CombinedSkillValue CombinedSkillValue::novice() {
+    return CombinedSkillValue(1, CHARACTER_SKILL_MASTERY_NOVICE);
+}
+
+CombinedSkillValue CombinedSkillValue::increaseLevel(CombinedSkillValue current) {
+    assert(current != CombinedSkillValue::none());
+    return CombinedSkillValue(current.level() + 1, current.mastery());
+}
+
+CombinedSkillValue CombinedSkillValue::increaseMastery(CombinedSkillValue current, CharacterSkillMastery newMastery) {
+    assert(current != CombinedSkillValue::none());
+    assert(static_cast<int>(newMastery) == static_cast<int>(current.mastery()) + 1);
+    return CombinedSkillValue(current.level(), newMastery);
+}
+
+CombinedSkillValue CombinedSkillValue::fromJoined(uint16_t joinedValue) {
+    CHARACTER_SKILL_LEVEL lvl  = ::GetSkillLevel(joinedValue);
+    CharacterSkillMastery mst = ::GetSkillMastery(joinedValue);
+    return CombinedSkillValue(lvl, mst);
 }
 
 uint16_t CombinedSkillValue::join() const {
@@ -22,42 +48,6 @@ int CombinedSkillValue::level() const {
     return _level;
 }
 
-CombinedSkillValue& CombinedSkillValue::setLevel(int level) {
-    assert(isLevelValid(level));
-    _level = level;
-    return *this;
-}
-
 CharacterSkillMastery CombinedSkillValue::mastery() const {
     return _mastery;
-}
-
-CombinedSkillValue& CombinedSkillValue::setMastery(CharacterSkillMastery mastery) {
-    assert(isMasteryValid(mastery));
-    _mastery = mastery;
-    return *this;
-}
-
-bool CombinedSkillValue::isLevelValid(int level) {
-    return level >= 0 && level <= 63;
-}
-
-bool CombinedSkillValue::isMasteryValid(CharacterSkillMastery mastery) {
-    return mastery == CHARACTER_SKILL_MASTERY_NONE || mastery == CHARACTER_SKILL_MASTERY_NOVICE || mastery == CHARACTER_SKILL_MASTERY_EXPERT ||
-           mastery == CHARACTER_SKILL_MASTERY_MASTER || mastery == CHARACTER_SKILL_MASTERY_GRANDMASTER;
-}
-
-CombinedSkillValue CombinedSkillValue::fromJoined(uint16_t joinedValue) {
-    CHARACTER_SKILL_LEVEL lvl  = ::GetSkillLevel(joinedValue);
-    CharacterSkillMastery mst = ::GetSkillMastery(joinedValue);
-    return CombinedSkillValue(lvl, mst);
-}
-
-CombinedSkillValue CombinedSkillValue::novice() {
-    return CombinedSkillValue(1, CHARACTER_SKILL_MASTERY_NOVICE);
-}
-
-void CombinedSkillValue::reset() {
-    _level = 0;
-    _mastery = CHARACTER_SKILL_MASTERY_NONE;
 }

--- a/src/Engine/Objects/CombinedSkillValue.h
+++ b/src/Engine/Objects/CombinedSkillValue.h
@@ -1,100 +1,30 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 
 #include "Engine/Objects/CharacterEnums.h"
 
-#include "Utility/Segment.h"
-
-/* Skill encodes level and mastery where first 0x3F are for skill level and 0x1C0 bits are for skill mastery.
- * So max possible stored skill level is 63.
- */
-
-inline Segment<CharacterSkillMastery> SkillMasteries() {
-    return Segment(CHARACTER_SKILL_MASTERY_FIRST, CHARACTER_SKILL_MASTERY_LAST);
-}
-
-inline CHARACTER_SKILL_LEVEL GetSkillLevel(const CHARACTER_SKILL skill_value) {
-    return skill_value & 0x3F;
-}
-
 /**
- * @offset 0x00458244.
+ * Simple POD-like class for storing full skill value (level and mastery).
  */
-inline CharacterSkillMastery GetSkillMastery(const CHARACTER_SKILL skill_value) {
-    // CHARACTER_SKILL_MASTERY_NONE equal CHARACTER_SKILL_MASTERY_NOVICE with skill level 0.
-    if (GetSkillLevel(skill_value) == 0)
-        return CHARACTER_SKILL_MASTERY_NONE;
-
-    switch (skill_value & 0x1C0) {
-        case 0x100:
-            return CHARACTER_SKILL_MASTERY_GRANDMASTER;
-        case 0x80:
-            return CHARACTER_SKILL_MASTERY_MASTER;
-        case 0x40:
-            return CHARACTER_SKILL_MASTERY_EXPERT;
-        case 0x00:
-            return CHARACTER_SKILL_MASTERY_NOVICE;
-    }
-
-    assert(false);  // should not get here
-    return CHARACTER_SKILL_MASTERY_NONE;
-}
-
-inline void SetSkillLevel(CHARACTER_SKILL *skill_value, CHARACTER_SKILL_LEVEL level) {
-    *skill_value = (*skill_value & ~0x3F) | (level & 0x3F);
-}
-
-inline void SetSkillMastery(CHARACTER_SKILL *skill_value, CharacterSkillMastery mastery) {
-    assert(mastery <= CHARACTER_SKILL_MASTERY_GRANDMASTER);
-
-    *skill_value &= 0x3F;
-
-    switch (mastery) {
-        case (CHARACTER_SKILL_MASTERY_EXPERT):
-            *skill_value |= 0x40;
-            break;
-        case (CHARACTER_SKILL_MASTERY_MASTER):
-            *skill_value |= 0x80;
-            break;
-        case (CHARACTER_SKILL_MASTERY_GRANDMASTER):
-            *skill_value |= 0x100;
-            break;
-        default:
-            return;
-    }
-}
-
-// TODO(pskelton): drop
-/**
- * Construct character skill value using skill mastery and skill level
- */
-inline CHARACTER_SKILL ConstructSkillValue(CharacterSkillMastery mastery, CHARACTER_SKILL_LEVEL level) {
-    CHARACTER_SKILL skill = 0;
-
-    SetSkillMastery(&skill, mastery);
-    SetSkillLevel(&skill, level);
-
-    return skill;
-}
-
-// Simple POD-like class for storing full skill value (level and mastery)
 class CombinedSkillValue {
  public:
     CombinedSkillValue();
     CombinedSkillValue(int level, CharacterSkillMastery mastery);
 
     static CombinedSkillValue none();
-    static CombinedSkillValue novice();
+    static CombinedSkillValue novice(int level = 1);
     static CombinedSkillValue increaseLevel(CombinedSkillValue current);
     static CombinedSkillValue increaseMastery(CombinedSkillValue current, CharacterSkillMastery newMastery);
-    static CombinedSkillValue fromJoined(uint16_t);
+    static CombinedSkillValue fromJoined(uint16_t joinedValue);
+    static std::pair<int, CharacterSkillMastery> fromJoinedUnchecked(uint16_t joinedValue);
 
     /**
      * @return                          Binary representation of a skill-mastery pair, as it was originally stored
      *                                  in M&M data structures.
      */
-    [[nodiscard]] uint16_t join() const;
+    [[nodiscard]] uint16_t joined() const;
 
     [[nodiscard]] int level() const;
     [[nodiscard]] CharacterSkillMastery mastery() const;

--- a/src/Engine/Objects/CombinedSkillValue.h
+++ b/src/Engine/Objects/CombinedSkillValue.h
@@ -80,27 +80,30 @@ inline CHARACTER_SKILL ConstructSkillValue(CharacterSkillMastery mastery, CHARAC
 
 // Simple POD-like class for storing full skill value (level and mastery)
 class CombinedSkillValue {
-    int _level = 0;
-    CharacterSkillMastery _mastery = CHARACTER_SKILL_MASTERY_NONE;
-
  public:
     CombinedSkillValue();
     CombinedSkillValue(int level, CharacterSkillMastery mastery);
 
-    // joins level and mastery into one integer
-    [[nodiscard]] uint16_t join() const;
-
-    int level() const;
-    CombinedSkillValue &setLevel(int level);
-
-    CharacterSkillMastery mastery() const;
-    CombinedSkillValue &setMastery(CharacterSkillMastery mastery);
-
-    static bool isLevelValid(int level);
-    static bool isMasteryValid(CharacterSkillMastery mastery);
+    static CombinedSkillValue none();
     static CombinedSkillValue novice();
+    static CombinedSkillValue increaseLevel(CombinedSkillValue current);
+    static CombinedSkillValue increaseMastery(CombinedSkillValue current, CharacterSkillMastery newMastery);
     static CombinedSkillValue fromJoined(uint16_t);
 
+    /**
+     * @return                          Binary representation of a skill-mastery pair, as it was originally stored
+     *                                  in M&M data structures.
+     */
+    [[nodiscard]] uint16_t join() const;
+
+    [[nodiscard]] int level() const;
+    [[nodiscard]] CharacterSkillMastery mastery() const;
+
     explicit operator bool() const { return _level > 0; }
-    void reset();
+
+    friend bool operator==(const CombinedSkillValue &l, const CombinedSkillValue &r) = default;
+
+ private:
+    int _level = 0;
+    CharacterSkillMastery _mastery = CHARACTER_SKILL_MASTERY_NONE;
 };

--- a/src/Engine/Objects/Monsters.cpp
+++ b/src/Engine/Objects/Monsters.cpp
@@ -128,6 +128,31 @@ SPELL_TYPE ParseSpellType(struct FrameTableTxtLine *tbl, int *next_token) {
     }
 }
 
+CombinedSkillValue ParseSkillValue(std::string_view skillString, std::string_view masteryString) {
+    if (skillString == "t") {
+        int a = 10;
+    }
+
+    int skill;
+    if (!tryDeserialize(skillString, &skill))
+        return CombinedSkillValue::none(); // TODO(captainurist): this does happen, investigate.
+
+    CharacterSkillMastery mastery;
+    if (masteryString == "N") {
+        mastery = CHARACTER_SKILL_MASTERY_NOVICE;
+    } else if (masteryString == "E") {
+        mastery = CHARACTER_SKILL_MASTERY_EXPERT;
+    } else if (masteryString == "M") {
+        mastery = CHARACTER_SKILL_MASTERY_MASTER;
+    } else if (masteryString == "G") {
+        mastery = CHARACTER_SKILL_MASTERY_GRANDMASTER;
+    } else {
+        assert(false); // TODO(captainurist): throw.
+    }
+
+    return CombinedSkillValue(skill, mastery);
+}
+
 //----- (00454CB4) --------------------------------------------------------
 int ParseAttackType(const char *damage_type_str) {
     switch (tolower(*damage_type_str)) {
@@ -857,7 +882,6 @@ void MonsterStats::Initialize() {
                         break;
                     case 25: {
                         int param_num;
-                        char type_flag;
                         strcpy(parse_str, test_string);
                         parse_str[0] = ' ';
                         parse_str[strlen(parse_str) - 1] = ' ';
@@ -866,27 +890,11 @@ void MonsterStats::Initialize() {
                             param_num = 1;
                             pInfos[curr_rec_num].uSpell1ID =
                                 ParseSpellType(&parsed_field, &param_num);
-                            type_flag = *parsed_field.pProperties[param_num];
                             pInfos[curr_rec_num].uSpellSkillAndMastery1 =
-                                atoi(parsed_field.pProperties[param_num + 1]) &
-                                0x003F;
-                            switch (type_flag) {
-                                case 'E':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery1 |= 0x0040;
-                                    break;
-                                case 'M':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery1 |= 0x0080;
-                                    break;
-                                case 'G':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery1 |= 0x0100;
-                                    break;
-                            }
+                                ParseSkillValue(parsed_field.pProperties[param_num + 1], parsed_field.pProperties[param_num]);
                         } else {
                             pInfos[curr_rec_num].uSpell1ID = SPELL_NONE;
-                            pInfos[curr_rec_num].uSpellSkillAndMastery1 = 0;
+                            pInfos[curr_rec_num].uSpellSkillAndMastery1 = CombinedSkillValue::none();
                         }
                     } break;
                     case 26:
@@ -895,7 +903,6 @@ void MonsterStats::Initialize() {
                         break;
                     case 27: {
                         int param_num;
-                        char type_flag;
                         strcpy(parse_str, test_string);
                         parse_str[0] = ' ';
                         parse_str[strlen(parse_str) - 1] = ' ';
@@ -904,27 +911,11 @@ void MonsterStats::Initialize() {
                             param_num = 1;
                             pInfos[curr_rec_num].uSpell2ID =
                                 ParseSpellType(&parsed_field, &param_num);
-                            type_flag = *parsed_field.pProperties[param_num];
                             pInfos[curr_rec_num].uSpellSkillAndMastery2 =
-                                atoi(parsed_field.pProperties[param_num + 1]) &
-                                0x003F;
-                            switch (type_flag) {
-                                case 'E':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery2 |= 0x0040;
-                                    break;
-                                case 'M':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery2 |= 0x0080;
-                                    break;
-                                case 'G':
-                                    pInfos[curr_rec_num]
-                                        .uSpellSkillAndMastery2 |= 0x0100;
-                                    break;
-                            }
+                                ParseSkillValue(parsed_field.pProperties[param_num + 1], parsed_field.pProperties[param_num]);
                         } else {
                             pInfos[curr_rec_num].uSpell2ID = SPELL_NONE;
-                            pInfos[curr_rec_num].uSpellSkillAndMastery2 = 0;
+                            pInfos[curr_rec_num].uSpellSkillAndMastery2 = CombinedSkillValue::none();
                         }
                     } break;
                     case 28: {

--- a/src/Engine/Objects/Monsters.h
+++ b/src/Engine/Objects/Monsters.h
@@ -11,6 +11,7 @@
 #include "Library/Color/Color.h"
 
 #include "Engine/Spells/SpellEnums.h"
+#include "Engine/Objects/CombinedSkillValue.h"
 
 #include "ActorEnums.h"
 #include "ItemEnums.h"
@@ -175,8 +176,8 @@ struct MonsterInfo {
     uint8_t uNumCharactersAttackedPerSpecialAbility = 0;
     uint16_t uID = 0;
     bool bBloodSplatOnDeath = 0;  // true for bloodsplat on death
-    uint16_t uSpellSkillAndMastery1 = 0;
-    uint16_t uSpellSkillAndMastery2 = 0;
+    CombinedSkillValue uSpellSkillAndMastery1;
+    CombinedSkillValue uSpellSkillAndMastery2;
     int16_t field_3C_some_special_attack = 0;
     int16_t field_3E = 0;
     unsigned int uHP = 0;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -45,7 +45,7 @@ static void reconstruct(int64_t src, GameTime *dst) {
 }
 
 static void snapshot(const CombinedSkillValue &src, uint16_t *dst) {
-    *dst = src.join();
+    *dst = src.joined();
 }
 
 static void reconstruct(const uint16_t &src, CombinedSkillValue *dst) {
@@ -1028,8 +1028,8 @@ void snapshot(const Actor &src, Actor_MM7 *dst) {
     dst->pMonsterInfo.numCharactersAttackedPerSpecialAbility = src.monsterInfo.uNumCharactersAttackedPerSpecialAbility;
     dst->pMonsterInfo.id = src.monsterInfo.uID;
     dst->pMonsterInfo.bloodSplatOnDeath = src.monsterInfo.bBloodSplatOnDeath;
-    dst->pMonsterInfo.spellSkillAndMastery1 = src.monsterInfo.uSpellSkillAndMastery1;
-    dst->pMonsterInfo.spellSkillAndMastery2 = src.monsterInfo.uSpellSkillAndMastery2;
+    snapshot(src.monsterInfo.uSpellSkillAndMastery1, &dst->pMonsterInfo.spellSkillAndMastery1);
+    snapshot(src.monsterInfo.uSpellSkillAndMastery2, &dst->pMonsterInfo.spellSkillAndMastery2);
     dst->pMonsterInfo.field_3C_some_special_attack = src.monsterInfo.field_3C_some_special_attack;
     dst->pMonsterInfo.field_3E = src.monsterInfo.field_3E;
     dst->pMonsterInfo.hp = src.monsterInfo.uHP;
@@ -1122,8 +1122,8 @@ void reconstruct(const Actor_MM7 &src, Actor *dst) {
     dst->monsterInfo.uNumCharactersAttackedPerSpecialAbility = src.pMonsterInfo.numCharactersAttackedPerSpecialAbility;
     dst->monsterInfo.uID = src.pMonsterInfo.id;
     dst->monsterInfo.bBloodSplatOnDeath = src.pMonsterInfo.bloodSplatOnDeath;
-    dst->monsterInfo.uSpellSkillAndMastery1 = src.pMonsterInfo.spellSkillAndMastery1;
-    dst->monsterInfo.uSpellSkillAndMastery2 = src.pMonsterInfo.spellSkillAndMastery2;
+    reconstruct(src.pMonsterInfo.spellSkillAndMastery1, &dst->monsterInfo.uSpellSkillAndMastery1);
+    reconstruct(src.pMonsterInfo.spellSkillAndMastery2, &dst->monsterInfo.uSpellSkillAndMastery2);
     dst->monsterInfo.field_3C_some_special_attack = src.pMonsterInfo.field_3C_some_special_attack;
     dst->monsterInfo.field_3E = src.pMonsterInfo.field_3E;
     dst->monsterInfo.uHP = src.pMonsterInfo.hp;

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -50,7 +50,7 @@ MM_DECLARE_FLAGS(SpellCastFlags, SpellCastFlag)
 MM_DECLARE_OPERATORS_FOR_FLAGS(SpellCastFlags)
 
 // Scrolls or NPC spells casted with MASTER mastery of skill level 5
-static const CHARACTER_SKILL SCROLL_OR_NPC_SPELL_SKILL_VALUE = ConstructSkillValue(CHARACTER_SKILL_MASTERY_MASTER, 5);
+static const CombinedSkillValue SCROLL_OR_NPC_SPELL_SKILL_VALUE(5, CHARACTER_SKILL_MASTERY_MASTER);
 
 // Recovery time when spell failed because of curse
 static const uint16_t SPELL_FAILURE_RECOVERY_TIME_ON_CURSE = 100;
@@ -66,7 +66,7 @@ struct CastSpellInfo {
     uint16_t uPlayerID_2;
     int16_t field_6; // ITEM_EQUIP_TYPE when enchanting.
     SpellCastFlags uFlags;
-    int16_t forced_spell_skill_level;
+    CombinedSkillValue forced_spell_skill_level;
     int spell_target_pid;
     int sound_id;
 };
@@ -85,15 +85,15 @@ struct CastSpellInfo {
  *
  * @offset 0x0042777D
  *
- * @param spell          ID of spell.
- * @param uPlayerID      ID of player casting spell.
- * @param skill_value    Skill value (mastery+skill level) spell is casted with.
- * @param flags          Spell flags. Can be empty or have several flags.
- * @param a6             ???
+ * @param spell                         ID of spell.
+ * @param uPlayerID                     ID of player casting spell.
+ * @param skill_value                   Skill value that the spell is cast with.
+ * @param flags                         Spell flags. Can be empty or have several flags.
+ * @param a6                            ???
  */
 void pushSpellOrRangedAttack(SPELL_TYPE spell,
                              unsigned int uPlayerID,
-                             CHARACTER_SKILL skill_value,
+                             CombinedSkillValue skill_value,
                              SpellCastFlags flags,
                              int a6);
 
@@ -101,7 +101,7 @@ void pushSpellOrRangedAttack(SPELL_TYPE spell,
  * Register spell cast on party with temple donation.
  * Temple spells are cast with MASTER mastery of skill level equal to the day of week.
  *
- * @param spell        ID of spell.
+ * @param spell                         ID of spell.
  */
 void pushTempleSpell(SPELL_TYPE spell);
 

--- a/src/Engine/Spells/SpellBuff.h
+++ b/src/Engine/Spells/SpellBuff.h
@@ -10,7 +10,7 @@ struct SpellBuff {
      * @offset 0x4584E0
      */
     bool Apply(GameTime time, CharacterSkillMastery uSkillMastery,
-               CHARACTER_SKILL_LEVEL uPower, int uOverlayID, uint8_t caster);
+               int uPower, int uOverlayID, uint8_t caster);
 
     /**
      * @offset 0x458585

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -705,7 +705,7 @@ bool SpellBuff::IsBuffExpiredToTime(GameTime time) {
 }
 
 bool SpellBuff::Apply(GameTime expire_time, CharacterSkillMastery uSkillMastery,
-                      CHARACTER_SKILL_LEVEL uPower, int uOverlayID,
+                      int uPower, int uOverlayID,
                       uint8_t caster) {
     // For bug catching
     Assert(uSkillMastery >= CHARACTER_SKILL_MASTERY_NOVICE && uSkillMastery <= CHARACTER_SKILL_MASTERY_GRANDMASTER
@@ -772,7 +772,7 @@ void SpellStats::Initialize() {
     }
 }
 
-void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHARACTER_SKILL_LEVEL skillLevel, int fromx,
+void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, int skillLevel, int fromx,
                     int fromy, int fromz, int tox, int toy, int toz) {
     // For bug catching
     Assert(skillMastery >= CHARACTER_SKILL_MASTERY_NOVICE && skillMastery <= CHARACTER_SKILL_MASTERY_GRANDMASTER,
@@ -1057,7 +1057,7 @@ bool IsSpellQuickCastableOnShiftClick(SPELL_TYPE uSpellID) {
     return (pSpellDatas[uSpellID].stats & 0xC) != 0;
 }
 
-int CalcSpellDamage(SPELL_TYPE uSpellID, CHARACTER_SKILL_LEVEL spellLevel, CharacterSkillMastery skillMastery, int currentHp) {
+int CalcSpellDamage(SPELL_TYPE uSpellID, int spellLevel, CharacterSkillMastery skillMastery, int currentHp) {
     int result;       // eax@1
     unsigned int diceSides;  // [sp-4h] [bp-8h]@9
 

--- a/src/Engine/Spells/Spells.h
+++ b/src/Engine/Spells/Spells.h
@@ -89,7 +89,7 @@ extern IndexedArray<uint16_t, SPELL_FIRST_WITH_SPRITE, SPELL_LAST_WITH_SPRITE> S
 /**
  * @offset 0x43AFE3
  */
-int CalcSpellDamage(SPELL_TYPE uSpellID, CHARACTER_SKILL_LEVEL spellLevel, CharacterSkillMastery skillMastery, int currentHp);
+int CalcSpellDamage(SPELL_TYPE uSpellID, int spellLevel, CharacterSkillMastery skillMastery, int currentHp);
 
 /**
  * @offset 0x427769
@@ -99,7 +99,7 @@ bool IsSpellQuickCastableOnShiftClick(SPELL_TYPE uSpellID);
 /**
  * Function for processing spells cast from game scripts.
  */
-void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, CHARACTER_SKILL_LEVEL skillLevel, int fromx,
+void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, int skillLevel, int fromx,
                     int fromy, int fromz, int tox, int toy, int toz);  // sub_448DF8
 
 void armageddonProgress();

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -501,7 +501,7 @@ IndexedArray<std::array<unsigned char, 5>, SPEECH_FIRST, SPEECH_LAST> expression
 
 std::array<int16_t, 4> pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing = {{34, 149, 264, 379}};
 
-IndexedArray<CHARACTER_SKILL_LEVEL, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> skills_max_level = {
+IndexedArray<int, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> skills_max_level = {
     {CHARACTER_SKILL_STAFF, 60},        {CHARACTER_SKILL_SWORD, 60},      {CHARACTER_SKILL_DAGGER, 60},
     {CHARACTER_SKILL_AXE, 60},          {CHARACTER_SKILL_SPEAR, 60},      {CHARACTER_SKILL_BOW, 60},
     {CHARACTER_SKILL_MACE, 60},         {CHARACTER_SKILL_BLASTER, 60},    {CHARACTER_SKILL_SHIELD, 60},

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -57,7 +57,7 @@ extern std::array<std::array<unsigned char, 25>, 48> byte_4ECF08;
 extern IndexedArray<std::array<unsigned char, 3>, SPEECH_FIRST, SPEECH_LAST> speechVariants;
 extern IndexedArray<std::array<unsigned char, 5>, SPEECH_FIRST, SPEECH_LAST> expressionVariants;
 extern std::array<int16_t, 4> pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing;
-extern IndexedArray<CHARACTER_SKILL_LEVEL, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> skills_max_level;
+extern IndexedArray<int, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> skills_max_level;
 extern IndexedArray<uint, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> base_recovery_times_per_weapon_type;
 extern std::array<IndexedArray<ClassSkillAffinity, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST>, 9> pSkillAvailabilityPerClass;
 extern IndexedArray<IndexedArray<CharacterSkillMastery, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST>, PLAYER_CLASS_FIRST, PLAYER_CLASS_LAST> skillMaxMasteryPerClass;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -546,7 +546,9 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
                 if (guild_membership_approved) {
                     pParty->TakeGold(gold_transaction_amount);
                     if (pParty->hasActiveCharacter()) {
-                        pParty->activeCharacter().SetSkillMastery(dword_F8B1AC_skill_being_taught, dword_F8B1B0_MasteryBeingTaught);
+                        CombinedSkillValue skillValue = pParty->activeCharacter().getSkillValue(dword_F8B1AC_skill_being_taught);
+                        pParty->activeCharacter().setSkillValue(dword_F8B1AC_skill_being_taught,
+                                                                CombinedSkillValue::increaseMastery(skillValue, dword_F8B1B0_MasteryBeingTaught));
                         pParty->activeCharacter().playReaction(SPEECH_SKILL_MASTERY_INC);
                     }
                     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -209,7 +209,7 @@ void CreateParty_EventLoop() {
             v4 = pGUIWindow_CurrentMenu->pCurrentPosActiveItem - pGUIWindow_CurrentMenu->pStartingPosActiveItem;
             pGUIWindow_CurrentMenu->pCurrentPosActiveItem = v4 % 7 + pGUIWindow_CurrentMenu->pStartingPosActiveItem + 7 * param;
             if (pPlayer[param].GetSkillIdxByOrder(2) != CHARACTER_SKILL_INVALID) {
-                pParty->pCharacters[param].pActiveSkills[pPlayer[param].GetSkillIdxByOrder(2)].reset();
+                pParty->pCharacters[param].pActiveSkills[pPlayer[param].GetSkillIdxByOrder(2)] = CombinedSkillValue::none();
             }
             break;
         }
@@ -219,7 +219,7 @@ void CreateParty_EventLoop() {
             v4 = pGUIWindow_CurrentMenu->pCurrentPosActiveItem - pGUIWindow_CurrentMenu->pStartingPosActiveItem;
             pGUIWindow_CurrentMenu->pCurrentPosActiveItem = v4 % 7 + pGUIWindow_CurrentMenu->pStartingPosActiveItem + 7 * param;
             if (pPlayer[param].GetSkillIdxByOrder(3) != CHARACTER_SKILL_INVALID)
-                pParty->pCharacters[param].pActiveSkills[pPlayer[param].GetSkillIdxByOrder(3)].reset();
+                pParty->pCharacters[param].pActiveSkills[pPlayer[param].GetSkillIdxByOrder(3)] = CombinedSkillValue::none();
         } break;
         case UIMSG_PlayerCreationChangeName:
             pAudioPlayer->playUISound(SOUND_ClickSkill);

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -636,7 +636,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     bool for_effects = false;
 
     if (pParty->hasActiveCharacter()) {
-        CHARACTER_SKILL_LEVEL skill_points = 0;
+        int skill_points = 0;
         CharacterSkillMastery skill_mastery = CHARACTER_SKILL_MASTERY_NONE;
         CombinedSkillValue idMonsterSkill = pParty->activeCharacter().getActualSkillValue(CHARACTER_SKILL_MONSTER_ID);
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -2190,11 +2190,6 @@ void Inventory_ItemPopupAndAlchemy() {
             return;
         }
 
-        // TODO(Nik-RE-dev): need to allow GetSkillMastery return CHARACTER_SKILL_MASTERY_NONE
-        if (!alchemySkill.level()) {
-            alchemySkill.setMastery(CHARACTER_SKILL_MASTERY_NONE);
-        }
-
         int damage_level = 0;
         if (!isPotion(potionID)) {
             // In this case potionID represent damage level

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -893,9 +893,9 @@ GAME_TEST(Issues, Issue661) {
 GAME_TEST(Issues, Issue662) {
     // "of Air magic" should give floor(skill / 2) skill level bonus (like all other such bonuses)
     test->loadGameFromTestData("issue_662.mm7");
-    // currently air magic is (expert) 6
+    EXPECT_EQ(pParty->pCharacters[3].pActiveSkills[CHARACTER_SKILL_AIR], CombinedSkillValue(6, CHARACTER_SKILL_MASTERY_EXPERT));
     EXPECT_EQ(pParty->pCharacters[3].GetItemsBonus(CHARACTER_ATTRIBUTE_SKILL_AIR), 3);
-    pParty->pCharacters[3].pActiveSkills[CHARACTER_SKILL_AIR].setLevel(5);
+    pParty->pCharacters[3].pActiveSkills[CHARACTER_SKILL_AIR] = CombinedSkillValue(5, CHARACTER_SKILL_MASTERY_EXPERT);
     EXPECT_EQ(pParty->pCharacters[3].GetItemsBonus(CHARACTER_ATTRIBUTE_SKILL_AIR), 2);
 }
 


### PR DESCRIPTION
* The reason for #1045 was constructing `CombinedSkillValue(1, CHARACTER_SKILL_MASTERY_NONE)`, this now asserts.
* Propagated `CombinedSkillValue` throughout the codebase, dropped old functions.
* Made `CombinedSkillValue` immutable, now has to go through factory functions instead.

Not adding a test for #1045 because it makes little sense. Adding an assertion to `CombinedSkillValue` w/o all the changes in this PR results in it firing pretty much on every single test.