### PR TITLE
Use std::abs to avoid float to int conversion

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -204,7 +204,7 @@ static bool CollideWithCylinder(const Vec3f &center_lo, float radius, float heig
     // This in turn is the distance from cylinder center to the line of actor's movement.
     Vec3f dir = collision_state.direction;
     float closest_dist = dist_x * dir.y - dist_y * dir.x;
-    if (abs(closest_dist) > sum_radius)
+    if (std::abs(closest_dist) > sum_radius)
         return false; // No chance to collide.
 
     // Length of dist vector projected onto collision_state.direction.
@@ -291,7 +291,7 @@ void CollideIndoorWithGeometry(bool ignore_ethereal) {
         if (!collision_state.bbox.intersects(pFace->pBounding))
             continue;
 
-        float distance = abs(pFace->facePlane.signedDistanceTo(collision_state.position_lo));
+        float distance = std::abs(pFace->facePlane.signedDistanceTo(collision_state.position_lo));
         if(distance > collision_state.move_distance + 16)
             continue;
 
@@ -440,7 +440,7 @@ void _46ED8A_collide_against_sprite_objects(Pid pid) {
 
         Vec3f dir = collision_state.direction;
         float closest_dist = dist_x * dir.y - dist_y * dir.x;
-        if (abs(closest_dist) > sum_radius)
+        if (std::abs(closest_dist) > sum_radius)
             continue;
 
         float dist_dot_dir = dist_x * dir.x + dist_y * dir.y;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -452,9 +452,9 @@ int IndoorLocation::GetSector(int sX, int sY, int sZ) {
         for (int s = 0; s < NumFoundFaceStore; ++s) {
             // calc distance between this face and party
             if (this->pFaces[FoundFaceStore[s]].uPolygonType == POLYGON_Floor)
-                CalcZDist = abs(sZ - this->pVertices[*this->pFaces[FoundFaceStore[s]].pVertexIDs].z);
+                CalcZDist = std::abs(sZ - this->pVertices[*this->pFaces[FoundFaceStore[s]].pVertexIDs].z);
             if (this->pFaces[FoundFaceStore[s]].uPolygonType == POLYGON_InBetweenFloorAndWall) {
-                CalcZDist = abs(sZ - this->pFaces[FoundFaceStore[s]].zCalc.calculate(sX, sY));
+                CalcZDist = std::abs(sZ - this->pFaces[FoundFaceStore[s]].zCalc.calculate(sX, sY));
             }
 
             // use this face if its smaller than the current min
@@ -499,7 +499,7 @@ void BLVFace::_get_normals(Vec3f *outU, Vec3f *outV) {
         outV->z = 0;
 
     } else if (this->uPolygonType == POLYGON_InBetweenFloorAndWall || this->uPolygonType == POLYGON_InBetweenCeilingAndWall) {
-        if (abs(this->facePlane.normal.z) < 0.70863342285f) { // Was 46441 fixpoint
+        if (std::abs(this->facePlane.normal.z) < 0.70863342285f) { // Was 46441 fixpoint
             outU->x = -this->facePlane.normal.y;
             outU->y = this->facePlane.normal.x;
             outU->z = 0;
@@ -1131,7 +1131,7 @@ int BLV_GetFloorLevel(const Vec3i &pos, int uSectorID, int *pFaceID) {
     for (uint i = 1; i < FacesFound; ++i) {
         int v38 = blv_floor_z[i];
 
-        if (abs(pos.z - v38) <= abs(pos.z - result)) {
+        if (std::abs(pos.z - v38) <= std::abs(pos.z - result)) {
             result = blv_floor_z[i];
             if (blv_floor_z[i] <= -29000) __debugbreak();
             faceId = blv_floor_id[i];
@@ -1186,7 +1186,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
     v9 = ((signed int)(TrigLUT.uIntegerPi + v8) >> 8) & 7;
     int v37 = pEventTimer->uTotalTimeElapsed;
     if (pParty->bTurnBasedModeOn) v37 = pMiscTimer->uTotalTimeElapsed;
-    v10 = abs(pLevelDecorations[uDecorationID].vPosition.x +
+    v10 = std::abs(pLevelDecorations[uDecorationID].vPosition.x +
               pLevelDecorations[uDecorationID].vPosition.y);
     v11 = pSpriteFrameTable->GetFrame(decoration->uSpriteID, v37 + v10);
 
@@ -1209,7 +1209,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
                                    &view_x, &view_y, &view_z);
 
     if (visible) {
-        if (2 * abs(view_x) >= abs(view_y)) {
+        if (2 * std::abs(view_x) >= std::abs(view_y)) {
             int projected_x = 0;
             int projected_y = 0;
             pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
@@ -1339,7 +1339,7 @@ bool Check_LOS_Obscurred_Indoors(const Vec3i &target, const Vec3i &from) {  // t
             }
 
             // TODO(captainurist): what's going on in this check?
-            if (abs(NegFacePlaceDist) / 16384.0f <= abs(dirDotNormal)) {
+            if (std::abs(NegFacePlaceDist) / 16384.0f <= std::abs(dirDotNormal)) {
                 float IntersectionDist = NegFacePlaceDist / dirDotNormal;
                 // less than zero means intersection is behind target point
                 if (IntersectionDist >= 0) {
@@ -1387,7 +1387,7 @@ bool Check_LOS_Obscurred_Outdoors_Bmodels(const Vec3i &target, const Vec3i &from
                         continue;  // can never hit
                 }
 
-                if (abs(NegFacePlaceDist) / 16384.0f <= abs(dirDotNormal)) {
+                if (std::abs(NegFacePlaceDist) / 16384.0f <= std::abs(dirDotNormal)) {
                     // calc how far along line interesction is
                     float IntersectionDist = NegFacePlaceDist /  dirDotNormal;
                     // less than zero means intersection is behind target point
@@ -1796,7 +1796,7 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 if (pParty->floor_face_id != PID_ID(collision_state.pid) && pFace->Pressure_Plate())
                     faceEvent = pIndoor->pFaceExtras[pFace->uFaceExtraID].uEventID;
             } else { // Not floor
-                int speed_dot_normal = abs(
+                int speed_dot_normal = std::abs(
                     pParty->speed.x * pFace->facePlane.normal.x +
                     pParty->speed.y * pFace->facePlane.normal.y +
                     pParty->speed.z * pFace->facePlane.normal.z);
@@ -2009,11 +2009,11 @@ int CalcDistPointToLine(int x1, int y1, int x2, int y2, int x3, int y3) {
 
     signed int result;
     // calc line length
-    result = integer_sqrt(abs(x2 - x1) * abs(x2 - x1) + abs(y2 - y1) * abs(y2 - y1));
+    result = integer_sqrt(std::abs(x2 - x1) * std::abs(x2 - x1) + std::abs(y2 - y1) * std::abs(y2 - y1));
 
     // orthogonal projection from line to point
     if (result)
-        result = abs(((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / result);
+        result = std::abs(((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / result);
 
     return result;
 }
@@ -2053,8 +2053,8 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
 
             // check spawn point is not in a model
             for (BSPModel &model : pOutdoor->pBModels) {
-                dist_y = abs(enc_spawn_point.vPosition.y - model.vBoundingCenter.y);
-                dist_x = abs(enc_spawn_point.vPosition.x - model.vBoundingCenter.x);
+                dist_y = std::abs(enc_spawn_point.vPosition.y - model.vBoundingCenter.y);
+                dist_x = std::abs(enc_spawn_point.vPosition.x - model.vBoundingCenter.x);
                 if (int_get_vector_length(dist_x, dist_y, 0) <
                     model.sBoundingRadius + 256) {
                     not_in_model = 1;
@@ -2092,7 +2092,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
                 enc_spawn_point.vPosition.z = indoor_floor_level;
                 if (indoor_floor_level != -30000) {
                     // break if spanwn point is okay
-                    if (abs(indoor_floor_level - pParty->pos.z) <= 1024) break;
+                    if (std::abs(indoor_floor_level - pParty->pos.z) <= 1024) break;
                 }
             }
         }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1390,7 +1390,7 @@ void OutdoorLocation::PrepareActorsDrawList() {
         bool visible = pCamera3D->ViewClip(x, y, z, &view_x, &view_y, &view_z);
 
         if (visible) {
-            if (2 * abs(view_x) >= abs(view_y)) {
+            if (2 * std::abs(view_x) >= std::abs(view_y)) {
                 int projected_x = 0;
                 int projected_y = 0;
                 pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
@@ -1555,8 +1555,8 @@ void ODM_GetTerrainNormalAt(int pos_x, int pos_y, Vec3i *out) {
 
     //float side1_dx, side1_dz, side1_dy, side2_dx, side2_dz, side2_dy;
 
-    int dx = abs(pos_x - grid_pos_x1);
-    int dy = abs(grid_pos_y1 - pos_y);
+    int dx = std::abs(pos_x - grid_pos_x1);
+    int dy = std::abs(grid_pos_y1 - pos_y);
     if (dy >= dx) {
         side2 = Vec3f(grid_pos_x2 - grid_pos_x1, 0.0f, x2y2_z - x1y2_z);
         side1 = Vec3f(0.0f, grid_pos_y1 - grid_pos_y2, x1y1_z - x1y2_z);
@@ -2023,7 +2023,7 @@ void ODM_ProcessPartyActions() {
                 Vec3i v98;
                 ODM_GetTerrainNormalAt(partyNewX, partyNewY, &v98);
                 int v35 = partyInputZSpeed + (8 * -(pEventTimer->uTimeElapsed * GetGravityStrength()));
-                int dot = abs(partyInputXSpeed * v98.x + partyInputYSpeed * v98.y + v35 * v98.z) >> 16;
+                int dot = std::abs(partyInputXSpeed * v98.x + partyInputYSpeed * v98.y + v35 * v98.z) >> 16;
                 partyInputXSpeed += fixpoint_mul(dot, v98.x);
                 partyInputYSpeed += fixpoint_mul(dot, v98.y);
                 partyInputZSpeed = v35 + fixpoint_mul(dot, v98.z);
@@ -2195,7 +2195,7 @@ void ODM_ProcessPartyActions() {
                 partySlopeMod = true;
 
                 // push party away from the surface
-                int dot = abs(partyInputYSpeed * pODMFace->facePlane.normal.y +
+                int dot = std::abs(partyInputYSpeed * pODMFace->facePlane.normal.y +
                            partyInputZSpeed * pODMFace->facePlane.normal.z +
                            partyInputXSpeed * pODMFace->facePlane.normal.x);
                 if ((collision_state.speed / 8) > dot)
@@ -2220,7 +2220,7 @@ void ODM_ProcessPartyActions() {
                 pParty->uFlags &= ~(PARTY_FLAGS_1_LANDING | PARTY_FLAGS_1_JUMPING);
 
                 // this pushes party slightly up away from the surface so you can climb it
-                float dot = abs(partyInputYSpeed * pODMFace->facePlane.normal.y +
+                float dot = std::abs(partyInputYSpeed * pODMFace->facePlane.normal.y +
                            partyInputZSpeed * pODMFace->facePlane.normal.z +
                            partyInputXSpeed * pODMFace->facePlane.normal.x);
                 if ((collision_state.speed / 8) > dot)
@@ -2597,7 +2597,7 @@ void UpdateActors_ODM() {
                 uint16_t Gravity = GetGravityStrength();
 
                 pActors[Actor_ITR].speed.z += -16 * pEventTimer->uTimeElapsed * Gravity;
-                int v73 = abs(Terrain_Norm.x * pActors[Actor_ITR].speed.x +
+                int v73 = std::abs(Terrain_Norm.x * pActors[Actor_ITR].speed.x +
                               Terrain_Norm.z * pActors[Actor_ITR].speed.z +
                               Terrain_Norm.y * pActors[Actor_ITR].speed.y) >> 15;
 
@@ -2891,7 +2891,7 @@ bool IsTerrainSlopeTooHigh(int pos_x, int pos_y) {
         party_x2z2_y == party_x1z2_y)
         return false;
 
-    int dx = abs(pos_x - party_grid_x1), dz = abs(party_grid_z1 - pos_y);
+    int dx = std::abs(pos_x - party_grid_x1), dz = std::abs(party_grid_z1 - pos_y);
 
     int y1, y2, y3;
     if (dz >= dx) {
@@ -2973,7 +2973,7 @@ int GetTerrainHeightsAroundParty2(int x, int y, bool *pIsOnWater, int bFloatAbov
     v14 = 0;
     if (!bFloatAboveWater && *pIsOnWater) v14 = -60;
     if (y_x1z1 != y_x2z1 || y_x2z1 != y_x2z2 || y_x2z2 != y_x1z2) {
-        if (abs(grid_y1 - y) >= abs(x - grid_x1)) {
+        if (std::abs(grid_y1 - y) >= std::abs(x - grid_x1)) {
             v8 = y_x1z2;
             v9 = y_x2z2;
             v10 = y_x1z1;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -726,9 +726,9 @@ void Actor::AggroSurroundingPeasants(unsigned int uActorID, int a2) {
         if (!actor->CanAct() || i == uActorID) continue;
 
         if (Actor::ArePeasantsOfSameFaction(victim, actor)) {
-            v4 = abs(actor->pos.x - victim->pos.x);
-            v5 = abs(actor->pos.y - victim->pos.y);
-            v6 = abs(actor->pos.z - victim->pos.z);
+            v4 = std::abs(actor->pos.x - victim->pos.x);
+            v5 = std::abs(actor->pos.y - victim->pos.y);
+            v6 = std::abs(actor->pos.z - victim->pos.z);
             if (int_get_vector_length(v4, v5, v6) < 4096) {
                 actor->monsterInfo.uHostilityType =
                     MonsterInfo::Hostility_Long;
@@ -1611,8 +1611,8 @@ void Actor::AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,
 
     x = pActors[uActor_id].initialPosition.x - pActors[uActor_id].pos.x;
     y = pActors[uActor_id].initialPosition.y - pActors[uActor_id].pos.y;
-    absx = abs(x);
-    absy = abs(y);
+    absx = std::abs(x);
+    absy = std::abs(y);
     if (absx <= absy)
         absx = absy + (absx / 2);
     else
@@ -1638,7 +1638,7 @@ void Actor::AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,
         return;
     }
     v10 = v9 + grng->random(256) - 128;
-    if (abs(v10 - pActors[uActor_id].yawAngle) > 256 &&
+    if (std::abs(v10 - pActors[uActor_id].yawAngle) > 256 &&
         !(pActors[uActor_id].attributes & ACTOR_ANIMATION)) {
         Actor::AI_Stand(uActor_id, uTarget_id, 256,
                         &doNotInitializeBecauseShouldBeRandom);
@@ -2184,9 +2184,9 @@ void Actor::_SelectTarget(unsigned int uActorID, Pid *OutTargetPID,
             v10 = pMonsterStats->pInfos[thisActor->monsterInfo.uID]
                       .uHostilityType;
         v11 = _4DF380_hostilityRanges[v10];
-        v23 = abs(thisActor->pos.x - actor->pos.x);
-        v27 = abs(thisActor->pos.y - actor->pos.y);
-        v12 = abs(thisActor->pos.z - actor->pos.z);
+        v23 = std::abs(thisActor->pos.x - actor->pos.x);
+        v27 = std::abs(thisActor->pos.y - actor->pos.y);
+        v12 = std::abs(thisActor->pos.z - actor->pos.z);
         if (v23 <= v11 && v27 <= v11 && v12 <= v11 &&
             Detect_Between_Objects(PID(OBJECT_Actor, i),
                                             PID(OBJECT_Actor, uActorID)) &&
@@ -2213,9 +2213,9 @@ void Actor::_SelectTarget(unsigned int uActorID, Pid *OutTargetPID,
                 v15 = _4DF380_hostilityRanges[v14];
             else
                 v15 = _4DF380_hostilityRanges[4];
-            uint v16 = abs(thisActor->pos.x - pParty->pos.x);
-            uint v28 = abs(thisActor->pos.y - pParty->pos.y);
-            uint v17 = abs(thisActor->pos.z - pParty->pos.z);
+            uint v16 = std::abs(thisActor->pos.x - pParty->pos.x);
+            uint v28 = std::abs(thisActor->pos.y - pParty->pos.y);
+            uint v17 = std::abs(thisActor->pos.z - pParty->pos.z);
             if (v16 <= v15 && v28 <= v15 && v17 <= v15 &&
                 (v16 * v16 + v28 * v28 + v17 * v17 < lowestRadius)) {
                 *OutTargetPID = PID(OBJECT_Character, 0);
@@ -2514,7 +2514,7 @@ void Actor::SummonMinion(int summonerId) {
         if (sectorId != actorSector) return;
         int z = BLV_GetFloorLevel(Vec3i(v15, v17, v27), sectorId);
         if (z != -30000) return;
-        if (abs(z - v27) > 1024) return;
+        if (std::abs(z - v27) > 1024) return;
     }
 
     extraSummonLevel = this->monsterInfo.uSpecialAbilityDamageDiceRolls;
@@ -3141,9 +3141,9 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
     } else {
         v61 = projectileSprite->field_60_distance_related_prolly_lod;
         if (projectileSprite->uSpellID != SPELL_DARK_SOULDRINKER) {
-            int d1 = abs(pParty->pos.x - projectileSprite->vPosition.x);
-            int d2 = abs(pParty->pos.y - projectileSprite->vPosition.y);
-            int d3 = abs(pParty->pos.z - projectileSprite->vPosition.z);
+            int d1 = std::abs(pParty->pos.x - projectileSprite->vPosition.x);
+            int d2 = std::abs(pParty->pos.y - projectileSprite->vPosition.y);
+            int d3 = std::abs(pParty->pos.z - projectileSprite->vPosition.z);
             v61 = int_get_vector_length(d1, d2, d3);
 
             if (v61 >= 5120 && !(pMonster->attributes & ACTOR_FULL_AI_STATE))  // 0x400
@@ -3671,9 +3671,9 @@ bool CheckActors_proximity() {
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) distance = 2560;
 
     for (uint i = 0; i < pActors.size(); ++i) {
-        for_x = abs(pActors[i].pos.x - pParty->pos.x);
-        for_y = abs(pActors[i].pos.y - pParty->pos.y);
-        for_z = abs(pActors[i].pos.z - pParty->pos.z);
+        for_x = std::abs(pActors[i].pos.x - pParty->pos.x);
+        for_y = std::abs(pActors[i].pos.y - pParty->pos.y);
+        for_z = std::abs(pActors[i].pos.z - pParty->pos.z);
         if (int_get_vector_length(for_x, for_y, for_z) < distance) {
             if (pActors[i].aiState != Dead) {
                 if (pActors[i].aiState != Dying &&
@@ -4073,9 +4073,9 @@ void Actor::MakeActorAIList_ODM() {
             continue;
         }
 
-        int delta_x = abs(pParty->pos.x - actor.pos.x);
-        int delta_y = abs(pParty->pos.y - actor.pos.y);
-        int delta_z = abs(pParty->pos.z - actor.pos.z);
+        int delta_x = std::abs(pParty->pos.x - actor.pos.x);
+        int delta_y = std::abs(pParty->pos.y - actor.pos.y);
+        int delta_z = std::abs(pParty->pos.z - actor.pos.z);
 
         int distance = int_get_vector_length(delta_x, delta_y, delta_z) - actor.radius;
         if (distance < 0)
@@ -4126,9 +4126,9 @@ int Actor::MakeActorAIList_BLV() {
             continue;
         }
 
-        int delta_x = abs(pParty->pos.x - actor.pos.x);
-        int delta_y = abs(pParty->pos.y - actor.pos.y);
-        int delta_z = abs(pParty->pos.z - actor.pos.z);
+        int delta_x = std::abs(pParty->pos.x - actor.pos.x);
+        int delta_y = std::abs(pParty->pos.y - actor.pos.y);
+        int delta_z = std::abs(pParty->pos.z - actor.pos.z);
 
         int distance = int_get_vector_length(delta_x, delta_y, delta_z) - actor.radius;
         if (distance < 0)
@@ -4310,7 +4310,7 @@ bool Detect_Between_Objects(Pid uObjID, Pid uObj2ID) {
             float pointplanedist = -portalface->facePlane.signedDistanceTo(pos1.toFloat());
 
             // epsilon check?
-            if (abs(pointplanedist) / 16384.0 > abs(facenotparallel)) continue;
+            if (std::abs(pointplanedist) / 16384.0 > std::abs(facenotparallel)) continue;
 
             // how far along line intersection is
             float intersect = pointplanedist / facenotparallel;
@@ -4414,7 +4414,7 @@ void Spawn_Light_Elemental(int spell_power, CharacterSkillMastery caster_skill_m
     if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR ||
             sectorId == partySectorId &&
             (zlevel = BLV_GetFloorLevel(actor->pos, sectorId), zlevel != -30000) &&
-            (zdiff = abs(zlevel - pParty->pos.z), zdiff <= 1024)) {
+            (zdiff = std::abs(zlevel - pParty->pos.z), zdiff <= 1024)) {
         actor->summonerId = PID(OBJECT_Character, spell_power);
 
         GameTime spell_length = GameTime::FromSeconds(duration_game_seconds);
@@ -4661,7 +4661,7 @@ void SpawnEncounter(MapInfo *pMapInfo, SpawnPoint *spawn, int a3, int a4, int a5
             v38 = BLV_GetFloorLevel(Vec3i(pPosX, a4, a3), v37);
             v39 = v38;
             if (v38 != -30000) {
-                if (abs(v38 - a3) <= 1024) {
+                if (std::abs(v38 - a3) <= 1024) {
                     a3 = v39;
                     if (a5)
                         pMonster->attributes |= ACTOR_AGGRESSOR;


### PR DESCRIPTION
After include rearrange some `abs` function calls became builtins with implicit float->int conversion.
Use std::abs in some files to arrange correct type deduction by libstdc++.