### PR TITLE
Moved OpenEnroth binary to src/Bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,24 +66,7 @@ include(CppLint)
 include(Dependencies)
 
 add_subdirectory(thirdparty)
-
 include_directories(${INCLUDE_DIRECTORIES} ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/test ${INCLUDE_THIRDPARTY_DIRS})
 add_subdirectory(test)
 add_subdirectory(src)
 
-if(BUILD_PLATFORM STREQUAL "android")
-    add_library(main SHARED)
-    target_sources(main PUBLIC src/Application/main.cpp src/Platform/Sdl/SdlMain.cpp)
-    target_check_style(main)
-    target_link_libraries(main application)
-else()
-    add_executable(OpenEnroth MACOSX_BUNDLE WIN32 src/Application/main.cpp)
-    target_check_style(OpenEnroth)
-    target_fix_libcxx_assertions(OpenEnroth)
-
-    target_link_libraries(OpenEnroth application)
-
-    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT OpenEnroth)
-
-    PREBUILT_DEPENDENCIES_RESOLVE(OpenEnroth)
-endif()

--- a/src/Bin/CMakeLists.txt
+++ b/src/Bin/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.20.4 FATAL_ERROR)
+
+add_subdirectory(OpenEnroth)

--- a/src/Bin/OpenEnroth/CMakeLists.txt
+++ b/src/Bin/OpenEnroth/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20.4 FATAL_ERROR)
+
+if(BUILD_PLATFORM STREQUAL "android")
+    add_library(main SHARED)
+    target_sources(main PUBLIC main.cpp)
+    target_check_style(main)
+    target_link_libraries(main application)
+else()
+    add_executable(OpenEnroth MACOSX_BUNDLE WIN32 main.cpp)
+    target_check_style(OpenEnroth)
+    target_fix_libcxx_assertions(OpenEnroth)
+
+    target_link_libraries(OpenEnroth application)
+
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT OpenEnroth)
+
+    PREBUILT_DEPENDENCIES_RESOLVE(OpenEnroth)
+endif()

--- a/src/Bin/OpenEnroth/main.cpp
+++ b/src/Bin/OpenEnroth/main.cpp
@@ -2,6 +2,9 @@
 #include <utility>
 #include <filesystem>
 
+#include "Application/GameStarter.h"
+#include "Application/GameOptions.h"
+
 #include "Engine/Components/Control/EngineControlComponent.h"
 #include "Engine/Components/Control/EngineController.h"
 #include "Engine/Components/Trace/EngineTraceSimplePlayer.h"
@@ -13,10 +16,6 @@
 #include "Library/Trace/EventTrace.h"
 
 #include "Utility/Format.h"
-
-#include "GameStarter.h"
-#include "GameOptions.h"
-#include "GameConfig.h"
 
 
 int runRetrace(GameOptions options) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.20.4 FATAL_ERROR)
 
 add_subdirectory(Application)
 add_subdirectory(Arcomage)
+add_subdirectory(Bin)
 add_subdirectory(Engine)
 add_subdirectory(GUI)
 add_subdirectory(Io)


### PR DESCRIPTION
This makes more sense than what we have now.

Will also move some of the source files there later.

And will create at least another binary in Bin, for dumping autogenerated enums.