### PR TITLE
require cmake 3.24 for linux

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -40,6 +40,7 @@ add_subdirectory(openal_soft)
 if(BUILD_PLATFORM STREQUAL "linux")
     find_package(SDL2 CONFIG REQUIRED GLOBAL) # GLOBAL is required for SDL2 to be available in src/
     add_library(SDL2::SDL2OE ALIAS SDL2::SDL2) # Link dynamically on linux.
+    cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 else()
     set(SDL_TEST OFF)
     set(SDL_SHARED OFF)


### PR DESCRIPTION
This change "solves" issue about error message on linux:
```
CMake Error at test/Bin/GameTest/CMakeLists.txt:10 (add_executable):
  Target "OpenEnroth_GameTest" links to target "SDL2::SDL2OE" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```
This error appeared in 142c1ed41071e297faaed2b2f12265203cb6ac5c

If nothing else works, merge it :)