### PR TITLE
Reopen std streams on Windows only when there's none

### DIFF
--- a/src/Application/GameStarter.cpp
+++ b/src/Application/GameStarter.cpp
@@ -16,7 +16,7 @@
 #include "Game.h"
 
 GameStarter::GameStarter(GameStarterOptions options): _options(std::move(options)) {
-    _logger = PlatformLogger::createStandardLogger(WIN_ENSURE_CONSOLE_OPTION);
+    _logger = PlatformLogger::createStandardLogger(WIN_ENSURE_OUTPUT_STREAMS_OPTION);
     auto setLogLevel = [logger = _logger.get()](PlatformLogLevel level) {
         logger->setLogLevel(APPLICATION_LOG, level);
         logger->setLogLevel(PLATFORM_LOG, level);

--- a/src/Platform/PlatformEnums.h
+++ b/src/Platform/PlatformEnums.h
@@ -101,7 +101,7 @@ enum class PlatformLogCategory {
 using enum PlatformLogCategory;
 
 enum PlatformLoggerOption {
-    WIN_ENSURE_CONSOLE_OPTION = 0x1
+    WIN_ENSURE_OUTPUT_STREAMS_OPTION = 0x1
 };
 using enum PlatformLoggerOption;
 MM_DECLARE_FLAGS(PlatformLoggerOptions, PlatformLoggerOption)

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -30,10 +30,12 @@ if(ENABLE_TESTS)
     add_custom_target(GameTest
             OpenEnroth_GameTest --test-path ${CMAKE_CURRENT_BINARY_DIR}/test_data/data
             DEPENDS OpenEnroth_GameTest OpenEnroth_TestData
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            USES_TERMINAL) # USES_TERMINAL makes the command print progress as it goes.
 
     add_custom_target(GameTest_NullRenderer
             OpenEnroth_GameTest --test-path ${CMAKE_CURRENT_BINARY_DIR}/test_data/data --renderer null
             DEPENDS OpenEnroth_GameTest OpenEnroth_TestData
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            USES_TERMINAL)
 endif()

--- a/test/Bin/UnitTest/CMakeLists.txt
+++ b/test/Bin/UnitTest/CMakeLists.txt
@@ -10,7 +10,8 @@ if(ENABLE_TESTS)
 
     add_custom_target(UnitTest OpenEnroth_UnitTest
             DEPENDS OpenEnroth_UnitTest
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            USES_TERMINAL)
 
     target_check_style(OpenEnroth_UnitTest)
 endif()


### PR DESCRIPTION
Also add `USES_TERMINAL` to test commands. Makes workflows output GameTest progress as it goes.