### PR TITLE
Get rid of questionable casts in PlayerFrameTable::GetFrameBy_x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,15 +75,16 @@ if(BUILD_COMPILER STREQUAL "gcc" OR BUILD_COMPILER STREQUAL "clang")
 endif()
 
 if(BUILD_COMPILER STREQUAL "gcc")
-    add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>)
-    add_link_options(-fuse-ld=gold)
-    add_link_options(-pthread)
+    add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>) # Enable assertions in libstdc++.
+    add_link_options(-fuse-ld=gold) # Use gold linker, faster than ld.
 elseif(BUILD_COMPILER STREQUAL "clang")
     add_compile_options(-Werror=unused-comparison) # Comparison result unused, not available in gcc.
     add_compile_options(-Werror=inconsistent-missing-override) # Clang-specific, goes with -Werror=suggest-override.
     add_compile_options(-Werror=invalid-noreturn) # function declared 'noreturn' should not return.
     enable_libcxx_assertions(FALSE)
 elseif(BUILD_COMPILER STREQUAL "msvc")
+    # /Zi -> /Z7: Pack debug info into .obj files, this is needed for ccache to work. Note that pdb for the binary
+    #             itself is still generated.
     string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ elseif(BUILD_COMPILER STREQUAL "clang")
     add_compile_options(-Werror=unused-comparison) # Comparison result unused, not available in gcc.
     add_compile_options(-Werror=inconsistent-missing-override) # Clang-specific, goes with -Werror=suggest-override.
     add_compile_options(-Werror=invalid-noreturn) # function declared 'noreturn' should not return.
+    add_compile_options(-Werror=uninitialized) # variable 'x' is used uninitialized.
     enable_libcxx_assertions(FALSE)
 elseif(BUILD_COMPILER STREQUAL "msvc")
     # /Zi -> /Z7: Pack debug info into .obj files, this is needed for ccache to work. Note that pdb for the binary

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -126,12 +126,12 @@ void ViewingParams::CenterOnPartyZoomOut() {
 void ViewingParams::CenterOnPartyZoomIn() {
     int MaxZoom;
 
-    if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR)
+    if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
         MaxZoom = 1536;
-    else if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
+    } else {
+        assert(uCurrentlyLoadedLevelType == LEVEL_INDOOR);
         MaxZoom = 3072;
-    else
-        assert(false);
+    }
 
     this->uMapBookMapZoom *= 2;
     if (this->uMapBookMapZoom > MaxZoom) this->uMapBookMapZoom = MaxZoom;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -219,7 +219,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
     int realPoints = uSkillMastery.level();
     CharacterSkillMastery masteryLevel = uSkillMastery.mastery();
     int distancemod = 3;
-    int spriteId;
+    int spriteId = -1;
 
     static const int ONE_THIRD_PI = TrigLUT.uIntegerPi / 3;
 
@@ -300,6 +300,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
 
             int meteors;
             switch (masteryLevel) {
+                default:
+                    assert(false);
                 case CHARACTER_SKILL_MASTERY_NOVICE:
                     meteors = 8;
                     break;
@@ -311,9 +313,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
                 case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                     meteors = 14;
-                    break;
-                default:
-                    assert(false);
                     break;
             }
 
@@ -480,6 +479,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
         {
             int spellPower;
             switch (masteryLevel) {
+                default:
+                    assert(false);
                 case CHARACTER_SKILL_MASTERY_NOVICE:
                 case CHARACTER_SKILL_MASTERY_EXPERT:
                     spellPower = 2 * realPoints + 40;
@@ -489,9 +490,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
                 case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                     spellPower = 6 * realPoints + 120;
-                    break;
-                default:
-                    assert(false);
                     break;
             }
 
@@ -563,6 +561,8 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             // TODO(Nik-RE-dev): calculation of duration is strange
             int spellPower;
             switch (masteryLevel) {
+                default:
+                    assert(false);
                 case CHARACTER_SKILL_MASTERY_NOVICE:
                 case CHARACTER_SKILL_MASTERY_EXPERT:
                     spellLength = GameTime::FromMinutes(64 + 5 * realPoints);
@@ -575,9 +575,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                     spellLength = GameTime::FromMinutes(64 + 20 * realPoints);
                     spellPower = 4 * realPoints;
-                    break;
-                default:
-                    assert(false);
                     break;
             }
 

--- a/src/Engine/Objects/Monsters.cpp
+++ b/src/Engine/Objects/Monsters.cpp
@@ -13,6 +13,7 @@
 
 #include "Utility/Memory/Blob.h"
 #include "Utility/String.h"
+#include "Utility/Exception.h"
 
 struct MonsterStats *pMonsterStats;
 struct MonsterList *pMonsterList;
@@ -141,7 +142,7 @@ CombinedSkillValue ParseSkillValue(std::string_view skillString, std::string_vie
     } else if (masteryString == "G") {
         mastery = CHARACTER_SKILL_MASTERY_GRANDMASTER;
     } else {
-        assert(false); // TODO(captainurist): throw.
+        throw Exception("Invalid character skill mastery string '{}'", masteryString);
     }
 
     return CombinedSkillValue(skill, mastery);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -326,6 +326,8 @@ void CastSpellInfoHelpers::castSpell() {
                 {
                     int spell_power;
                     switch (spell_mastery) {
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_NOVICE:
                             spell_power = 2;
                             break;
@@ -336,8 +338,6 @@ void CastSpellInfoHelpers::castSpell() {
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                             spell_power = 4;
                             break;
-                        default:
-                            assert(false);
                     }
                     pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT]
                         .Apply(pParty->GetPlayingTime() + GameTime::FromHours(spell_level), spell_mastery, spell_power, 0, 0);
@@ -740,6 +740,8 @@ void CastSpellInfoHelpers::castSpell() {
                 {
                     int spell_power;
                     switch (spell_mastery) {
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_NOVICE:
                             spell_power = 1;
                             break;
@@ -752,8 +754,6 @@ void CastSpellInfoHelpers::castSpell() {
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                             spell_power = 10;
                             break;
-                        default:
-                            assert(false);
                     }
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
                     pParty->pCharacters[pCastSpell->uPlayerID_2].pCharacterBuffs[CHARACTER_BUFF_REGENERATION]
@@ -1258,6 +1258,8 @@ void CastSpellInfoHelpers::castSpell() {
                 {
                     int shots_num;
                     switch (spell_mastery) {
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_NOVICE:
                             shots_num = 1;
                             break;
@@ -1270,8 +1272,6 @@ void CastSpellInfoHelpers::castSpell() {
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                             shots_num = 7;
                             break;
-                        default:
-                            assert(false);
                     }
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pParty->pos + Vec3i(0, 0, pParty->height / 3);
@@ -2456,6 +2456,9 @@ void CastSpellInfoHelpers::castSpell() {
                     int spell_power;
 
                     switch (spell_mastery) {
+                        case CHARACTER_SKILL_MASTERY_NOVICE: // MM6 have different durations
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_EXPERT:
                             spell_duration = GameTime::FromHours(3 * spell_level);
                             spell_power = 3 * spell_level + 10;
@@ -2468,9 +2471,6 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = GameTime::FromHours(5 * spell_level);
                             spell_power = 5 * spell_level + 10;
                             break;
-                        case CHARACTER_SKILL_MASTERY_NOVICE: // MM6 have different durations
-                        default:
-                            assert(false);
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS]
@@ -2504,6 +2504,10 @@ void CastSpellInfoHelpers::castSpell() {
                     int spell_power;
 
                     switch (spell_mastery) {
+                        case CHARACTER_SKILL_MASTERY_NOVICE: // In MM6 this spell is different and is of dark magic
+                        case CHARACTER_SKILL_MASTERY_EXPERT:
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_MASTER:
                             spell_duration = GameTime::FromHours(4 * spell_level);
                             spell_power = 4 * spell_level;
@@ -2512,10 +2516,6 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = GameTime::FromHours(5 * spell_level);
                             spell_power = 5 * spell_level;
                             break;
-                        case CHARACTER_SKILL_MASTERY_NOVICE: // In MM6 this spell is different and is of dark magic
-                        case CHARACTER_SKILL_MASTERY_EXPERT:
-                        default:
-                            assert(false);
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
@@ -2618,6 +2618,8 @@ void CastSpellInfoHelpers::castSpell() {
                 {
                     int target_monster_level;
                     switch (spell_mastery) {
+                        default:
+                            assert(false);
                         case CHARACTER_SKILL_MASTERY_NOVICE:
                             target_monster_level = 2 * spell_level;
                             break;
@@ -2630,8 +2632,6 @@ void CastSpellInfoHelpers::castSpell() {
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
                             target_monster_level = 5 * spell_level;
                             break;
-                        default:
-                            assert(false);
                     }
                     int zombie_hp_limit = target_monster_level * 10;
                     if (pCastSpell->spell_target_pid == PID_INVALID) {

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -829,7 +829,7 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, int
     }
 
     GameTime spell_length;
-    int spell_power;
+    int spell_power = 0;
     int launch_angle;
     int launch_speed;
     int spell_num_objects;
@@ -942,22 +942,16 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, int
                     assert(false);
                     break;
             }
-            switch (uSpellID) {
-                case SPELL_AIR_SHIELD:
-                    spell_power = 0;
-                    buff_id = PARTY_BUFF_SHIELD;
-                    break;
-                case SPELL_EARTH_STONESKIN:
-                    spell_power = skillLevel + 5;
-                    buff_id = PARTY_BUFF_STONE_SKIN;
-                    break;
-                case SPELL_SPIRIT_HEROISM:
-                    spell_power = skillLevel + 5;
-                    buff_id = PARTY_BUFF_HEROISM;
-                    break;
-                default:
-                    assert(false);
-                    break;
+            if (uSpellID == SPELL_AIR_SHIELD) {
+                spell_power = 0;
+                buff_id = PARTY_BUFF_SHIELD;
+            } else if (uSpellID == SPELL_EARTH_STONESKIN) {
+                spell_power = skillLevel + 5;
+                buff_id = PARTY_BUFF_STONE_SKIN;
+            } else {
+                assert(uSpellID == SPELL_SPIRIT_HEROISM);
+                spell_power = skillLevel + 5;
+                buff_id = PARTY_BUFF_HEROISM;
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
             pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, 0);
@@ -988,29 +982,21 @@ void eventCastSpell(SPELL_TYPE uSpellID, CharacterSkillMastery skillMastery, int
             spell_length = GameTime::FromHours(skillLevel);
             spell_power = skillLevel * std::to_underlying(skillMastery);
 
-            switch (uSpellID) {
-                case SPELL_FIRE_PROTECTION_FROM_FIRE:
-                    buff_id = PARTY_BUFF_RESIST_FIRE;
-                    break;
-                case SPELL_AIR_PROTECTION_FROM_AIR:
-                    buff_id = PARTY_BUFF_RESIST_AIR;
-                    break;
-                case SPELL_WATER_PROTECTION_FROM_WATER:
-                    buff_id = PARTY_BUFF_RESIST_WATER;
-                    break;
-                case SPELL_EARTH_PROTECTION_FROM_EARTH:
-                    buff_id = PARTY_BUFF_RESIST_EARTH;
-                    break;
-                case SPELL_MIND_PROTECTION_FROM_MIND:
-                    buff_id = PARTY_BUFF_RESIST_MIND;
-                    break;
-                case SPELL_BODY_PROTECTION_FROM_BODY:
-                    buff_id = PARTY_BUFF_RESIST_BODY;
-                    break;
-                default:
-                    assert(false);
-                    break;
+            if (uSpellID == SPELL_FIRE_PROTECTION_FROM_FIRE) {
+                buff_id = PARTY_BUFF_RESIST_FIRE;
+            } else if (uSpellID == SPELL_AIR_PROTECTION_FROM_AIR) {
+                buff_id = PARTY_BUFF_RESIST_AIR;
+            } else if (uSpellID == SPELL_WATER_PROTECTION_FROM_WATER) {
+                buff_id = PARTY_BUFF_RESIST_WATER;
+            } else if (uSpellID == SPELL_EARTH_PROTECTION_FROM_EARTH) {
+                buff_id = PARTY_BUFF_RESIST_EARTH;
+            } else if (uSpellID == SPELL_MIND_PROTECTION_FROM_MIND) {
+                buff_id = PARTY_BUFF_RESIST_MIND;
+            } else {
+                assert(uSpellID == SPELL_BODY_PROTECTION_FROM_BODY);
+                buff_id = PARTY_BUFF_RESIST_BODY;
             }
+
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
             pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, 0);
             //    pAudioPlayer->PlaySound((SoundID)word_4EE088_sound_ids[uSpellID],

--- a/src/Engine/Tables/CharacterFrameTable.cpp
+++ b/src/Engine/Tables/CharacterFrameTable.cpp
@@ -12,31 +12,21 @@ unsigned int PlayerFrameTable::GetFrameIdByExpression(CharacterExpressionID expr
 }
 
 //----- (00494B10) --------------------------------------------------------
-PlayerFrame *PlayerFrameTable::GetFrameBy_x(unsigned int uFramesetID,
-                                            unsigned int uFrameID) {
-    unsigned int v3;      // esi@1
-    int16_t v6;           // dx@2
-    int v7;               // edx@3
-    char *i;              // eax@3
-    int v9;               // ecx@5
-    PlayerFrame *result;  // eax@6
+PlayerFrame *PlayerFrameTable::GetFrameBy_x(int uFramesetID, int gameTime) {
+    if (this->pFrames[uFramesetID].uFlags & 1 && this->pFrames[uFramesetID].uAnimLength != 0) {
+        // Processing animated character expressions - e.g., CHARACTER_EXPRESSION_YES & CHARACTER_EXPRESSION_NO.
+        int time = (gameTime >> 3) % this->pFrames[uFramesetID].uAnimLength;
 
-    v3 = uFramesetID;
-    if (this->pFrames[uFramesetID].uFlags & 1 &&
-        (v6 = this->pFrames[uFramesetID].uAnimLength) != 0) {
-        v7 = ((signed int)uFrameID >> 3) % (uint16_t)v6;
-        for (i = (char *)&this->pFrames[uFramesetID].uAnimTime;; i += 10) {
-            v9 = *(short *)i;
-            if (v7 <= v9) break;
-            v7 -= v9;
-            ++v3;
+        while (true) {
+            int frameTime = this->pFrames[uFramesetID].uAnimTime;
+            if (time < frameTime)
+                break;
+            time -= frameTime;
+            ++uFramesetID;
+            assert(this->pFrames[uFramesetID].expression == CHARACTER_EXPRESSION_INVALID); // Shouldn't jump into another expression.
         }
-        result = &this->pFrames[v3];
-    } else {
-        result = &this->pFrames[uFramesetID];
     }
-
-    return result;
+    return &this->pFrames[uFramesetID];
 }
 
 //----- (00494B5E) --------------------------------------------------------

--- a/src/Engine/Tables/CharacterFrameTable.h
+++ b/src/Engine/Tables/CharacterFrameTable.h
@@ -16,7 +16,7 @@ struct PlayerFrame {
 
 struct PlayerFrameTable {
     unsigned int GetFrameIdByExpression(CharacterExpressionID expression);
-    PlayerFrame *GetFrameBy_x(unsigned int uFramesetID, unsigned int uFrameID);
+    PlayerFrame *GetFrameBy_x(int uFramesetID, int gameTime);
     PlayerFrame *GetFrameBy_y(int *a2, int *a3, int a4);
     int FromFileTxt(const char *Args);
 

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -63,6 +63,8 @@ void GUIWindow_Tavern::arcomageRulesDialogue() {
     if (352 - pTextHeight < 8) {
         font = pFontCreate;
         pTextHeight = pFontCreate->CalcTextHeight(str, dialog_window.uFrameWidth, 12) + 7;
+    } else {
+        return; // TODO(captainurist): what's going on here?
     }
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);
     render->DrawTextureNew(8 / 640.0f, (347 - pTextHeight) / 480.0f, _591428_endcap);

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -268,8 +268,8 @@ void ArenaFight() {
     int v3;                  // eax@10
     signed int v4;           // esi@10
     signed int v6;           // ebx@34
-    signed int v13;          // eax@49
-    int v14;                 // esi@49
+    signed int v13 = 0;          // eax@49
+    int v14 = 0;                 // esi@49
     int v15;                 // edx@50
     signed int v17;          // ecx@51
     int v18;                 // edx@53
@@ -278,7 +278,7 @@ void ArenaFight() {
     int16_t v23[LAST_ARENA_FIGHTER_TYPE] {};        // [sp+Ch] [bp-134h]@39
     int16_t monster_ids[6] {};  // [sp+128h] [bp-18h]@56
     int v26;                 // [sp+134h] [bp-Ch]@1
-    int num_monsters;        // [sp+13Ch] [bp-4h]@17
+    int num_monsters = 0;        // [sp+13Ch] [bp-4h]@17
 
     v26 = 0;
     pParty->field_7B5_in_arena_quest = uDialogueType;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -671,28 +671,19 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
         }
     } else if (option >= DIALOGUE_SCRIPTED_LINE_1 && option <= DIALOGUE_SCRIPTED_LINE_6) {
         int npc_event_id;
-
-        switch (option) {
-          case DIALOGUE_SCRIPTED_LINE_1:
+        if (option == DIALOGUE_SCRIPTED_LINE_1) {
             npc_event_id = speakingNPC->dialogue_1_evt_id;
-            break;
-          case DIALOGUE_SCRIPTED_LINE_2:
+        } else if (option == DIALOGUE_SCRIPTED_LINE_2) {
             npc_event_id = speakingNPC->dialogue_2_evt_id;
-            break;
-          case DIALOGUE_SCRIPTED_LINE_3:
+        } else if (option == DIALOGUE_SCRIPTED_LINE_3) {
             npc_event_id = speakingNPC->dialogue_3_evt_id;
-            break;
-          case DIALOGUE_SCRIPTED_LINE_4:
+        } else if (option == DIALOGUE_SCRIPTED_LINE_4) {
             npc_event_id = speakingNPC->dialogue_4_evt_id;
-            break;
-          case DIALOGUE_SCRIPTED_LINE_5:
+        } else if (option == DIALOGUE_SCRIPTED_LINE_5) {
             npc_event_id = speakingNPC->dialogue_5_evt_id;
-            break;
-          case DIALOGUE_SCRIPTED_LINE_6:
+        } else {
+            assert(option == DIALOGUE_SCRIPTED_LINE_6);
             npc_event_id = speakingNPC->dialogue_6_evt_id;
-            break;
-          default:
-            break;
         }
 
         handleScriptedNPCTopicSelection(option, npc_event_id);


### PR DESCRIPTION
* Clean up `PlayerFrameTable::GetFrameBy_x`, get rid of `char *`-based pointer arithmetic there, make frame length handling consistent (because of `v7 <= v9` check instead of `v7 < v9`, the first frame was always longer by a single tick than it should be).
* Add `-Werror=uninitialized` that resulted in windows game tests acting up on previous iterations of this PR. Only in clang for now.