### PR TITLE
Cleaning up Vis::Intersect_Ray_Face

### DIFF
--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -261,15 +261,14 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
 
     // TODO(pskelton): fov calcs only need recalculating on level change or if we add config option
     // fov projection calcs
-    unit_fov = 0.5 / std::tan(odm_fov_rad / 2.0);
+    float halfFovTan = std::tan(odm_fov_rad / 2.0);
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
-        unit_fov = 0.5 / std::tan(blv_fov_rad / 2.0);
+        halfFovTan = std::tan(blv_fov_rad / 2.0);
 
-    ViewPlaneDist_X = (double)pViewport->uScreenWidth * unit_fov;
-    ViewPlaneDist_Y = (double)pViewport->uScreenHeight * unit_fov;
+    ViewPlaneDistPixels = (double)pViewport->uScreenWidth * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDist_X);
+    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
     screenCenterX = (double)pViewport->uScreenCenterX;
     screenCenterY = (double)pViewport->uScreenCenterY - pViewport->uScreen_TL_Y;
@@ -280,7 +279,7 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
     float HalfAngleX = (pi / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (pi / 2.0) - (std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDist_X));
+    float HalfAngleY = (pi / 2.0) - (std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
         HalfAngleX = (pi / 2.0) - (blv_fov_rad / 2.0);
@@ -467,7 +466,7 @@ void Camera3D::Project(RenderVertexSoft *pVertices, unsigned int uNumVertices, b
 
         RHW = 1.0 / (v->vWorldViewPosition.x + 0.0000001);
         v->_rhw = RHW;
-        viewscalefactor = RHW * ViewPlaneDist_X;
+        viewscalefactor = RHW * ViewPlaneDistPixels;
 
         v->vWorldViewProjX = (double)pViewport->uScreenCenterX -
                              viewscalefactor * (double)v->vWorldViewPosition.y;

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -81,16 +81,13 @@ struct Camera3D {
     // using w comp of vec4 for dotdist
     std::array<glm::vec4, 6> FrustumPlanes = {{}};
 
-    // unit fov is normalised focal ratio
-    float unit_fov = 0;
     // field of view in vertical direction in degrees for GL
     float fov_y_deg = 0;
     // centre of the game viewport
     float screenCenterX = 0;
     float screenCenterY = 0;
-    // these are the effective focal distances of the camera in x and y
-    float ViewPlaneDist_X = 0;
-    float ViewPlaneDist_Y = 0;
+    // these are the effective focal distances of the camera in screen space pixels.
+    float ViewPlaneDistPixels = 0;
 
     // Camera field of view angles in degrees and radians
     int odm_fov_deg = 75;
@@ -104,7 +101,7 @@ struct Camera3D {
     // camera cos + sin values in both forms to avoid repeated calculation
     void CalculateRotations(int cameraYaw, int cameraPitch);
     int _viewYaw = 0;
-    int _viewPitch = 0;
+    int _viewPitch = 0; // TODO(captainurist): up is negative? wtf???
     float _yawRotationSine = 0;
     float _yawRotationCosine = 0;
     float _pitchRotationSine = 0;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1214,7 +1214,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
             int projected_y = 0;
             pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
 
-            float billb_scale = v11->scale * pCamera3D->ViewPlaneDist_X / view_x;
+            float billb_scale = v11->scale * pCamera3D->ViewPlaneDistPixels / view_x;
 
             int screen_space_half_width = static_cast<int>(billb_scale * v11->hw_sprites[(int64_t)v9]->uWidth / 2.0f);
             int screen_space_height = static_cast<int>(billb_scale * v11->hw_sprites[(int64_t)v9]->uHeight);
@@ -1237,9 +1237,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
                         uSectorID;
 
                     pBillboardRenderList[uNumBillboardsToDraw - 1].fov_x =
-                        pCamera3D->ViewPlaneDist_X;
-                    pBillboardRenderList[uNumBillboardsToDraw - 1].fov_y =
-                        pCamera3D->ViewPlaneDist_Y;
+                        pCamera3D->ViewPlaneDistPixels;
                     pBillboardRenderList[uNumBillboardsToDraw - 1].screenspace_projection_factor_x = billb_scale;
                     pBillboardRenderList[uNumBillboardsToDraw - 1].screenspace_projection_factor_y = billb_scale;
                     pBillboardRenderList[uNumBillboardsToDraw - 1].field_1E = v30;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1272,24 +1272,24 @@ bool Check_LineOfSight(const Vec3i &target, const Vec3i &from) {  // target from
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
         // offset 32 to side and check LOS
-        Vec3i targetmod = target + Vec3i::fromPolar(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
-        Vec3i frommod = from + Vec3i::fromPolar(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
+        Vec3i targetmod = target + Vec3i::fromPolarRetarded(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
+        Vec3i frommod = from + Vec3i::fromPolarRetarded(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
         LOS_Obscurred2 = Check_LOS_Obscurred_Indoors(targetmod, frommod);
 
         // offset other side and repeat check
-        targetmod = target + Vec3i::fromPolar(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
-        frommod = from + Vec3i::fromPolar(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
+        targetmod = target + Vec3i::fromPolarRetarded(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
+        frommod = from + Vec3i::fromPolarRetarded(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
         LOS_Obscurred = Check_LOS_Obscurred_Indoors(targetmod, frommod);
     } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
         // TODO(pskelton): Need to add check against terrain
         // offset 32 to side and check LOS
-        Vec3i targetmod = target + Vec3i::fromPolar(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
-        Vec3i frommod = from + Vec3i::fromPolar(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
+        Vec3i targetmod = target + Vec3i::fromPolarRetarded(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
+        Vec3i frommod = from + Vec3i::fromPolarRetarded(32, AngleToTarget + TrigLUT.uIntegerHalfPi, 0);
         LOS_Obscurred2 = Check_LOS_Obscurred_Outdoors_Bmodels(targetmod, frommod);
 
         // offset other side and repeat check
-        targetmod = target + Vec3i::fromPolar(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
-        frommod = from + Vec3i::fromPolar(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
+        targetmod = target + Vec3i::fromPolarRetarded(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
+        frommod = from + Vec3i::fromPolarRetarded(32, AngleToTarget - TrigLUT.uIntegerHalfPi, 0);
         LOS_Obscurred = Check_LOS_Obscurred_Outdoors_Bmodels(targetmod, frommod);
     }
 

--- a/src/Engine/Graphics/LocationTime.h
+++ b/src/Engine/Graphics/LocationTime.h
@@ -7,7 +7,7 @@
 struct LocationTime {
     GameTime last_visit;
     std::string sky_texture_name;
-    int day_attrib = 0; // TODO(caprainurist): actually WeatherFlags, see DAY_ATTRIB_FOG.
+    int day_attrib = 0; // TODO(captainurist): actually WeatherFlags, see DAY_ATTRIB_FOG.
     int day_fogrange_1 = 0;
     int day_fogrange_2 = 0;
 };

--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -874,8 +874,8 @@ void RenderOpenGL::DrawIndoorSky(unsigned int uNumVertices, int uFaceID) {
     double rot_to_rads = ((2 * pi_double) / 2048);
 
     // lowers clouds as party goes up
-    float  blv_horizon_height_offset = ((pCamera3D->ViewPlaneDist_X * pCamera3D->vCameraPos.z)
-        / (pCamera3D->ViewPlaneDist_X + pCamera3D->GetFarClip())
+    float  blv_horizon_height_offset = ((pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
+        / (pCamera3D->ViewPlaneDistPixels + pCamera3D->GetFarClip())
         + (pBLVRenderParams->uViewportCenterY));
 
     double cam_y_rot_rad = (double)pCamera3D->_viewPitch * rot_to_rads;
@@ -884,7 +884,7 @@ void RenderOpenGL::DrawIndoorSky(unsigned int uNumVertices, int uFaceID) {
     float height_to_far_clip = std::sin(pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
 
     float blv_bottom_y_proj = ((pBLVRenderParams->uViewportCenterY) -
-        pCamera3D->ViewPlaneDist_X /
+        pCamera3D->ViewPlaneDistPixels /
         (depth_to_far_clip + 0.0000001f) *
         (height_to_far_clip - pCamera3D->vCameraPos.z));
 
@@ -893,7 +893,7 @@ void RenderOpenGL::DrawIndoorSky(unsigned int uNumVertices, int uFaceID) {
     float v_18y = 0.0f;
     float v_18z = -std::cos((pCamera3D->_viewPitch + 16) * rot_to_rads);
 
-    float inv_viewplanedist = 1.0f / pCamera3D->ViewPlaneDist_X;
+    float inv_viewplanedist = 1.0f / pCamera3D->ViewPlaneDistPixels;
 
     // copy to buff in
     for (uint i = 0; i < pFace->uNumVertices; ++i) {
@@ -2002,15 +2002,15 @@ void RenderOpenGL::DrawOutdoorSky() {
     double rot_to_rads = ((2 * pi_double) / 2048);
 
     // lowers clouds as party goes up
-    float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDist_X * pCamera3D->vCameraPos.z)
-        / ((double)pCamera3D->ViewPlaneDist_X + pCamera3D->GetFarClip())
+    float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
+        / ((double)pCamera3D->ViewPlaneDistPixels + pCamera3D->GetFarClip())
         + (double)(pViewport->uScreenCenterY));
 
     float depth_to_far_clip = std::cos((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
     float height_to_far_clip = std::sin((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
 
     float bot_y_proj = ((double)(pViewport->uScreenCenterY) -
-        (double)pCamera3D->ViewPlaneDist_X /
+        (double)pCamera3D->ViewPlaneDistPixels /
         (depth_to_far_clip + 0.0000001) *
         (height_to_far_clip - (double)pCamera3D->vCameraPos.z));
 
@@ -2064,7 +2064,7 @@ void RenderOpenGL::DrawOutdoorSky() {
         VertexRenderList[3].vWorldViewProjX = (double)(signed int)pViewport->uViewportBR_X;  // 468
         VertexRenderList[3].vWorldViewProjY = (double)(signed int)pViewport->uViewportTL_Y;  // 8
 
-        float widthperpixel = 1 / pCamera3D->ViewPlaneDist_X;
+        float widthperpixel = 1 / pCamera3D->ViewPlaneDistPixels;
 
         for (uint i = 0; i < pSkyPolygon.uNumVertices; ++i) {
             // outbound screen X dist

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1395,7 +1395,7 @@ void OutdoorLocation::PrepareActorsDrawList() {
                 int projected_y = 0;
                 pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
 
-                float proj_scale = frame->scale * (pCamera3D->ViewPlaneDist_X) / (view_x);
+                float proj_scale = frame->scale * (pCamera3D->ViewPlaneDistPixels) / (view_x);
                 int screen_space_half_width = static_cast<int>(proj_scale * frame->hw_sprites[Sprite_Octant]->uWidth / 2.0f);
                 int screen_space_height = static_cast<int>(proj_scale * frame->hw_sprites[Sprite_Octant]->uHeight);
 

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -214,8 +214,7 @@ bool ParticleEngine::ViewProject_TrueIfStillVisible_BLV(unsigned int uParticleID
     if (!pCamera3D->ViewClip(x_int, y_int_, z_int_, &xt, &yt, &zt, 0)) return false;
     pCamera3D->Project(xt, yt, zt, &pParticle->uScreenSpaceX, &pParticle->uScreenSpaceY);
 
-    pParticle->fov_x = pCamera3D->ViewPlaneDist_X;
-    pParticle->fov_y = pCamera3D->ViewPlaneDist_Y;
+    pParticle->fov_x = pCamera3D->ViewPlaneDistPixels;
 
     /*pParticle->screenspace_scale = fixed::FromFloat(pParticle->particle_size) *
                                    fixed::FromFloat(pParticle->fov_x) / x;*/

--- a/src/Engine/Graphics/ParticleEngine.h
+++ b/src/Engine/Graphics/ParticleEngine.h
@@ -77,7 +77,6 @@ struct Particle {
     int sZValue2 = 0;             // line end z
     float screenspace_scale = 1.0;  // fixed screenspace_scale {};  // int _screenspace_scale;
     float fov_x = 0;
-    float fov_y = 0;
     Color uLightColor_bgr;
 };
 

--- a/src/Engine/Graphics/RenderBase.cpp
+++ b/src/Engine/Graphics/RenderBase.cpp
@@ -193,7 +193,7 @@ void RenderBase::DrawSpriteObjects() {
                     int projected_y = 0;
                     pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
 
-                    float billb_scale = frame->scale * pCamera3D->ViewPlaneDist_X / view_x;
+                    float billb_scale = frame->scale * pCamera3D->ViewPlaneDistPixels / view_x;
 
                     int screen_space_half_width = static_cast<int>(billb_scale * frame->hw_sprites[octant]->uWidth / 2.0f);
                     int screen_space_height = static_cast<int>(billb_scale * frame->hw_sprites[octant]->uHeight);
@@ -331,7 +331,7 @@ void RenderBase::PrepareDecorationsRenderList_ODM() {
                             int projected_y = 0;
                             pCamera3D->Project(view_x, view_y, view_z, &projected_x, &projected_y);
 
-                            float _v41 = frame->scale * (pCamera3D->ViewPlaneDist_X) / (view_x);
+                            float _v41 = frame->scale * (pCamera3D->ViewPlaneDistPixels) / (view_x);
 
                             int screen_space_half_width = static_cast<int>(_v41 * frame->hw_sprites[(int64_t)v37]->uWidth / 2.0f);
                             int screen_space_height = static_cast<int>(_v41 * frame->hw_sprites[(int64_t)v37]->uHeight);

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -655,7 +655,7 @@ bool Vis::CheckIntersectBModel(BLVFace *pFace, Vec3s IntersectPoint, signed int 
 
 //----- (0046A0A1) --------------------------------------------------------
 int UnprojectX(int x) {
-    int v3 = pCamera3D->ViewPlaneDist_X;
+    int v3 = pCamera3D->ViewPlaneDistPixels;
 
     return TrigLUT.atan2(x - pViewport->uScreenCenterX, v3) -
            TrigLUT.uIntegerHalfPi;
@@ -663,7 +663,7 @@ int UnprojectX(int x) {
 
 //----- (0046A0F6) --------------------------------------------------------
 int UnprojectY(int y) {
-    int v3 = pCamera3D->ViewPlaneDist_X;
+    int v3 = pCamera3D->ViewPlaneDistPixels;
 
     return TrigLUT.atan2(y - pViewport->uScreenCenterY, v3) -
            TrigLUT.uIntegerHalfPi;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -674,7 +674,7 @@ void Vis::CastPickRay(float fMouseX, float fMouseY, float fPickDepth, Vec3f *ori
 
     int yawAngle = pCamera3D->_viewYaw + UnprojectX(fMouseX);
     int pitchAngle = -pCamera3D->_viewPitch + UnprojectY(fMouseY);
-    *step = Vec3f::fromPolar(fPickDepth, yawAngle, pitchAngle);
+    *step = Vec3f::fromPolarRetarded(fPickDepth, yawAngle, pitchAngle);
 }
 
 //----- (004C2551) --------------------------------------------------------

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -672,8 +672,8 @@ void Vis::CastPickRay(float fMouseX, float fMouseY, float fPickDepth, Vec3f *ori
     origin->x = pCamera3D->vCameraPos.x;
     origin->y = pCamera3D->vCameraPos.y;
 
-    int yawAngle = pCamera3D->_viewYaw + UnprojectX(fMouseX);
-    int pitchAngle = -pCamera3D->_viewPitch + UnprojectY(fMouseY);
+    int yawAngle = (pCamera3D->_viewYaw + UnprojectX(fMouseX)) & TrigLUT.uDoublePiMask;
+    int pitchAngle = (-pCamera3D->_viewPitch + UnprojectY(fMouseY)) & TrigLUT.uDoublePiMask;
     *step = Vec3f::fromPolarRetarded(fPickDepth, yawAngle, pitchAngle);
 }
 

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -671,24 +671,15 @@ int UnprojectY(int y) {
 
 //----- (004C248E) --------------------------------------------------------
 void Vis::CastPickRay(RenderVertexSoft *pRay, float fMouseX, float fMouseY, float fPickDepth) {
-    Vec3i pStartR;        // ST08_12@1
-    RenderVertexSoft v11[2];  // [sp+2Ch] [bp-74h]@1
-
-    int yawAngle = pCamera3D->_viewYaw + UnprojectX(fMouseX);
-    int pitchAngle = -pCamera3D->_viewPitch + UnprojectY(fMouseY);
-
+    Vec3f pStartR;
     pStartR.z = pCamera3D->vCameraPos.z;
     pStartR.x = pCamera3D->vCameraPos.x;
     pStartR.y = pCamera3D->vCameraPos.y;
 
-    v11[1].vWorldPosition.x = pCamera3D->vCameraPos.x;
-    v11[1].vWorldPosition.y = pCamera3D->vCameraPos.y;
-    v11[1].vWorldPosition.z = pCamera3D->vCameraPos.z;
-
-    v11[0].vWorldPosition = pStartR.toFloat() + Vec3f::fromPolar(fPickDepth, yawAngle, pitchAngle);
-
-    pRay[0] = v11[1];
-    pRay[1] = v11[0];
+    int yawAngle = pCamera3D->_viewYaw + UnprojectX(fMouseX);
+    int pitchAngle = -pCamera3D->_viewPitch + UnprojectY(fMouseY);
+    pRay[0].vWorldPosition = pStartR;
+    pRay[1].vWorldPosition = pStartR + Vec3f::fromPolar(fPickDepth, yawAngle, pitchAngle);
 }
 
 //----- (004C2551) --------------------------------------------------------

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -107,10 +107,10 @@ class Vis {
     void PickBillboards_Mouse(float fPickDepth, float fX, float fY,
                               Vis_SelectionList *list,
                               Vis_SelectionFilter *filter);
-    void PickIndoorFaces_Mouse(float fDepth, struct RenderVertexSoft *pRay,
+    void PickIndoorFaces_Mouse(float fDepth, const Vec3f &rayOrigin, const Vec3f &rayStep,
                                Vis_SelectionList *list,
                                Vis_SelectionFilter *filter);
-    void PickOutdoorFaces_Mouse(float fDepth, struct RenderVertexSoft *pRay,
+    void PickOutdoorFaces_Mouse(float fDepth, const Vec3f &rayOrigin, const Vec3f &rayStep,
                                 Vis_SelectionList *list,
                                 Vis_SelectionFilter *filter,
                                 bool only_reachable);
@@ -137,14 +137,12 @@ class Vis {
     void SortVectors_x(RenderVertexSoft *pArray, int start, int end);
     Vis_PIDAndDepth get_object_zbuf_val(Vis_ObjectInfo *info);
     Vis_PIDAndDepth get_picked_object_zbuf_val();
-    bool Intersect_Ray_Face(struct RenderVertexSoft *pRayStart,
-                            struct RenderVertexSoft *pRayEnd, float *pDepth,
+    bool Intersect_Ray_Face(const Vec3f &origin, const Vec3f &step, float *pDepth,
                             RenderVertexSoft *Intersection, BLVFace *pFace,
                             signed int pBModelID);
     bool CheckIntersectBModel(BLVFace *pFace, Vec3s IntersectPoint,
                               signed int sModelID);
-    void CastPickRay(RenderVertexSoft *pRay, float fMouseX, float fMouseY,
-                     float fPickDepth);
+    void CastPickRay(float fMouseX, float fMouseY, float fPickDepth, Vec3f *origin, Vec3f *step);
     void SortVerticesByX(struct RenderVertexD3D3 *pArray, unsigned int uStart,
                          unsigned int uEnd);
     void SortVerticesByY(struct RenderVertexD3D3 *pArray, unsigned int uStart,

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -902,13 +902,13 @@ void Actor::GetDirectionInfo(Pid uObj1ID, Pid uObj2ID,
             if (id1 == 0) {
                 // Do nothing.
             } else if (id1 == 4) {
-                out1 += Vec3i::fromPolar(24, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3i::fromPolarRetarded(24, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
             } else if (id1 == 3) {
-                out1 += Vec3i::fromPolar(8, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3i::fromPolarRetarded(8, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
             } else if (id1 == 2) {
-                out1 += Vec3i::fromPolar(8, TrigLUT.uIntegerHalfPi + pParty->_viewYaw, 0);
+                out1 += Vec3i::fromPolarRetarded(8, TrigLUT.uIntegerHalfPi + pParty->_viewYaw, 0);
             } else if (id1 == 1) {
-                out1 += Vec3i::fromPolar(24, TrigLUT.uIntegerHalfPi + pParty->_viewYaw, 0);
+                out1 += Vec3i::fromPolarRetarded(24, TrigLUT.uIntegerHalfPi + pParty->_viewYaw, 0);
             }
             break;
         }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -101,7 +101,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
             if (length_vector < pDepth) {
                 pDepth = length_vector;
             }
-            pOut = objectPos + Vec3i::fromPolar(pDepth, yawAngle, pitchAngle);
+            pOut = objectPos + Vec3i::fromPolarRetarded(pDepth, yawAngle, pitchAngle);
 
             pSpellObject.containing_item.Reset();
             pSpellObject.spell_skill = CHARACTER_SKILL_MASTERY_NONE;

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -77,16 +77,16 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
         case 0:
             break;  // do nothing
         case 1:
-            vPosition += Vec3i::fromPolar(24, TrigLUT.uIntegerDoublePi - uFacing, 0);
+            vPosition += Vec3i::fromPolarRetarded(24, TrigLUT.uIntegerDoublePi - uFacing, 0);
             break;
         case 2:
-            vPosition += Vec3i::fromPolar(8, TrigLUT.uIntegerDoublePi - uFacing, 0);
+            vPosition += Vec3i::fromPolarRetarded(8, TrigLUT.uIntegerDoublePi - uFacing, 0);
             break;
         case 3:
-            vPosition += Vec3i::fromPolar(8, TrigLUT.uIntegerPi - uFacing, 0);
+            vPosition += Vec3i::fromPolarRetarded(8, TrigLUT.uIntegerPi - uFacing, 0);
             break;
         case 4:
-            vPosition += Vec3i::fromPolar(24, TrigLUT.uIntegerPi - uFacing, 0);
+            vPosition += Vec3i::fromPolarRetarded(24, TrigLUT.uIntegerPi - uFacing, 0);
             break;
         default:
             assert(false);

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -66,15 +66,15 @@ bool sr_42620A(RenderVertexSoft *p) { // maybe near clipping on projectiles
     float v17;            // ST04_4@8
     float v18;            // ST00_4@8
 
-    if (p->vWorldViewPosition.x < pCamera3D->ViewPlaneDist_X ||
-        (v2 = pCamera3D->ViewPlaneDist_X < p[1].vWorldViewPosition.x, v3 = 0,
-         v4 = pCamera3D->ViewPlaneDist_X == p[1].vWorldViewPosition.x,
+    if (p->vWorldViewPosition.x < pCamera3D->ViewPlaneDistPixels ||
+        (v2 = pCamera3D->ViewPlaneDistPixels < p[1].vWorldViewPosition.x, v3 = 0,
+         v4 = pCamera3D->ViewPlaneDistPixels == p[1].vWorldViewPosition.x,
 
          !(v2 | v4))) {
-        if (p->vWorldViewPosition.x < pCamera3D->ViewPlaneDist_X) {
-            v6 = pCamera3D->ViewPlaneDist_X < p[1].vWorldViewPosition.x;
+        if (p->vWorldViewPosition.x < pCamera3D->ViewPlaneDistPixels) {
+            v6 = pCamera3D->ViewPlaneDistPixels < p[1].vWorldViewPosition.x;
             v7 = 0;
-            v8 = pCamera3D->ViewPlaneDist_X == p[1].vWorldViewPosition.x;
+            v8 = pCamera3D->ViewPlaneDistPixels == p[1].vWorldViewPosition.x;
 
             if (!(v6 | v8)) {
                 //logger->Info("sr_42620A reject");
@@ -82,16 +82,16 @@ bool sr_42620A(RenderVertexSoft *p) { // maybe near clipping on projectiles
             }
         }
         //logger->Info("sr_42620A pass");
-        v9 = pCamera3D->ViewPlaneDist_X < p->vWorldViewPosition.x;
+        v9 = pCamera3D->ViewPlaneDistPixels < p->vWorldViewPosition.x;
         v10 = 0;
-        v11 = pCamera3D->ViewPlaneDist_X == p->vWorldViewPosition.x;
+        v11 = pCamera3D->ViewPlaneDistPixels == p->vWorldViewPosition.x;
 
         if (v9 | v11) {
             float v16 =
                 1.0f / (p->vWorldViewPosition.x - p[1].vWorldViewPosition.x);
             v17 = (p->vWorldViewPosition.y - p[1].vWorldViewPosition.y) * v16;
             v18 = (p->vWorldViewPosition.z - p[1].vWorldViewPosition.z) * v16;
-            float v19 = pCamera3D->ViewPlaneDist_X - p[1].vWorldViewPosition.x;
+            float v19 = pCamera3D->ViewPlaneDistPixels - p[1].vWorldViewPosition.x;
             p[1].vWorldViewPosition.x = v19 + p[1].vWorldViewPosition.x;
             p[1].vWorldViewPosition.y = v17 * v19 + p[1].vWorldViewPosition.y;
             p[1].vWorldViewPosition.z = v19 * v18 + p[1].vWorldViewPosition.z;
@@ -100,7 +100,7 @@ bool sr_42620A(RenderVertexSoft *p) { // maybe near clipping on projectiles
                 1.0f / (p[1].vWorldViewPosition.x - p->vWorldViewPosition.x);
             v13 = (p[1].vWorldViewPosition.y - p->vWorldViewPosition.y) * v12;
             v14 = (p[1].vWorldViewPosition.z - p->vWorldViewPosition.z) * v12;
-            float v15 = pCamera3D->ViewPlaneDist_X - p->vWorldViewPosition.x;
+            float v15 = pCamera3D->ViewPlaneDistPixels - p->vWorldViewPosition.x;
             p->vWorldViewPosition.x = v15 + p->vWorldViewPosition.x;
             p->vWorldViewPosition.y = v13 * v15 + p->vWorldViewPosition.y;
             p->vWorldViewPosition.z = v15 * v14 + p->vWorldViewPosition.z;
@@ -244,8 +244,8 @@ void SpellFxRenderer::DrawProjectiles() {
         pCamera3D->Project(v, 2, 0);
 
         // 20.0f is width scaling factor
-        v10 = pCamera3D->ViewPlaneDist_X / v[1].vWorldViewPosition.x * 20.0f;
-        v11 = pCamera3D->ViewPlaneDist_X / v[0].vWorldViewPosition.x * 20.0f;
+        v10 = pCamera3D->ViewPlaneDistPixels / v[1].vWorldViewPosition.x * 20.0f;
+        v11 = pCamera3D->ViewPlaneDistPixels / v[0].vWorldViewPosition.x * 20.0f;
         render->DrawProjectile(v[0].vWorldViewProjX, v[0].vWorldViewProjY,
                                v[0].vWorldViewPosition.x, v11,
                                v[1].vWorldViewProjX, v[1].vWorldViewProjY,

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -2229,7 +2229,7 @@ void Inventory_ItemPopupAndAlchemy() {
             pAudioPlayer->playUISound(SOUND_fireBall);
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
 
-            Vec3i pos = pParty->pos + Vec3i(0, 0, pParty->eyeLevel) + Vec3i::fromPolar(64, pParty->_viewYaw, pParty->_viewPitch);
+            Vec3i pos = pParty->pos + Vec3i(0, 0, pParty->eyeLevel) + Vec3i::fromPolarRetarded(64, pParty->_viewYaw, pParty->_viewPitch);
             SpriteObject::dropItemAt(SPRITE_SPELL_FIRE_FIREBALL_IMPACT, pos, 0);
             if (pParty->activeCharacter().CanAct()) {
                 pParty->activeCharacter().playReaction(SPEECH_POTION_EXPLODE);

--- a/src/Utility/Geometry/Vec.h
+++ b/src/Utility/Geometry/Vec.h
@@ -95,6 +95,14 @@ struct Vec3 {
         return Vec3(sinYaw * cosPitch * length, cosYaw * cosPitch * length, sinPitch * length);
     }
 
+    static Vec3 fromPolar(T length, int yaw, int pitch) {
+        float cosPitch = TrigLUT.cos(pitch);
+        float sinPitch = TrigLUT.sin(pitch);
+        float cosYaw = TrigLUT.cos(yaw);
+        float sinYaw = TrigLUT.sin(yaw);
+        return Vec3(cosYaw * cosPitch * length, sinYaw * cosPitch * length, sinPitch * length);
+    }
+
     Vec2<T> xy() {
         return Vec2<T>(x, y);
     }

--- a/src/Utility/Geometry/Vec.h
+++ b/src/Utility/Geometry/Vec.h
@@ -86,7 +86,8 @@ struct Vec3 {
 
     constexpr Vec3(T a, T b, T c) : x(a), y(b), z(c) {}
 
-    static Vec3 fromPolar(T length, int yaw, int pitch) {
+    // TODO(captainurist): this one messes up x and y in return value, drop!
+    static Vec3 fromPolarRetarded(T length, int yaw, int pitch) {
         float cosPitch = TrigLUT.cos(pitch);
         float sinPitch = TrigLUT.sin(pitch);
         float cosYaw = TrigLUT.cos(yaw);


### PR DESCRIPTION
So basically wanted to fix the swapped x/y coords in `Vis::Intersect_Ray_Face`, and it's a rabbit hole.

Need to merge this one, then will do another PR that changes `TrigLUT::atan2` and retraces a bunch of tests, then will be able to merge in the x/y fix.