### PR TITLE
Class Pid & trace-only turn-based tests

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2074,7 +2074,7 @@ void Game::onPressSpace() {
                           &vis_sprite_filter_3, &vis_door_filter);
 
     uint16_t pid = _vis->get_picked_object_zbuf_val().object_pid;
-    if (pid != PID_INVALID) {
+    if (pid != 0) {
         DoInteractionWithTopmostZObject(pid);
     }
 }

--- a/src/Engine/AttackList.cpp
+++ b/src/Engine/AttackList.cpp
@@ -7,12 +7,12 @@ std::vector<AttackDescription> attackList;
 //----- (0040261D) --------------------------------------------------------
 // void stru298::Add(int16_t uID, int16_t a3, int16_t x, int16_t y, int16_t z, ABILITY_INDEX a7, char a8);
 
-void pushMeleeAttack(int16_t pid, Vec3i pos, ABILITY_INDEX ability) {
+void pushMeleeAttack(Pid pid, Vec3i pos, ABILITY_INDEX ability) {
     // Registered melee attack use the same distance as ranged attacks
     int effectDistance = engine->config->gameplay.RangedAttackDepth.value();
     attackList.push_back({pid, pos, effectDistance, true, ability});
 }
 
-void pushAoeAttack(int16_t pid, int aoeDistance, Vec3i pos, ABILITY_INDEX ability) {
+void pushAoeAttack(Pid pid, int aoeDistance, Vec3i pos, ABILITY_INDEX ability) {
     attackList.push_back({pid, pos, aoeDistance, false, ability});
 }

--- a/src/Engine/AttackList.h
+++ b/src/Engine/AttackList.h
@@ -4,11 +4,12 @@
 #include <vector>
 
 #include "Engine/Objects/ActorEnums.h"
+#include "Engine/Pid.h"
 
 #include "Utility/Geometry/Vec.h"
 
 struct AttackDescription {
-    int16_t pid;
+    Pid pid;
     Vec3i pos;
     int attackRange;
     bool isMelee; // Melee attack or magic AOE
@@ -27,7 +28,7 @@ extern std::vector<AttackDescription> attackList;  // for area of effect damage
  * @param   ability        ???
  * @offset 0x40261D
  */
-extern void pushAoeAttack(int16_t pid, int aoeDistance, Vec3i pos, ABILITY_INDEX ability);
+extern void pushAoeAttack(Pid pid, int aoeDistance, Vec3i pos, ABILITY_INDEX ability);
 
 /**
  * Register melee attack performed by an actor.
@@ -36,4 +37,4 @@ extern void pushAoeAttack(int16_t pid, int aoeDistance, Vec3i pos, ABILITY_INDEX
  * @param   pos            Position of an attacker
  * @param   ability        ???
  */
-extern void pushMeleeAttack(int16_t pid, Vec3i pos, ABILITY_INDEX ability);
+extern void pushMeleeAttack(Pid pid, Vec3i pos, ABILITY_INDEX ability);

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -40,6 +40,7 @@ set(ENGINE_HEADERS
         OurMath.h
         Party.h
         PartyEnums.h
+        Pid.h
         PriceCalculator.h
         SaveLoad.h
         SpellFxRenderer.h

--- a/src/Engine/Events/EventInterpreter.h
+++ b/src/Engine/Events/EventInterpreter.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "Engine/MM7.h"
+#include "Engine/Pid.h"
 #include "Engine/Events/EventIR.h"
 #include "Engine/Events/EventMap.h"
 

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -147,7 +147,7 @@ static bool CollidePointWithFace(BLVFace *face, const Vec3f &pos, const Vec3f &d
  * @param ignore_ethereal               Whether ethereal faces should be ignored by this function.
  * @param model_idx                     Model index, or `MODEL_INDOOR`.
 */
-static void CollideBodyWithFace(BLVFace *face, int face_pid, bool ignore_ethereal, int model_idx) {
+static void CollideBodyWithFace(BLVFace *face, Pid face_pid, bool ignore_ethereal, int model_idx) {
     auto collide_once = [&](const Vec3f &old_pos, const Vec3f &new_pos, const Vec3f &dir, int radius) {
         float distance_old = face->facePlane.signedDistanceTo(old_pos);
         float distance_new = face->facePlane.signedDistanceTo(new_pos);
@@ -189,7 +189,7 @@ static void CollideBodyWithFace(BLVFace *face, int face_pid, bool ignore_etherea
  * @param jagged_top                    See `CollideWithParty`.
  * @return                              Whether there is a collision.
  */
-static bool CollideWithCylinder(const Vec3f &center_lo, float radius, float height, int pid, bool jagged_top) {
+static bool CollideWithCylinder(const Vec3f &center_lo, float radius, float height, Pid pid, bool jagged_top) {
     BBoxf bbox = BBoxf::forCylinder(center_lo, radius, height);
     if (!collision_state.bbox.intersects(bbox))
         return false;
@@ -273,7 +273,7 @@ bool CollisionState::PrepareAndCheckIfStationary(int dt_fp) {
         BBoxf::cubic(this->position_hi, this->radius_hi) |
         BBoxf::cubic(this->new_position_hi, this->radius_hi);
 
-    this->pid = 0;
+    this->pid = Pid();
     this->adjusted_move_distance = this->move_distance;
 
     return false;
@@ -341,7 +341,7 @@ void CollideOutdoorWithModels(bool ignore_ethereal) {
             if (face.Ethereal() || face.isPortal()) // TODO: this doesn't respect ignore_ethereal parameter
                 continue;
 
-            int pid = PID(OBJECT_Face, (mface.index | (model.index << 6)));
+            Pid pid = Pid::odmFace(model.index, mface.index);
             CollideBodyWithFace(&face, pid, ignore_ethereal, model.index);
         }
     }
@@ -457,7 +457,7 @@ void _46ED8A_collide_against_sprite_objects(unsigned int pid) {
 }
 
 void CollideWithParty(bool jagged_top) {
-    CollideWithCylinder(pParty->pos.toFloat(), 2 * pParty->radius, pParty->height, 4, jagged_top);
+    CollideWithCylinder(pParty->pos.toFloat(), 2 * pParty->radius, pParty->height, Pid::character(0), jagged_top);
 }
 
 void ProcessActorCollisionsBLV(Actor &actor, bool isAboveGround, bool isFlying) {

--- a/src/Engine/Graphics/Collisions.h
+++ b/src/Engine/Graphics/Collisions.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Engine/Pid.h"
+
 #include "Utility/Geometry/Vec.h"
 #include "Utility/Geometry/BBox.h"
 
@@ -34,7 +36,7 @@ struct CollisionState {
     float move_distance;  // Desired movement distance for current iteration, minus the distance already covered.
     float adjusted_move_distance;  // Movement distance for current iteration, adjusted after collision checks.
     int uSectorID = 0;  // Indoor sector id.
-    unsigned int pid;  // PID of the object that we're collided with.
+    Pid pid;  // PID of the object that we're collided with.
     int ignored_face_id;  // Don't check collisions with this face.
     BBoxf bbox;
     float min_move_distance = 0.01; // Minimal movement distance, anything below this value gets rounded down to zero.

--- a/src/Engine/Graphics/RenderEntities.h
+++ b/src/Engine/Graphics/RenderEntities.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <array>
 
+#include "Engine/Pid.h"
+
 #include "Library/Color/Color.h"
 
 #include "Utility/Geometry/Vec.h"
@@ -27,7 +29,7 @@ struct RenderBillboard {
     int16_t screen_space_x;
     int16_t screen_space_y;
     int16_t screen_space_z;
-    uint16_t object_pid;
+    Pid object_pid;
     uint16_t dimming_level;
     Color sTintColor;
     SpriteFrame *pSpriteFrame;

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -251,7 +251,7 @@ bool CanInteractWithActor(unsigned int id) {
 void InteractWithActor(unsigned int id) {
     assert(CanInteractWithActor(id));
 
-    Actor::AI_FaceObject(id, 4, 0, 0);
+    Actor::AI_FaceObject(id, Pid::character(0), 0, 0);
     if (pActors[id].npcId) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_StartNPCDialogue, id, 0);
     } else {

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -443,7 +443,7 @@ unsigned short Vis::PickClosestActor(ObjectType object_type, unsigned int pick_d
     Vis_static_sub_4C1944_stru_F8BDE8.create_object_pointers(Vis_SelectionList::Unique);
     Vis_static_sub_4C1944_stru_F8BDE8.sort_object_pointers();
 
-    if (!Vis_static_sub_4C1944_stru_F8BDE8.uSize) return -1;
+    if (!Vis_static_sub_4C1944_stru_F8BDE8.uSize) return 0;
     return Vis_static_sub_4C1944_stru_F8BDE8.object_pointers[0]->object_pid;
 }
 
@@ -494,7 +494,7 @@ void Vis::SortVectors_x(RenderVertexSoft *pArray, int start, int end) {
 Vis_PIDAndDepth InvalidPIDAndDepth() {
     Vis_PIDAndDepth result;
     result.depth = 0;
-    result.object_pid = PID_INVALID;
+    result.object_pid = 0;
     return result;
 }
 

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -409,7 +409,7 @@ void Vis::PickOutdoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
                     // int v13 = fixpoint_from_float(/*v12,
                     // */intersection.vWorldViewPosition.x); v13 &= 0xFFFF0000;
                     // v13 += PID(OBJECT_Face, j | (i << 6));
-                    uint32_t pid =
+                    Pid pid =
                         PID(OBJECT_Face, face.index | (model.index << 6));
                     list->AddObject(&face, VisObjectType_Face,
                                     intersection.vWorldViewPosition.x, pid);
@@ -426,7 +426,7 @@ void Vis::PickOutdoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
 }
 
 //----- (004C1944) --------------------------------------------------------
-unsigned short Vis::PickClosestActor(ObjectType object_type, unsigned int pick_depth,
+Pid Vis::PickClosestActor(ObjectType object_type, unsigned int pick_depth,
                                      VisSelectFlags select_flags, int not_at_ai_state, int at_ai_state) {
     Vis_SelectionFilter selectionFilter;  // [sp+18h] [bp-20h]@3
 
@@ -443,7 +443,7 @@ unsigned short Vis::PickClosestActor(ObjectType object_type, unsigned int pick_d
     Vis_static_sub_4C1944_stru_F8BDE8.create_object_pointers(Vis_SelectionList::Unique);
     Vis_static_sub_4C1944_stru_F8BDE8.sort_object_pointers();
 
-    if (!Vis_static_sub_4C1944_stru_F8BDE8.uSize) return 0;
+    if (!Vis_static_sub_4C1944_stru_F8BDE8.uSize) return Pid();
     return Vis_static_sub_4C1944_stru_F8BDE8.object_pointers[0]->object_pid;
 }
 
@@ -494,7 +494,7 @@ void Vis::SortVectors_x(RenderVertexSoft *pArray, int start, int end) {
 Vis_PIDAndDepth InvalidPIDAndDepth() {
     Vis_PIDAndDepth result;
     result.depth = 0;
-    result.object_pid = 0;
+    result.object_pid = Pid();
     return result;
 }
 

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -55,7 +55,7 @@ using Vis_Object = std::variant<std::monostate, int /* index */, ODMFace *, BLVF
 
 struct Vis_ObjectInfo {
     Vis_Object object;
-    uint16_t object_pid = PID_INVALID;
+    uint16_t object_pid = 0;
     int16_t depth = -1;
     VisObjectType object_type = VisObjectType_Any;
 };

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -47,7 +47,7 @@ extern Vis_SelectionFilter vis_sprite_filter_3;  // 00F93E6C
 extern Vis_SelectionFilter vis_sprite_filter_4;  // static to sub_44EEA7
 
 struct Vis_PIDAndDepth {
-    uint16_t object_pid;
+    Pid object_pid;
     int16_t depth;
 };
 
@@ -55,7 +55,7 @@ using Vis_Object = std::variant<std::monostate, int /* index */, ODMFace *, BLVF
 
 struct Vis_ObjectInfo {
     Vis_Object object;
-    uint16_t object_pid = 0;
+    Pid object_pid = Pid();
     int16_t depth = -1;
     VisObjectType object_type = VisObjectType_Any;
 };
@@ -68,7 +68,7 @@ struct Vis_SelectionList {
     void create_object_pointers(PointerCreationType type = All);
     void sort_object_pointers();
 
-    inline void AddObject(Vis_Object object, VisObjectType type, int depth, int pid) {
+    inline void AddObject(Vis_Object object, VisObjectType type, int depth, Pid pid) {
         object_pool[uSize].object = object;
         object_pool[uSize].object_type = type;
         object_pool[uSize].depth = depth;
@@ -128,7 +128,7 @@ class Vis {
                                      float *out_center_y);
     bool IsPointInsideD3DBillboard(struct RenderBillboardD3D *billboard, float x,
                                    float y);
-    unsigned short PickClosestActor(ObjectType object_type, unsigned int pick_depth,
+    Pid PickClosestActor(ObjectType object_type, unsigned int pick_depth,
                                     VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
     void _4C1A02();
     void SortVectors_x(RenderVertexSoft *pArray, int start, int end);

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -6,7 +6,7 @@
 #include "Utility/Geometry/Plane.h"
 
 #include "Engine/Objects/ActorEnums.h"
-#include "Engine/MM7.h"
+#include "Engine/Pid.h"
 #include "Camera.h"
 
 class BSPModel;

--- a/src/Engine/MM7.h
+++ b/src/Engine/MM7.h
@@ -2,11 +2,6 @@
 
 #include <cstdint>
 
-#define PID(type, id) (uint16_t)((((8 * (id))) | (std::to_underlying(type))) & 0xFFFF)  // packed id
-#define PID_TYPE(pid) static_cast<ObjectType>((pid)&7)          // extract type
-#define PID_ID(pid) (uint32_t)(((pid)&0xFFFF) >> 3)  // extract value
-#define PID_INVALID (uint16_t)(-1)
-
 typedef unsigned int uint;
 typedef unsigned char uchar;
 typedef unsigned short ushort;

--- a/src/Engine/MapInfo.cpp
+++ b/src/Engine/MapInfo.cpp
@@ -307,7 +307,7 @@ void MapInfo::SpawnRandomTreasure(SpawnPoint *a2) {
     a1a.spell_level = 0;
     a1a.uSpellID = SPELL_NONE;
     a1a.spell_target_pid = 0;
-    a1a.spell_caster_pid = 0;
+    a1a.spell_caster_pid = Pid();
     a1a.uSpriteFrameID = 0;
     a1a.uSectorID = pIndoor->GetSector(a2->vPosition.x, a2->vPosition.y, a2->vPosition.z);
     a1a.Create(0, 0, 0, 0);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1063,7 +1063,7 @@ void Actor::StandAwhile(unsigned int uActorID) {
 }
 
 //----- (00403C6C) --------------------------------------------------------
-void Actor::AI_MeleeAttack(unsigned int uActorID, signed int sTargetPid,
+void Actor::AI_MeleeAttack(unsigned int uActorID, Pid sTargetPid,
                            struct AIDirection *arg0) {
     int16_t v6;        // esi@6
     int16_t v7;        // edi@6
@@ -1313,7 +1313,7 @@ void Actor::StealFrom(unsigned int uActorID) {
 }
 
 //----- (00403A60) --------------------------------------------------------
-void Actor::AI_SpellAttack2(unsigned int uActorID, signed int edx0,
+void Actor::AI_SpellAttack2(unsigned int uActorID, Pid edx0,
                             AIDirection *pDir) {
     Actor *v3;           // ebx@1
     int16_t v4;          // esi@3
@@ -1325,7 +1325,7 @@ void Actor::AI_SpellAttack2(unsigned int uActorID, signed int edx0,
     AIDirection a3;      // [sp+Ch] [bp-48h]@9
     AIDirection v18;     // [sp+28h] [bp-2Ch]@9
     int v19;             // [sp+44h] [bp-10h]@6
-    signed int a2;       // [sp+48h] [bp-Ch]@1
+    Pid a2;       // [sp+48h] [bp-Ch]@1
     int v21;             // [sp+4Ch] [bp-8h]@3
     unsigned int pDira;  // [sp+5Ch] [bp+8h]@10
 
@@ -1387,7 +1387,7 @@ void Actor::AI_SpellAttack2(unsigned int uActorID, signed int edx0,
 }
 
 //----- (00403854) --------------------------------------------------------
-void Actor::AI_SpellAttack1(unsigned int uActorID, signed int sTargetPid,
+void Actor::AI_SpellAttack1(unsigned int uActorID, Pid sTargetPid,
                             AIDirection *pDir) {
     Actor *v3;           // ebx@1
     int16_t v4;          // esi@3
@@ -1463,7 +1463,7 @@ void Actor::AI_SpellAttack1(unsigned int uActorID, signed int sTargetPid,
 }
 
 //----- (0040368B) --------------------------------------------------------
-void Actor::AI_MissileAttack2(unsigned int uActorID, signed int sTargetPid,
+void Actor::AI_MissileAttack2(unsigned int uActorID, Pid sTargetPid,
                               AIDirection *pDir) {
     Actor *v3;           // ebx@1
     int16_t v4;          // esi@3
@@ -1528,7 +1528,7 @@ void Actor::AI_MissileAttack2(unsigned int uActorID, signed int sTargetPid,
 }
 
 //----- (00403476) --------------------------------------------------------
-void Actor::AI_MissileAttack1(unsigned int uActorID, signed int sTargetPid,
+void Actor::AI_MissileAttack1(unsigned int uActorID, Pid sTargetPid,
                               AIDirection *pDir) {
     Actor *v3;         // ebx@1
     int xpos;            // esi@3
@@ -1918,7 +1918,7 @@ void Actor::playSound(unsigned int uActorID, ActorSounds uSoundID) {
 }
 
 //----- (00402AD7) --------------------------------------------------------
-void Actor::AI_Pursue1(unsigned int uActorID, unsigned int a2, signed int arg0,
+void Actor::AI_Pursue1(unsigned int uActorID, Pid a2, signed int arg0,
                        signed int uActionLength, AIDirection *pDir) {
     Actor *v7;         // ebx@1
     unsigned int v8;   // ecx@1
@@ -2018,7 +2018,7 @@ void Actor::AI_Flee(unsigned int uActorID, signed int sTargetPid,
 }
 
 //----- (0040281C) --------------------------------------------------------
-void Actor::AI_Pursue2(unsigned int uActorID, unsigned int a2,
+void Actor::AI_Pursue2(unsigned int uActorID, Pid a2,
                        signed int uActionLength, AIDirection *pDir, int a5) {
     int v6;                // eax@1
     Actor *v7;             // ebx@1
@@ -2075,7 +2075,7 @@ void Actor::AI_Pursue2(unsigned int uActorID, unsigned int a2,
 }
 
 //----- (00402686) --------------------------------------------------------
-void Actor::AI_Pursue3(unsigned int uActorID, unsigned int a2,
+void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
                        signed int uActionLength, AIDirection *a4) {
     int v5;                // eax@1
     Actor *v6;             // ebx@1
@@ -2136,7 +2136,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, unsigned int a2,
 }
 
 //----- (00401221) --------------------------------------------------------
-void Actor::_SelectTarget(unsigned int uActorID, int *OutTargetPID,
+void Actor::_SelectTarget(unsigned int uActorID, Pid *OutTargetPID,
                           bool can_target_party) {
     int v5;                     // ecx@1
     signed int v10;             // eax@13
@@ -2155,7 +2155,7 @@ void Actor::_SelectTarget(unsigned int uActorID, int *OutTargetPID,
     lowestRadius = UINT_MAX;
     v5 = 0;
     // TODO(pskelton): change to PID_INVALID and sort logic in calling funcs
-    *OutTargetPID = 0;
+    *OutTargetPID = Pid();
     closestId = 0;
     assert(uActorID < pActors.size());
     Actor *thisActor = &pActors[uActorID];
@@ -2586,7 +2586,7 @@ void Actor::UpdateActorAI() {
     ObjectType target_pid_type;     // [sp+70h] [bp-40h]@83
     AIDirection *pDir;       // [sp+7Ch] [bp-34h]@129
     int v81;                 // [sp+9Ch] [bp-14h]@100
-    signed int target_pid;   // [sp+ACh] [bp-4h]@83
+    Pid target_pid;   // [sp+ACh] [bp-4h]@83
     uint v38;
 
     // Build AI array
@@ -3040,7 +3040,7 @@ void Actor::InitializeActors() {
     if (pParty->isPartyGood()) good = true;
     if (pParty->isPartyEvil()) evil = true;
 
-    ai_near_actors_targets_pid.fill(0);
+    ai_near_actors_targets_pid.fill(Pid());
 
     for (uint i = 0; i < pActors.size(); ++i) {
         Actor *actor = &pActors[i];

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -988,7 +988,7 @@ void Actor::GetDirectionInfo(unsigned int uObj1ID, unsigned int uObj2ID,
 }
 
 //----- (00404030) --------------------------------------------------------
-void Actor::AI_FaceObject(unsigned int uActorID, unsigned int uObjID, int UNUSED,
+void Actor::AI_FaceObject(unsigned int uActorID, Pid uObjID, int UNUSED,
                           AIDirection *Dir_In) {
     AIDirection *Dir_Out;
     AIDirection Dir_Ret;
@@ -1016,7 +1016,7 @@ void Actor::AI_FaceObject(unsigned int uActorID, unsigned int uObjID, int UNUSED
 }
 
 //----- (00403F58) --------------------------------------------------------
-void Actor::AI_StandOrBored(unsigned int uActorID, signed int uObjID,
+void Actor::AI_StandOrBored(unsigned int uActorID, Pid uObjID,
                             int uActionLength, AIDirection *a4) {
     if (grng->random(2))  // 0 or 1
         AI_Bored(uActorID, uObjID, a4);
@@ -1599,7 +1599,7 @@ void Actor::AI_MissileAttack1(unsigned int uActorID, Pid sTargetPid,
 }
 
 //----- (004032B2) --------------------------------------------------------
-void Actor::AI_RandomMove(unsigned int uActor_id, unsigned int uTarget_id,
+void Actor::AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,
                           int radius, int uActionLength) {
     int x;                                             // ebx@1
     int absy;                                          // eax@1
@@ -1721,7 +1721,7 @@ char Actor::_4031C1_update_job_never_gets_called(
 }
 
 //----- (004030AD) --------------------------------------------------------
-void Actor::AI_Stun(unsigned int uActorID, signed int edx0,
+void Actor::AI_Stun(unsigned int uActorID, Pid edx0,
                     int stunRegardlessOfState) {
     int16_t v7;      // ax@16
     AIDirection a3;  // [sp+Ch] [bp-40h]@16
@@ -1758,7 +1758,7 @@ void Actor::AI_Stun(unsigned int uActorID, signed int edx0,
 }
 
 //----- (00402F87) --------------------------------------------------------
-void Actor::AI_Bored(unsigned int uActorID, unsigned int uObjID,
+void Actor::AI_Bored(unsigned int uActorID, Pid uObjID,
                      AIDirection *a4) {
     unsigned int v7;  // eax@3
     unsigned int v9;  // eax@3
@@ -1945,7 +1945,7 @@ void Actor::AI_Pursue1(unsigned int uActorID, Pid a2, signed int arg0,
     if (MonsterStats::BelongsToSupertype(v7->monsterInfo.uID,
                                          MONSTER_SUPERTYPE_TREANT)) {
         if (!uActionLength) uActionLength = 256;
-        Actor::AI_StandOrBored(uActorID, 4, uActionLength, v10);
+        Actor::AI_StandOrBored(uActorID, Pid::character(0), uActionLength, v10);
         return;
     }
     if (v10->uDistance < 307.2) {
@@ -1974,7 +1974,7 @@ void Actor::AI_Pursue1(unsigned int uActorID, Pid a2, signed int arg0,
 }
 
 //----- (00402968) --------------------------------------------------------
-void Actor::AI_Flee(unsigned int uActorID, signed int sTargetPid,
+void Actor::AI_Flee(unsigned int uActorID, Pid sTargetPid,
                     int uActionLength, AIDirection *a4) {
     Actor *v5;         // ebx@1
     int v7;            // ecx@2
@@ -1996,7 +1996,7 @@ void Actor::AI_Flee(unsigned int uActorID, signed int sTargetPid,
                                              MONSTER_SUPERTYPE_TREANT) ||
             PID_TYPE(sTargetPid) == OBJECT_Actor && v13->uDistance < 307.2) {
             if (!uActionLength) uActionLength = 256;
-            Actor::AI_StandOrBored(uActorID, 4, uActionLength, v13);
+            Actor::AI_StandOrBored(uActorID, Pid::character(0), uActionLength, v13);
         } else {
             if (v5->moveSpeed)
                 v5->currentActionLength =
@@ -2047,7 +2047,7 @@ void Actor::AI_Pursue2(unsigned int uActorID, Pid a2,
     if (MonsterStats::BelongsToSupertype(v7->monsterInfo.uID,
                                          MONSTER_SUPERTYPE_TREANT)) {
         if (!uActionLength) uActionLength = 256;
-        Actor::AI_StandOrBored(uActorID, 4, uActionLength, v10);
+        Actor::AI_StandOrBored(uActorID, Pid::character(0), uActionLength, v10);
         return;
     }
     if ((signed int)v10->uDistance < a5) {
@@ -2103,7 +2103,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
     if (MonsterStats::BelongsToSupertype(v6->monsterInfo.uID,
                                          MONSTER_SUPERTYPE_TREANT)) {
         if (!uActionLength) uActionLength = 256;
-        return Actor::AI_StandOrBored(uActorID, 4, uActionLength, a4);
+        return Actor::AI_StandOrBored(uActorID, Pid::character(0), uActionLength, a4);
     }
     if (a4->uDistance < 307.2) {
         if (!uActionLength) uActionLength = 256;
@@ -2382,7 +2382,7 @@ void Actor::PrepareSprites(char load_sounds_if_bit1_set) {
 void Actor::Remove() { this->aiState = Removed; }
 
 //----- (0043B1B0) --------------------------------------------------------
-void Actor::ActorDamageFromMonster(signed int attacker_id,
+void Actor::ActorDamageFromMonster(Pid attacker_id,
                                    unsigned int actor_id, Vec3i *pVelocity,
                                    ABILITY_INDEX a4) {
     int v4;            // ebx@1
@@ -2897,13 +2897,13 @@ void Actor::UpdateActorAI() {
         if (pActor->monsterInfo.uHostilityType != MonsterInfo::Hostility_Long ||
             !target_pid || v81 >= 5120 || v45 != ABILITY_ATTACK2) {
             if (pActor->monsterInfo.uMovementType == MONSTER_MOVEMENT_TYPE_SHORT) {
-                Actor::AI_RandomMove(actor_id, 4, 1024, 0);
+                Actor::AI_RandomMove(actor_id, Pid::character(0), 1024, 0);
             } else if (pActor->monsterInfo.uMovementType == MONSTER_MOVEMENT_TYPE_MEDIUM) {
-                Actor::AI_RandomMove(actor_id, 4, 2560, 0);
+                Actor::AI_RandomMove(actor_id, Pid::character(0), 2560, 0);
             } else if (pActor->monsterInfo.uMovementType == MONSTER_MOVEMENT_TYPE_LONG) {
-                Actor::AI_RandomMove(actor_id, 4, 5120, 0);
+                Actor::AI_RandomMove(actor_id, Pid::character(0), 5120, 0);
             } else if (pActor->monsterInfo.uMovementType == MONSTER_MOVEMENT_TYPE_FREE) {
-                Actor::AI_RandomMove(actor_id, 4, 10240, 0);
+                Actor::AI_RandomMove(actor_id, Pid::character(0), 10240, 0);
             } else if (pActor->monsterInfo.uMovementType == MONSTER_MOVEMENT_TYPE_STATIONARY) {
                 Actor::GetDirectionInfo(actorPid, 4, &v72, 0);
                 v58 = (pActor->monsterInfo.uRecoveryTime * flt_debugrecmod3);
@@ -3069,7 +3069,7 @@ void Actor::InitializeActors() {
     }
 }
 //----- (00439474) --------------------------------------------------------
-void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
+void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
                                    Vec3i *pVelocity) {
     SpriteObject *projectileSprite;  // ebx@1
     Actor *pMonster;                 // esi@7

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3561,11 +3561,7 @@ int stru319::FindClosestActor(int pick_depth, int a3 /*Relates to targeting/not 
     {
         select_flags = (a3 != 0) ? VisSelectFlags_1 : None;
         if (target_undead) select_flags |= TargetUndead;
-        v7 = vis->PickClosestActor(OBJECT_Actor, pick_depth, static_cast<VisSelectFlags>(select_flags), 657456, -1);
-        if (v7 != -1)
-            return (uint16_t)v7;
-        else
-            return 0;
+        return vis->PickClosestActor(OBJECT_Actor, pick_depth, static_cast<VisSelectFlags>(select_flags), 657456, -1);
     }
     /*else // software impl
     {

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -4227,7 +4227,7 @@ int Actor::MakeActorAIList_BLV() {
 }
 
 //----- (004070EF) --------------------------------------------------------
-bool Detect_Between_Objects(unsigned int uObjID, unsigned int uObj2ID) {
+bool Detect_Between_Objects(Pid uObjID, Pid uObj2ID) {
     // get object 1 info
     int obj1_pid = PID_ID(uObjID);
     int obj1_sector;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2674,7 +2674,7 @@ void Actor::UpdateActorAI() {
     for (int v78 = 0; v78 < ai_arrays_size; ++v78) {
         uint actor_id = ai_near_actors_ids[v78];
         assert(actor_id < pActors.size());
-        int actorPid = PID(OBJECT_Actor, actor_id);
+        Pid actorPid = PID(OBJECT_Actor, actor_id);
 
         Actor *pActor = &pActors[actor_id];
 
@@ -4838,7 +4838,7 @@ double sub_43AE12(signed int a1) {
 }
 
 //----- (0043B057) --------------------------------------------------------
-void ItemDamageFromActor(unsigned int uObjID, unsigned int uActorID,
+void ItemDamageFromActor(Pid uObjID, unsigned int uActorID,
                          Vec3i *pVelocity) {
     int v6;      // eax@4
     int damage;  // edi@4

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3523,7 +3523,7 @@ int stru319::_427546(int a2) {
     return result;
 }
 //----- (0042F184) --------------------------------------------------------
-int stru319::FindClosestActor(int pick_depth, int a3 /*Relates to targeting/not targeting allies?*/, int target_undead) {
+Pid stru319::FindClosestActor(int pick_depth, int a3 /*Relates to targeting/not targeting allies?*/, int target_undead) {
     int v4;       // edi@1
     stru319 *v5;  // esi@1
     VisSelectFlags select_flags;       // eax@2

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -7,6 +7,7 @@
 #include "Engine/Objects/Items.h"
 #include "Engine/Objects/Monsters.h"
 #include "Engine/Objects/CombinedSkillValue.h"
+#include "Engine/Pid.h"
 
 #include "Utility/Geometry/Vec.h"
 #include "Utility/IndexedArray.h"
@@ -253,7 +254,7 @@ void npcSetItem(int npc, ITEM_TYPE item, int a3);
  * @offset 0x448A98
  */
 void toggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag, bool bValue);
-bool Detect_Between_Objects(unsigned int uObjID, unsigned int uObj2ID);
+bool Detect_Between_Objects(Pid uObjID, Pid uObj2ID);
 void Spawn_Light_Elemental(int spell_power, CharacterSkillMastery caster_skill_mastery, int duration_game_seconds);
 void SpawnEncounter(struct MapInfo *pMapInfo, SpawnPoint *spawn, int a3, int a4, int a5);
 /**

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -87,16 +87,16 @@ class Actor {
         return attributes & ACTOR_NEARBY;
     }
 
-    static void _SelectTarget(unsigned int uActorID, int *OutTargetPID,
+    static void _SelectTarget(unsigned int uActorID, Pid *OutTargetPID,
                               bool can_target_party);
-    static void AI_Pursue3(unsigned int uActorID, unsigned int a2,
+    static void AI_Pursue3(unsigned int uActorID, Pid a2,
                            signed int uActionLength, struct AIDirection *a4);
-    static void AI_Pursue2(unsigned int uActorID, unsigned int a2,
+    static void AI_Pursue2(unsigned int uActorID, Pid a2,
                            signed int uActionLength, struct AIDirection *pDir,
                            int a5);
     static void AI_Flee(unsigned int uActorID, signed int edx0,
                         int uActionLength, struct AIDirection *a4);
-    static void AI_Pursue1(unsigned int uActorID, unsigned int a2,
+    static void AI_Pursue1(unsigned int uActorID, Pid a2,
                            signed int arg0, signed int uActionLength,
                            struct AIDirection *pDir);
     /**
@@ -112,15 +112,15 @@ class Actor {
                                                      signed int a2, int a3);
     static void AI_RandomMove(unsigned int uActor_id, unsigned int uTarget_id,
                               int radius, int uActionLength);
-    static void AI_MissileAttack1(unsigned int uActorID, signed int sTargetPid,
+    static void AI_MissileAttack1(unsigned int uActorID, Pid sTargetPid,
                                   struct AIDirection *pDir);
-    static void AI_MissileAttack2(unsigned int uActorID, signed int sTargetPid,
+    static void AI_MissileAttack2(unsigned int uActorID, Pid sTargetPid,
                                   struct AIDirection *pDir);
-    static void AI_SpellAttack1(unsigned int uActorID, signed int sTargetPid,
+    static void AI_SpellAttack1(unsigned int uActorID, Pid sTargetPid,
                                 struct AIDirection *pDir);
-    static void AI_SpellAttack2(unsigned int uActorID, signed int sTargetPid,
+    static void AI_SpellAttack2(unsigned int uActorID, Pid sTargetPid,
                                 struct AIDirection *pDir);
-    static void AI_MeleeAttack(unsigned int uActorID, signed int sTargetPid,
+    static void AI_MeleeAttack(unsigned int uActorID, Pid sTargetPid,
                                struct AIDirection *arg0);
     static void StandAwhile(unsigned int uActorID);
     static void AI_Stand(unsigned int uActorID, unsigned int object_to_face_pid,

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -94,7 +94,7 @@ class Actor {
     static void AI_Pursue2(unsigned int uActorID, Pid a2,
                            signed int uActionLength, struct AIDirection *pDir,
                            int a5);
-    static void AI_Flee(unsigned int uActorID, signed int edx0,
+    static void AI_Flee(unsigned int uActorID, Pid edx0,
                         int uActionLength, struct AIDirection *a4);
     static void AI_Pursue1(unsigned int uActorID, Pid a2,
                            signed int arg0, signed int uActionLength,
@@ -105,12 +105,12 @@ class Actor {
     static void playSound(unsigned int uActorID, ActorSounds uSoundID);
     static void Die(unsigned int uActorID);
     static void resurrect(unsigned int uActorID);
-    static void AI_Bored(unsigned int uActorID, unsigned int uObjID,
+    static void AI_Bored(unsigned int uActorID, Pid uObjID,
                          struct AIDirection *a4);
-    static void AI_Stun(unsigned int uActorID, signed int edx0, int arg0);
+    static void AI_Stun(unsigned int uActorID, Pid edx0, int arg0);
     static char _4031C1_update_job_never_gets_called(unsigned int uActorID,
                                                      signed int a2, int a3);
-    static void AI_RandomMove(unsigned int uActor_id, unsigned int uTarget_id,
+    static void AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,
                               int radius, int uActionLength);
     static void AI_MissileAttack1(unsigned int uActorID, Pid sTargetPid,
                                   struct AIDirection *pDir);
@@ -125,9 +125,9 @@ class Actor {
     static void StandAwhile(unsigned int uActorID);
     static void AI_Stand(unsigned int uActorID, unsigned int object_to_face_pid,
                          unsigned int uActionLength, struct AIDirection *a4);
-    static void AI_StandOrBored(unsigned int uActorID, signed int uObjID,
+    static void AI_StandOrBored(unsigned int uActorID, Pid uObjID,
                                 int uActionLength, struct AIDirection *a4);
-    static void AI_FaceObject(unsigned int uActorID, unsigned int uObjID,
+    static void AI_FaceObject(unsigned int uActorID, Pid uObjID,
                               int UNUSED, struct AIDirection *Dir_In);
     static void GetDirectionInfo(unsigned int uObj1ID, unsigned int uObj2ID,
                                  struct AIDirection *pOut, int a4);
@@ -136,7 +136,7 @@ class Actor {
                                 int type, ABILITY_INDEX a4);
     static void AI_SpellAttack(unsigned int uActorID, struct AIDirection *pDir,
                                SPELL_TYPE uSpellID, ABILITY_INDEX a4, CombinedSkillValue uSkill);
-    static void ActorDamageFromMonster(int attacker_id, unsigned int actor_id,
+    static void ActorDamageFromMonster(Pid attacker_id, unsigned int actor_id,
                                        Vec3i *pVelocity, ABILITY_INDEX a4);
 
     static unsigned short GetObjDescId(SPELL_TYPE spellId);
@@ -160,7 +160,7 @@ class Actor {
     static void AddOnDamageOverlay(unsigned int uActorID, int overlayType, int damage);
 
     static void Arena_summon_actor(int monster_id, int x, int y, int z);
-    static void DamageMonsterFromParty(int a1, unsigned int uActorID_Monster,
+    static void DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
                                        Vec3i *pVelocity);
     static void MakeActorAIList_ODM();
     static int MakeActorAIList_BLV();

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -262,7 +262,7 @@ void SpawnEncounter(struct MapInfo *pMapInfo, SpawnPoint *spawn, int a3, int a4,
  */
 void evaluateAoeDamage();
 double sub_43AE12(signed int a1);
-void ItemDamageFromActor(unsigned int uObjID, unsigned int uActorID,
+void ItemDamageFromActor(Pid uObjID, unsigned int uActorID,
                          Vec3i *pVelocity);
 
 // TODO: in original binary almost all calls are with appendOnly=true, only Spawn_Light_Elemental uses

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -23,7 +23,7 @@ struct stru319 {
 
     int which_player_to_attack(Actor *pActor);
     int _427546(int a2);
-    int FindClosestActor(int pick_depth, int a3, int target_undead);
+    Pid FindClosestActor(int pick_depth, int a3, int target_undead);
 
     char field_0 = 0;
 

--- a/src/Engine/Objects/ActorEnums.h
+++ b/src/Engine/Objects/ActorEnums.h
@@ -51,19 +51,6 @@ enum class ACTOR_BUFF_INDEX {
 };
 using enum ACTOR_BUFF_INDEX;
 
-/*  295 */
-enum class ObjectType {
-    OBJECT_None = 0x0,
-    OBJECT_Door = 0x1,          // PID_ID is index in pIndoor->pDoors.
-    OBJECT_Item = 0x2,          // PID_ID is index in pSpriteObjects array. Note that not all sprite objects are items.
-    OBJECT_Actor = 0x3,         // PID_ID is index in pActors array.
-    OBJECT_Character = 0x4,        // PID_ID is character index in [0..3].
-    OBJECT_Decoration = 0x5,    // PID_ID is index in pLevelDecorations array.
-    OBJECT_Face = 0x6,          // PID_ID is ((model_id << 6) + face_id) outdoors, face_id indoors.
-    OBJECT_Light = 0x7,
-};
-using enum ObjectType;
-
 /*  264 */
 enum class AIState : uint16_t {
     Standing = 0x0,

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -7279,7 +7279,7 @@ void Character::_42FA66_do_explosive_impact(int xpos, int ypos, int zpos, int a4
     if (actchar >= 1 || actchar <= 4) {
         a1a.spell_caster_pid = PID(OBJECT_Character, actchar - 1);
     } else {
-        a1a.spell_caster_pid = 0;
+        a1a.spell_caster_pid = Pid();
     }
 
     int id = a1a.Create(0, 0, 0, 0);

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -127,7 +127,7 @@ bool Chest::open(int uChestID, int objectPid) {
             pSpellObject.uAttributes = SPRITE_IGNORE_RANGE | SPRITE_NO_Z_BUFFER;
             pSpellObject.uSectorID = pIndoor->GetSector(pOut);
             pSpellObject.uSpriteFrameID = 0;
-            pSpellObject.spell_caster_pid = 0;
+            pSpellObject.spell_caster_pid = Pid();
             pSpellObject.spell_target_pid = 0;
             pSpellObject.uFacing = 0;
             pSpellObject.Create(0, 0, 0, 0);

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -6,6 +6,7 @@
 #include "Engine/Objects/SpriteObjectEnums.h"
 #include "Engine/Objects/ActorEnums.h"
 #include "Engine/Spells/SpellEnums.h"
+#include "Engine/Pid.h"
 
 #include "Library/Color/Color.h"
 
@@ -82,7 +83,7 @@ struct SpriteObject {
     int spell_level = 0;
     CharacterSkillMastery spell_skill = CHARACTER_SKILL_MASTERY_NONE;
     int field_54 = 0;
-    int spell_caster_pid = 0;
+    Pid spell_caster_pid;
     int spell_target_pid = 0;
     char field_60_distance_related_prolly_lod = 0;
     ABILITY_INDEX spellCasterAbility = ABILITY_ATTACK1;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -713,7 +713,7 @@ void Party::yell() {
                 actor.monsterInfo.uHostilityType != MonsterInfo::Hostility_Long &&
                 actor.monsterInfo.uMovementType != MONSTER_MOVEMENT_TYPE_STATIONARY) {
                 if ((actor.pos - pParty->pos).length() < 512) {
-                    Actor::AI_Flee(i, 4, 0, 0);
+                    Actor::AI_Flee(i, Pid::character(0), 0, 0);
                 }
             }
         }

--- a/src/Engine/Pid.h
+++ b/src/Engine/Pid.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cstdint>
+#include <cassert>
+
+#include "Utility/Workaround/ToUnderlying.h"
+
+#define PID(type, id) (Pid(type, id))  // packed id
+#define PID_TYPE(pid) (detail::pidType(pid))          // extract type
+#define PID_ID(pid) (detail::pidId(pid))  // extract value
+#define PID_INVALID (uint16_t(-1))
+
+enum class ObjectType {
+    OBJECT_None = 0x0,
+    OBJECT_Door = 0x1,          // PID_ID is index in pIndoor->pDoors.
+    OBJECT_Item = 0x2,          // PID_ID is index in pSpriteObjects array. Note that not all sprite objects are items.
+    OBJECT_Actor = 0x3,         // PID_ID is index in pActors array.
+    OBJECT_Character = 0x4,     // PID_ID is character index in [0..3].
+    OBJECT_Decoration = 0x5,    // PID_ID is index in pLevelDecorations array.
+    OBJECT_Face = 0x6,          // PID_ID is ((model_id << 6) + face_id) outdoors, face_id indoors.
+    OBJECT_Light = 0x7,
+};
+using enum ObjectType;
+
+class Pid {
+ public:
+    enum {
+        ID_MAX = 0xFFFF >> 3,
+        ODM_FACE_ID_MAX = 0x3F,
+        ODM_MODEL_ID_MAX = 0x7F
+    };
+
+    constexpr Pid() = default;
+
+    constexpr Pid(ObjectType objectType, int id) {
+        assert(id >= 0 && id <= ID_MAX);
+        _value = (id << 3) + std::to_underlying(objectType);
+    }
+
+    static constexpr Pid door(int id) {
+        return Pid(OBJECT_Door, id);
+    }
+
+    static constexpr Pid item(int id) {
+        return Pid(OBJECT_Item, id);
+    }
+
+    static constexpr Pid actor(int id) {
+        return Pid(OBJECT_Actor, id);
+    }
+
+    static constexpr Pid character(int id) {
+        assert(id >= 0 && id <= 5); // TODO(captainurist): Should be <= 3, but 4-5 are used for hirelings in UIMSG_OnCastTownPortal.
+        return Pid(OBJECT_Character, id);
+    }
+
+    static constexpr Pid decoration(int id) {
+        return Pid(OBJECT_Decoration, id);
+    }
+
+    static constexpr Pid odmFace(int modelId, int faceId) {
+        assert(modelId >= 0 && modelId <= ODM_MODEL_ID_MAX);
+        assert(faceId >= 0 && faceId <= ODM_FACE_ID_MAX);
+        return Pid(OBJECT_Face, (modelId << 6) + faceId);
+    }
+
+    static constexpr Pid blvFace(int id) {
+        return Pid(OBJECT_Face, id);
+    }
+
+    static constexpr Pid fromPacked(uint16_t value) {
+        Pid result;
+        result._value = value;
+        return result;
+    }
+
+    [[nodiscard]] constexpr ObjectType type() const {
+        return static_cast<ObjectType>(_value & 0x7);
+    }
+
+    [[nodiscard]] constexpr int id() const {
+        return _value >> 3;
+    }
+
+    uint16_t packed() const {
+        return _value;
+    }
+
+    friend bool operator==(const Pid &l, const Pid &r) = default;
+
+    explicit operator bool() const {
+        return _value != 0;
+    }
+
+    bool operator!() const {
+        return _value == 0;
+    }
+
+    // TODO(captainurist): compatibility layer, drop!
+    operator uint16_t() const {
+        return _value;
+    }
+
+ private:
+    uint16_t _value = 0;
+};
+
+// TODO(captainurist): compatibility layer, drop once migration is finished.
+namespace detail {
+inline ObjectType pidType(const Pid &pid) {
+    return pid.type();
+}
+inline ObjectType pidType(uint16_t pid) {
+    return Pid::fromPacked(pid).type();
+}
+inline int pidId(const Pid &pid) {
+    return pid.id();
+}
+inline int pidId(uint16_t pid) {
+    return Pid::fromPacked(pid).id();
+}
+} // namespace detail

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1366,7 +1366,7 @@ void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->spell_level = src.spell_level;
     dst->spell_skill = static_cast<CharacterSkillMastery>(src.spell_skill);
     dst->field_54 = src.field_54;
-    dst->spell_caster_pid = src.spell_caster_pid;
+    dst->spell_caster_pid = Pid::fromPacked(src.spell_caster_pid);
     dst->spell_target_pid = src.spell_target_pid;
     dst->field_60_distance_related_prolly_lod = src.field_60_distance_related_prolly_lod;
     dst->spellCasterAbility = static_cast<ABILITY_INDEX>(src.spellCasterAbility);

--- a/src/Engine/SpawnPoint.h
+++ b/src/Engine/SpawnPoint.h
@@ -2,6 +2,7 @@
 
 #include "Engine/Objects/ActorEnums.h"
 #include "Engine/Objects/ItemEnums.h"
+#include "Engine/Pid.h"
 
 #include "Utility/Geometry/Vec.h"
 

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -1126,7 +1126,7 @@ void armageddonProgress() {
             actor.currentHP -= incomingDamage;
 
             if (actor.currentHP >= 0) {
-                Actor::AI_Stun(actor.id, 4, 0);
+                Actor::AI_Stun(actor.id, Pid::character(0), 0);
             } else {
                 Actor::Die(actor.id);
                 if (actor.monsterInfo.uExp) {

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -235,6 +235,7 @@ void stru262_TurnBased::End(bool bPlaySound) {
     pEventTimer->StopGameTime();
     dword_50C994 = 0;
     dword_50C998_turnbased_icon_1A = 0;
+    uActorQueueSize = 0;
 }
 // 50C994: using guessed type int dword_50C994;
 // 50C998: using guessed type int dword_50C998_turnbased_icon_1A;

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -4,6 +4,7 @@
 
 #include "Engine/Engine.h"
 #include "Engine/Time.h"
+#include "Engine/Pid.h"
 
 #include "Engine/TurnEngine/TurnEngine.h"
 

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -145,7 +145,7 @@ void stru262_TurnBased::Start() {
                     PID(OBJECT_Actor, ai_near_actors_ids[i]),
                     ai_near_actors_targets_pid[ai_near_actors_ids[i]], &v31, 0);
                 v30 = v31;
-                Actor::AI_StandOrBored(ai_near_actors_ids[i], 4, 32, &v30);
+                Actor::AI_StandOrBored(ai_near_actors_ids[i], Pid::character(0), 32, &v30);
 
                 TurnBased_QueueElem &element = this->pQueue.emplace_back();
                 element.uPackedID = PID(OBJECT_Actor, ai_near_actors_ids[i]);
@@ -244,7 +244,7 @@ void stru262_TurnBased::AITurnBasedAction() {
     AIDirection v14;    // [sp+20h] [bp-4Ch]@21
     AIDirection v15;    // [sp+3Ch] [bp-30h]@21
     Actor *curr_actor;  // [sp+58h] [bp-14h]@2
-    int target_pid;     // [sp+5Ch] [bp-10h]@6
+    Pid target_pid;     // [sp+5Ch] [bp-10h]@6
     int j;
 
     for (uint i = 0; i < pActors.size(); ++i) {
@@ -992,7 +992,7 @@ void stru262_TurnBased::ActorAIChooseNewTargets() {
     AIDirection a3;           // [sp+Ch] [bp-6Ch]@8
     AIDirection v9;           // [sp+28h] [bp-50h]@8
     AIDirection a4;           // [sp+44h] [bp-34h]@8
-    unsigned int target_pid;  // [sp+60h] [bp-18h]@1
+    Pid target_pid;  // [sp+60h] [bp-18h]@1
     int uActorID;             // [sp+68h] [bp-10h]@4
     int i;
 

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -647,7 +647,7 @@ void stru262_TurnBased::AI_Action_(int queue_index) {
     ABILITY_INDEX v14;                // eax@29
     AIDirection a3;         // [sp+Ch] [bp-44h]@10
     AIDirection v18;        // [sp+28h] [bp-28h]@10
-    signed int v22;         // [sp+58h] [bp+8h]@10
+    Pid v22;         // [sp+58h] [bp+8h]@10
 
     pQueue[queue_index].uActionLength = 0;
     if (PID_TYPE(pQueue[queue_index].uPackedID) == OBJECT_Actor) {

--- a/src/Engine/TurnEngine/TurnEngine.h
+++ b/src/Engine/TurnEngine/TurnEngine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "Utility/Flags.h"
 
 enum class TurnEngineFlag {
@@ -47,7 +49,6 @@ struct stru262_TurnBased {
         turns_count = 0;
         turn_stage = TE_NONE;
         ai_turn_timer = 0;
-        uActorQueueSize = 0;
         turn_initiative = 0;
         uActionPointsLeft = 0;
         flags = 0;
@@ -76,12 +77,11 @@ struct stru262_TurnBased {
     int turns_count;
     TURN_ENGINE_TURN_STAGE turn_stage;  // if = 2 - action
     int ai_turn_timer;
-    int uActorQueueSize;  // c
     int turn_initiative;
     int uActionPointsLeft;  // 14
     TurnEngineFlags flags;
     int pending_actions;
-    TurnBased_QueueElem pQueue[530];  // 20
+    std::vector<TurnBased_QueueElem> pQueue;  // 20
 };
 
 extern struct stru262_TurnBased *pTurnEngine;

--- a/src/Engine/TurnEngine/TurnEngine.h
+++ b/src/Engine/TurnEngine/TurnEngine.h
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "Engine/Pid.h"
+
 #include "Utility/Flags.h"
 
 enum class TurnEngineFlag {
@@ -33,12 +35,12 @@ using enum TURN_ENGINE_TURN_STAGE;
 
 struct TurnBased_QueueElem {
     inline TurnBased_QueueElem() {
-        uPackedID = 0;
+        uPackedID = Pid();
         actor_initiative = 0;
         uActionLength = 0;
         AI_action_type = TE_AI_STAND;
     }
-    int uPackedID;
+    Pid uPackedID;
     int actor_initiative;  // act first who have less
     int uActionLength;
     TURN_ENGINE_AI_ACTION AI_action_type;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2394,7 +2394,7 @@ IndexedArray<IndexedArray<CharacterSkillMastery, CHARACTER_SKILL_FIRST, CHARACTE
 }};
 
 int ai_arrays_size;
-std::array<int, 500> ai_near_actors_targets_pid;
+std::array<Pid, 500> ai_near_actors_targets_pid;
 std::array<unsigned int, 500> ai_near_actors_ids;
 
 char byte_4FAA24;  // turn over break??

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "Engine/MM7.h"
+#include "Engine/Pid.h"
 #include "Engine/Objects/ItemEnums.h"
 #include "Engine/Objects/CharacterEnums.h"
 
@@ -62,7 +63,7 @@ extern IndexedArray<uint, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST> base_reco
 extern std::array<IndexedArray<ClassSkillAffinity, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST>, 9> pSkillAvailabilityPerClass;
 extern IndexedArray<IndexedArray<CharacterSkillMastery, CHARACTER_SKILL_FIRST, CHARACTER_SKILL_LAST>, PLAYER_CLASS_FIRST, PLAYER_CLASS_LAST> skillMaxMasteryPerClass;
 
-extern std::array<int, 500> ai_near_actors_targets_pid;
+extern std::array<Pid, 500> ai_near_actors_targets_pid;
 extern std::array<unsigned int, 500> ai_near_actors_ids;
 extern int ai_arrays_size;
 

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -4,6 +4,7 @@
 #include "Engine/LOD.h"
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
+#include "Engine/Pid.h"
 #include "Engine/SaveLoad.h"
 #include "Engine/Objects/Actor.h"
 #include "Engine/TurnEngine/TurnEngine.h"

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -9,6 +9,7 @@
 #include "Engine/Objects/Actor.h"
 #include "Engine/Objects/NPC.h"
 #include "Engine/Party.h"
+#include "Engine/Pid.h"
 #include "Engine/mm7_data.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/Engine.h"

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1362,21 +1362,19 @@ void GameUI_DrawPortraits() {
     if (pParty->bTurnBasedModeOn) {
         if (pTurnEngine->turn_stage != TE_WAIT) {
             if (PID_TYPE(pTurnEngine->pQueue[0].uPackedID) == OBJECT_Character) {
-                if (pTurnEngine->uActorQueueSize > 0) {
-                    for (uint i = 0; i < (uint)pTurnEngine->uActorQueueSize; ++i) {
-                        if (PID_TYPE(pTurnEngine->pQueue[i].uPackedID) != OBJECT_Character)
-                            break;
+                for (uint i = 0; i < pTurnEngine->pQueue.size(); ++i) {
+                    if (PID_TYPE(pTurnEngine->pQueue[i].uPackedID) != OBJECT_Character)
+                        break;
 
-                        auto alert_texture = game_ui_player_alert_green;
-                        if (pParty->GetRedAlert())
-                            alert_texture = game_ui_player_alert_red;
-                        else if (pParty->GetYellowAlert())
-                            alert_texture = game_ui_player_alert_yellow;
+                    auto alert_texture = game_ui_player_alert_green;
+                    if (pParty->GetRedAlert())
+                        alert_texture = game_ui_player_alert_red;
+                    else if (pParty->GetYellowAlert())
+                        alert_texture = game_ui_player_alert_yellow;
 
-                        render->DrawTextureNew(
-                            (pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing[PID_ID(pTurnEngine->pQueue[i].uPackedID)] - 4) / 640.0f,
-                            384 / 480.0f, alert_texture); // was 385
-                    }
+                    render->DrawTextureNew(
+                        (pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing[PID_ID(pTurnEngine->pQueue[i].uPackedID)] - 4) / 640.0f,
+                        384 / 480.0f, alert_texture); // was 385
                 }
             }
         }

--- a/src/Media/Audio/AudioPlayer.h
+++ b/src/Media/Audio/AudioPlayer.h
@@ -3,7 +3,6 @@
 #include <map>
 #include <unordered_set>
 #include <string>
-#include <memory>
 #include <list>
 
 #include "Utility/Workaround/ToUnderlying.h"
@@ -12,7 +11,7 @@
 #include "Utility/Memory/Blob.h"
 #include "Utility/Streams/FileInputStream.h"
 #include "Media/Media.h"
-#include "Engine/MM7.h"
+#include "Engine/Pid.h"
 #include "Engine/Spells/SpellEnums.h"
 #include "Engine/Objects/ActorEnums.h"
 

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 90bcf10209587b1d35c33ff78cee50a81d28d983
+            GIT_TAG 38dfd34c3bb127b3e37a02637a3c82ff6f682e76
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Tests/TestIssues.cpp
+++ b/test/Tests/TestIssues.cpp
@@ -1223,6 +1223,13 @@ GAME_TEST(Issues, Issue735c) {
     EXPECT_EQ(mapTape, tape("out01.odm", "d28.blv")); // Emerald Isle -> Dragon's cave.
 }
 
+GAME_TEST(Issues, Issue735d) {
+    // Trace-only test: turn-based battle with ~60 monsters in a dungeon, casting poison cloud.
+    auto turnBasedTape = test->tape([] { return pParty->bTurnBasedModeOn; });
+    test->playTraceFromTestData("issue_735d.mm7", "issue_735d.json");
+    EXPECT_EQ(turnBasedTape, tape(false, true, false));
+}
+
 GAME_TEST(Issues, Issue741) {
     // Game crashing when walking into a wall in Temple of the moon
     test->playTraceFromTestData("issue_741.mm7", "issue_741.json");


### PR DESCRIPTION
Working on #735 & #542.

`Pid` is rolled out slowly so that if I break smth, tests will catch it.