### PR TITLE
Don't access sprite LOD private fields from Vis code

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1084,6 +1084,9 @@ void Engine::ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows() {
     if (mouse)
         mouse->SetCursorImage("MICON1");
 
+    // Render billboards are used in hit tests, but we're releasing textures, so can't use them anymore.
+    render->uNumBillboardsToDraw = 0;
+
     pBitmaps_LOD->ReleaseAll2();
     pSprites_LOD->DeleteSomeOtherSprites();
     pIcons_LOD->ReleaseAll2();

--- a/src/Engine/Graphics/Image.cpp
+++ b/src/Engine/Graphics/Image.cpp
@@ -15,11 +15,11 @@ GraphicsImage::GraphicsImage(bool lazy_initialization): _lazyInitialization(lazy
 GraphicsImage::~GraphicsImage() = default;
 
 GraphicsImage *GraphicsImage::Create(RgbaImage image) {
-    std::unique_ptr<GraphicsImage> result = std::make_unique<GraphicsImage>(false);
+    GraphicsImage *result = new GraphicsImage(false);
     result->_initialized = true;
     result->_rgbaImage = std::move(image);
     result->_renderId = render->CreateTexture(result->_rgbaImage);
-    return result.release();
+    return result;
 }
 
 GraphicsImage *GraphicsImage::Create(size_t width, size_t height) {
@@ -66,7 +66,7 @@ std::string *GraphicsImage::GetName() {
     return _loader->GetResourceNamePtr();
 }
 
-bool GraphicsImage::Release() {
+void GraphicsImage::Release() {
     if (_loader) {
         if (!assets->releaseSprite(_loader->GetResourceName()))
             if (!assets->releaseImage(_loader->GetResourceName()))
@@ -76,7 +76,6 @@ bool GraphicsImage::Release() {
     releaseRenderId();
 
     delete this;
-    return true;
 }
 
 [[nodiscard]] TextureRenderId GraphicsImage::renderId(bool load) {

--- a/src/Engine/Graphics/Image.h
+++ b/src/Engine/Graphics/Image.h
@@ -15,7 +15,6 @@ class ImageLoader;
 class GraphicsImage {
  public:
     explicit GraphicsImage(bool lazy_initialization = true);
-    ~GraphicsImage();
 
     static GraphicsImage *Create(RgbaImage image);
     static GraphicsImage *Create(size_t width, size_t height);
@@ -33,10 +32,13 @@ class GraphicsImage {
 
     std::string *GetName();
 
-    bool Release();
+    void Release();
 
     [[nodiscard]] TextureRenderId renderId(bool load = true);
     void releaseRenderId();
+
+ protected:
+    ~GraphicsImage(); // Call Release() instead.
 
  protected:
     bool _lazyInitialization = false;

--- a/src/Engine/Graphics/Nuklear.cpp
+++ b/src/Engine/Graphics/Nuklear.cpp
@@ -792,11 +792,8 @@ void Nuklear::Release(WindowType winType, bool is_reload) {
         for (auto it = wins[winType].imgs.begin(); it != wins[winType].imgs.end(); it++, i++) {
             if ((*it)->asset) {
                 render->NuklearImageFree((*it)->asset);
-                if ((*it)->asset->Release())
-                    logger->info("Nuklear: [{}] asset {} unloaded", wins[winType].tmpl, i);
-                else
-                    logger->warning("Nuklear: [{}] asset {} unloading failed!", wins[winType].tmpl, i);
-
+                (*it)->asset->Release();
+                logger->info("Nuklear: [{}] asset {} unloaded", wins[winType].tmpl, i);
                 delete *it;
             }
         }

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -258,37 +258,25 @@ bool Vis::IsPointInsideD3DBillboard(RenderBillboardD3D *billboard, float x, floa
     float drH = billboard->pQuads[1].pos.y - drY;
 
     // simple bounds check
-    if (x > drX && x > billboard->pQuads[3].pos.x) return 0;
-    if (x < drX && x < billboard->pQuads[3].pos.x) return 0;
-    if (y > drY && y > billboard->pQuads[1].pos.y) return 0;
-    if (y < drY && y < billboard->pQuads[1].pos.y) return 0;
+    if (x > drX && x > billboard->pQuads[3].pos.x) return false;
+    if (x < drX && x < billboard->pQuads[3].pos.x) return false;
+    if (y > drY && y > billboard->pQuads[1].pos.y) return false;
+    if (y < drY && y < billboard->pQuads[1].pos.y) return false;
 
     // for small items dont bother with the per pixel checks
     if (abs(drH) < 5 || abs(drW) < 5) {
-            return 1;
+        return true;
     }
 
-    Sprite *ownerSprite = nullptr;
-    for (int i = 0; i < pSprites_LOD->pSprites.size(); ++i) {
-        if ((void *)pSprites_LOD->pSprites[i].texture == billboard->texture) {
-            ownerSprite = &pSprites_LOD->pSprites[i];
-            break;
-        }
-    }
+    RgbaImageView rgba = billboard->texture->rgba();
 
-    if (ownerSprite == nullptr) return false;
+    int sx = rgba.width() * (x - drX) / drW;
+    int sy = rgba.height() * (y - drY) / drH;
 
-    int sx =
-        ownerSprite->uAreaX + int(ownerSprite->uWidth * (x - drX) / drW);
-    int sy =
-        ownerSprite->uAreaY + int(ownerSprite->uHeight * (y - drY) / drH);
+    if (sx < 0 || sx >= rgba.width()) return false;
+    if (sy < 0 || sy >= rgba.height()) return false;
 
-    LODSprite *spriteHeader = ownerSprite->sprite_header;
-
-    if (sy < 0 || sy >= spriteHeader->uHeight) return false;
-    if (sx < 0 || sx >= spriteHeader->uWidth) return false;
-
-    return spriteHeader->bitmap[sy][sx] != 0;
+    return rgba[sy][sx] != Color();
 }
 
 //----- (004C16B4) --------------------------------------------------------


### PR DESCRIPTION
Dropping the code that touches the privates of LOD classes.

Preparing to split LOD classes into texture/sprite cache parts and the actual LOD readers/writers.