### PR TITLE
More LOD-related changes

### DIFF
--- a/src/Engine/GameResourceManager.cpp
+++ b/src/Engine/GameResourceManager.cpp
@@ -31,8 +31,8 @@ Blob GameResourceManager::uncompressPseudoTexture(const Blob &input) {
     TextureHeader header;
     deserialize(stream, &header);
 
-    Blob result = stream.readBlobOrFail(header.uTextureSize);
-    if (header.uDecompressedSize)
-        result = zlib::Uncompress(result, header.uDecompressedSize);
+    Blob result = stream.readBlobOrFail(header.dataSize);
+    if (header.decompressedSize)
+        result = zlib::Uncompress(result, header.decompressedSize);
     return result;
 }

--- a/src/Engine/Graphics/ImageLoader.cpp
+++ b/src/Engine/Graphics/ImageLoader.cpp
@@ -69,7 +69,7 @@ bool Paletted_Img_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImag
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) || (tex->paletted_pixels == nullptr))
         return false;
 
-    *indexedImage = GrayscaleImage::copy(tex->header.uTextureWidth, tex->header.uTextureHeight, tex->paletted_pixels);
+    *indexedImage = GrayscaleImage::copy(tex->header.width, tex->header.height, tex->paletted_pixels);
     *palette = MakePaletteSolid(tex->pPalette24);
     *rgbaImage = makeRgbaImage(*indexedImage, *palette);
 
@@ -81,9 +81,9 @@ bool ColorKey_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImag
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) || (tex->paletted_pixels == nullptr))
         return false;
 
-    *indexedImage = GrayscaleImage::copy(tex->header.uTextureWidth, tex->header.uTextureHeight, tex->paletted_pixels);
+    *indexedImage = GrayscaleImage::copy(tex->header.width, tex->header.height, tex->paletted_pixels);
 
-    if (tex->header.pBits & 512) {
+    if (tex->header.flags & 512) {
         *palette = MakePaletteAlpha(tex->pPalette24);
     } else {
         *palette = MakePaletteColorKey(tex->pPalette24, colorkey);
@@ -99,9 +99,9 @@ bool Image16bit_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedIm
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) || (tex->paletted_pixels == nullptr))
         return false;
 
-    *indexedImage = GrayscaleImage::copy(tex->header.uTextureWidth, tex->header.uTextureHeight, tex->paletted_pixels);
+    *indexedImage = GrayscaleImage::copy(tex->header.width, tex->header.height, tex->paletted_pixels);
 
-    if (tex->header.pBits & 512) {
+    if (tex->header.flags & 512) {
         *palette = MakePaletteAlpha(tex->pPalette24);
     } else {
         *palette = MakePaletteSolid(tex->pPalette24);
@@ -117,9 +117,9 @@ bool Alpha_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage, 
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) || (tex->paletted_pixels == nullptr))
         return false;
 
-    *indexedImage = GrayscaleImage::copy(tex->header.uTextureWidth, tex->header.uTextureHeight, tex->paletted_pixels);
+    *indexedImage = GrayscaleImage::copy(tex->header.width, tex->header.height, tex->paletted_pixels);
 
-    if ((tex->header.pBits == 0) || (tex->header.pBits & 512)) {
+    if ((tex->header.flags == 0) || (tex->header.flags & 512)) {
         *palette = MakePaletteAlpha(tex->pPalette24);
     } else {
         *palette = MakePaletteColorKey(tex->pPalette24, colorTable.TealMask);
@@ -207,16 +207,16 @@ static Color ProcessTransparentPixel(const GrayscaleImage &image, const Palette 
 
 bool Bitmaps_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage, Palette *palette) {
     Texture_MM7 *tex = lod->loadTexture(this->resource_name);
-    int num_pixels = tex->header.uTextureWidth * tex->header.uTextureHeight;
+    int num_pixels = tex->header.width * tex->header.height;
 
     Assert(tex->paletted_pixels);
     Assert(tex->pPalette24);
 
     std::string name;
-    reconstruct(tex->header.pName, &name);
+    reconstruct(tex->header.name, &name);
 
-    size_t w = tex->header.uTextureWidth;
-    size_t h = tex->header.uTextureHeight;
+    size_t w = tex->header.width;
+    size_t h = tex->header.height;
 
     *indexedImage = GrayscaleImage::copy(w, h, tex->paletted_pixels); // NOLINT: this is not std::copy.
 

--- a/src/Engine/Graphics/ImageLoader.cpp
+++ b/src/Engine/Graphics/ImageLoader.cpp
@@ -245,8 +245,8 @@ bool Bitmaps_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage
 bool Sprites_LOD_Loader::Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage, Palette *palette) {
     Sprite *pSprite = lod->loadSprite(this->resource_name);
 
-    size_t w = pSprite->sprite_header->uWidth;
-    size_t h = pSprite->sprite_header->uHeight;
+    size_t w = pSprite->sprite_header->width;
+    size_t h = pSprite->sprite_header->height;
 
     *rgbaImage = RgbaImage::solid(w, h, Color());
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -331,7 +331,7 @@ void IndoorLocation::Load(const std::string &filename, int num_days_played, int 
     IndoorDelta_MM7 delta;
     if (Blob blob = pSave_LOD->LoadCompressed(dlv_filename)) {
         try {
-            deserialize(blob, &delta, context(location));
+            deserialize(blob, &delta, tags::context(location));
 
             // Level was changed externally and we have a save there? Don't crash, just respawn.
             if (delta.header.totalFacesCount > 0 && delta.header.decorationCount > 0 &&
@@ -356,12 +356,12 @@ void IndoorLocation::Load(const std::string &filename, int num_days_played, int 
     assert(respawnInitial + respawnTimed <= 1);
 
     if (respawnInitial) {
-        deserialize(pGames_LOD->read(dlv_filename), &delta, context(location));
+        deserialize(pGames_LOD->read(dlv_filename), &delta, tags::context(location));
         *indoor_was_respawned = true;
     } else if (respawnTimed) {
         auto header = delta.header;
         auto visibleOutlines = delta.visibleOutlines;
-        deserialize(pGames_LOD->read(dlv_filename), &delta, context(location));
+        deserialize(pGames_LOD->read(dlv_filename), &delta, tags::context(location));
         delta.header = header;
         delta.visibleOutlines = visibleOutlines;
         *indoor_was_respawned = true;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -880,7 +880,7 @@ void OutdoorLocation::Load(const std::string &filename, int days_played, int res
     OutdoorDelta_MM7 delta;
     if (Blob blob = pSave_LOD->LoadCompressed(ddm_filename)) {
         try {
-            deserialize(blob, &delta, context(location));
+            deserialize(blob, &delta, tags::context(location));
 
             size_t totalFaces = 0;
             for (BSPModel &model : pBModels)
@@ -909,13 +909,13 @@ void OutdoorLocation::Load(const std::string &filename, int days_played, int res
     assert(respawnInitial + respawnTimed <= 1);
 
     if (respawnInitial) {
-        deserialize(pGames_LOD->read(ddm_filename), &delta, context(location));
+        deserialize(pGames_LOD->read(ddm_filename), &delta, tags::context(location));
         *outdoors_was_respawned = true;
     } else if (respawnTimed) {
         auto header = delta.header;
         auto fullyRevealedCells = delta.fullyRevealedCells;
         auto partiallyRevealedCells = delta.partiallyRevealedCells;
-        deserialize(pGames_LOD->read(ddm_filename), &delta, context(location));
+        deserialize(pGames_LOD->read(ddm_filename), &delta, tags::context(location));
         delta.header = header;
         delta.fullyRevealedCells = fullyRevealedCells;
         delta.partiallyRevealedCells = partiallyRevealedCells;

--- a/src/Engine/Graphics/Texture_MM7.cpp
+++ b/src/Engine/Graphics/Texture_MM7.cpp
@@ -6,9 +6,9 @@
 #include "Engine/ErrorHandling.h"
 
 void Texture_MM7::Release() {
-    header.pName[0] = 0;
+    header.name[0] = 0;
 
-    if (header.pBits & 0x0400) {
+    if (header.flags & 0x0400) {
         __debugbreak();
     }
 

--- a/src/Engine/Graphics/Texture_MM7.h
+++ b/src/Engine/Graphics/Texture_MM7.h
@@ -9,7 +9,8 @@
 struct TextureHeader {
     std::array<char, 16> name; // TODO(captainurist): there's quite a lot of unsafe .data() calls for this field.
     uint32_t size; // Width * height, size of the first mipmap. Can be followed by smaller size bitmaps, down to 16x16.
-    uint32_t dataSize; // Size of the pixel data that follows, in bytes. Can be larger than `size` if mipmaps are present. Can be compressed.
+    uint32_t dataSize; // Size of the pixel data that follows, in bytes.
+                       // Can be larger than `size` if mipmaps are present. Can be compressed. Doesn't include palette.
     uint16_t width;
     uint16_t height;
     int16_t widthLn2;  // log2(width) for power of 2 sizes, otherwise 0.

--- a/src/Engine/Graphics/Texture_MM7.h
+++ b/src/Engine/Graphics/Texture_MM7.h
@@ -7,21 +7,22 @@
 
 #pragma pack(push, 1)
 struct TextureHeader {
-    std::array<char, 16> pName; // TODO(captainurist): there's quite a lot of unsafe .data() calls for this field.
-    uint32_t uSizeOfMaxLevelOfDetail;
-    uint32_t uTextureSize;
-    uint16_t uTextureWidth;
-    uint16_t uTextureHeight;
-    int16_t uWidthLn2;  // log2(uTextureWidth)
-    int16_t uHeightLn2;  // log2(uTextureHeight)
-    int16_t uWidthMinus1;
-    int16_t uHeightMinus1;
-    int16_t palette_id1;
-    int16_t palette_id2;
-    uint32_t uDecompressedSize;
-    uint32_t pBits;  // 0x0002 - generate mipmaps
-    // 0x0200 - 0th palette entry is transparent, else colorkey
-    // 0x0400 - don't free buffers (???)
+    std::array<char, 16> name; // TODO(captainurist): there's quite a lot of unsafe .data() calls for this field.
+    uint32_t size; // Width * height, size of the first mipmap. Can be followed by smaller size bitmaps, down to 16x16.
+    uint32_t dataSize; // Size of the pixel data that follows, in bytes. Can be larger than `size` if mipmaps are present. Can be compressed.
+    uint16_t width;
+    uint16_t height;
+    int16_t widthLn2;  // log2(width) for power of 2 sizes, otherwise 0.
+    int16_t heightLn2;  // log2(height) for power of 2 sizes, otherwise 0.
+    int16_t widthMinus1; // Seems to be set only for power of 2 sizes. Can be random garbage.
+    int16_t heightMinus1; // Seems to be set only for power of 2 sizes. Can be random garbage.
+    int16_t paletteId; // Palette id, actually palette is stored with the image, so this field isn't needed.
+    int16_t anotherPaletteId; // Seems to always be zero?
+    uint32_t decompressedSize; // Size of the decompressed pixel data, 0 if pixel data is not compressed.
+    uint32_t flags; // 0x0002 - has mipmaps
+                    // 0x0100 - not an image, but a text file (???)
+                    // 0x0200 - 0th palette entry is transparent, else colorkey
+                    // 0x0400 - don't free buffers (???)
 };
 #pragma pack(pop)
 MM_DECLARE_MEMCOPY_SERIALIZABLE(TextureHeader)

--- a/src/Engine/LOD.cpp
+++ b/src/Engine/LOD.cpp
@@ -532,10 +532,10 @@ Blob LOD::File::LoadCompressedTexture(const std::string &pContainer) {
     if (fread(&DstBuf, sizeof(TextureHeader), 1, File) != 1)
         return Blob();
 
-    if (DstBuf.uDecompressedSize) {
-        return zlib::Uncompress(Blob::read(File, DstBuf.uTextureSize), DstBuf.uDecompressedSize);
+    if (DstBuf.decompressedSize) {
+        return zlib::Uncompress(Blob::read(File, DstBuf.dataSize), DstBuf.decompressedSize);
     } else {
-        return Blob::read(File, DstBuf.uTextureSize);
+        return Blob::read(File, DstBuf.dataSize);
     }
 }
 

--- a/src/Engine/LodSpriteCache.h
+++ b/src/Engine/LodSpriteCache.h
@@ -12,16 +12,18 @@
 class LodReader;
 
 #pragma pack(push, 1)
+// See https://github.com/GrayFace/MMExtension/blob/4d6600f164315f38157591d7f0307a86594c22ef/Src/RSPak/Extra/RSLod.pas#L553.
 struct LODSpriteHeader {
-    char pName[12] = {};         // 0
-    uint32_t uSpriteSize = 0;        // C
-    uint16_t uWidth = 0;         // 10  SW width (as opposed to Sprite::BufferWidth)
-    uint16_t uHeight = 0;        // 12  SW height
-    uint16_t uPaletteId = 0;     // 14
-    uint16_t word_16 = 0;        // 16
-    uint16_t uTexturePitch = 0;  // 18
-    uint16_t word_1A = 0;        // 1a  flags - 1024 delete bitmap
-    uint32_t uDecompressedSize = 0;  // 1c
+    std::array<char, 12> name = {};
+    uint32_t dataSize = 0; // Size of the pixel data, in bytes.
+    uint16_t width = 0; // SW width.
+    uint16_t height = 0; // SW height, also the number of `LODSpriteLine`s that follow.
+    uint16_t paletteId = 0; // Palette id, references "palXXX".
+    uint16_t unk_0 = 0; // Always 0?
+    uint16_t emptyBottomLines = 0; // Number of clear lines at the bottom (tail of sprite lines array).
+                                   // They are still set in sprite lines array, so this info is redundant.
+    uint16_t flags = 0; // Used at runtime only?
+    uint32_t decompressedSize = 0; // Size of the decompressed pixel data, 0 if pixel data is not compressed.
 };
 #pragma pack(pop)
 

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -61,7 +61,7 @@ void LoadGame(unsigned int uSlot) {
     pSave_LOD->LoadFile(to_file_path, 0);
 
     SaveGameHeader header;
-    deserialize(*pSave_LOD, &header, via<SaveGame_MM7>());
+    deserialize(*pSave_LOD, &header, tags::via<SaveGame_MM7>);
 
     // TODO(captainurist): incapsulate this too
     pParty->bTurnBasedModeOn = false;  // We always start in realtime after loading a game.
@@ -187,7 +187,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
     save_header.locationName = pCurrentMapName;
     save_header.playingTime = pParty->GetPlayingTime();
 
-    serialize(save_header, pSave_LOD, via<SaveGame_MM7>());
+    serialize(save_header, pSave_LOD, tags::via<SaveGame_MM7>);
 
     // TODO(captainurist): incapsulate this too
     for (size_t i = 0; i < 4; ++i) {  // 4 - players
@@ -215,10 +215,10 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
         CompactLayingItemsList();
 
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-            serialize(*pIndoor, &uncompressed, via<IndoorDelta_MM7>());
+            serialize(*pIndoor, &uncompressed, tags::via<IndoorDelta_MM7>);
         } else {
             assert(uCurrentlyLoadedLevelType == LEVEL_OUTDOOR);
-            serialize(*pOutdoor, &uncompressed, via<OutdoorDelta_MM7>());
+            serialize(*pOutdoor, &uncompressed, tags::via<OutdoorDelta_MM7>);
         }
 
         LOD::CompressedHeader odm_data;

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -145,16 +145,16 @@ void deserialize(InputStream &src, IndoorLocation_MM7 *dst) {
     deserialize(src, &dst->header);
     deserialize(src, &dst->vertices);
     deserialize(src, &dst->faces);
-    deserialize(src, &dst->faceData, presized(dst->header.uFaces_fdata_Size / sizeof(uint16_t)));
-    deserialize(src, &dst->faceTextures, presized(dst->faces.size()));
+    deserialize(src, &dst->faceData, tags::presized(dst->header.uFaces_fdata_Size / sizeof(uint16_t)));
+    deserialize(src, &dst->faceTextures, tags::presized(dst->faces.size()));
     deserialize(src, &dst->faceExtras);
-    deserialize(src, &dst->faceExtraTextures, presized(dst->faceExtras.size()));
+    deserialize(src, &dst->faceExtraTextures, tags::presized(dst->faceExtras.size()));
     deserialize(src, &dst->sectors);
-    deserialize(src, &dst->sectorData, presized(dst->header.uSector_rdata_Size / sizeof(uint16_t)));
-    deserialize(src, &dst->sectorLightData, presized(dst->header.uSector_lrdata_Size / sizeof(uint16_t)));
+    deserialize(src, &dst->sectorData, tags::presized(dst->header.uSector_rdata_Size / sizeof(uint16_t)));
+    deserialize(src, &dst->sectorLightData, tags::presized(dst->header.uSector_lrdata_Size / sizeof(uint16_t)));
     deserialize(src, &dst->doorCount);
     deserialize(src, &dst->decorations);
-    deserialize(src, &dst->decorationNames, presized(dst->decorations.size()));
+    deserialize(src, &dst->decorationNames, tags::presized(dst->decorations.size()));
     deserialize(src, &dst->lights);
     deserialize(src, &dst->bspNodes);
     deserialize(src, &dst->spawnPoints);
@@ -279,13 +279,13 @@ void reconstruct(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
 void serialize(const IndoorDelta_MM7 &src, OutputStream *dst) {
     serialize(src.header, dst);
     serialize(src.visibleOutlines, dst);
-    serialize(src.faceAttributes, dst, unsized());
-    serialize(src.decorationFlags, dst, unsized());
+    serialize(src.faceAttributes, dst, tags::unsized);
+    serialize(src.decorationFlags, dst, tags::unsized);
     serialize(src.actors, dst);
     serialize(src.spriteObjects, dst);
     serialize(src.chests, dst);
-    serialize(src.doors, dst, unsized());
-    serialize(src.doorsData, dst, unsized());
+    serialize(src.doors, dst, tags::unsized);
+    serialize(src.doorsData, dst, tags::unsized);
     serialize(src.eventVariables, dst);
     serialize(src.locationTime, dst);
 }
@@ -293,13 +293,13 @@ void serialize(const IndoorDelta_MM7 &src, OutputStream *dst) {
 void deserialize(InputStream &src, IndoorDelta_MM7 *dst, ContextTag<IndoorLocation_MM7> ctx) {
     deserialize(src, &dst->header);
     deserialize(src, &dst->visibleOutlines);
-    deserialize(src, &dst->faceAttributes, presized(ctx->faces.size()));
-    deserialize(src, &dst->decorationFlags, presized(ctx->decorations.size()));
+    deserialize(src, &dst->faceAttributes, tags::presized(ctx->faces.size()));
+    deserialize(src, &dst->decorationFlags, tags::presized(ctx->decorations.size()));
     deserialize(src, &dst->actors);
     deserialize(src, &dst->spriteObjects);
     deserialize(src, &dst->chests);
-    deserialize(src, &dst->doors, presized(ctx->doorCount));
-    deserialize(src, &dst->doorsData, presized(ctx->header.uDoors_ddata_Size / sizeof(int16_t)));
+    deserialize(src, &dst->doors, tags::presized(ctx->doorCount));
+    deserialize(src, &dst->doorsData, tags::presized(ctx->header.uDoors_ddata_Size / sizeof(int16_t)));
     deserialize(src, &dst->eventVariables);
     deserialize(src, &dst->locationTime);
 }
@@ -411,21 +411,21 @@ void deserialize(InputStream &src, OutdoorLocation_MM7 *dst) {
     deserialize(src, &dst->normalCount);
     deserialize(src, &dst->someOtherMap);
     deserialize(src, &dst->normalMap);
-    deserialize(src, &dst->normals, presized(dst->normalCount));
+    deserialize(src, &dst->normals, tags::presized(dst->normalCount));
     deserialize(src, &dst->models);
 
     dst->modelExtras.clear();
     for (const BSPModelData_MM7 &model : dst->models) {
         BSPModelExtras_MM7 &extra = dst->modelExtras.emplace_back();
-        deserialize(src, &extra.vertices, presized(model.uNumVertices));
-        deserialize(src, &extra.faces, presized(model.uNumFaces));
-        deserialize(src, &extra.faceOrdering, presized(model.uNumFaces));
-        deserialize(src, &extra.bspNodes, presized(model.uNumNodes));
-        deserialize(src, &extra.faceTextures, presized(model.uNumFaces));
+        deserialize(src, &extra.vertices, tags::presized(model.uNumVertices));
+        deserialize(src, &extra.faces, tags::presized(model.uNumFaces));
+        deserialize(src, &extra.faceOrdering, tags::presized(model.uNumFaces));
+        deserialize(src, &extra.bspNodes, tags::presized(model.uNumNodes));
+        deserialize(src, &extra.faceTextures, tags::presized(model.uNumFaces));
     }
 
     deserialize(src, &dst->decorations);
-    deserialize(src, &dst->decorationNames, presized(dst->decorations.size()));
+    deserialize(src, &dst->decorationNames, tags::presized(dst->decorations.size()));
     deserialize(src, &dst->decorationPidList);
     deserialize(src, &dst->decorationMap);
     deserialize(src, &dst->spawnPoints);
@@ -496,8 +496,8 @@ void serialize(const OutdoorDelta_MM7 &src, OutputStream *dst) {
     serialize(src.header, dst);
     serialize(src.fullyRevealedCells, dst);
     serialize(src.partiallyRevealedCells, dst);
-    serialize(src.faceAttributes, dst, unsized());
-    serialize(src.decorationFlags, dst, unsized());
+    serialize(src.faceAttributes, dst, tags::unsized);
+    serialize(src.decorationFlags, dst, tags::unsized);
     serialize(src.actors, dst);
     serialize(src.spriteObjects, dst);
     serialize(src.chests, dst);
@@ -513,8 +513,8 @@ void deserialize(InputStream &src, OutdoorDelta_MM7 *dst, ContextTag<OutdoorLoca
     deserialize(src, &dst->header);
     deserialize(src, &dst->fullyRevealedCells);
     deserialize(src, &dst->partiallyRevealedCells);
-    deserialize(src, &dst->faceAttributes, presized(totalFaces));
-    deserialize(src, &dst->decorationFlags, presized(ctx->decorations.size()));
+    deserialize(src, &dst->faceAttributes, tags::presized(totalFaces));
+    deserialize(src, &dst->decorationFlags, tags::presized(ctx->decorations.size()));
     deserialize(src, &dst->actors);
     deserialize(src, &dst->spriteObjects);
     deserialize(src, &dst->chests);
@@ -566,6 +566,6 @@ void reconstruct(const SpriteFrameTable_MM7 &src, SpriteFrameTable *dst) {
 void deserialize(InputStream &src, SpriteFrameTable_MM7 *dst) {
     deserialize(src, &dst->frameCount);
     deserialize(src, &dst->eframeCount);
-    deserialize(src, &dst->frames, presized(dst->frameCount));
-    deserialize(src, &dst->eframes, presized(dst->eframeCount));
+    deserialize(src, &dst->frames, tags::presized(dst->frameCount));
+    deserialize(src, &dst->eframes, tags::presized(dst->eframeCount));
 }

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -449,7 +449,7 @@ void snapshot(const Party &src, Party_MM7 *dst) {
     dst->numBountiesCollected = src.uNumBountiesCollected;
 
     snapshot(src.monster_id_for_hunting, &dst->monsterIdForHunting);
-    snapshot(src.monster_for_hunting_killed, &dst->monsterForHuntingKilled, convert<bool, int16_t>());
+    snapshot(src.monster_for_hunting_killed, &dst->monsterForHuntingKilled, tags::convert<bool, int16_t>);
 
     dst->daysPlayedWithoutRest = src.days_played_without_rest;
 
@@ -548,7 +548,7 @@ void reconstruct(const Party_MM7 &src, Party *dst) {
     dst->uNumBountiesCollected = src.numBountiesCollected;
 
     reconstruct(src.monsterIdForHunting, &dst->monster_id_for_hunting);
-    reconstruct(src.monsterForHuntingKilled, &dst->monster_for_hunting_killed, convert<int16_t, bool>());
+    reconstruct(src.monsterForHuntingKilled, &dst->monster_for_hunting_killed, tags::convert<int16_t, bool>);
 
     dst->days_played_without_rest = src.daysPlayedWithoutRest;
 
@@ -646,7 +646,7 @@ void snapshot(const Character &src, Player_MM7 *dst) {
     dst->field_100 = src.field_100;
     dst->field_104 = src.field_104;
 
-    snapshot(src.pActiveSkills, &dst->activeSkills, segment<CHARACTER_SKILL_FIRST_VISIBLE, CHARACTER_SKILL_LAST_VISIBLE>());
+    snapshot(src.pActiveSkills, &dst->activeSkills, tags::segment<CHARACTER_SKILL_FIRST_VISIBLE, CHARACTER_SKILL_LAST_VISIBLE>);
     snapshot(src._achievedAwardsBits, &dst->achievedAwardsBits);
     snapshot(src.spellbook.bHaveSpell, &dst->spellbook.haveSpell);
 
@@ -897,7 +897,7 @@ void reconstruct(const Player_MM7 &src, Character *dst) {
     dst->field_100 = src.field_100;
     dst->field_104 = src.field_104;
 
-    reconstruct(src.activeSkills, &dst->pActiveSkills, segment<CHARACTER_SKILL_FIRST_VISIBLE, CHARACTER_SKILL_LAST_VISIBLE>());
+    reconstruct(src.activeSkills, &dst->pActiveSkills, tags::segment<CHARACTER_SKILL_FIRST_VISIBLE, CHARACTER_SKILL_LAST_VISIBLE>);
     reconstruct(src.achievedAwardsBits, &dst->_achievedAwardsBits);
     reconstruct(src.spellbook.haveSpell, &dst->spellbook.bHaveSpell);
 

--- a/src/Engine/Snapshots/TableSerialization.cpp
+++ b/src/Engine/Snapshots/TableSerialization.cpp
@@ -20,11 +20,11 @@ void deserialize(const TriBlob &src, PlayerFrameTable *dst) {
     dst->pFrames.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pFrames, appendVia<PlayerFrame_MM7>());
+        deserialize(src.mm6, &dst->pFrames, append(), via<PlayerFrame_MM7>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->pFrames, appendVia<PlayerFrame_MM7>());
+        deserialize(src.mm7, &dst->pFrames, append(), via<PlayerFrame_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->pFrames, appendVia<PlayerFrame_MM7>());
+        deserialize(src.mm8, &dst->pFrames, append(), via<PlayerFrame_MM7>());
 
     assert(!dst->pFrames.empty());
 }
@@ -33,11 +33,11 @@ void deserialize(const TriBlob &src, ChestList *dst) {
     dst->vChests.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->vChests, appendVia<ChestDesc_MM7>());
+        deserialize(src.mm6, &dst->vChests, append(), via<ChestDesc_MM7>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->vChests, appendVia<ChestDesc_MM7>());
+        deserialize(src.mm7, &dst->vChests, append(), via<ChestDesc_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->vChests, appendVia<ChestDesc_MM7>());
+        deserialize(src.mm8, &dst->vChests, append(), via<ChestDesc_MM7>());
 
     assert(!dst->vChests.empty());
 }
@@ -46,18 +46,18 @@ void deserialize(const TriBlob &src, DecorationList *dst) {
     dst->pDecorations.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pDecorations, appendVia<DecorationDesc_MM6>());
+        deserialize(src.mm6, &dst->pDecorations, append(), via<DecorationDesc_MM6>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->pDecorations, appendVia<DecorationDesc_MM7>());
+        deserialize(src.mm7, &dst->pDecorations, append(), via<DecorationDesc_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->pDecorations, appendVia<DecorationDesc_MM7>());
+        deserialize(src.mm8, &dst->pDecorations, append(), via<DecorationDesc_MM7>());
 
     assert(!dst->pDecorations.empty());
 }
 
 void deserialize(const TriBlob &src, IconFrameTable *dst) {
     dst->pIcons.clear();
-    deserialize(src.mm7, &dst->pIcons, appendVia<IconFrame_MM7>());
+    deserialize(src.mm7, &dst->pIcons, append(), via<IconFrame_MM7>());
 
     for (size_t i = 0; i < dst->pIcons.size(); ++i)
         dst->pIcons[i].id = i;
@@ -69,11 +69,11 @@ void deserialize(const TriBlob &src, MonsterList *dst) {
     dst->pMonsters.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pMonsters, appendVia<MonsterDesc_MM6>());
+        deserialize(src.mm6, &dst->pMonsters, append(), via<MonsterDesc_MM6>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->pMonsters, appendVia<MonsterDesc_MM7>());
+        deserialize(src.mm7, &dst->pMonsters, append(), via<MonsterDesc_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->pMonsters, appendVia<MonsterDesc_MM7>());
+        deserialize(src.mm8, &dst->pMonsters, append(), via<MonsterDesc_MM7>());
 
     assert(!dst->pMonsters.empty());
 }
@@ -82,11 +82,11 @@ void deserialize(const TriBlob &src, ObjectList *dst) {
     dst->pObjects.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pObjects, appendVia<ObjectDesc_MM6>());
+        deserialize(src.mm6, &dst->pObjects, append(), via<ObjectDesc_MM6>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->pObjects, appendVia<ObjectDesc_MM7>());
+        deserialize(src.mm7, &dst->pObjects, append(), via<ObjectDesc_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->pObjects, appendVia<ObjectDesc_MM7>());
+        deserialize(src.mm8, &dst->pObjects, append(), via<ObjectDesc_MM7>());
 
     assert(!dst->pObjects.empty());
 }
@@ -95,11 +95,11 @@ void deserialize(const TriBlob &src, OverlayList *dst) {
     dst->pOverlays.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pOverlays, appendVia<OverlayDesc_MM7>());
+        deserialize(src.mm6, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
     if (src.mm7)
-        deserialize(src.mm7, &dst->pOverlays, appendVia<OverlayDesc_MM7>());
+        deserialize(src.mm7, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
     if (src.mm8)
-        deserialize(src.mm8, &dst->pOverlays, appendVia<OverlayDesc_MM7>());
+        deserialize(src.mm8, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
 
     assert(!dst->pOverlays.empty());
 }
@@ -109,13 +109,13 @@ void deserialize(const TriBlob &src, SpriteFrameTable *dst) {
 }
 
 void deserialize(const TriBlob &src, TextureFrameTable *dst) {
-    deserialize(src.mm7, &dst->textures, appendVia<TextureFrame_MM7>());
+    deserialize(src.mm7, &dst->textures, append(), via<TextureFrame_MM7>());
 
     assert(!dst->textures.empty());
 }
 
 void deserialize(const TriBlob &src, TileTable *dst) {
-    deserialize(src.mm7, &dst->tiles, appendVia<TileDesc_MM7>());
+    deserialize(src.mm7, &dst->tiles, append(), via<TileDesc_MM7>());
 
     assert(!dst->tiles.empty());
 }

--- a/src/Engine/Snapshots/TableSerialization.cpp
+++ b/src/Engine/Snapshots/TableSerialization.cpp
@@ -20,11 +20,11 @@ void deserialize(const TriBlob &src, PlayerFrameTable *dst) {
     dst->pFrames.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pFrames, append(), via<PlayerFrame_MM7>());
+        deserialize(src.mm6, &dst->pFrames, tags::append, tags::via<PlayerFrame_MM7>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->pFrames, append(), via<PlayerFrame_MM7>());
+        deserialize(src.mm7, &dst->pFrames, tags::append, tags::via<PlayerFrame_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->pFrames, append(), via<PlayerFrame_MM7>());
+        deserialize(src.mm8, &dst->pFrames, tags::append, tags::via<PlayerFrame_MM7>);
 
     assert(!dst->pFrames.empty());
 }
@@ -33,11 +33,11 @@ void deserialize(const TriBlob &src, ChestList *dst) {
     dst->vChests.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->vChests, append(), via<ChestDesc_MM7>());
+        deserialize(src.mm6, &dst->vChests, tags::append, tags::via<ChestDesc_MM7>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->vChests, append(), via<ChestDesc_MM7>());
+        deserialize(src.mm7, &dst->vChests, tags::append, tags::via<ChestDesc_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->vChests, append(), via<ChestDesc_MM7>());
+        deserialize(src.mm8, &dst->vChests, tags::append, tags::via<ChestDesc_MM7>);
 
     assert(!dst->vChests.empty());
 }
@@ -46,18 +46,18 @@ void deserialize(const TriBlob &src, DecorationList *dst) {
     dst->pDecorations.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pDecorations, append(), via<DecorationDesc_MM6>());
+        deserialize(src.mm6, &dst->pDecorations, tags::append, tags::via<DecorationDesc_MM6>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->pDecorations, append(), via<DecorationDesc_MM7>());
+        deserialize(src.mm7, &dst->pDecorations, tags::append, tags::via<DecorationDesc_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->pDecorations, append(), via<DecorationDesc_MM7>());
+        deserialize(src.mm8, &dst->pDecorations, tags::append, tags::via<DecorationDesc_MM7>);
 
     assert(!dst->pDecorations.empty());
 }
 
 void deserialize(const TriBlob &src, IconFrameTable *dst) {
     dst->pIcons.clear();
-    deserialize(src.mm7, &dst->pIcons, append(), via<IconFrame_MM7>());
+    deserialize(src.mm7, &dst->pIcons, tags::append, tags::via<IconFrame_MM7>);
 
     for (size_t i = 0; i < dst->pIcons.size(); ++i)
         dst->pIcons[i].id = i;
@@ -69,11 +69,11 @@ void deserialize(const TriBlob &src, MonsterList *dst) {
     dst->pMonsters.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pMonsters, append(), via<MonsterDesc_MM6>());
+        deserialize(src.mm6, &dst->pMonsters, tags::append, tags::via<MonsterDesc_MM6>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->pMonsters, append(), via<MonsterDesc_MM7>());
+        deserialize(src.mm7, &dst->pMonsters, tags::append, tags::via<MonsterDesc_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->pMonsters, append(), via<MonsterDesc_MM7>());
+        deserialize(src.mm8, &dst->pMonsters, tags::append, tags::via<MonsterDesc_MM7>);
 
     assert(!dst->pMonsters.empty());
 }
@@ -82,11 +82,11 @@ void deserialize(const TriBlob &src, ObjectList *dst) {
     dst->pObjects.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pObjects, append(), via<ObjectDesc_MM6>());
+        deserialize(src.mm6, &dst->pObjects, tags::append, tags::via<ObjectDesc_MM6>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->pObjects, append(), via<ObjectDesc_MM7>());
+        deserialize(src.mm7, &dst->pObjects, tags::append, tags::via<ObjectDesc_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->pObjects, append(), via<ObjectDesc_MM7>());
+        deserialize(src.mm8, &dst->pObjects, tags::append, tags::via<ObjectDesc_MM7>);
 
     assert(!dst->pObjects.empty());
 }
@@ -95,27 +95,27 @@ void deserialize(const TriBlob &src, OverlayList *dst) {
     dst->pOverlays.clear();
 
     if (src.mm6)
-        deserialize(src.mm6, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
+        deserialize(src.mm6, &dst->pOverlays, tags::append, tags::via<OverlayDesc_MM7>);
     if (src.mm7)
-        deserialize(src.mm7, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
+        deserialize(src.mm7, &dst->pOverlays, tags::append, tags::via<OverlayDesc_MM7>);
     if (src.mm8)
-        deserialize(src.mm8, &dst->pOverlays, append(), via<OverlayDesc_MM7>());
+        deserialize(src.mm8, &dst->pOverlays, tags::append, tags::via<OverlayDesc_MM7>);
 
     assert(!dst->pOverlays.empty());
 }
 
 void deserialize(const TriBlob &src, SpriteFrameTable *dst) {
-    deserialize(src.mm7, dst, via<SpriteFrameTable_MM7>());
+    deserialize(src.mm7, dst, tags::via<SpriteFrameTable_MM7>);
 }
 
 void deserialize(const TriBlob &src, TextureFrameTable *dst) {
-    deserialize(src.mm7, &dst->textures, append(), via<TextureFrame_MM7>());
+    deserialize(src.mm7, &dst->textures, tags::append, tags::via<TextureFrame_MM7>);
 
     assert(!dst->textures.empty());
 }
 
 void deserialize(const TriBlob &src, TileTable *dst) {
-    deserialize(src.mm7, &dst->tiles, append(), via<TileDesc_MM7>());
+    deserialize(src.mm7, &dst->tiles, tags::append, tags::via<TileDesc_MM7>);
 
     assert(!dst->tiles.empty());
 }

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -385,6 +385,8 @@ void ItemTable::generateItem(ITEM_TREASURE_LEVEL treasure_level, unsigned int uT
     if (uTreasureType) {  // generate known treasure type
         ITEM_EQUIP_TYPE requested_equip;
         CharacterSkillType requested_skill = CHARACTER_SKILL_INVALID;
+        // TODO(captainurist): enum!
+        //  See https://github.com/GrayFace/MMExtension/blob/4d6600f164315f38157591d7f0307a86594c22ef/Scripts/Core/ConstAndBits.lua#L592
         switch (uTreasureType) {
             case 20:
                 requested_equip = EQUIP_SINGLE_HANDED;

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -266,6 +266,8 @@ enum class MenuType {
 };
 using enum MenuType;
 
+// TODO(captainurist): check against this:
+//  https://github.com/GrayFace/MMExtension/blob/4d6600f164315f38157591d7f0307a86594c22ef/Scripts/Core/ConstAndBits.lua#L875
 enum class ScreenType {
     SCREEN_GAME = 0,
     SCREEN_MENU = 1,

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -76,7 +76,7 @@ GUIWindow_Save::GUIWindow_Save() :
             pSavegameList->pSavegameHeader[i].name = localization->GetString(LSTR_EMPTY_SAVESLOT);
         } else {
             pLODFile.Open(str);
-            deserialize(pLODFile.LoadRaw("header.bin"), &pSavegameList->pSavegameHeader[i], via<SaveGameHeader_MM7>());
+            deserialize(pLODFile.LoadRaw("header.bin"), &pSavegameList->pSavegameHeader[i], tags::via<SaveGameHeader_MM7>);
 
             if (pSavegameList->pSavegameHeader[i].name.empty()) {
                 // blank so add something - suspect quicksaves
@@ -186,7 +186,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
         }
 
         if (!pLODFile.Open(str)) __debugbreak();
-        deserialize(pLODFile.LoadRaw("header.bin"), &pSavegameList->pSavegameHeader[i], via<SaveGameHeader_MM7>());
+        deserialize(pLODFile.LoadRaw("header.bin"), &pSavegameList->pSavegameHeader[i], tags::via<SaveGameHeader_MM7>);
 
         if (iequals(pSavegameList->pFileList[i], localization->GetString(LSTR_AUTOSAVE_MM7))) {
             pSavegameList->pSavegameHeader[i].name = localization->GetString(LSTR_AUTOSAVE);

--- a/src/Library/Application/PlatformApplication.h
+++ b/src/Library/Application/PlatformApplication.h
@@ -5,6 +5,7 @@
 #include <typeindex>
 #include <vector>
 #include <unordered_map>
+#include <utility>
 
 #include "Platform/PlatformOpenGLOptions.h"
 
@@ -59,7 +60,7 @@ class PlatformApplication {
         install(component.get());
 
         // TODO(captainurist): drop shared_ptr here once we have std::move_only_function
-        _cleanupRoutines.push_back([this, component = std::shared_ptr<T>(component.release())] {
+        _cleanupRoutines.push_back([this, component = std::shared_ptr<T>(std::move(component))] {
             remove(component.get());
         });
     }

--- a/src/Library/Binary/BinaryConcepts.h
+++ b/src/Library/Binary/BinaryConcepts.h
@@ -3,42 +3,40 @@
 #include <concepts>
 #include <type_traits>
 
+namespace detail {
+template<class T>
+struct is_span : std::false_type {};
+
+template<class T, size_t N>
+struct is_span<std::span<T, N>> : std::true_type {};
+} // namespace detail
+
+template<class T>
+struct is_binary_serialization_proxy : std::false_type {};
+
+template<class T>
+constexpr bool is_binary_serialization_proxy_v = is_binary_serialization_proxy<T>::value;
+
 /**
- * Concepts checking that `serialize()` is callable with the provided arguments.
+ * Concept checking that the provided type is not a proxy binary serialization type.
  */
-template<class Src, class Dst, class... Tag>
-concept BinarySerializable = requires(const Src &src, Dst *dst, Tag... tag) {
-    { serialize(src, dst, tag...) } -> std::same_as<void>;
+template<class T>
+concept NonBinaryProxy = !is_binary_serialization_proxy_v<std::remove_cvref_t<T>>;
+
+/**
+ * Concept for std::vector-like containers.
+ */
+template<class Container>
+concept ResizableContiguousContainer = requires (Container &container, size_t newSize) {
+    typename Container::value_type;
+    { container.resize(newSize) } -> std::same_as<void>;
+    { container.size() } -> std::same_as<size_t>;
+    { container.data() } -> std::convertible_to<const typename Container::value_type *>;
 }; // NOLINT
 
 /**
- * Concept checking that `deserialize()` is callable with the provided arguments.
+ * Concept that matches std::span. This is mainly needed so that overloads that take `std::span` won't accidentally
+ * trigger user-defined conversions, and thus won't be callable with `std::vector` or other span-compatible types.
  */
-template<class Src, class Dst, class... Tag>
-concept BinaryDeserializable = requires(Src &src, Dst *dst, Tag... tag) {
-    { deserialize(src, dst, tag...) } -> std::same_as<void>;
-}; // NOLINT
-
-template<class T>
-struct is_proxy_binary_serialization_source : std::false_type {};
-
-template<class T>
-constexpr bool is_proxy_binary_serialization_source_v = is_proxy_binary_serialization_source<T>::value;
-
-template<class T>
-struct is_proxy_binary_serialization_target : std::false_type {};
-
-template<class T>
-constexpr bool is_proxy_binary_serialization_target_v = is_proxy_binary_serialization_target<T>::value;
-
-/**
- * Concept checking that the provided type is not a proxy serialization source type.
- */
-template<class Src>
-concept RegularBinarySource = !is_proxy_binary_serialization_source_v<std::remove_cvref_t<Src>>;
-
-/**
- * Concept checking that the provided type is not a proxy serialization target type.
- */
-template<class Dst>
-concept RegularBinaryTarget = !is_proxy_binary_serialization_target_v<std::remove_cvref_t<Dst>>;
+template<class Container>
+concept StdSpan = detail::is_span<Container>::value;

--- a/src/Library/Binary/BinaryConcepts.h
+++ b/src/Library/Binary/BinaryConcepts.h
@@ -3,25 +3,80 @@
 #include <concepts>
 #include <type_traits>
 
-namespace detail {
 template<class T>
-struct is_span : std::false_type {};
-
-template<class T, size_t N>
-struct is_span<std::span<T, N>> : std::true_type {};
-} // namespace detail
+struct is_proxy_binary_source : std::false_type {};
 
 template<class T>
-struct is_binary_serialization_proxy : std::false_type {};
+struct is_proxy_binary_sink : std::false_type {};
 
 template<class T>
-constexpr bool is_binary_serialization_proxy_v = is_binary_serialization_proxy<T>::value;
+struct is_proxy_binarizable : std::false_type {};
 
 /**
- * Concept checking that the provided type is not a proxy binary serialization type.
+ * Binary serialization provides a set of overloads, and when there's too many, a moment comes when they need to be
+ * explicitly ordered. Consider the following overloads:
+ * ```
+ * template<class T, class... Tag>
+ * void serialize(const T &src, Blob *dst, const Tag &...); // #1
+ * template<class Src, class Dst, class Via>
+ * void serialize(const Src &src, Dst *dst, ViaTag<Via>); // #2
+ * ```
+ *
+ * And the following call:
+ * ```
+ * Blob blob;
+ * serialize(SomeData{}, &blob, tags::via<SomeData_Bin>);
+ * ```
+ *
+ * This call is ambiguous because the types provided match both overloads, with neither one being a better match.
+ * Besides, the ambiguity is genuine here - the order really doesn't matter, so whether `#1` calls into `#2` or the
+ * other way around, result stays the same. However, this is C++, so we need to:
+ * 1. Pick the order we like.
+ * 2. Guide the compiler into it.
+ *
+ * In this particular case it makes sense to disambiguate on `src` and `dst` first, and then process all the tags.
+ * How to do it? We can introduce the notion of 'proxy' binary serialization types:
+ * - Proxy source is a type that can be deserialized-from, and that simply replaces the `src` with another type
+ *   and forwards to another `deserialize` overload.
+ * - Proxy sink is a type that can be serialized-into, and that simply replaces the `dst` with another type
+ *   and forwards to another `serialize` overload.
+ * - Proxy binarizable types are basically the same thing, but for client types that are serialized into binary form /
+ *   deserialized from binary form by forwarding the corresponding call to another type. Note that calling serialize /
+ *   deserialize for members doesn't mean that a type is a proxy.
+ *
+ * Thus, proxy types stand in contrast to regular, or "leaf" types - types for which non-template overloads are
+ * provided. All overloads that process tags require regular `src` and `dst` arguments, and this provides natural
+ * ordering:
+ * 1. First, all `src` / `dst` transformations are carried out.
+ * 2. Then, tags are applied in order.
+ *
+ * To achieve this, the following concepts are provided:
+ * - `RegularBinarySource` to denote a non-proxy binary source (e.g., an `InputStream`).
+ * - `RegularBinarySink` to denote a non-proxy binary sink (e.g., an `OutputStream`).
+ * - `RegularBinarizable` to denote a non-proxy client type to be serialized or deserialized.
+ *
+ * Then, for the types that actually are proxies, the following type traits are provided for specialization:
+ * - `is_proxy_binary_source` for proxy binary sources.
+ * - `is_proxy_binary_sink` for proxy binary sinks.
+ * - `is_proxy_binarizable` for proxy client types.
+ *
+ * @see RegularBinarySink
+ * @see RegularBinarizable
  */
 template<class T>
-concept NonBinaryProxy = !is_binary_serialization_proxy_v<std::remove_cvref_t<T>>;
+concept RegularBinarySource = !is_proxy_binary_source<std::remove_cvref_t<T>>::value;
+
+/**
+ * @see RegularBinarySource
+ */
+template<class T>
+concept RegularBinarySink = !is_proxy_binary_sink<std::remove_cvref_t<T>>::value;
+
+/**
+ * @see RegularBinarySource
+ */
+template<class T>
+concept RegularBinarizable = !is_proxy_binarizable<std::remove_cvref_t<T>>::value;
 
 /**
  * Concept for std::vector-like containers.
@@ -34,9 +89,17 @@ concept ResizableContiguousContainer = requires (Container &container, size_t ne
     { container.data() } -> std::convertible_to<const typename Container::value_type *>;
 }; // NOLINT
 
+namespace detail {
+template<class T>
+struct is_span : std::false_type {};
+
+template<class T, size_t N>
+struct is_span<std::span<T, N>> : std::true_type {};
+} // namespace detail
+
 /**
- * Concept that matches std::span. This is mainly needed so that overloads that take `std::span` won't accidentally
- * trigger user-defined conversions, and thus won't be callable with `std::vector` or other span-compatible types.
+ * Concept that matches std::span. This is mainly needed so that overloads that take `std::span` don't accidentally
+ * trigger user-defined conversions, and thus aren't callable with `std::vector` or other span-compatible types.
  */
-template<class Container>
-concept StdSpan = detail::is_span<Container>::value;
+template<class T>
+concept StdSpan = detail::is_span<T>::value;

--- a/src/Library/Binary/BinaryTags.h
+++ b/src/Library/Binary/BinaryTags.h
@@ -32,7 +32,7 @@ class ContextTag {
 namespace tags {
 /**
  * Serialization tag that instructs the binary serialization framework to NOT write the vector size
- * into the stream. Note that this implies that you'll have to use the `presized` tag when deserializing.
+ * into the stream. Note that this implies that you'll have to use the `tags::presized` tag when deserializing.
  *
  * @see presized
  */
@@ -41,7 +41,7 @@ constexpr UnsizedTag unsized;
 /**
  * Deserialization tag that instructs the binary serialization to use the supplied vector size instead of
  * reading it from the stream. Note that this implies that the serialization must have been performed with the
- * `unsized` tag.
+ * `tags::unsized` tag.
  *
  * @param size                          Number of elements to deserialize.
  * @return                              Tag object to be passed into the `deserialize` call.
@@ -54,7 +54,7 @@ constexpr PresizedTag presized(size_t size) {
 /**
  * Deserialization tag that instructs the binary serialization framework to append deserialized elements
  * into the target vector instead of replacing its contents. This is useful when you want to deserialize several
- * sequences into the same `std::vector` object - normally subsequent `deserialize` calls would replace the vector
+ * sequences into the same `std::vector` - normally, subsequent `deserialize` calls would replace the vector
  * contents, but using this tag lets you accumulate the results of several `deserialize` calls instead.
  */
 constexpr AppendTag append;
@@ -62,7 +62,7 @@ constexpr AppendTag append;
 /**
  * This tag is mainly for the users who want to pass additional context into their serialization routines.
  * The way to do this is to accept a `ContextTag` as the last parameter in the serialization function, and
- * then pass the context itself by calling `tags::context` at call site.
+ * then pass the context into the call by invoking `tags::context` at the call site.
  *
  * @param ctx                           Context to pass to the serialization routine.
  * @return                              Tag object containing a reference to the passed context.

--- a/src/Library/Binary/BinaryTags.h
+++ b/src/Library/Binary/BinaryTags.h
@@ -5,7 +5,7 @@
 struct UnsizedTag {};
 
 struct PresizedTag {
-    explicit PresizedTag(size_t size) : size(size) {}
+    constexpr explicit PresizedTag(size_t size) : size(size) {}
 
     size_t size;
 };
@@ -15,13 +15,13 @@ struct AppendTag {};
 template<class T>
 class ContextTag {
  public:
-    explicit ContextTag(const T &ctx) : _ctx(ctx) {}
+    constexpr explicit ContextTag(const T &ctx) : _ctx(ctx) {}
 
-    const T *operator->() const {
+    constexpr const T *operator->() const {
         return &_ctx;
     }
 
-    const T &operator*() const {
+    constexpr const T &operator*() const {
         return _ctx;
     }
 
@@ -29,19 +29,17 @@ class ContextTag {
     const T &_ctx;
 };
 
+namespace tags {
 /**
- * Creates a serialization tag that instructs the binary serialization framework to NOT write the vector size
+ * Serialization tag that instructs the binary serialization framework to NOT write the vector size
  * into the stream. Note that this implies that you'll have to use the `presized` tag when deserializing.
  *
- * @return                              Tag object to be passed into the `serialize` call.
  * @see presized
  */
-inline UnsizedTag unsized() {
-    return {};
-}
+constexpr UnsizedTag unsized;
 
 /**
- * Creates a deserialization tag that instructs the binary serialization to use the supplied vector size instead of
+ * Deserialization tag that instructs the binary serialization to use the supplied vector size instead of
  * reading it from the stream. Note that this implies that the serialization must have been performed with the
  * `unsized` tag.
  *
@@ -49,31 +47,29 @@ inline UnsizedTag unsized() {
  * @return                              Tag object to be passed into the `deserialize` call.
  * @see unsized
  */
-inline PresizedTag presized(size_t size) {
+constexpr PresizedTag presized(size_t size) {
     return PresizedTag(size);
 }
 
 /**
- * Creates a deserialization tag that instructs the binary serialization framework to append deserialized elements
+ * Deserialization tag that instructs the binary serialization framework to append deserialized elements
  * into the target vector instead of replacing its contents. This is useful when you want to deserialize several
  * sequences into the same `std::vector` object - normally subsequent `deserialize` calls would replace the vector
- * contents, but using this wrapper lets you accumulate the results of several `deserialize` calls instead.
- *
- * @return                              Tag object to be passed into `deserialize` call.
+ * contents, but using this tag lets you accumulate the results of several `deserialize` calls instead.
  */
-inline AppendTag append() {
-    return {};
-}
+constexpr AppendTag append;
 
 /**
- * This tag factory function is mainly for the users who want to pass additional context into their serialization
- * routines. The way to do this is to accept a `ContextTag` as the last parameter in the serialization function, and
- * then pass the context itself by calling `context` at call site.
+ * This tag is mainly for the users who want to pass additional context into their serialization routines.
+ * The way to do this is to accept a `ContextTag` as the last parameter in the serialization function, and
+ * then pass the context itself by calling `tags::context` at call site.
  *
  * @param ctx                           Context to pass to the serialization routine.
  * @return                              Tag object containing a reference to the passed context.
  */
 template<class T>
-inline ContextTag<T> context(const T &ctx) {
+constexpr ContextTag<T> context(const T &ctx) {
     return ContextTag<T>(ctx);
 }
+
+} // namespace tags

--- a/src/Library/Binary/BlobSerialization.h
+++ b/src/Library/Binary/BlobSerialization.h
@@ -9,10 +9,10 @@
 
 #include "BinaryConcepts.h"
 
-// Blob is a proxy binary serialization type, and we need to tell other overloads not to handle it.
-// This way overloads for Blob will always come first in the call chain, and this is what we want.
 template<>
-struct is_binary_serialization_proxy<Blob> : std::true_type {};
+struct is_proxy_binary_sink<Blob> : std::true_type {};
+template<>
+struct is_proxy_binary_source<Blob> : std::true_type {};
 
 template<class Src, class... Tags>
 void serialize(const Src &src, Blob *dst, const Tags &... tags) {

--- a/src/Library/Binary/BlobSerialization.h
+++ b/src/Library/Binary/BlobSerialization.h
@@ -12,23 +12,21 @@
 // Blob is a proxy binary serialization type, and we need to tell other overloads not to handle it.
 // This way overloads for Blob will always come first in the call chain, and this is what we want.
 template<>
-struct is_proxy_binary_serialization_source<Blob> : std::true_type {};
-template<>
-struct is_proxy_binary_serialization_target<Blob> : std::true_type {};
+struct is_binary_serialization_proxy<Blob> : std::true_type {};
 
-template<class Src, class... Tag>
-void serialize(const Src &src, Blob *dst, const Tag &... tag) {
+template<class Src, class... Tags>
+void serialize(const Src &src, Blob *dst, const Tags &... tags) {
     std::string tmp;
     StringOutputStream stream(&tmp);
-    serialize(src, &stream, tag...);
+    serialize(src, &stream, tags...);
     *dst = Blob::fromString(std::move(tmp));
 }
 
-template<class Dst, class... Tag>
-void deserialize(const Blob &src, Dst *dst, const Tag &... tag) {
+template<class Dst, class... Tags>
+void deserialize(const Blob &src, Dst *dst, const Tags &... tags) {
     // Using MemoryInputStream and not BlobInputStream is intentional. BlobInputStream is heavier, and we don't need
     // its functionality here.
     MemoryInputStream stream(src.data(), src.size());
-    deserialize(stream, dst, tag...);
+    deserialize(stream, dst, tags...);
     // TODO(captainurist): check that there's no data left in the stream.
 }

--- a/src/Library/Binary/ContainerSerialization.h
+++ b/src/Library/Binary/ContainerSerialization.h
@@ -68,15 +68,15 @@ void serialize(const Span &src, OutputStream *dst) {
 //
 
 template<class T, size_t N>
-struct is_binary_serialization_proxy<std::array<T, N>> : std::true_type {}; // std::array forwards to std::span.
+struct is_proxy_binarizable<std::array<T, N>> : std::true_type {}; // std::array forwards to std::span.
 
-template<class T, size_t N, class... Tags>
-void serialize(const std::array<T, N> &src, OutputStream *dst, const Tags &... tags) {
+template<class T, size_t N, RegularBinarySink Dst, class... Tags>
+void serialize(const std::array<T, N> &src, Dst *dst, const Tags &... tags) {
     serialize(std::span(src), dst, tags...);
 }
 
-template<class T, size_t N, class... Tags>
-void deserialize(InputStream &src, std::array<T, N> *dst, const Tags &... tags) {
+template<RegularBinarySource Src, class T, size_t N, class... Tags>
+void deserialize(Src &src, std::array<T, N> *dst, const Tags &... tags) {
     std::span span(*dst);
     deserialize(src, &span, tags...);
 }
@@ -87,10 +87,10 @@ void deserialize(InputStream &src, std::array<T, N> *dst, const Tags &... tags) 
 //
 
 template<ResizableContiguousContainer Container>
-struct is_binary_serialization_proxy<Container> : std::true_type {}; // ResizableContiguousContainer forwards to std::span.
+struct is_proxy_binarizable<Container> : std::true_type {}; // ResizableContiguousContainer forwards to std::span.
 
-template<ResizableContiguousContainer Container, class... Tags>
-void serialize(const Container &src, OutputStream *dst, const Tags &... tags) {
+template<ResizableContiguousContainer Src, RegularBinarySink Dst, class... Tags>
+void serialize(const Src &src, Dst *dst, const Tags &... tags) {
     assert(src.size() <= UINT32_MAX);
 
     uint32_t size = src.size();
@@ -99,8 +99,8 @@ void serialize(const Container &src, OutputStream *dst, const Tags &... tags) {
     serialize(span, dst, tags...);
 }
 
-template<ResizableContiguousContainer Container, class... Tags>
-void deserialize(InputStream &src, Container *dst, const Tags &... tags) {
+template<RegularBinarySource Src, ResizableContiguousContainer Dst, class... Tags>
+void deserialize(Src &src, Dst *dst, const Tags &... tags) {
     uint32_t size;
     deserialize(src, &size);
 
@@ -109,20 +109,20 @@ void deserialize(InputStream &src, Container *dst, const Tags &... tags) {
     deserialize(src, &span, tags...);
 }
 
-template<ResizableContiguousContainer Container, class... Tags>
-void serialize(const Container &src, OutputStream *dst, UnsizedTag, const Tags &... tags) {
+template<ResizableContiguousContainer Src, RegularBinarySink Dst, class... Tags>
+void serialize(const Src &src, Dst *dst, UnsizedTag, const Tags &... tags) {
     serialize(std::span(src), dst, tags...);
 }
 
-template<ResizableContiguousContainer Container, class... Tags>
-void deserialize(InputStream &src, Container *dst, PresizedTag tag, const Tags &... tags) {
+template<RegularBinarySource Src, ResizableContiguousContainer Dst, class... Tags>
+void deserialize(Src &src, Dst *dst, PresizedTag tag, const Tags &... tags) {
     dst->resize(tag.size);
     std::span span(dst->data(), dst->size());
     deserialize(src, &span, tags...);
 }
 
-template<ResizableContiguousContainer Container, class... Tags>
-void deserialize(InputStream &src, Container *dst, AppendTag, const Tags &... tags) {
+template<RegularBinarySource Src, ResizableContiguousContainer Dst, class... Tags>
+void deserialize(Src &src, Dst *dst, AppendTag, const Tags &... tags) {
     detail::AppendWrapper wrapper(dst);
     deserialize(src, &wrapper, tags...);
 }

--- a/src/Library/Binary/ContainerSerialization.h
+++ b/src/Library/Binary/ContainerSerialization.h
@@ -70,15 +70,15 @@ void serialize(const Span &src, OutputStream *dst) {
 template<class T, size_t N>
 struct is_binary_serialization_proxy<std::array<T, N>> : std::true_type {}; // std::array forwards to std::span.
 
-template<class T, size_t N>
-void serialize(const std::array<T, N> &src, OutputStream *dst) {
-    serialize(std::span(src), dst);
+template<class T, size_t N, class... Tags>
+void serialize(const std::array<T, N> &src, OutputStream *dst, const Tags &... tags) {
+    serialize(std::span(src), dst, tags...);
 }
 
-template<class T, size_t N>
-void deserialize(InputStream &src, std::array<T, N> *dst) {
+template<class T, size_t N, class... Tags>
+void deserialize(InputStream &src, std::array<T, N> *dst, const Tags &... tags) {
     std::span span(*dst);
-    deserialize(src, &span);
+    deserialize(src, &span, tags...);
 }
 
 

--- a/src/Library/Snapshots/CMakeLists.txt
+++ b/src/Library/Snapshots/CMakeLists.txt
@@ -9,4 +9,16 @@ set(LIBRARY_SNAPSHOTS_HEADERS
 # No sources here, so it's an INTERFACE library. Also, I have no idea how the text aligns so well.
 add_library(library_snapshots INTERFACE ${LIBRARY_SNAPSHOTS_SOURCES} ${LIBRARY_SNAPSHOTS_HEADERS})
 target_check_style(library_snapshots)
-target_link_libraries(library_snapshots INTERFACE utility)
+target_link_libraries(library_snapshots INTERFACE library_binary utility)
+
+if(ENABLE_TESTS)
+    set(TEST_LIBRARY_SNAPSHOTS_SOURCES Tests/Snapshots_ut.cpp)
+
+    add_library(test_library_snapshots OBJECT ${TEST_LIBRARY_SNAPSHOTS_SOURCES})
+    target_compile_definitions(test_library_snapshots PRIVATE TEST_GROUP=Snapshots)
+    target_link_libraries(test_library_snapshots PUBLIC testing_unit library_snapshots)
+
+    target_check_style(test_library_snapshots)
+
+    target_link_libraries(OpenEnroth_UnitTest PUBLIC test_library_snapshots)
+endif()

--- a/src/Library/Snapshots/CommonSnapshots.h
+++ b/src/Library/Snapshots/CommonSnapshots.h
@@ -4,12 +4,15 @@
 #include <algorithm>
 #include <array>
 #include <string>
-#include <vector>
+#include <span> // NOLINT
 #include <type_traits>
+
+#include "Library/Binary/BinaryConcepts.h"
 
 #include "Utility/Segment.h"
 #include "Utility/IndexedArray.h"
-#include "Utility/IndexedBitset.h"
+
+#include "SnapshotConcepts.h"
 
 //
 // Identity snapshotting.
@@ -73,20 +76,24 @@ void reconstruct(const std::array<char, N> &src, std::string *dst) {
 // std::vector support.
 //
 
-template<class T1, class T2, class... Tag> requires (!std::is_same_v<T1, T2> && sizeof...(Tag) <= 1)
-void snapshot(const std::vector<T1> &src, std::vector<T2> *dst, const Tag &... tag) {
-    dst->clear();
-    dst->reserve(src.size());
-    for (const T1 &element : src)
-        snapshot(element, &dst->emplace_back(), tag...);
+template<ResizableContiguousContainer Src, ResizableContiguousContainer Dst, class... Tags> requires DifferentElementTypes<Src, Dst>
+void snapshot(const Src &src, Dst *dst, const Tags &... tags) {
+    dst->resize(src.size());
+
+    std::span srcSpan(src.data(), src.size());
+    std::span dstSpan(dst->data(), dst->size());
+    for (size_t i = 0; i < srcSpan.size(); i++)
+        snapshot(srcSpan[i], &dstSpan[i], tags...);
 }
 
-template<class T1, class T2, class... Tag> requires (!std::is_same_v<T1, T2> && sizeof...(Tag) <= 1)
-void reconstruct(const std::vector<T1> &src, std::vector<T2> *dst, const Tag &... tag) {
-    dst->clear();
-    dst->reserve(src.size());
-    for (const T1 &element : src)
-        reconstruct(element, &dst->emplace_back(), tag...);
+template<ResizableContiguousContainer Src, ResizableContiguousContainer Dst, class... Tags> requires DifferentElementTypes<Src, Dst>
+void reconstruct(const Src &src, Dst *dst, const Tags &... tags) {
+    dst->resize(src.size());
+
+    std::span srcSpan(src.data(), src.size());
+    std::span dstSpan(dst->data(), dst->size());
+    for (size_t i = 0; i < srcSpan.size(); i++)
+        reconstruct(srcSpan[i], &dstSpan[i], tags...);
 }
 
 
@@ -94,18 +101,18 @@ void reconstruct(const std::vector<T1> &src, std::vector<T2> *dst, const Tag &..
 // std::array support.
 //
 
-template<class T1, size_t N1, class T2, size_t N2, class... Tag> requires (!std::is_same_v<T1, T2> && sizeof...(Tag) <= 1)
-void snapshot(const std::array<T1, N1> &src, std::array<T2, N2> *dst, const Tag &... tag) {
+template<class T1, size_t N1, class T2, size_t N2, class... Tags> requires (!std::is_same_v<T1, T2>)
+void snapshot(const std::array<T1, N1> &src, std::array<T2, N2> *dst, const Tags &... tags) {
     static_assert(N1 == N2, "Expected arrays of equal size.");
     for (size_t i = 0; i < N1; i++)
-        snapshot(src[i], &(*dst)[i], tag...);
+        snapshot(src[i], &(*dst)[i], tags...);
 }
 
-template<class T1, size_t N1, class T2, size_t N2, class... Tag> requires (!std::is_same_v<T1, T2> && sizeof...(Tag) <= 1)
-void reconstruct(const std::array<T1, N1> &src, std::array<T2, N2> *dst, const Tag &... tag) {
+template<class T1, size_t N1, class T2, size_t N2, class... Tags> requires (!std::is_same_v<T1, T2>)
+void reconstruct(const std::array<T1, N1> &src, std::array<T2, N2> *dst, const Tags &... tags) {
     static_assert(N1 == N2, "Expected arrays of equal size.");
     for (size_t i = 0; i < N1; i++)
-        reconstruct(src[i], &(*dst)[i], tag...);
+        reconstruct(src[i], &(*dst)[i], tags...);
 }
 
 
@@ -113,18 +120,18 @@ void reconstruct(const std::array<T1, N1> &src, std::array<T2, N2> *dst, const T
 // IndexedArray support
 //
 
-template<class T1, size_t N, class T2, auto L, auto H, class... Tag>
-void snapshot(const IndexedArray<T2, L, H> &src, std::array<T1, N> *dst, const Tag &... tag) {
+template<class T1, size_t N, class T2, auto L, auto H, class... Tags>
+void snapshot(const IndexedArray<T2, L, H> &src, std::array<T1, N> *dst, const Tags &... tags) {
     static_assert(IndexedArray<T2, L, H>::SIZE == N, "Expected arrays of equal size.");
     for (size_t i = 0; auto index : src.indices())
-        snapshot(src[index], &(*dst)[i++], tag...);
+        snapshot(src[index], &(*dst)[i++], tags...);
 }
 
-template<class T1, size_t N, class T2, auto L, auto H, class... Tag>
-void reconstruct(const std::array<T1, N> &src, IndexedArray<T2, L, H> *dst, const Tag &... tag) {
+template<class T1, size_t N, class T2, auto L, auto H, class... Tags>
+void reconstruct(const std::array<T1, N> &src, IndexedArray<T2, L, H> *dst, const Tags &... tags) {
     static_assert(IndexedArray<T2, L, H>::SIZE == N, "Expected arrays of equal size.");
     for (size_t i = 0; auto index : dst->indices())
-        reconstruct(src[i++], &(*dst)[index], tag...);
+        reconstruct(src[i++], &(*dst)[index], tags...);
 }
 
 

--- a/src/Library/Snapshots/SnapshotConcepts.h
+++ b/src/Library/Snapshots/SnapshotConcepts.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <type_traits>
+
+template<class Container1, class Container2>
+concept DifferentElementTypes = !std::is_same_v<typename Container1::value_type, typename Container2::value_type>;

--- a/src/Library/Snapshots/SnapshotSerialization.h
+++ b/src/Library/Snapshots/SnapshotSerialization.h
@@ -29,7 +29,7 @@ constexpr ViaTag<Via> via;
 // Note: in theory the overloads below could accept a Tags... tail parameter and forward it to reconstruct / snapshot,
 // but I can't think of any sane use case where this would be needed. So, no tag tails.
 
-template<NonBinaryProxy Src, NonBinaryProxy Dst, class Via> requires (!StdSpan<Dst>) // std::span is handled below.
+template<RegularBinarySource Src, RegularBinarizable Dst, class Via> requires (!StdSpan<Dst>) // std::span is handled below.
 void deserialize(Src &src, Dst *dst, ViaTag<Via>) {
     static_assert(!std::is_same_v<Via, Dst>, "Intermediate and target types must be different.");
 
@@ -38,7 +38,7 @@ void deserialize(Src &src, Dst *dst, ViaTag<Via>) {
     reconstruct(tmp, dst);
 }
 
-template<NonBinaryProxy Src, NonBinaryProxy Dst, class Via> requires (!StdSpan<Src>) // std::span is handled below.
+template<RegularBinarizable Src, RegularBinarySink Dst, class Via> requires (!StdSpan<Src>) // std::span is handled below.
 void serialize(const Src &src, Dst *dst, ViaTag<Via>) {
     static_assert(!std::is_same_v<Via, Src>, "Intermediate and source types must be different.");
 
@@ -47,13 +47,13 @@ void serialize(const Src &src, Dst *dst, ViaTag<Via>) {
     serialize(tmp, dst);
 }
 
-template<NonBinaryProxy Src, StdSpan Dst, class Via>
+template<RegularBinarySource Src, StdSpan Dst, class Via>
 void deserialize(Src &src, Dst *dst, ViaTag<Via> tag) {
     for (auto &element : *dst)
         deserialize(src, &element, tag);
 }
 
-template<StdSpan Src, NonBinaryProxy Dst, class Via>
+template<StdSpan Src, RegularBinarySink Dst, class Via>
 void serialize(const Src &src, Dst *dst, ViaTag<Via> tag) {
     for (const auto &element : src)
         serialize(element, dst, tag);

--- a/src/Library/Snapshots/SnapshotSerialization.h
+++ b/src/Library/Snapshots/SnapshotSerialization.h
@@ -5,46 +5,10 @@
 
 #include "Library/Binary/BinarySerialization.h"
 
-class InputStream;
 namespace detail {
-template<class Via>
-struct AppendViaTag {};
 template<class Via>
 struct ViaTag {};
 } // namespace detail
-
-/**
- * Creates a deserialization tag that instructs the binary serialization framework to read a vector of `Via` objects
- * from the stream, and then reconstruct them into game objects & append those to the target vector.
- *
- * Example usage:
- * ```
- * std::vector<MonsterDesc> monsters;
- * Blob monstersBlob = readMonstersBlob();
- * deserialize(monstersBlob, &monsters, appendVia<MonsterDesc_MM7>());
- * ```
- *
- * @tparam Via                          Intermediate type to read from the stream.
- * @return                              Tag object to be passed into the `deserialize` call.
- */
-template<class Via>
-detail::AppendViaTag<Via> appendVia() {
-    return {};
-}
-
-template<class Dst, class Via>
-void deserialize(InputStream &src, std::vector<Dst> *dst, detail::AppendViaTag<Via>) {
-    static_assert(!std::is_same_v<Via, Dst>, "Intermediate and target types must be different.");
-
-    uint32_t size;
-    deserialize(src, &size);
-
-    Via tmp;
-    for (size_t i = 0; i < size; i++) {
-        deserialize(src, &tmp);
-        reconstruct(tmp, &dst->emplace_back());
-    }
-}
 
 /**
  * Creates a deserialization tag that instructs the binary serialization framework to first read a `Via` object
@@ -65,8 +29,8 @@ detail::ViaTag<Via> via() {
     return {};
 }
 
-template<RegularBinarySource Src, class Dst, class Via>
-void deserialize(Src &&src, Dst *dst, detail::ViaTag<Via>) {
+template<NonBinaryProxy Src, NonBinaryProxy Dst, class Via> requires (!StdSpan<Dst>) // std::span is handled below.
+void deserialize(Src &src, Dst *dst, detail::ViaTag<Via>) {
     static_assert(!std::is_same_v<Via, Dst>, "Intermediate and target types must be different.");
 
     Via tmp;
@@ -74,11 +38,23 @@ void deserialize(Src &&src, Dst *dst, detail::ViaTag<Via>) {
     reconstruct(tmp, dst);
 }
 
-template<class Src, RegularBinaryTarget Dst, class Via>
+template<NonBinaryProxy Src, NonBinaryProxy Dst, class Via> requires (!StdSpan<Src>) // std::span is handled below.
 void serialize(const Src &src, Dst *dst, detail::ViaTag<Via>) {
     static_assert(!std::is_same_v<Via, Src>, "Intermediate and source types must be different.");
 
     Via tmp;
     snapshot(src, &tmp);
     serialize(tmp, dst);
+}
+
+template<NonBinaryProxy Src, StdSpan Dst, class Via>
+void deserialize(Src &src, Dst *dst, detail::ViaTag<Via> tag) {
+    for (auto &element : *dst)
+        deserialize(src, &element, tag);
+}
+
+template<StdSpan Src, NonBinaryProxy Dst, class Via>
+void serialize(const Src &src, Dst *dst, detail::ViaTag<Via> tag) {
+    for (const auto &element : src)
+        serialize(element, dst, tag);
 }

--- a/src/Library/Snapshots/SnapshotSerialization.h
+++ b/src/Library/Snapshots/SnapshotSerialization.h
@@ -26,6 +26,9 @@ template<class Via>
 constexpr ViaTag<Via> via;
 } // namespace tags
 
+// Note: in theory the overloads below could accept a Tags... tail parameter and forward it to reconstruct / snapshot,
+// but I can't think of any sane use case where this would be needed. So, no tag tails.
+
 template<NonBinaryProxy Src, NonBinaryProxy Dst, class Via> requires (!StdSpan<Dst>) // std::span is handled below.
 void deserialize(Src &src, Dst *dst, ViaTag<Via>) {
     static_assert(!std::is_same_v<Via, Dst>, "Intermediate and target types must be different.");

--- a/src/Library/Snapshots/Tests/Snapshots_ut.cpp
+++ b/src/Library/Snapshots/Tests/Snapshots_ut.cpp
@@ -21,54 +21,57 @@ void reconstruct(const Int_MM &src, int *dst) {
     *dst = src.value;
 }
 
-UNIT_TEST(Snapshots, Serialization) {
-    std::vector<int> ints012 = {0, 1, 2};
-    std::vector<int> ints345 = {3, 4, 5};
-    std::vector<int> ints012345 = {0, 1, 2, 3, 4 ,5};
+static const std::vector<int> ints012 = {0, 1, 2};
+static const std::vector<int> ints345 = {3, 4, 5};
+static const std::vector<int> ints012345 = {0, 1, 2, 3, 4, 5};
 
-    // Simple via.
-    Blob blob0;
-    std::vector<int> ref0;
-    serialize(ints012, &blob0, via<Int_MM>());
-    deserialize(blob0, &ref0, via<Int_MM>());
-    EXPECT_EQ(ref0, ints012);
+UNIT_TEST(Snapshots, Via) {
+    Blob blob;
+    std::vector<int> ref = {100, 200}; // Also test overwrite.
+    serialize(ints012, &blob, via<Int_MM>());
+    deserialize(blob, &ref, via<Int_MM>());
+    EXPECT_EQ(ref, ints012);
+}
 
-    // Unsized + via.
-    Blob blob1;
-    std::vector<int> ref1;
-    serialize(ints012, &blob1, unsized(), via<Int_MM>());
-    deserialize(blob1, &ref1, presized(3), via<Int_MM>());
-    EXPECT_EQ(ref1, ints012);
+UNIT_TEST(Snapshots, SizedVia) {
+    Blob blob;
+    std::vector<int> ref = {100, 200}; // Also test overwrite.
+    serialize(ints012, &blob, unsized(), via<Int_MM>());
+    deserialize(blob, &ref, presized(3), via<Int_MM>());
+    EXPECT_EQ(ref, ints012);
+}
 
-    // Multiple unsized + via.
-    std::string string2;
-    StringOutputStream output2(&string2);
-    std::vector<int> ref2;
-    serialize(ints012, &output2, unsized(), via<Int_MM>());
-    serialize(ints345, &output2, unsized(), via<Int_MM>());
-    MemoryInputStream input2(string2.data(), string2.size());
-    deserialize(input2, &ref2, presized(6), via<Int_MM>());
-    EXPECT_EQ(ref2, ints012345);
+UNIT_TEST(Snapshots, MultiSizedVia) {
+    std::string string;
+    StringOutputStream output(&string);
+    std::vector<int> ref = {100, 200}; // Also test overwrite.
+    serialize(ints012, &output, unsized(), via<Int_MM>());
+    serialize(ints345, &output, unsized(), via<Int_MM>());
+    MemoryInputStream input2(string.data(), string.size());
+    deserialize(input2, &ref, presized(6), via<Int_MM>());
+    EXPECT_EQ(ref, ints012345);
+}
 
-    // append + presized + via.
-    std::string string3;
-    StringOutputStream output3(&string3);
-    std::vector<int> ref3;
-    serialize(ints012, &output3, unsized(), via<Int_MM>());
-    serialize(ints345, &output3, unsized(), via<Int_MM>());
-    MemoryInputStream input3(string3.data(), string3.size());
-    deserialize(input3, &ref3, append(), presized(3), via<Int_MM>());
-    deserialize(input3, &ref3, append(), presized(3), via<Int_MM>());
-    EXPECT_EQ(ref3, ints012345);
+UNIT_TEST(Snapshots, AppendSizedVia) {
+    std::string string;
+    StringOutputStream output(&string);
+    std::vector<int> ref;
+    serialize(ints012, &output, unsized(), via<Int_MM>());
+    serialize(ints345, &output, unsized(), via<Int_MM>());
+    MemoryInputStream input3(string.data(), string.size());
+    deserialize(input3, &ref, append(), presized(3), via<Int_MM>());
+    deserialize(input3, &ref, append(), presized(3), via<Int_MM>());
+    EXPECT_EQ(ref, ints012345);
+}
 
-    // append + via
-    std::string string4;
-    StringOutputStream output4(&string4);
-    std::vector<int> ref4;
-    serialize(ints012, &output4, via<Int_MM>());
-    serialize(ints345, &output4, via<Int_MM>());
-    MemoryInputStream input4(string4.data(), string4.size());
-    deserialize(input4, &ref4, append(), via<Int_MM>());
-    deserialize(input4, &ref4, append(), via<Int_MM>());
-    EXPECT_EQ(ref4, ints012345);
+UNIT_TEST(Snapshots, AppendVia) {
+    std::string string;
+    StringOutputStream output(&string);
+    std::vector<int> ref;
+    serialize(ints012, &output, via<Int_MM>());
+    serialize(ints345, &output, via<Int_MM>());
+    MemoryInputStream input4(string.data(), string.size());
+    deserialize(input4, &ref, append(), via<Int_MM>());
+    deserialize(input4, &ref, append(), via<Int_MM>());
+    EXPECT_EQ(ref, ints012345);
 }

--- a/src/Library/Snapshots/Tests/Snapshots_ut.cpp
+++ b/src/Library/Snapshots/Tests/Snapshots_ut.cpp
@@ -75,3 +75,13 @@ UNIT_TEST(Snapshots, AppendVia) {
     deserialize(input4, &ref, tags::append, tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012345);
 }
+
+UNIT_TEST(Snapshots, ArrayVia) {
+    const std::array<int, 3> ints123 = {1, 2, 3};
+
+    Blob blob;
+    std::array<int, 3> ref;
+    serialize(ints123, &blob, tags::via<Int_MM>);
+    deserialize(blob, &ref, tags::via<Int_MM>);
+    EXPECT_EQ(ref, ints123);
+}

--- a/src/Library/Snapshots/Tests/Snapshots_ut.cpp
+++ b/src/Library/Snapshots/Tests/Snapshots_ut.cpp
@@ -1,0 +1,74 @@
+#include "Testing/Unit/UnitTest.h"
+
+#include "Library/Snapshots/CommonSnapshots.h"
+#include "Library/Snapshots/SnapshotSerialization.h"
+
+#include "Utility/Streams/StringOutputStream.h"
+#include "Utility/Streams/MemoryInputStream.h"
+
+struct Int_MM {
+    int dummy;
+    int value;
+};
+MM_DECLARE_MEMCOPY_SERIALIZABLE(Int_MM)
+
+void snapshot(int src, Int_MM *dst) {
+    dst->dummy = 0;
+    dst->value = src;
+}
+
+void reconstruct(const Int_MM &src, int *dst) {
+    *dst = src.value;
+}
+
+UNIT_TEST(Snapshots, Serialization) {
+    std::vector<int> ints012 = {0, 1, 2};
+    std::vector<int> ints345 = {3, 4, 5};
+    std::vector<int> ints012345 = {0, 1, 2, 3, 4 ,5};
+
+    // Simple via.
+    Blob blob0;
+    std::vector<int> ref0;
+    serialize(ints012, &blob0, via<Int_MM>());
+    deserialize(blob0, &ref0, via<Int_MM>());
+    EXPECT_EQ(ref0, ints012);
+
+    // Unsized + via.
+    Blob blob1;
+    std::vector<int> ref1;
+    serialize(ints012, &blob1, unsized(), via<Int_MM>());
+    deserialize(blob1, &ref1, presized(3), via<Int_MM>());
+    EXPECT_EQ(ref1, ints012);
+
+    // Multiple unsized + via.
+    std::string string2;
+    StringOutputStream output2(&string2);
+    std::vector<int> ref2;
+    serialize(ints012, &output2, unsized(), via<Int_MM>());
+    serialize(ints345, &output2, unsized(), via<Int_MM>());
+    MemoryInputStream input2(string2.data(), string2.size());
+    deserialize(input2, &ref2, presized(6), via<Int_MM>());
+    EXPECT_EQ(ref2, ints012345);
+
+    // append + presized + via.
+    std::string string3;
+    StringOutputStream output3(&string3);
+    std::vector<int> ref3;
+    serialize(ints012, &output3, unsized(), via<Int_MM>());
+    serialize(ints345, &output3, unsized(), via<Int_MM>());
+    MemoryInputStream input3(string3.data(), string3.size());
+    deserialize(input3, &ref3, append(), presized(3), via<Int_MM>());
+    deserialize(input3, &ref3, append(), presized(3), via<Int_MM>());
+    EXPECT_EQ(ref3, ints012345);
+
+    // append + via
+    std::string string4;
+    StringOutputStream output4(&string4);
+    std::vector<int> ref4;
+    serialize(ints012, &output4, via<Int_MM>());
+    serialize(ints345, &output4, via<Int_MM>());
+    MemoryInputStream input4(string4.data(), string4.size());
+    deserialize(input4, &ref4, append(), via<Int_MM>());
+    deserialize(input4, &ref4, append(), via<Int_MM>());
+    EXPECT_EQ(ref4, ints012345);
+}

--- a/src/Library/Snapshots/Tests/Snapshots_ut.cpp
+++ b/src/Library/Snapshots/Tests/Snapshots_ut.cpp
@@ -28,16 +28,16 @@ static const std::vector<int> ints012345 = {0, 1, 2, 3, 4, 5};
 UNIT_TEST(Snapshots, Via) {
     Blob blob;
     std::vector<int> ref = {100, 200}; // Also test overwrite.
-    serialize(ints012, &blob, via<Int_MM>());
-    deserialize(blob, &ref, via<Int_MM>());
+    serialize(ints012, &blob, tags::via<Int_MM>);
+    deserialize(blob, &ref, tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012);
 }
 
 UNIT_TEST(Snapshots, SizedVia) {
     Blob blob;
     std::vector<int> ref = {100, 200}; // Also test overwrite.
-    serialize(ints012, &blob, unsized(), via<Int_MM>());
-    deserialize(blob, &ref, presized(3), via<Int_MM>());
+    serialize(ints012, &blob, tags::unsized, tags::via<Int_MM>);
+    deserialize(blob, &ref, tags::presized(3), tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012);
 }
 
@@ -45,10 +45,10 @@ UNIT_TEST(Snapshots, MultiSizedVia) {
     std::string string;
     StringOutputStream output(&string);
     std::vector<int> ref = {100, 200}; // Also test overwrite.
-    serialize(ints012, &output, unsized(), via<Int_MM>());
-    serialize(ints345, &output, unsized(), via<Int_MM>());
+    serialize(ints012, &output, tags::unsized, tags::via<Int_MM>);
+    serialize(ints345, &output, tags::unsized, tags::via<Int_MM>);
     MemoryInputStream input2(string.data(), string.size());
-    deserialize(input2, &ref, presized(6), via<Int_MM>());
+    deserialize(input2, &ref, tags::presized(6), tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012345);
 }
 
@@ -56,11 +56,11 @@ UNIT_TEST(Snapshots, AppendSizedVia) {
     std::string string;
     StringOutputStream output(&string);
     std::vector<int> ref;
-    serialize(ints012, &output, unsized(), via<Int_MM>());
-    serialize(ints345, &output, unsized(), via<Int_MM>());
+    serialize(ints012, &output, tags::unsized, tags::via<Int_MM>);
+    serialize(ints345, &output, tags::unsized, tags::via<Int_MM>);
     MemoryInputStream input3(string.data(), string.size());
-    deserialize(input3, &ref, append(), presized(3), via<Int_MM>());
-    deserialize(input3, &ref, append(), presized(3), via<Int_MM>());
+    deserialize(input3, &ref, tags::append, tags::presized(3), tags::via<Int_MM>);
+    deserialize(input3, &ref, tags::append, tags::presized(3), tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012345);
 }
 
@@ -68,10 +68,10 @@ UNIT_TEST(Snapshots, AppendVia) {
     std::string string;
     StringOutputStream output(&string);
     std::vector<int> ref;
-    serialize(ints012, &output, via<Int_MM>());
-    serialize(ints345, &output, via<Int_MM>());
+    serialize(ints012, &output, tags::via<Int_MM>);
+    serialize(ints345, &output, tags::via<Int_MM>);
     MemoryInputStream input4(string.data(), string.size());
-    deserialize(input4, &ref, append(), via<Int_MM>());
-    deserialize(input4, &ref, append(), via<Int_MM>());
+    deserialize(input4, &ref, tags::append, tags::via<Int_MM>);
+    deserialize(input4, &ref, tags::append, tags::via<Int_MM>);
     EXPECT_EQ(ref, ints012345);
 }

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -44,11 +44,11 @@ void SoundList::FromFile(const Blob &data_mm6, const Blob &data_mm7, const Blob 
     std::vector<SoundInfo> sounds;
 
     if (data_mm6)
-        deserialize(data_mm6, &sounds, append(), via<SoundInfo_MM6>());
+        deserialize(data_mm6, &sounds, tags::append, tags::via<SoundInfo_MM6>);
     if (data_mm7)
-        deserialize(data_mm7, &sounds, append(), via<SoundInfo_MM7>());
+        deserialize(data_mm7, &sounds, tags::append, tags::via<SoundInfo_MM7>);
     if (data_mm8)
-        deserialize(data_mm8, &sounds, append(), via<SoundInfo_MM7>());
+        deserialize(data_mm8, &sounds, tags::append, tags::via<SoundInfo_MM7>);
 
     assert(!sounds.empty());
 

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -44,11 +44,11 @@ void SoundList::FromFile(const Blob &data_mm6, const Blob &data_mm7, const Blob 
     std::vector<SoundInfo> sounds;
 
     if (data_mm6)
-        deserialize(data_mm6, &sounds, appendVia<SoundInfo_MM6>());
+        deserialize(data_mm6, &sounds, append(), via<SoundInfo_MM6>());
     if (data_mm7)
-        deserialize(data_mm7, &sounds, appendVia<SoundInfo_MM7>());
+        deserialize(data_mm7, &sounds, append(), via<SoundInfo_MM7>());
     if (data_mm8)
-        deserialize(data_mm8, &sounds, appendVia<SoundInfo_MM7>());
+        deserialize(data_mm8, &sounds, append(), via<SoundInfo_MM7>());
 
     assert(!sounds.empty());
 

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -171,7 +171,7 @@ class AVAudioStream : public AVStreamWrapper {
                 int got_samples = swr_convert(
                     converter, dst_channels, frame->nb_samples,
                     (const uint8_t**)frame->data, frame->nb_samples);
-                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(tmp_buf.release(), tmp_size));
+                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(std::move(tmp_buf), tmp_size));
                 if (got_samples > 0) {
                     if (!result) {
                         result = tmp_blob;
@@ -251,7 +251,7 @@ class AVVideoStream : public AVStreamWrapper {
                     assert(false);
                 }
 
-                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(tmp_buf.release(), tmp_size));
+                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(std::move(tmp_buf), tmp_size));
 
                 if (!result) {
                     result = tmp_blob;
@@ -1180,7 +1180,7 @@ std::shared_ptr<Blob> AudioBaseDataSource::GetNextBuffer() {
                     pConverter, dst_channels, frame->nb_samples,
                     (const uint8_t **)frame->data, frame->nb_samples);
 
-                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(tmp_buf.release(), tmp_size));
+                std::shared_ptr<Blob> tmp_blob = std::make_shared<Blob>(Blob::fromMalloc(std::move(tmp_buf), tmp_size));
 
                 if (got_samples > 0) {
                     if (!buffer) {

--- a/src/Utility/Streams/FileInputStream.h
+++ b/src/Utility/Streams/FileInputStream.h
@@ -14,16 +14,16 @@ class FileInputStream : public InputStream {
 
     void open(std::string_view path);
 
-    bool isOpen() const {
+    [[nodiscard]] bool isOpen() const {
         return _file != nullptr;
     }
 
-    virtual size_t read(void *data, size_t size) override;
-    virtual size_t skip(size_t size) override;
+    [[nodiscard]] virtual size_t read(void *data, size_t size) override;
+    [[nodiscard]] virtual size_t skip(size_t size) override;
     virtual void close() override;
     void seek(size_t pos);
 
-    FILE *handle() {
+    [[nodiscard]] FILE *handle() {
         return _file;
     }
 

--- a/src/Utility/Streams/FileOutputStream.h
+++ b/src/Utility/Streams/FileOutputStream.h
@@ -14,7 +14,7 @@ class FileOutputStream : public OutputStream {
 
     void open(std::string_view path);
 
-    bool isOpen() const {
+    [[nodiscard]] bool isOpen() const {
         return _file != nullptr;
     }
 
@@ -23,7 +23,7 @@ class FileOutputStream : public OutputStream {
     virtual void flush() override;
     virtual void close() override;
 
-    FILE *handle() {
+    [[nodiscard]] FILE *handle() {
         return _file;
     }
 


### PR DESCRIPTION
* Renamings & docs in LOD header structs.
* Added a couple of enum TODOs.
* More `[[nodiscard]]` in stream APIs.
* Chainable tags in binary serialization & snapshots frameworks.
* All tags moved to `namespace tags` so that we have less wtfs at call site.