### PR TITLE
Don't cancel workflow runs on new commits

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,9 +6,9 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build_android:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,9 +6,9 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build_linux:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,9 +6,9 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build_macos:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,9 +6,9 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build_windows:


### PR DESCRIPTION
Note: I'm commenting the code instead of removing it in case we'll need to use this piece in other workflows. GH actions is magic, don't want to lose this esoteric knowledge.