### PR TITLE
resolve amd shader compile error

### DIFF
--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,5 +1,7 @@
 precision highp float;
-//precision highp usamplerBuffer;
+#ifdef GL_ES
+precision highp usamplerBuffer;
+#endif
 
 in vec4 colour;
 in vec2 texuv;

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,6 +1,6 @@
+precision highp float;
 #ifdef GL_ES
-    precision highp float;
-    precision highp sampler2DArray;
+precision highp usamplerBuffer;
 #endif
 
 in vec4 colour;

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,5 +1,5 @@
-precision highp float;
 #ifdef GL_ES
+    precision highp float;
     precision highp sampler2DArray;
 #endif
 

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,5 +1,5 @@
+precision highp float;
 #ifdef GL_ES
-    precision highp float;
     precision highp sampler2DArray;
 #endif
 

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp usamplerBuffer;
+    precision highp float;
+    precision highp usamplerBuffer;
 #endif
 
 in vec4 colour;

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,5 +1,5 @@
 precision highp float;
-precision highp usamplerBuffer;
+//precision highp usamplerBuffer;
 
 in vec4 colour;
 in vec2 texuv;

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp usamplerBuffer;
+    precision highp float;
+    precision highp sampler2DArray;
 #endif
 
 in vec4 colour;

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -1,5 +1,5 @@
 precision highp float;
-precision highp sampler2DArray;
+//precision highp sampler2DArray;
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp sampler2DArray;
+    precision highp float;
+    precision highp sampler2DArray;
 #endif
 
 in vec4 vertexColour;

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -1,5 +1,7 @@
 precision highp float;
-//precision highp sampler2DArray;
+#ifdef GL_ES
+precision highp sampler2DArray;
+#endif
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/gldecalshader.frag
+++ b/resources/shaders/gldecalshader.frag
@@ -1,4 +1,6 @@
-precision highp float;
+#ifdef GL_ES
+    precision highp float;
+#endif
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/glforcepershader.frag
+++ b/resources/shaders/glforcepershader.frag
@@ -1,4 +1,6 @@
-precision highp float;
+#ifdef GL_ES
+    precision highp float;
+#endif
 
 in vec4 colour;
 in vec4 texuv;

--- a/resources/shaders/gllinesshader.frag
+++ b/resources/shaders/gllinesshader.frag
@@ -1,4 +1,6 @@
-precision highp float;
+#ifdef GL_ES
+    precision highp float;
+#endif
 
 in vec4 colour;
 

--- a/resources/shaders/glnuklear.frag
+++ b/resources/shaders/glnuklear.frag
@@ -1,4 +1,7 @@
-precision highp float;
+#ifdef GL_ES
+    precision highp float;
+#endif
+
 uniform sampler2D Texture;
 
 in vec2 Frag_UV;

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -1,5 +1,5 @@
 precision highp float;
-precision highp sampler2DArray;
+//precision highp sampler2DArray;
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp sampler2DArray;
+    precision highp float;
+    precision highp sampler2DArray;
 #endif
 
 in vec4 vertexColour;

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -1,5 +1,7 @@
 precision highp float;
-//precision highp sampler2DArray;
+#ifdef GL_ES
+precision highp sampler2DArray;
+#endif
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/glterrain.frag
+++ b/resources/shaders/glterrain.frag
@@ -1,5 +1,5 @@
 precision highp float;
-precision highp sampler2DArray;
+//precision highp sampler2DArray;
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/glterrain.frag
+++ b/resources/shaders/glterrain.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp sampler2DArray;
+    precision highp float;
+    precision highp sampler2DArray;
 #endif
 
 in vec4 vertexColour;

--- a/resources/shaders/glterrain.frag
+++ b/resources/shaders/glterrain.frag
@@ -1,5 +1,7 @@
 precision highp float;
-//precision highp sampler2DArray;
+#ifdef GL_ES
+precision highp sampler2DArray;
+#endif
 
 in vec4 vertexColour;
 in vec2 texuv;

--- a/resources/shaders/gltextshader.frag
+++ b/resources/shaders/gltextshader.frag
@@ -1,4 +1,6 @@
-precision highp float;
+#ifdef GL_ES
+    precision highp float;
+#endif
 
 in vec4 colour;
 in vec2 texuv;

--- a/resources/shaders/gltwodshader.frag
+++ b/resources/shaders/gltwodshader.frag
@@ -1,5 +1,7 @@
 precision highp float;
-//precision highp usamplerBuffer;
+#ifdef GL_ES
+precision highp usamplerBuffer;
+#endif
 
 in vec4 colour;
 in vec2 texuv;

--- a/resources/shaders/gltwodshader.frag
+++ b/resources/shaders/gltwodshader.frag
@@ -1,6 +1,6 @@
-precision highp float;
 #ifdef GL_ES
-precision highp usamplerBuffer;
+    precision highp float;
+    precision highp usamplerBuffer;
 #endif
 
 in vec4 colour;

--- a/resources/shaders/gltwodshader.frag
+++ b/resources/shaders/gltwodshader.frag
@@ -1,5 +1,5 @@
 precision highp float;
-precision highp usamplerBuffer;
+//precision highp usamplerBuffer;
 
 in vec4 colour;
 in vec2 texuv;


### PR DESCRIPTION
Default precision qualifiers in GLSL 3.30 cannot be applied to sampler types. Or any type other than int or float. precision lowp sampler2D; is a valid statement, but only in OpenGL ES, not regular OpenGL.

Fixes #1120 