### PR TITLE
More test cleanup & taping for tests

### DIFF
--- a/src/Engine/Components/Trace/EngineTracePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTracePlayer.cpp
@@ -29,7 +29,8 @@ EngineTracePlayer::~EngineTracePlayer() {
 }
 
 void EngineTracePlayer::playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath,
-                                  EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback) {
+                                  EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback,
+                                  std::function<void()> tickCallback) {
     assert(!isPlaying());
 
     _tracePath = tracePath;
@@ -64,7 +65,7 @@ void EngineTracePlayer::playTrace(EngineController *game, const std::string &sav
         postLoadCallback();
 
     checkState(_trace->header.startState, true);
-    _simplePlayer->playTrace(game, std::move(_trace->events), _tracePath, _flags);
+    _simplePlayer->playTrace(game, std::move(_trace->events), _tracePath, _flags, std::move(tickCallback));
     checkState(_trace->header.endState, false);
 }
 

--- a/src/Engine/Components/Trace/EngineTracePlayer.h
+++ b/src/Engine/Components/Trace/EngineTracePlayer.h
@@ -37,9 +37,11 @@ class EngineTracePlayer : private PlatformApplicationAware {
      * @param tracePath                 Path to trace file.
      * @param flags                     Playback flags.
      * @param postLoadCallback          Callback to call once the saved game is loaded.
+     * @param tickCallback              Callback to call every frame and also before & after running the trace.
      */
     void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath,
-                   EngineTracePlaybackFlags flags = 0, std::function<void()> postLoadCallback = {});
+                   EngineTracePlaybackFlags flags = 0, std::function<void()> postLoadCallback = {},
+                   std::function<void()> tickCallback = {});
 
     [[nodiscard]] bool isPlaying() const {
         return _trace != nullptr;

--- a/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
@@ -16,7 +16,7 @@ EngineTraceSimplePlayer::EngineTraceSimplePlayer() = default;
 EngineTraceSimplePlayer::~EngineTraceSimplePlayer() = default;
 
 void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std::unique_ptr<PlatformEvent>> events,
-                                        const std::string &tracePath, EngineTracePlaybackFlags flags) {
+                                        const std::string &tracePath, EngineTracePlaybackFlags flags, std::function<void()> tickCallback) {
     assert(!isPlaying());
 
     _playing = true;
@@ -25,9 +25,15 @@ void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std:
     _tracePath = tracePath;
     _flags = flags;
 
+    if (tickCallback)
+        tickCallback();
+
     for (std::unique_ptr<PlatformEvent> &event : events) {
         if (event->type == EVENT_PAINT) {
             game->tick(1);
+
+            if (tickCallback)
+                tickCallback();
 
             const PaintEvent *paintEvent = static_cast<const PaintEvent *>(event.get());
             checkTime(paintEvent);
@@ -36,6 +42,9 @@ void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std:
             game->postEvent(std::move(event));
         }
     }
+
+    if (tickCallback)
+        tickCallback();
 }
 
 void EngineTraceSimplePlayer::checkTime(const PaintEvent *paintEvent) {

--- a/src/Engine/Components/Trace/EngineTraceSimplePlayer.h
+++ b/src/Engine/Components/Trace/EngineTraceSimplePlayer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <functional>
 
 #include "Library/Application/PlatformApplicationAware.h"
 
@@ -31,9 +32,11 @@ class EngineTraceSimplePlayer : private PlatformApplicationAware {
      * @param tracePath                 Path to trace file that the events were loaded from. Used only for error
      *                                  reporting.
      * @param flags                     Playback flags.
+     * @param tickCallback              Callback to run at the end of every frame & also once at the start and at the
+     *                                  end of the trace.
      */
     void playTrace(EngineController *game, std::vector<std::unique_ptr<PlatformEvent>> events,
-                   const std::string &tracePath, EngineTracePlaybackFlags flags);
+                   const std::string &tracePath, EngineTracePlaybackFlags flags, std::function<void()> tickCallback = {});
 
     bool isPlaying() const {
         return _playing;

--- a/test/Testing/Game/CMakeLists.txt
+++ b/test/Testing/Game/CMakeLists.txt
@@ -6,6 +6,7 @@ if(ENABLE_TESTS)
             TestController.cpp)
     set(TESTING_GAME_HEADERS
             GameTest.h
+            TestTape.h
             TestController.h)
 
     add_library(testing_game ${TESTING_GAME_SOURCES} ${TESTING_GAME_HEADERS})

--- a/test/Testing/Game/TestController.cpp
+++ b/test/Testing/Game/TestController.cpp
@@ -37,12 +37,16 @@ void TestController::playTraceFromTestData(const std::string &saveName, const st
         fullPathInTestData(saveName),
         fullPathInTestData(traceName),
         flags,
-        std::move(postLoadCallback)
+        std::move(postLoadCallback),
+        [this] {
+            runTapeCallbacks();
+        }
     );
 }
 
 void TestController::prepareForNextTest() {
     engine->config->resetForTest();
+    _tapeCallbacks.clear();
 
     // This is frame time for tests that are implemented by manually sending events from the test code.
     // For such tests, frame time value is taken from config defaults.
@@ -53,4 +57,9 @@ void TestController::prepareForNextTest() {
 
 void TestController::restart(int frameTimeMs) {
     ::application->get<EngineDeterministicComponent>()->restart(frameTimeMs);
+}
+
+void TestController::runTapeCallbacks() {
+    for (const auto &callback : _tapeCallbacks)
+        callback();
 }

--- a/test/Testing/Game/TestController.h
+++ b/test/Testing/Game/TestController.h
@@ -25,8 +25,22 @@ class TestController {
 
     void prepareForNextTest();
 
-    void restart(int frameTimeMs);
+    void restart(int frameTimeMs); // TODO(captainurist): need a better name here.
 
+    /**
+     * Creates a tape object that will record changes in a value computed by the provided callback throughout the
+     * execution of a trace.
+     *
+     * The callback is called on every frame, and also before and after running the trace, and unique values are stored
+     * on a tape. This effectively means that if, for example, the provided callback always returns the same value,
+     * then you'll get a tape of size 1.
+     *
+     * A typical use case is to create a tape, call `playTraceFromTestData` to play a trace, then check the data
+     * stored on the tape.
+     *
+     * @param callback                  Callback that will calculate the values to store on a tape.
+     * @return                          Tape object.
+     */
     template<class Callback, class T = std::invoke_result_t<Callback>>
     TestTape<T> tape(Callback callback) {
         auto state = std::make_shared<detail::TestTapeState<T>>(std::move(callback));

--- a/test/Testing/Game/TestController.h
+++ b/test/Testing/Game/TestController.h
@@ -3,8 +3,13 @@
 #include <filesystem>
 #include <string>
 #include <functional>
+#include <utility>
+#include <vector>
+#include <memory>
 
 #include "Engine/Components/Trace/EngineTraceEnums.h"
+
+#include "TestTape.h"
 
 class EngineController;
 
@@ -22,7 +27,18 @@ class TestController {
 
     void restart(int frameTimeMs);
 
+    template<class Callback, class T = std::invoke_result_t<Callback>>
+    TestTape<T> tape(Callback callback) {
+        auto state = std::make_shared<detail::TestTapeState<T>>(std::move(callback));
+        _tapeCallbacks.push_back([state] { state->tick(); });
+        return TestTape<T>(std::move(state));
+    }
+
+ private:
+    void runTapeCallbacks();
+
  private:
     EngineController *_controller;
     std::filesystem::path _testDataPath;
+    std::vector<std::function<void()>> _tapeCallbacks;
 };

--- a/test/Testing/Game/TestTape.h
+++ b/test/Testing/Game/TestTape.h
@@ -48,8 +48,21 @@ class TestTape {
 
     T delta() {
         assert(!values().empty());
-
         return values().back() - values().front();
+    }
+
+    T min() const {
+        assert(!values().empty());
+        return *std::min_element(values().begin(), values().end());
+    }
+
+    T max() const {
+        assert(!values().empty());
+        return *std::max_element(values().begin(), values().end());
+    }
+
+    bool contains(T value) {
+        return std::find(values().begin(), values().end(), value) != values().end();
     }
 
     template<class Y>

--- a/test/Testing/Game/TestTape.h
+++ b/test/Testing/Game/TestTape.h
@@ -57,6 +57,8 @@ class TestTape {
         return std::equal(l.values().begin(), l.values().end(), r.begin(), r.end());
     }
 
+    // operator!= and operators with switched arguments are auto-generated.
+
     friend void PrintTo(const TestTape &tape, std::ostream* stream) { // gtest printers support.
         using namespace testing; // NOLINT
         *stream << PrintToString(tape.values());
@@ -66,6 +68,15 @@ class TestTape {
     std::shared_ptr<detail::TestTapeState<T>> _state;
 };
 
+/**
+ * Basically a convenient shortcut to create vectors that can then be compared with `TestTape` objects inside
+ * the `EXPECT_EQ` and `ASSERT_EQ` gtest macros.
+ *
+ * Example code:
+ * ```
+ * EXPECT_EQ(strengthTape, tape(2, 4, 6)); // Two +2 strength barrels.
+ * ```
+ */
 template<class T, class... Tail>
 std::vector<T> tape(T first, Tail... tail) {
     return std::initializer_list<T>{std::move(first), std::move(tail)...};

--- a/test/Testing/Game/TestTape.h
+++ b/test/Testing/Game/TestTape.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cassert>
+#include <algorithm>
+#include <functional>
+#include <ostream>
+#include <vector>
+#include <memory>
+#include <utility>
+
+namespace testing {} // Forward-declare gtest namespace.
+
+namespace detail {
+template<class T>
+class TestTapeState {
+ public:
+    explicit TestTapeState(std::function<T()> callback) : _callback(std::move(callback)) {
+        assert(_callback);
+    }
+
+    void tick() {
+        T value = _callback();
+        if (_values.empty() || _values.back() != value)
+            _values.push_back(std::move(value));
+    }
+
+    const std::vector<T> &values() const {
+        return _values;
+    }
+
+ private:
+    std::function<T()> _callback;
+    std::vector<T> _values;
+};
+} // namespace detail
+
+
+template<class T>
+class TestTape {
+ public:
+    explicit TestTape(std::shared_ptr<detail::TestTapeState<T>> state) : _state(std::move(state)) {
+        assert(_state);
+    }
+
+    const std::vector<T> &values() const {
+        return _state->values();
+    }
+
+    T delta() {
+        assert(!values().empty());
+
+        return values().back() - values().front();
+    }
+
+    template<class Y>
+    friend bool operator==(const TestTape &l, const std::vector<Y> &r) {
+        return std::equal(l.values().begin(), l.values().end(), r.begin(), r.end());
+    }
+
+    friend void PrintTo(const TestTape &tape, std::ostream* stream) { // gtest printers support.
+        using namespace testing; // NOLINT
+        *stream << PrintToString(tape.values());
+    }
+
+ private:
+    std::shared_ptr<detail::TestTapeState<T>> _state;
+};
+
+template<class T, class... Tail>
+std::vector<T> tape(T first, Tail... tail) {
+    return std::initializer_list<T>{std::move(first), std::move(tail)...};
+}

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -62,6 +62,14 @@ static std::initializer_list<CharacterBuffs> allPotionBuffs() {
     return result;
 }
 
+static auto makeHealthTape(TestController *test) {
+    return test->tape(&totalPartyHealth);
+}
+
+static auto makeMapTape(TestController *test) {
+    return test->tape([] { return toLower(pCurrentMapName); });
+}
+
 // 100
 
 GAME_TEST(Issues, Issue123) {
@@ -73,14 +81,14 @@ GAME_TEST(Issues, Issue123) {
 
 GAME_TEST(Issues, Issue125) {
     // check that fireballs hurt party
-    auto healthTape = test->tape(&totalPartyHealth);
+    auto healthTape = makeHealthTape(test);
     test->playTraceFromTestData("issue_125.mm7", "issue_125.json");
     EXPECT_LT(healthTape.delta(), 0);
 }
 
 GAME_TEST(Issues, Issue159) {
     // Exception when entering Tidewater Caverns
-    auto mapTape = test->tape([] { return toLower(pCurrentMapName); });
+    auto mapTape = makeMapTape(test);
     test->playTraceFromTestData("issue_159.mm7", "issue_159.json");
     EXPECT_EQ(mapTape, tape("out13.odm", "d17.blv", "out13.odm"));
 }
@@ -156,12 +164,12 @@ GAME_TEST(Issues, Issue198) {
 
 GAME_TEST(Issues, Issue201) {
     // Unhandled EVENT_ShowMovie in Event Processor
-    auto healthTape = test->tape(&totalPartyHealth);
+    auto healthTape = makeHealthTape(test);
+    auto mapTape = makeMapTape(test);
     auto daysTape = test->tape([] { return pParty->GetPlayingTime().GetDays(); });
-    auto mapTape = test->tape([] { return toLower(pCurrentMapName); });
     test->playTraceFromTestData("issue_201.mm7", "issue_201.json");
     EXPECT_GT(healthTape.delta(), 0); // Party should heal.
-    EXPECT_EQ(mapTape, tape("out01.odm", "out02.odm")); // Emerald isle to harmondale.
+    EXPECT_EQ(mapTape, tape("out01.odm", "out02.odm")); // Emerald isle to Harmondale.
     EXPECT_EQ(daysTape.delta(), 7); // Time should advance by a week.
 }
 
@@ -211,7 +219,7 @@ GAME_TEST(Issues, Issue248) {
     // Crash in NPC dialog.
     auto screenTape = test->tape([] { return current_screen_type; });
     test->playTraceFromTestData("issue_248.mm7", "issue_248.json");
-    EXPECT_EQ(screenTape, tape(CURRENT_SCREEN::SCREEN_GAME, CURRENT_SCREEN::SCREEN_NPC_DIALOGUE, CURRENT_SCREEN::SCREEN_GAME));
+    EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_NPC_DIALOGUE, SCREEN_GAME));
 }
 
 GAME_TEST(Issues, Issue268_939) {


### PR DESCRIPTION
Was thinking for quite some time how to properly test the things I want to test, so this is an abstraction I came up with.

Examples:
```cpp
    auto daysTape = test->tape([] { return pParty->GetPlayingTime().GetDays(); });
    test->playTraceFromTestData("issue_201.mm7", "issue_201.json");
    EXPECT_EQ(daysTape.delta(), 7); // Time should advance by a week.
```

And:
```cpp
    auto mapTape = test->tape([] { return toLower(pCurrentMapName); });
    test->playTraceFromTestData("issue_159.mm7", "issue_159.json");
    EXPECT_EQ(mapTape, tape("out13.odm", "d17.blv", "out13.odm")); // In and out, 20 minute adventure.
```