### PR TITLE
Force game engine resume before exit to properly handle SIGINT from console

### DIFF
--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -574,6 +574,7 @@ bool GameWindowHandler::closeEvent(const PlatformWindowEvent *event) {
 
     // TODO(captainurist): That's a very convoluted way to exit the game, redo this properly once we have a unified
     //                     event loop.
+    dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_APP_INACTIVE;
     application()->get<EngineControlComponent>()->runControlRoutine([] (EngineController *game) {
         game->goToMainMenu();
         game->pressGuiButton("MainMenu_ExitGame");


### PR DESCRIPTION
When window lose focus engine becomes inactive.
This in turn prevents current game exiting method to work if it is requested (for example by using Ctrl+C in console).