### PR TITLE
Don't route GraphicsImage creation through IRender

### DIFF
--- a/src/Engine/AssetsManager.cpp
+++ b/src/Engine/AssetsManager.cpp
@@ -1,11 +1,12 @@
 #include "Engine/AssetsManager.h"
 
-#include <algorithm>
+#include <memory>
 
-#include "Engine/Graphics/IRender.h"
 #include "Engine/Graphics/ImageLoader.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/EngineIocContainer.h"
+#include "Engine/LodTextureCache.h"
+#include "Engine/LodSpriteCache.h"
 
 #include "GUI/GUIFont.h"
 
@@ -29,8 +30,6 @@ void AssetsManager::releaseAllTextures() {
     }
 
     ReloadFonts();
-
-    return;
 }
 
 bool AssetsManager::releaseImage(const std::string &name) {
@@ -51,7 +50,7 @@ GraphicsImage *AssetsManager::getImage_Paletted(const std::string &name) {
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_Paletted(name);
+        auto image = GraphicsImage::Create(std::make_unique<Paletted_Img_Loader>(pIcons_LOD, filename));
         images[filename] = image;
         return image;
     }
@@ -65,7 +64,7 @@ GraphicsImage *AssetsManager::getImage_ColorKey(const std::string &name, Color c
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_ColorKey(name, colorkey);
+        auto image = GraphicsImage::Create(std::make_unique<ColorKey_LOD_Loader>(pIcons_LOD, filename, colorkey));
         images[filename] = image;
         return image;
     }
@@ -80,7 +79,7 @@ GraphicsImage *AssetsManager::getImage_Solid(const std::string &name) {
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_Solid(name);
+        auto image = GraphicsImage::Create(std::make_unique<Image16bit_LOD_Loader>(pIcons_LOD, filename));
         images[filename] = image;
         return image;
     }
@@ -93,7 +92,7 @@ GraphicsImage *AssetsManager::getImage_Alpha(const std::string &name) {
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_Alpha(name);
+        auto image = GraphicsImage::Create(std::make_unique<Alpha_LOD_Loader>(pIcons_LOD, filename));
         images[filename] = image;
         return image;
     }
@@ -106,20 +105,7 @@ GraphicsImage *AssetsManager::getImage_PCXFromIconsLOD(const std::string &name) 
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_PCXFromIconsLOD(name);
-        images[filename] = image;
-        return image;
-    }
-
-    return i->second;
-}
-
-GraphicsImage *AssetsManager::getImage_PCXFromNewLOD(const std::string &name) {
-    std::string filename = toLower(name);
-
-    auto i = images.find(filename);
-    if (i == images.end()) {
-        auto image = render->CreateTexture_PCXFromNewLOD(name);
+        auto image = GraphicsImage::Create(std::make_unique<PCX_LOD_Compressed_Loader>(pIcons_LOD, filename));
         images[filename] = image;
         return image;
     }
@@ -132,7 +118,7 @@ GraphicsImage *AssetsManager::getImage_PCXFromFile(const std::string &name) {
 
     auto i = images.find(filename);
     if (i == images.end()) {
-        auto image = render->CreateTexture_PCXFromFile(name);
+        auto image = GraphicsImage::Create(std::make_unique<PCX_File_Loader>(filename));
         images[filename] = image;
         return image;
     }
@@ -145,9 +131,9 @@ GraphicsImage *AssetsManager::getBitmap(const std::string &name) {
 
     auto i = bitmaps.find(filename);
     if (i == bitmaps.end()) {
-        auto texture = render->CreateTexture(filename);
-        bitmaps[filename] = texture;
-        return texture;
+        auto image = GraphicsImage::Create(std::make_unique<Bitmaps_LOD_Loader>(pBitmaps_LOD, filename));
+        bitmaps[filename] = image;
+        return image;
     }
 
     return i->second;
@@ -171,9 +157,9 @@ GraphicsImage *AssetsManager::getSprite(const std::string &name) {
 
     auto i = sprites.find(filename);
     if (i == sprites.end()) {
-        auto texture = render->CreateSprite(filename);
-        sprites[filename] = texture;
-        return texture;
+        auto image = GraphicsImage::Create(std::make_unique<Sprites_LOD_Loader>(pSprites_LOD, filename));
+        sprites[filename] = image;
+        return image;
     }
 
     return i->second;

--- a/src/Engine/AssetsManager.h
+++ b/src/Engine/AssetsManager.h
@@ -25,7 +25,6 @@ class AssetsManager {
 
     GraphicsImage *getImage_PCXFromFile(const std::string &name);
     GraphicsImage *getImage_PCXFromIconsLOD(const std::string &name);
-    GraphicsImage *getImage_PCXFromNewLOD(const std::string &name);
 
     GraphicsImage *getBitmap(const std::string &name);
     GraphicsImage *getSprite(const std::string &name);

--- a/src/Engine/Graphics/IRender.h
+++ b/src/Engine/Graphics/IRender.h
@@ -58,22 +58,6 @@ class IRender {
     virtual struct nk_image NuklearImageLoad(GraphicsImage *img) = 0;
     virtual void NuklearImageFree(GraphicsImage *img) = 0;
 
-    virtual GraphicsImage *CreateTexture_Paletted(const std::string &name) = 0;
-    virtual GraphicsImage *CreateTexture_ColorKey(const std::string &name, Color colorkey) = 0;
-    virtual GraphicsImage *CreateTexture_Solid(const std::string &name) = 0;
-    virtual GraphicsImage *CreateTexture_Alpha(const std::string &name) = 0;
-
-    virtual GraphicsImage *CreateTexture_PCXFromFile(const std::string &name) = 0;
-    virtual GraphicsImage *CreateTexture_PCXFromIconsLOD(const std::string &name) = 0;
-    virtual GraphicsImage *CreateTexture_PCXFromNewLOD(const std::string &name) = 0;
-    virtual GraphicsImage *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) = 0;
-
-    virtual GraphicsImage *CreateTexture_Blank(unsigned int width, unsigned int height) = 0;
-    virtual GraphicsImage *CreateTexture_Blank(RgbaImage image) = 0;
-
-    virtual GraphicsImage *CreateTexture(const std::string &name) = 0;
-    virtual GraphicsImage *CreateSprite(const std::string &name) = 0;
-
     virtual void ClearBlack() = 0;
     virtual void PresentBlackScreen() = 0;
 

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -244,7 +244,7 @@ void RenderOpenGL::SaveWinnersCertificate(const std::string &filePath) {
     SavePCXImage32(filePath, sPixels);
 
     // reverse input and save to texture for later
-    assets->winnerCert = CreateTexture_Blank(std::move(sPixels));
+    assets->winnerCert = GraphicsImage::Create(std::move(sPixels));
 }
 
 bool RenderOpenGL::InitializeFullscreen() {
@@ -803,7 +803,7 @@ void RenderOpenGL::BlendTextures(int x, int y, GraphicsImage *imgin, GraphicsIma
 
         int w = imgin->width();
         int h = imgin->height();
-        GraphicsImage *temp = render->CreateTexture_Blank(w, h);
+        GraphicsImage *temp = GraphicsImage::Create(w, h);
         RgbaImage &dstImage = temp->rgba();
 
         Color c = maskImage.pixels()[2700];  // guess at brightest pixel
@@ -881,7 +881,7 @@ void RenderOpenGL::TexturePixelRotateDraw(float u, float v, GraphicsImage *img, 
             int width = img->width();
             int height = img->height();
             if (!cachedtemp[thisslot]) {
-                cachedtemp[thisslot] = CreateTexture_Blank(width, height);
+                cachedtemp[thisslot] = GraphicsImage::Create(width, height);
             }
 
             const Palette &palette = img->palette();

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -617,7 +617,7 @@ Blob RenderBase::PackScreenshot(const unsigned int width, const unsigned int hei
 }
 
 GraphicsImage *RenderBase::TakeScreenshot(const unsigned int width, const unsigned int height) {
-    return CreateTexture_Blank(MakeScreenshot32(width, height));
+    return GraphicsImage::Create(MakeScreenshot32(width, height));
 }
 
 void RenderBase::DrawTextureGrayShade(float a2, float a3, GraphicsImage *a4) {
@@ -734,52 +734,4 @@ void RenderBase::PresentBlackScreen() {
     BeginScene2D();
     ClearBlack();
     Present();
-}
-
-GraphicsImage *RenderBase::CreateTexture_Paletted(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<Paletted_Img_Loader>(pIcons_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_ColorKey(const std::string &name, Color colorkey) {
-    return GraphicsImage::Create(std::make_unique<ColorKey_LOD_Loader>(pIcons_LOD, name, colorkey));
-}
-
-GraphicsImage *RenderBase::CreateTexture_Solid(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<Image16bit_LOD_Loader>(pIcons_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_Alpha(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<Alpha_LOD_Loader>(pIcons_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_PCXFromIconsLOD(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<PCX_LOD_Compressed_Loader>(pIcons_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_PCXFromNewLOD(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<PCX_LOD_Compressed_Loader>(pSave_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_PCXFromFile(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<PCX_File_Loader>(name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<PCX_LOD_Raw_Loader>(pLOD, name));
-}
-
-GraphicsImage *RenderBase::CreateTexture_Blank(unsigned int width, unsigned int height) {
-    return GraphicsImage::Create(width, height);
-}
-
-GraphicsImage *RenderBase::CreateTexture_Blank(RgbaImage image) {
-    return GraphicsImage::Create(std::move(image));
-}
-
-GraphicsImage *RenderBase::CreateTexture(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<Bitmaps_LOD_Loader>(pBitmaps_LOD, name));
-}
-
-GraphicsImage *RenderBase::CreateSprite(const std::string &name) {
-    return GraphicsImage::Create(std::make_unique<Sprites_LOD_Loader>(pSprites_LOD, name));
 }

--- a/src/Engine/Graphics/RenderBase.h
+++ b/src/Engine/Graphics/RenderBase.h
@@ -52,22 +52,6 @@ class RenderBase : public IRender {
     virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene() override;
     virtual void PresentBlackScreen() override;
 
-    virtual GraphicsImage *CreateTexture_Paletted(const std::string &name) override;
-    virtual GraphicsImage *CreateTexture_ColorKey(const std::string &name, Color colorkey) override;
-    virtual GraphicsImage *CreateTexture_Solid(const std::string &name) override;
-    virtual GraphicsImage *CreateTexture_Alpha(const std::string &name) override;
-
-    virtual GraphicsImage *CreateTexture_PCXFromFile(const std::string &name) override;
-    virtual GraphicsImage *CreateTexture_PCXFromIconsLOD(const std::string &name) override;
-    virtual GraphicsImage *CreateTexture_PCXFromNewLOD(const std::string &name) override;
-    virtual GraphicsImage *CreateTexture_PCXFromLOD(LOD::File *pLOD, const std::string &name) override;
-
-    virtual GraphicsImage *CreateTexture_Blank(unsigned int width, unsigned int height) override;
-    virtual GraphicsImage *CreateTexture_Blank(RgbaImage image) override;
-
-    virtual GraphicsImage *CreateTexture(const std::string &name) override;
-    virtual GraphicsImage *CreateSprite(const std::string &name) override;
-
  protected:
     unsigned int Billboard_ProbablyAddToListAndSortByZOrder(float z);
     void TransformBillboard(const SoftwareBillboard *a2, const RenderBillboard *pBillboard);

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <algorithm>
 #include <string>
+#include <memory>
 
 #include "Engine/Engine.h"
 #include "Engine/LOD.h"
@@ -74,7 +75,7 @@ void LoadGame(unsigned int uSlot) {
             LloydBeacon &beacon = player->vBeacons[j];
             std::string str = fmt::format("lloyd{}{}.pcx", i + 1, j + 1);
             //beacon.image = Image::Create(new PCX_LOD_Raw_Loader(pNew_LOD, str));
-            beacon.image = render->CreateTexture_PCXFromLOD(pSave_LOD, str);
+            beacon.image = GraphicsImage::Create(std::make_unique<PCX_LOD_Raw_Loader>(pSave_LOD, str));
             beacon.image->rgba(); // Force load!
         }
     }

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -97,8 +97,8 @@ GUIFont *GUIFont::LoadFont(const char *pFontFile, const char *pFontPalette) {
 void GUIFont::CreateFontTex() {
     this->ReleaseFontTex();
     // create blank textures
-    this->fonttex = render->CreateTexture_Blank(512, 512);
-    this->fontshadow = render->CreateTexture_Blank(512, 512);
+    this->fonttex = GraphicsImage::Create(512, 512);
+    this->fontshadow = GraphicsImage::Create(512, 512);
     Color *pPixelsfont = this->fonttex->rgba().pixels().data();
     Color *pPixelsshadow = this->fontshadow->rgba().pixels().data();
 

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -177,7 +177,7 @@ void DrawBook_Map_sub(unsigned int tl_x, unsigned int tl_y, unsigned int br_x, i
 
         static GraphicsImage *minimaptemp = nullptr;
         if (!minimaptemp) {
-            minimaptemp = render->CreateTexture_Blank(screenWidth, screenHeight);
+            minimaptemp = GraphicsImage::Create(screenWidth, screenHeight);
         }
         Color *minitempix = minimaptemp->rgba().pixels().data();
         const Color *minimap_pixels = viewparams->location_minimap->rgba().pixels().data();

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -33,7 +33,7 @@ GUICredits::GUICredits() :
 
     width = 250;
     height = pFontQuick->GetStringHeight2(pFontCChar, text, &credit_window, 0, 1) + 2 * credit_window.uFrameHeight;
-    cred_texture = render->CreateTexture_Blank(width, height);
+    cred_texture = GraphicsImage::Create(width, height);
 
     pFontQuick->DrawCreditsEntry(pFontCChar, 0, credit_window.uFrameHeight, width, height, colorTable.CornFlowerBlue, colorTable.Primrose, text, cred_texture);
 

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1437,7 +1437,7 @@ void GameUI_DrawMinimap(unsigned int uX, unsigned int uY, unsigned int uZ,
     if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
         static GraphicsImage *minimaptemp;
         if (!minimaptemp) {
-            minimaptemp = render->CreateTexture_Blank(uWidth, uHeight);
+            minimaptemp = GraphicsImage::Create(uWidth, uHeight);
         }
 
         static uint16_t pOdmMinimap[117][137];

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <filesystem>
 #include <algorithm>
+#include <memory>
 
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
@@ -85,7 +86,7 @@ GUIWindow_Save::GUIWindow_Save() :
                 pSavegameList->pSavegameHeader[i].name = test;
             }
 
-            pSavegameList->pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
+            pSavegameList->pSavegameThumbnails[i] = GraphicsImage::Create(std::make_unique<PCX_LOD_Raw_Loader>(&pLODFile, "image.pcx"));
             if (pSavegameList->pSavegameThumbnails[i]->width() == 0) {
                 pSavegameList->pSavegameThumbnails[i]->Release();
                 pSavegameList->pSavegameThumbnails[i] = nullptr;
@@ -199,7 +200,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
             pSavegameList->pSavegameHeader[i].name = test;
         }
 
-        pSavegameList->pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
+        pSavegameList->pSavegameThumbnails[i] = GraphicsImage::Create(std::make_unique<PCX_LOD_Raw_Loader>(&pLODFile, "image.pcx"));
 
         if (pSavegameList->pSavegameThumbnails[i]->width() == 0) {
             pSavegameList->pSavegameThumbnails[i]->Release();

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -487,7 +487,7 @@ class Movie : public IMovie {
 
 
         // create texture
-        GraphicsImage *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
+        GraphicsImage *tex = GraphicsImage::Create(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
 
         // holds decoded audio
         std::queue<std::shared_ptr<Blob>, std::deque<std::shared_ptr<Blob>>> buffq;
@@ -806,7 +806,7 @@ void MPlayer::HouseMovieLoop() {
 
     static GraphicsImage *tex;
     if (!tex) {
-        tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
+        tex = GraphicsImage::Create(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
     }
 
     std::shared_ptr<Blob> buffer = pMovie_Track->GetFrame();
@@ -871,7 +871,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
     Sizei scaleSize;
 
     // create texture
-    GraphicsImage *tex = render->CreateTexture_Blank(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
+    GraphicsImage *tex = GraphicsImage::Create(pMovie_Track->GetWidth(), pMovie_Track->GetHeight());
 
     if (pMovie->GetFormat() == "bink") {
         logger->verbose("bink file");


### PR DESCRIPTION
Doing minor `IRender` cleanup, preparing for `NullRender`.