### PR TITLE
Refactor status bar

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -393,7 +393,7 @@ void Game::closeTargetedSpellWindow() {
             pGUIWindow_CastTargetedSpell->Release();  // test to fix enchanting issue
             pGUIWindow_CastTargetedSpell = nullptr;  // test to fix enchanting issue
             _mouse->SetCursorImage("MICON1");
-            game_ui_status_bar_event_string_expiration_time = 0;
+            _engine->_statusBar->clearEvent();
             IsEnchantingInProgress = false;
             back_to_game();
         }
@@ -533,7 +533,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window
                 pGUIWindow_CurrentMenu = new GUIWindow_QuestBook();
@@ -552,7 +552,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window
                 pGUIWindow_CurrentMenu = new GUIWindow_AutonotesBook();
@@ -571,7 +571,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window;
                 pGUIWindow_CurrentMenu = new GUIWindow_MapBook();
@@ -590,7 +590,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window
                 pGUIWindow_CurrentMenu = new GUIWindow_CalendarBook();
@@ -609,7 +609,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window
                 pGUIWindow_CurrentMenu = new GUIWindow_JournalBook();
@@ -619,7 +619,7 @@ void Game::processQueuedMessages() {
                 if (current_screen_type == SCREEN_DEBUG) {
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                     break;
                 }
                 if (current_screen_type != SCREEN_GAME) continue;
@@ -674,7 +674,7 @@ void Game::processQueuedMessages() {
                         pGUIWindow_CastTargetedSpell->Release();
                         pGUIWindow_CastTargetedSpell = 0;
                         _mouse->SetCursorImage("MICON1");
-                        game_ui_status_bar_event_string_expiration_time = 0;
+                        _engine->_statusBar->clearEvent();
                         IsEnchantingInProgress = false;
                         back_to_game();
                     }
@@ -808,9 +808,8 @@ void Game::processQueuedMessages() {
                                     DialogueEnding();
                                     current_screen_type = SCREEN_GAME;
                                     continue;
-                                case SCREEN_BRANCHLESS_NPC_DIALOG:  // click
-                                                                    // escape
-                                    GameUI_StatusBar_ClearEventString();
+                                case SCREEN_BRANCHLESS_NPC_DIALOG:  // click escape
+                                    _engine->_statusBar->clearEvent();
 
                                     ReleaseBranchlessDialogue();
                                     DialogueEnding();
@@ -1225,12 +1224,12 @@ void Game::processQueuedMessages() {
                     pAudioPlayer->playUISound(SOUND_error);
                     status_string = "Can't jump to that location!";
                 }
-                GameUI_SetStatusBar(status_string);
+                _engine->_statusBar->setEvent(status_string);
                 continue;
             }
             case UIMSG_CastQuickSpell: {
                 if (_engine->IsUnderwater()) {
-                    GameUI_SetStatusBar(LSTR_CANT_DO_UNDERWATER);
+                    _engine->_statusBar->setEvent(LSTR_CANT_DO_UNDERWATER);
                     pAudioPlayer->playUISound(SOUND_error);
                     continue;
                 }
@@ -1299,7 +1298,7 @@ void Game::processQueuedMessages() {
                 continue;
             case UIMSG_Wait5Minutes:
                 if (currentRestType == REST_HEAL) {
-                    GameUI_SetStatusBar(LSTR_ALREADY_RESTING);
+                    _engine->_statusBar->setEvent(LSTR_ALREADY_RESTING);
                     pAudioPlayer->playUISound(SOUND_error);
                     continue;
                 }
@@ -1310,7 +1309,7 @@ void Game::processQueuedMessages() {
                 continue;
             case UIMSG_Wait1Hour:
                 if (currentRestType == REST_HEAL) {
-                    GameUI_SetStatusBar(LSTR_ALREADY_RESTING);
+                    _engine->_statusBar->setEvent(LSTR_ALREADY_RESTING);
                     pAudioPlayer->playUISound(SOUND_error);
                     continue;
                 }
@@ -1345,21 +1344,21 @@ void Game::processQueuedMessages() {
 
                 if (CheckActors_proximity()) {
                     if (pParty->bTurnBasedModeOn) {
-                        GameUI_SetStatusBar(LSTR_CANT_REST_IN_TURN_BASED);
+                        _engine->_statusBar->setEvent(LSTR_CANT_REST_IN_TURN_BASED);
                         continue;
                     }
 
                     if (pParty->uFlags & (PARTY_FLAGS_1_AIRBORNE | PARTY_FLAGS_1_STANDING_ON_WATER)) // airbourne or on water
-                        GameUI_SetStatusBar(LSTR_CANT_REST_HERE);
+                        _engine->_statusBar->setEvent(LSTR_CANT_REST_HERE);
                     else
-                        GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
+                        _engine->_statusBar->setEvent(LSTR_HOSTILE_ENEMIES_NEARBY);
 
                     if (!pParty->hasActiveCharacter()) continue;
                     pParty->activeCharacter().playReaction(SPEECH_CANT_REST_HERE);
                     continue;
                 }
                 if (pParty->bTurnBasedModeOn) {
-                    GameUI_SetStatusBar(LSTR_CANT_REST_IN_TURN_BASED);
+                    _engine->_statusBar->setEvent(LSTR_CANT_REST_IN_TURN_BASED);
                     continue;
                 }
 
@@ -1374,14 +1373,14 @@ void Game::processQueuedMessages() {
                 }
 
                 if (pParty->bTurnBasedModeOn) {
-                    GameUI_SetStatusBar(LSTR_CANT_REST_IN_TURN_BASED);
+                    _engine->_statusBar->setEvent(LSTR_CANT_REST_IN_TURN_BASED);
                     continue;
                 }
 
                 if (pParty->uFlags & (PARTY_FLAGS_1_AIRBORNE | PARTY_FLAGS_1_STANDING_ON_WATER))
-                    GameUI_SetStatusBar(LSTR_CANT_REST_HERE);
+                    _engine->_statusBar->setEvent(LSTR_CANT_REST_HERE);
                 else
-                    GameUI_SetStatusBar(LSTR_HOSTILE_ENEMIES_NEARBY);
+                    _engine->_statusBar->setEvent(LSTR_HOSTILE_ENEMIES_NEARBY);
 
                 if (!pParty->hasActiveCharacter()) continue;
                 pParty->activeCharacter().playReaction(SPEECH_CANT_REST_HERE);
@@ -1389,12 +1388,12 @@ void Game::processQueuedMessages() {
             case UIMSG_Rest8Hour:
                 engine->_messageQueue->clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
                 if (currentRestType != REST_NONE) {
-                    GameUI_SetStatusBar(LSTR_ALREADY_RESTING);
+                    _engine->_statusBar->setEvent(LSTR_ALREADY_RESTING);
                     pAudioPlayer->playUISound(SOUND_error);
                     continue;
                 }
                 if (pParty->GetFood() < foodRequiredToRest) {
-                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_FOOD);
+                    _engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_FOOD);
                     if (pParty->hasActiveCharacter() && pParty->activeCharacter().CanAct()) {
                         pParty->activeCharacter().playReaction(SPEECH_NOT_ENOUGH_FOOD);
                     }
@@ -1429,7 +1428,7 @@ void Game::processQueuedMessages() {
                             currentRestType = REST_NONE;
 
                             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 0, 0);
-                            GameUI_SetStatusBar(LSTR_ENCOUNTER);
+                            _engine->_statusBar->setEvent(LSTR_ENCOUNTER);
                             pAudioPlayer->playUISound(SOUND_encounter);
                             continue;
                         }
@@ -1446,7 +1445,7 @@ void Game::processQueuedMessages() {
                 continue;
             case UIMSG_WaitTillDawn:
                 if (currentRestType == REST_HEAL) {
-                    GameUI_SetStatusBar(LSTR_ALREADY_RESTING);
+                    _engine->_statusBar->setEvent(LSTR_ALREADY_RESTING);
                     pAudioPlayer->playUISound(SOUND_error);
                     continue;
                 }
@@ -1458,12 +1457,12 @@ void Game::processQueuedMessages() {
 
             case UIMSG_HintSelectRemoveQuickSpellBtn: {
                 if (spellbookSelectedSpell != SPELL_NONE && spellbookSelectedSpell != pParty->activeCharacter().uQuickSpell) {
-                    GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_SET_S_AS_READY_SPELL, pSpellStats->pInfos[spellbookSelectedSpell].name));
+                    _engine->_statusBar->setPermanent(LSTR_FMT_SET_S_AS_READY_SPELL, pSpellStats->pInfos[spellbookSelectedSpell].name);
                 } else {
                     if (pParty->activeCharacter().uQuickSpell != SPELL_NONE)
-                        GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_REMOVE_QUICKSPELL));
+                        _engine->_statusBar->setPermanent(LSTR_CLICK_TO_REMOVE_QUICKSPELL);
                     else
-                        GameUI_StatusBar_Set(localization->GetString(LSTR_CLICK_TO_SET_QUICKSPELL));
+                        _engine->_statusBar->setPermanent(LSTR_CLICK_TO_SET_QUICKSPELL);
                 }
                 continue;
             }
@@ -1478,9 +1477,9 @@ void Game::processQueuedMessages() {
                 }
                 SPELL_TYPE selectedSpell = static_cast<SPELL_TYPE>(11 * pParty->activeCharacter().lastOpenedSpellbookPage + uMessageParam + 1);
                 if (spellbookSelectedSpell == selectedSpell) {
-                    GameUI_StatusBar_Set(localization->FormatString(LSTR_CAST_S, pSpellStats->pInfos[selectedSpell].name));
+                    _engine->_statusBar->setPermanent(LSTR_CAST_S, pSpellStats->pInfos[selectedSpell].name);
                 } else {
-                    GameUI_StatusBar_Set(localization->FormatString(LSTR_SELECT_S, pSpellStats->pInfos[selectedSpell].name));
+                    _engine->_statusBar->setPermanent(LSTR_SELECT_S, pSpellStats->pInfos[selectedSpell].name);
                 }
                 continue;
             }
@@ -1585,7 +1584,7 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 if (_engine->IsUnderwater()) {
-                    GameUI_SetStatusBar(LSTR_CANT_DO_UNDERWATER);
+                    _engine->_statusBar->setEvent(LSTR_CANT_DO_UNDERWATER);
                     pAudioPlayer->playUISound(SOUND_error);
                 } else {
                     engine->_messageQueue->clear();
@@ -1603,7 +1602,7 @@ void Game::processQueuedMessages() {
                                 // close out current window
                                 back_to_game();
                                 onEscape();
-                                GameUI_StatusBar_Clear();
+                                _engine->_statusBar->clearAll();
                             }
                             // open window
                             new OnButtonClick2({ 476, 450 }, { 0, 0 }, pBtn_CastSpell);
@@ -1627,7 +1626,7 @@ void Game::processQueuedMessages() {
                     // close out current window
                     back_to_game();
                     onEscape();
-                    GameUI_StatusBar_Clear();
+                    _engine->_statusBar->clearAll();
                 }
                 // open window
                 new OnButtonClick2({560, 450}, {0, 0}, pBtn_QuickReference);
@@ -1676,7 +1675,7 @@ void Game::processQueuedMessages() {
                 int cost = skillValue.level() + 1;
 
                 if (character->uSkillPoints < cost) {
-                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_SKILL_POINTS);
+                    _engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_SKILL_POINTS);
                 } else {
                     if (skillValue.level() < skills_max_level[skill]) {
                         character->setSkillValue(skill, CombinedSkillValue::increaseLevel(skillValue));
@@ -1684,7 +1683,7 @@ void Game::processQueuedMessages() {
                         character->playReaction(SPEECH_SKILL_INCREASE);
                         pAudioPlayer->playUISound(SOUND_quest);
                     } else {
-                        GameUI_SetStatusBar(LSTR_SKILL_ALREADY_MASTERED);
+                        _engine->_statusBar->setEvent(LSTR_SKILL_ALREADY_MASTERED);
                     }
                 }
                 continue;
@@ -1747,10 +1746,7 @@ void Game::processQueuedMessages() {
                 GameUI_OnPlayerPortraitLeftClick(uMessageParam);
                 continue;
             case UIMSG_ShowStatus_Funds: {
-                GameUI_StatusBar_Set(localization->FormatString(
-                    LSTR_FMT_D_TOTAL_GOLD_D_IN_BANK,
-                    pParty->GetGold() + pParty->uNumGoldInBank,
-                    pParty->uNumGoldInBank));
+                engine->_statusBar->setPermanent(LSTR_FMT_D_TOTAL_GOLD_D_IN_BANK, pParty->GetGold() + pParty->uNumGoldInBank, pParty->uNumGoldInBank);
                 continue;
             }
             case UIMSG_ShowStatus_DateTime:
@@ -1764,27 +1760,22 @@ void Game::processQueuedMessages() {
                         uNumSeconds = 0;
                     if (pParty->uCurrentHour == 0) currHour = 12;
                 }
-                GameUI_StatusBar_Set(fmt::format(
-                    "{}:{:02}{} {} {} {} {}", currHour,
-                    pParty->uCurrentMinute,
-                    localization->GetAmPm(uNumSeconds),
-                    localization->GetDayName(pParty->uCurrentDayOfMonth % 7),
-                    7 * pParty->uCurrentMonthWeek + pParty->uCurrentDayOfMonth % 7 + 1,
-                    localization->GetMonthName(pParty->uCurrentMonth),
-                    pParty->uCurrentYear));
+                engine->_statusBar->setPermanent(fmt::format("{}:{:02}{} {} {} {} {}", currHour, pParty->uCurrentMinute, localization->GetAmPm(uNumSeconds),
+                                                            localization->GetDayName(pParty->uCurrentDayOfMonth % 7),
+                                                            7 * pParty->uCurrentMonthWeek + pParty->uCurrentDayOfMonth % 7 + 1,
+                                                            localization->GetMonthName(pParty->uCurrentMonth), pParty->uCurrentYear));
                 continue;
 
             case UIMSG_ShowStatus_Food: {
-                GameUI_StatusBar_Set(localization->FormatString(
-                    LSTR_FMT_YOU_HAVE_D_FOOD, pParty->GetFood()));
+                engine->_statusBar->setPermanent(LSTR_FMT_YOU_HAVE_D_FOOD, pParty->GetFood());
                 continue;
             }
 
             case UIMSG_ShowStatus_Player: {
                 Character *character = &pParty->pCharacters[uMessageParam - 1];
 
-                GameUI_StatusBar_Set(fmt::format("{}: {}", NameAndTitle(character->name, character->classType),
-                                                 localization->GetCharacterConditionName(character->GetMajorConditionIdx())));
+                engine->_statusBar->setPermanent(fmt::format("{}: {}", NameAndTitle(character->name, character->classType),
+                                                            localization->GetCharacterConditionName(character->GetMajorConditionIdx())));
 
                 _mouse->uPointingObjectID = Pid(OBJECT_Character, (unsigned char)(8 * uMessageParam - 8) | 4);
                 continue;
@@ -1793,9 +1784,9 @@ void Game::processQueuedMessages() {
             case UIMSG_ShowStatus_ManaHP: {
                 Character *character = &pParty->pCharacters[uMessageParam - 1];
 
-                GameUI_StatusBar_Set(fmt::format("{} / {} {}    {} / {} {}",
-                                                 character->GetHealth(), character->GetMaxHealth(), localization->GetString(LSTR_HIT_POINTS),
-                                                 character->GetMana(), character->GetMaxMana(), localization->GetString(LSTR_SPELL_POINTS)));
+                engine->_statusBar->setPermanent(fmt::format("{} / {} {}    {} / {} {}",
+                                                            character->GetHealth(), character->GetMaxHealth(), localization->GetString(LSTR_HIT_POINTS),
+                                                            character->GetMana(), character->GetMaxMana(), localization->GetString(LSTR_SPELL_POINTS)));
                 continue;
             }
 
@@ -2134,7 +2125,8 @@ void Game::gameLoop() {
             pEventTimer->Update();
             pMiscTimer->Update();
 
-            GameUI_StatusBar_Update();
+            _engine->_statusBar->update();
+
             if (pMiscTimer->bPaused && !pEventTimer->bPaused)
                 pMiscTimer->Resume();
             if (pEventTimer->bTackGameTime && !pParty->bTurnBasedModeOn)
@@ -2153,10 +2145,7 @@ void Game::gameLoop() {
                 }
             }
             pAudioPlayer->UpdateSounds();
-            // expire timed status messages
-            if (game_ui_status_bar_event_string_expiration_time != 0 && game_ui_status_bar_event_string_expiration_time < platform->tickCount()) {
-                 GameUI_StatusBar_Clear();
-            }
+            _engine->_statusBar->update();
             if (uGameState == GAME_STATE_PLAYING) {
                 _engine->Draw();
                 continue;
@@ -2264,7 +2253,7 @@ void Game::gameLoop() {
                     pParty->pCharacters[playerId].playReaction(SPEECH_CHEATED_DEATH);
                 }
 
-                GameUI_SetStatusBar(LSTR_CHEATED_THE_DEATH);
+                _engine->_statusBar->setEvent(LSTR_CHEATED_THE_DEATH);
                 uGameState = GAME_STATE_PLAYING;
 
                 // need to clear messages here??

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -57,7 +57,7 @@ void Game_StartNewGameWhilePlaying(bool force_start) {
         uGameState = GAME_STATE_NEWGAME_OUT_GAMEMENU;
         current_screen_type = SCREEN_GAME;
     } else {
-        GameUI_SetStatusBar(LSTR_START_NEW_GAME_PROMPT);
+        engine->_statusBar->setEvent(LSTR_START_NEW_GAME_PROMPT);
         pAudioPlayer->playUISound(SOUND_quest);
         confirmationState = CONFIRM_NEW_GAME;
     }
@@ -72,7 +72,7 @@ void Game_QuitGameWhilePlaying(bool force_quit) {
         pAudioPlayer->playUISound(SOUND_WoodDoorClosing);
         uGameState = GAME_STATE_GAME_QUITTING_TO_MAIN_MENU;
     } else {
-        GameUI_SetStatusBar(LSTR_EXIT_GAME_PROMPT);
+        engine->_statusBar->setEvent(LSTR_EXIT_GAME_PROMPT);
         pAudioPlayer->playUISound(SOUND_quest);
         confirmationState = CONFIRM_QUIT;
     }
@@ -82,7 +82,7 @@ void Game_OpenLoadGameDialog() {
     engine->_messageQueue->clear();
     pGUIWindow_CurrentMenu->Release();
     pGUIWindow_CurrentMenu = nullptr;
-    game_ui_status_bar_event_string_expiration_time = 0;
+    engine->_statusBar->clearEvent();
     // LoadUI_Load(1);
     current_screen_type = SCREEN_LOADGAME;
     pGUIWindow_CurrentMenu = new GUIWindow_Load(true);
@@ -172,7 +172,7 @@ void Menu::EventLoop() {
                 continue;
             case UIMSG_Game_OpenSaveGameDialog: {
                 pGUIWindow_CurrentMenu->Release();
-                game_ui_status_bar_event_string_expiration_time = 0;
+                engine->_statusBar->clearEvent();
                 current_screen_type = SCREEN_SAVEGAME;
                 pGUIWindow_CurrentMenu = new GUIWindow_Save();
                 // SaveUI_Load(current_screen_type = SCREEN_SAVEGAME);
@@ -482,7 +482,7 @@ void Menu::MenuLoop() {
         render->BeginScene2D();
         engine->DrawGUI();
         GUI_UpdateWindows();
-        GameUI_StatusBar_Draw();
+        engine->_statusBar->draw();
         render->Present();
 
         EventLoop();

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -213,7 +213,7 @@ void Engine::DrawGUI() {
     // if (render->pRenderD3D)
     mouse->DrawCursorToTarget();
     GameUI_DrawRightPanelFrames();
-    GameUI_StatusBar_Draw();
+    _statusBar->draw();
 
     if (!pMovie_Track && uGameState != GAME_STATE_CHANGE_LOCATION) {  // ! pVideoPlayer->pSmackerMovie)
         GameUI_DrawMinimap(488, 16, 625, 133, viewparams->uMinimapZoom, true);  // redraw = pParty->uFlags & 2);
@@ -828,7 +828,7 @@ void Engine::MM7_Initialize() {
 
     MM6_Initialize();
 
-    GameUI_StatusBar_Update(true);
+    _statusBar = std::make_unique<StatusBar>();
 
     MM7_LoadLods();
 
@@ -1382,7 +1382,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
                 if (!character.hasUnderwaterSuitEquipped()) {
                     character.receiveDamage((int64_t)character.GetMaxHealth() * 0.1, DMGT_FIRE);
                     if (pParty->uFlags & PARTY_FLAGS_1_WATER_DAMAGE) {
-                        GameUI_SetStatusBarShortNotification(localization->GetString(LSTR_YOURE_DROWNING));
+                        engine->_statusBar->setEventShort(LSTR_YOURE_DROWNING);
                     }
                 } else {
                     character.playEmotion(CHARACTER_EXPRESSION_SMILE, 0);
@@ -1399,7 +1399,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
         for (Character &character : pParty->pCharacters) {
             character.receiveDamage((int64_t)character.GetMaxHealth() * 0.1, DMGT_FIRE);
             if (pParty->uFlags & PARTY_FLAGS_1_BURNING) {
-                GameUI_SetStatusBarShortNotification(localization->GetString(LSTR_ON_FIRE));
+                engine->_statusBar->setEventShort(LSTR_ON_FIRE);
             }
         }
     }

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -34,6 +34,7 @@ struct stru10;
 class Logger;
 class GUIMessageQueue;
 class GameResourceManager;
+class StatusBar;
 
 /*  320 */
 enum class GameState {
@@ -152,6 +153,7 @@ class Engine {
 
     std::unique_ptr<GUIMessageQueue> _messageQueue;
     std::unique_ptr<GameResourceManager> _gameResourceManager;
+    std::unique_ptr<StatusBar> _statusBar;
 };
 
 extern Engine *engine;

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -371,8 +371,14 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
         case EVENT_InputString:
             // Originally starting step was checked to ensure skipping this command when returning from dialogue.
             // Changed to using "step + 1" to go to next event
+            //
+            // TODO(Nik-RE-dev): this event is not used in MM7. In GrayFace's data it's called "Question" and must have additional arguments
+            // that control where events executions must be continued on correct/incorrect input.
+            __debugbreak();
+#if 0
             game_ui_status_bar_event_string = (ir.data.text_id < engine->_levelStrings.size()) ? engine->_levelStrings[ir.data.text_id] : "";
             StartBranchlessDialogue(_eventId, step + 1, (int)EVENT_InputString);
+#endif
             return -1;
         case EVENT_StatusText:
             if (activeLevelDecoration) {
@@ -380,11 +386,11 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                     current_npc_text = pNPCTopics[ir.data.text_id - 1].pText;
                 }
                 if (_canShowMessages) {
-                    GameUI_SetStatusBar(pNPCTopics[ir.data.text_id - 1].pText);
+                    engine->_statusBar->setEvent(pNPCTopics[ir.data.text_id - 1].pText);
                 }
             } else {
                 if (_canShowMessages) {
-                    GameUI_SetStatusBar((ir.data.text_id < engine->_levelStrings.size()) ? engine->_levelStrings[ir.data.text_id] : "");
+                    engine->_statusBar->setEvent((ir.data.text_id < engine->_levelStrings.size()) ? engine->_levelStrings[ir.data.text_id] : "");
                 }
             }
             break;

--- a/src/Engine/Events/Processor.cpp
+++ b/src/Engine/Events/Processor.cpp
@@ -152,9 +152,7 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
     dword_5B65C4_cancelEventProcessing = 0; // TODO: rename and contain in this module or better remove it altogether
 
     if (!eventId) {
-        if (!game_ui_status_bar_event_string_expiration_time) {
-            GameUI_SetStatusBar(LSTR_NOTHING_HERE);
-        }
+        engine->_statusBar->nothingHere();
         return;
     }
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1438,7 +1438,7 @@ char DoInteractionWithTopmostZObject(Pid pid) {
                     if (pParty->hasActiveCharacter()) {
                         InteractWithActor(id);
                     } else {
-                        GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                        engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
                     }
                 }
             }
@@ -1449,7 +1449,7 @@ char DoInteractionWithTopmostZObject(Pid pid) {
             if (pParty->hasActiveCharacter()) {
                 DecorationInteraction(id, pid);
             } else {
-                GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
             }
             break;
 
@@ -1471,11 +1471,11 @@ char DoInteractionWithTopmostZObject(Pid pid) {
                 if (pParty->hasActiveCharacter()) {
                     eventProcessor(pOutdoor->pBModels[bmodel_id].pFaces[face_id].sCogTriggeredID, pid, 1);
                 } else {
-                    GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                    engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
                 }
             } else {
                 if (!(pIndoor->pFaces[id].uAttributes & FACE_CLICKABLE)) {
-                    GameUI_StatusBar_NothingHere();
+                    engine->_statusBar->nothingHere();
                     return 1;
                 }
                 if (pIndoor->pFaces[id].uAttributes & FACE_HAS_EVENT || !pIndoor->pFaceExtras[pIndoor->pFaces[id].uFaceExtraID].uEventID) {
@@ -1485,7 +1485,7 @@ char DoInteractionWithTopmostZObject(Pid pid) {
                 if (pParty->hasActiveCharacter()) {
                     eventProcessor((int16_t)pIndoor->pFaceExtras[pIndoor->pFaces[id].uFaceExtraID].uEventID, pid, 1);
                 } else {
-                    GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                    engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
                 }
             }
             return 0;

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -228,7 +228,7 @@ void ItemInteraction(unsigned int item_id) {
             return;
         }
 
-        GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName);
+        engine->_statusBar->setEvent(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName);
 
         // TODO: WTF? 184 / 185 qbits are associated with Tatalia's Mercenery Guild Harmondale raids. Are these about castle's tapestries ?
         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER) {
@@ -318,7 +318,7 @@ void Engine::onGameViewportClick() {
                         InteractWithActor(mon_id);
                     } else {
                         // Do not interact with actors with no active character
-                        GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                        engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
                     }
                 } else {
                     pParty->dropHeldItem();
@@ -348,7 +348,7 @@ void Engine::onGameViewportClick() {
                 // Do not interact with decoration with no active character
                 DecorationInteraction(id, pid);
             } else {
-                GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+                engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
             }
         } else {
             pParty->dropHeldItem();
@@ -359,7 +359,7 @@ void Engine::onGameViewportClick() {
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
             if (!pIndoor->pFaces[pid.id()].Clickable()) {
                 if (pParty->pPickedItem.uItemID == ITEM_NULL) {
-                    GameUI_StatusBar_NothingHere();
+                    engine->_statusBar->nothingHere();
                 } else {
                     pParty->dropHeldItem();
                 }
@@ -371,7 +371,7 @@ void Engine::onGameViewportClick() {
             const ODMFace &model = pOutdoor->face(pid);
             if (!model.Clickable()) {
                 if (pParty->pPickedItem.uItemID == ITEM_NULL) {
-                    GameUI_StatusBar_NothingHere();
+                    engine->_statusBar->nothingHere();
                 } else {
                     pParty->dropHeldItem();
                 }
@@ -385,7 +385,7 @@ void Engine::onGameViewportClick() {
             eventProcessor(eventId, pid, 1);
         } else {
             // Do not interact with faces with no active character
-            GameUI_SetStatusBar(localization->GetString(LSTR_NOBODY_IS_IN_CONDITION));
+            engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
         }
     } else {
         pParty->dropHeldItem();

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3279,9 +3279,9 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
         Actor::AggroSurroundingPeasants(uActorID_Monster, 1);
         if (engine->config->settings.ShowHits.value()) {
             if (projectileSprite)
-                GameUI_SetStatusBar(LSTR_FMT_S_SHOOTS_S_FOR_U, character->name, pMonster->name, uDamageAmount);
+                engine->_statusBar->setEvent(LSTR_FMT_S_SHOOTS_S_FOR_U, character->name, pMonster->name, uDamageAmount);
             else
-                GameUI_SetStatusBar(LSTR_FMT_S_HITS_S_FOR_U, character->name, pMonster->name, uDamageAmount);
+                engine->_statusBar->setEvent(LSTR_FMT_S_HITS_S_FOR_U, character->name, pMonster->name, uDamageAmount);
         }
     } else {
         Actor::Die(uActorID_Monster);
@@ -3296,7 +3296,7 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
         }
         character->playReaction(speech);
         if (engine->config->settings.ShowHits.value()) {
-            GameUI_SetStatusBar(LSTR_FMT_S_INFLICTS_U_KILLING_S, character->name, uDamageAmount, pMonster->name);
+            engine->_statusBar->setEvent(LSTR_FMT_S_INFLICTS_U_KILLING_S, character->name, uDamageAmount, pMonster->name);
         }
     }
     if (pMonster->buffs[ACTOR_BUFF_PAIN_REFLECTION].Active() && uDamageAmount != 0)
@@ -3310,11 +3310,7 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
             extraRecoveryTime = (int)(debug_combat_recovery_mul * flt_debugrecmod3 * 20.0);
         pMonster->monsterInfo.uRecoveryTime += extraRecoveryTime;
         if (engine->config->settings.ShowHits.value()) {
-            GameUI_SetStatusBar(
-                LSTR_FMT_S_STUNS_S,
-                character->name,
-                pMonster->name
-            );
+            engine->_statusBar->setEvent(LSTR_FMT_S_STUNS_S, character->name, pMonster->name);
         }
     }
     if (hit_will_paralyze && pMonster->CanAct() &&
@@ -3323,11 +3319,7 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
         GameTime v46 = GameTime(0, maceSkill.level());  // ??
         pMonster->buffs[ACTOR_BUFF_PARALYZED].Apply((pParty->GetPlayingTime() + v46), maceSkill.mastery(), 0, 0, 0);
         if (engine->config->settings.ShowHits.value()) {
-            GameUI_SetStatusBar(
-                LSTR_FMT_S_PARALYZES_S,
-                character->name,
-                pMonster->name
-            );
+            engine->_statusBar->setEvent(LSTR_FMT_S_PARALYZES_S, character->name, pMonster->name);
         }
     }
     if (knockbackValue > 10) knockbackValue = 10;
@@ -3688,9 +3680,9 @@ bool CheckActors_proximity() {
 
 void StatusBarItemFound(int num_gold_found, const std::string &item_unidentified_name) {
     if (num_gold_found != 0) {
-        GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_GOLD_AND_ITEM, num_gold_found, item_unidentified_name);
+        engine->_statusBar->setEvent(LSTR_FMT_YOU_FOUND_GOLD_AND_ITEM, num_gold_found, item_unidentified_name);
     } else {
-        GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, item_unidentified_name);
+        engine->_statusBar->setEvent(LSTR_FMT_YOU_FOUND_ITEM, item_unidentified_name);
     }
 }
 

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -615,7 +615,7 @@ int Character::HasSkill(CharacterSkillType skill) const {
         return 1;
     } else {
         // TODO(captainurist): this doesn't belong to a getter!!!
-        GameUI_SetStatusBar(LSTR_FMT_S_DOES_NOT_HAVE_SKILL, this->name);
+        engine->_statusBar->setEvent(LSTR_FMT_S_DOES_NOT_HAVE_SKILL, this->name);
         return 0;
     }
 }
@@ -1469,7 +1469,7 @@ int Character::StealFromActor(
     if (grng->random(100) < 5 || fineIfFailed > currMaxItemValue ||
         actroPtr->ActorEnemy()) {  // busted
         Actor::AggroSurroundingPeasants(uActorID, 1);
-        GameUI_SetStatusBar(LSTR_FMT_S_WAS_CAUGHT_STEALING, this->name);
+        engine->_statusBar->setEvent(LSTR_FMT_S_WAS_CAUGHT_STEALING, this->name);
         return STEAL_BUSTED;
     } else {
         int random = grng->random(100);
@@ -1477,7 +1477,7 @@ int Character::StealFromActor(
         if (random >= 70) {  // stealing gold
             if (!actroPtr->items[3].isGold()) {
                 // no gold to steal - fail
-                GameUI_SetStatusBar(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
+                engine->_statusBar->setEvent(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
                 return STEAL_NOTHING;
             }
 
@@ -1495,9 +1495,9 @@ int Character::StealFromActor(
 
             if (enchBonusSum) {
                 pParty->partyFindsGold(enchBonusSum, GOLD_RECEIVE_NOSHARE_SILENT);
-                GameUI_SetStatusBar(LSTR_FMT_S_STOLE_D_GOLD, this->name, enchBonusSum);
+                engine->_statusBar->setEvent(LSTR_FMT_S_STOLE_D_GOLD, this->name, enchBonusSum);
             } else {
-                GameUI_SetStatusBar(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
+                engine->_statusBar->setEvent(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
             }
 
             return STEAL_SUCCESS;
@@ -1527,14 +1527,14 @@ int Character::StealFromActor(
                 }
 
                 if (carriedItemId != ITEM_NULL) {
-                    GameUI_SetStatusBar(LSTR_FMT_S_STOLE_D_ITEM, this->name, pItemTable->pItems[carriedItemId].pUnidentifiedName);
+                    engine->_statusBar->setEvent(LSTR_FMT_S_STOLE_D_ITEM, this->name, pItemTable->pItems[carriedItemId].pUnidentifiedName);
                     pParty->setHoldingItem(&tempItem);
                     return STEAL_SUCCESS;
                 }
             }
         }
 
-        GameUI_SetStatusBar(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
+        engine->_statusBar->setEvent(LSTR_FMT_S_FAILED_TO_STEAL, this->name);
         return STEAL_NOTHING;
     }
 }
@@ -3534,7 +3534,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             playerAffected->Heal(2);
             playerAffected->playReaction(SPEECH_DRINK_POTION);
         } else {
-            GameUI_SetStatusBar(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
+            engine->_statusBar->setEvent(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
@@ -3807,7 +3807,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
                 break;
 
             default:
-                GameUI_SetStatusBar(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
+                engine->_statusBar->setEvent(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
                 pAudioPlayer->playUISound(SOUND_error);
                 return;
         }
@@ -3834,12 +3834,12 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             return;
         }
         if (!playerAffected->CanAct()) {
-            GameUI_SetStatusBar(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
+            engine->_statusBar->setEvent(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
         if (engine->IsUnderwater()) {
-            GameUI_SetStatusBar(LSTR_CANT_DO_UNDERWATER);
+            engine->_statusBar->setEvent(LSTR_CANT_DO_UNDERWATER);
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
@@ -3865,12 +3865,12 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
     if (pParty->pPickedItem.isBook()) {
         SPELL_TYPE bookSpellId = bookSpellIds[pParty->pPickedItem.uItemID];
         if (playerAffected->spellbook.bHaveSpell[bookSpellId - SPELL_FIRST_REGULAR]) {
-            GameUI_SetStatusBar(LSTR_FMT_YOU_ALREADY_KNOW_S_SPELL, pParty->pPickedItem.GetDisplayName());
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_ALREADY_KNOW_S_SPELL, pParty->pPickedItem.GetDisplayName());
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
         if (!playerAffected->CanAct()) {
-            GameUI_SetStatusBar(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
+            engine->_statusBar->setEvent(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
@@ -3880,7 +3880,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
         CombinedSkillValue val = playerAffected->getSkillValue(skill);
 
         if (requiredMastery > val.mastery() || val.level() == 0) {
-            GameUI_SetStatusBar(LSTR_FMT_DONT_HAVE_SKILL_TO_LEAN_S, pParty->pPickedItem.GetDisplayName());
+            engine->_statusBar->setEvent(LSTR_FMT_DONT_HAVE_SKILL_TO_LEAN_S, pParty->pPickedItem.GetDisplayName());
             playerAffected->playReaction(SPEECH_CANT_LEARN_SPELL);
             return;
         }
@@ -3918,7 +3918,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             return;
         }
 
-        GameUI_SetStatusBar(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
+        engine->_statusBar->setEvent(LSTR_FMT_THAT_PLAYER_IS_S, localization->GetCharacterConditionName(playerAffected->GetMajorConditionIdx()));
         pAudioPlayer->playUISound(SOUND_error);
         return;
     }
@@ -4009,7 +4009,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
                     break;
                 }
             }
-            GameUI_SetStatusBar(status);
+            engine->_statusBar->setEvent(status);
 
             spell_fx_renderer->SetPlayerBuffAnim(SPELL_QUEST_COMPLETED, targetCharacter);
             playerAffected->playReaction(SPEECH_QUEST_GOT);
@@ -4046,7 +4046,7 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             TeleportToNWCDungeon();
             return;
         } else {
-            GameUI_SetStatusBar(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
+            engine->_statusBar->setEvent(LSTR_FMT_S_CANT_BE_USED_THIS_WAY, pParty->pPickedItem.GetDisplayName());
             pAudioPlayer->playUISound(SOUND_error);
             return;
         }
@@ -4606,7 +4606,7 @@ void Character::SetVariable(VariableType var_type, signed int var_value) {
         case VAR_RandomGold:
             gold = grng->random(var_value) + 1;
             pParty->SetGold(gold);
-            GameUI_SetStatusBar(LSTR_FMT_YOU_HAVE_D_GOLD, gold);
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_HAVE_D_GOLD, gold);
             GameUI_DrawFoodAndGold();
             return;
         case VAR_FixedFood:
@@ -4616,7 +4616,7 @@ void Character::SetVariable(VariableType var_type, signed int var_value) {
         case VAR_RandomFood:
             food = grng->random(var_value) + 1;
             pParty->SetFood(food);
-            GameUI_SetStatusBar(localization->FormatString(LSTR_FMT_YOU_HAVE_D_FOOD, food));
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_HAVE_D_FOOD, food);
             GameUI_DrawFoodAndGold();
             PlayAwardSound_Anim();
             return;
@@ -5139,7 +5139,7 @@ void Character::AddVariable(VariableType var_type, signed int val) {
             if (val == 0) val = 1;
             food = grng->random(val) + 1;
             pParty->GiveFood(food);
-            GameUI_SetStatusBar(LSTR_FMT_YOU_FIND_D_FOOD, food);
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_FIND_D_FOOD, food);
             GameUI_DrawFoodAndGold();
             PlayAwardSound();
             return;
@@ -5246,7 +5246,7 @@ void Character::AddVariable(VariableType var_type, signed int val) {
             return;
         case VAR_FixedFood:
             pParty->GiveFood(val);
-            GameUI_SetStatusBar(LSTR_FMT_YOU_FIND_D_FOOD, val);
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_FIND_D_FOOD, val);
             PlayAwardSound();
             return;
         case VAR_MightBonus:
@@ -5751,7 +5751,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             if (randGold > pParty->GetGold())
                 randGold = pParty->GetGold();
             pParty->TakeGold(randGold);
-            GameUI_SetStatusBar(LSTR_FMT_YOU_LOSE_D_GOLD, randGold);
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_LOSE_D_GOLD, randGold);
             GameUI_DrawFoodAndGold();
             return;
         case VAR_FixedFood:
@@ -5763,7 +5763,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             if (randFood > pParty->GetFood())
                 randFood = pParty->GetFood();
             pParty->TakeFood(randFood);
-            GameUI_SetStatusBar(LSTR_FMT_YOU_LOSE_D_FOOD, randFood);
+            engine->_statusBar->setEvent(LSTR_FMT_YOU_LOSE_D_FOOD, randFood);
             GameUI_DrawFoodAndGold();
             PlayAwardSound_Anim98();
             return;
@@ -6400,7 +6400,7 @@ void DamageCharacterFromMonster(Pid uObjID, ABILITY_INDEX dmgSource, Vec3i *pPos
         // GM unarmed 1% chance to evade attacks per skill point
         if (playerPtr->getActualSkillValue(CHARACTER_SKILL_UNARMED).mastery() >= CHARACTER_SKILL_MASTERY_GRANDMASTER &&
             grng->random(100) < playerPtr->getActualSkillValue(CHARACTER_SKILL_UNARMED).level()) {
-            GameUI_SetStatusBar(LSTR_FMT_S_EVADES_DAMAGE, playerPtr->name);
+            engine->_statusBar->setEvent(LSTR_FMT_S_EVADES_DAMAGE, playerPtr->name);
             playerPtr->playReaction(SPEECH_AVOID_DAMAGE);
             return;
         }
@@ -6589,7 +6589,7 @@ void DamageCharacterFromMonster(Pid uObjID, ABILITY_INDEX dmgSource, Vec3i *pPos
                 // GM unarmed 1% chance to evade attack per skill point
                 if (playerPtr->getActualSkillValue(CHARACTER_SKILL_UNARMED).mastery() >= CHARACTER_SKILL_MASTERY_GRANDMASTER &&
                     grng->random(100) < playerPtr->getActualSkillValue(CHARACTER_SKILL_UNARMED).level()) {
-                    GameUI_SetStatusBar(LSTR_FMT_S_EVADES_DAMAGE, playerPtr->name);
+                    engine->_statusBar->setEvent(LSTR_FMT_S_EVADES_DAMAGE, playerPtr->name);
                     playerPtr->playReaction(SPEECH_AVOID_DAMAGE);
                     return;
                 }

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -182,7 +182,7 @@ bool Chest::ChestUI_WritePointedObjectStatusString() {
             ///////////////////////////////////////////////
             // normal picking
 
-            GameUI_StatusBar_Set(item->GetDisplayName());
+            engine->_statusBar->setPermanent(item->GetDisplayName());
             uLastPointedObjectID = Pid::dummy();
             return 1;
 
@@ -231,7 +231,7 @@ bool Chest::ChestUI_WritePointedObjectStatusString() {
                     pixels += pix_chk_x + pix_chk_y*imgwidth;
 
                     if (*pixels & 0xFF000000) {
-                            GameUI_StatusBar_Set(item->GetDisplayName());
+                            engine->_statusBar->setPermanent(item->GetDisplayName());
                             uLastPointedObjectID = 1;
                             return 1;
                     }
@@ -516,7 +516,7 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
             if (pParty->hasActiveCharacter() && (InventSlot = pParty->activeCharacter().AddItem(-1, chestitem.uItemID)) != 0) {  // can place
                 memcpy(&pParty->activeCharacter().pInventoryItemList[InventSlot - 1], &chestitem, 0x24u);
                 grabcount++;
-                GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[chestitem.uItemID].pUnidentifiedName);
+                engine->_statusBar->setEvent(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[chestitem.uItemID].pUnidentifiedName);
             } else {  // no room so set as holding item
                 pParty->setHoldingItem(&chestitem);
                 RemoveItemAtChestIndex(loop);
@@ -530,10 +530,10 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
     }
 
     if (grabcount > 1 || goldcount > 1) {  // found items
-        GameUI_SetStatusBar(fmt::format("You found {} item(s) and {} Gold!", grabcount, goldamount));
+        engine->_statusBar->setEvent(fmt::format("You found {} item(s) and {} Gold!", grabcount, goldamount));
     }
     if (grabcount == 0 && goldcount == 0) {
-        GameUI_SetStatusBar(LSTR_NOTHING_HERE);
+        engine->_statusBar->setEvent(LSTR_NOTHING_HERE);
     }
 }
 

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -196,7 +196,7 @@ int UseNPCSkill(NPCProf profession, int id) {
 
         case WindMaster: {
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-                GameUI_SetStatusBar(LSTR_CANT_FLY_INDOORS);
+                engine->_statusBar->setEvent(LSTR_CANT_FLY_INDOORS);
                 pAudioPlayer->playUISound(SOUND_fizzle);
             } else {
                 // Spell power was changed to 0 because it does not have meaning for this buff

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -1051,7 +1051,7 @@ void Party::partyFindsGold(int amount, GoldReceivePolicy policy) {
     }
     AddGold(goldToGain - hirelingSalaries);
     if (status.length() > 0) {
-        GameUI_SetStatusBar(status);
+        engine->_statusBar->setEvent(status);
     }
 }
 

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -286,12 +286,12 @@ void DoSavegame(unsigned int uSlot) {
     }
 
     if (pCurrentMapName == "d05.blv")
-        GameUI_SetStatusBar(LSTR_NO_SAVING_IN_ARENA);
+        engine->_statusBar->setEvent(LSTR_NO_SAVING_IN_ARENA);
 
     // TODO(captainurist): This ^v doesn't seem right, need an else block?
 
     pEventTimer->Resume();
-    GameUI_SetStatusBar(LSTR_GAME_SAVED);
+    engine->_statusBar->setEvent(LSTR_GAME_SAVED);
 }
 
 void SavegameList::Initialize() {

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -71,7 +71,7 @@ static void initSpellSprite(SpriteObject *spritePtr,
  */
 static void spellFailed(CastSpellInfo *pCastSpell,
                         int error_str_id) {
-    GameUI_SetStatusBar(error_str_id);
+    engine->_statusBar->setEvent(error_str_id);
     pAudioPlayer->playUISound(SOUND_spellfail0201);
     pCastSpell->uSpellID = SPELL_NONE;
 }
@@ -1973,14 +1973,14 @@ void CastSpellInfoHelpers::castSpell() {
                         }
                         if (gold_num > 0) {
                             if (item.uItemID != ITEM_NULL)
-                                GameUI_SetStatusBar(fmt::format("({}), and {} gold", item.GetDisplayName(), gold_num));
+                                engine->_statusBar->setEvent(fmt::format("({}), and {} gold", item.GetDisplayName(), gold_num));
                             else
-                                GameUI_SetStatusBar(fmt::format("{} gold", gold_num));
+                                engine->_statusBar->setEvent(fmt::format("{} gold", gold_num));
                         } else {
                             if (item.uItemID != ITEM_NULL) {
-                                GameUI_SetStatusBar(fmt::format("({})", item.GetDisplayName()));
+                                engine->_statusBar->setEvent(fmt::format("({})", item.GetDisplayName()));
                             } else {
-                                GameUI_SetStatusBar("nothing");
+                                engine->_statusBar->nothingHere();
                             }
                         }
 
@@ -2167,7 +2167,7 @@ void CastSpellInfoHelpers::castSpell() {
                         if (pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].uEquipType == EQUIP_GOLD) {
                             pParty->partyFindsGold(pSpriteObjects[obj_id].containing_item.special_enchantment, GOLD_RECEIVE_SHARE);
                         } else {
-                            GameUI_SetStatusBar(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName);
+                            engine->_statusBar->setEvent(LSTR_FMT_YOU_FOUND_ITEM, pItemTable->pItems[pSpriteObjects[obj_id].containing_item.uItemID].pUnidentifiedName);
                             if (!pParty->addItemToParty(&pSpriteObjects[obj_id].containing_item)) {
                                 pParty->setHoldingItem(&pSpriteObjects[obj_id].containing_item);
                             }
@@ -2961,7 +2961,7 @@ void CastSpellInfoHelpers::cancelSpellCastInProgress() {
                 pGUIWindow_CastTargetedSpell = nullptr;
             }
             mouse->SetCursorImage("MICON1");
-            GameUI_StatusBar_Update(true);
+            engine->_statusBar->clearEvent();
             IsEnchantingInProgress = false;
             back_to_game();
 

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2447,11 +2447,6 @@ int dword_5B65C4_cancelEventProcessing;
 int npcIdToDismissAfterDialogue;
 // std::array<char, 777> byte_5C3427;
 
-// TODO(pskelton): GameStatusBar class
-std::string game_ui_status_bar_event_string;
-std::string game_ui_status_bar_string;
-unsigned int game_ui_status_bar_event_string_expiration_time;
-
 int _5C35C0_force_party_death = false;
 int bDialogueUI_InitializeActor_NPC_ID;
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -115,9 +115,6 @@ extern int Start_Party_Teleport_Flag;
 
 extern int dword_5B65C4_cancelEventProcessing;
 extern int npcIdToDismissAfterDialogue;
-extern std::string game_ui_status_bar_event_string;
-extern std::string game_ui_status_bar_string;
-extern unsigned int game_ui_status_bar_event_string_expiration_time; // In terms of Platform::tickCount.
 extern int _5C35C0_force_party_death;
 extern int bDialogueUI_InitializeActor_NPC_ID;
 

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -154,7 +154,7 @@ void GUIWindow_LloydsBook::hintBeaconSlot(int beaconId) {
     if (_recallingBeacon) {
         if (beacon.uBeaconTime) {
             std::string mapName = pMapStats->pInfos[beacon.mapId].pName;
-            GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_RECALL_TO_S, mapName));
+            engine->_statusBar->setPermanent(LSTR_FMT_RECALL_TO_S, mapName);
         }
     } else {
         MAP_TYPE mapId = pMapStats->GetMapInfo(pCurrentMapName);
@@ -165,9 +165,9 @@ void GUIWindow_LloydsBook::hintBeaconSlot(int beaconId) {
 
         if (beacon.uBeaconTime) {
             std::string mapName2 = pMapStats->pInfos[beacon.mapId].pName;
-            GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_SET_S_OVER_S, mapName, mapName2));
+            engine->_statusBar->setPermanent(LSTR_FMT_SET_S_OVER_S, mapName, mapName2);
         } else {
-            GameUI_StatusBar_Set(localization->FormatString(LSTR_FMT_SET_S_TO_S, mapName));
+            engine->_statusBar->setPermanent(LSTR_FMT_SET_S_TO_S, mapName);
         }
     }
 }

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -174,5 +174,5 @@ void GUIWindow_TownPortalBook::hintTown(int townId) {
         return;
     }
 
-    GameUI_StatusBar_Set(localization->FormatString(LSTR_TOWN_PORTAL_TO_S, pMapStats->pInfos[townPortalList[townId].mapInfoID].pName));
+    engine->_statusBar->setPermanent(LSTR_TOWN_PORTAL_TO_S, pMapStats->pInfos[townPortalList[townId].mapInfoID].pName);
 }

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -209,7 +209,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
                 ++itemcount;
         }
 
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
+        engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
 
         if (!itemcount) {  // shop empty
             GameTime nextGenTime = pParty->PartyTimes.guildNextRefreshTime[houseId()];
@@ -325,7 +325,7 @@ void GUIWindow_MagicGuild::houseScreenClick() {
 
                     if (pParty->GetGold() < uPriceItemService) {
                         playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
-                        GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                        engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                         return;
                     }
 
@@ -342,7 +342,7 @@ void GUIWindow_MagicGuild::houseScreenClick() {
                     }
 
                     pParty->activeCharacter().playReaction(SPEECH_NO_ROOM);
-                    GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
+                    engine->_statusBar->setEvent(LSTR_INVENTORY_IS_FULL);
                 }
             }
         }

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -62,7 +62,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
         } else {
             int  v27;
             if (pParty->GetGold() < pPrice) {
-                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                 v27 = 4;
             } else {
                 pParty->TakeGold(pPrice);

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -285,7 +285,7 @@ void GUIWindow_Shop::sellDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), colorTable.White);
+        engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_SELL), colorTable.White);
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
 
@@ -314,7 +314,7 @@ void GUIWindow_Shop::identifyDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), colorTable.White);
+        engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_IDENTIFY), colorTable.White);
 
         Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
 
@@ -351,7 +351,7 @@ void GUIWindow_Shop::repairDialogue() {
     CharacterUI_InventoryTab_Draw(&pParty->activeCharacter(), true);
 
     if (checkIfPlayerCanInteract()) {
-        GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), colorTable.White);
+        engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_REPAIR), colorTable.White);
 
         Pointi pt = dialogwin.mouse->GetCursorPos();
 
@@ -398,9 +398,9 @@ void GUIWindow_WeaponShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (item_num) {
@@ -470,9 +470,9 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (pItemCount) {
@@ -573,9 +573,9 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
         }
 
         if (isStealingModeActive()) {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_STEAL_ITEM), colorTable.White);
         } else {
-            GameUI_StatusBar_DrawImmediate(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
+            engine->_statusBar->drawForced(localization->GetString(LSTR_SELECT_ITEM_TO_BUY), colorTable.White);
         }
 
         if (item_num) {
@@ -941,12 +941,12 @@ void GUIWindow_Shop::houseScreenClick() {
                         pParty->TakeGold(uPriceItemService);
                         item.uAttributes |= ITEM_IDENTIFIED;
                         pParty->activeCharacter().playReaction(SPEECH_SHOP_IDENTIFY);
-                        GameUI_SetStatusBar(LSTR_DONE);
+                        engine->_statusBar->setEvent(LSTR_DONE);
                         return;
                     }
 
                     playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
-                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                    engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                     return;
                 }
 
@@ -981,12 +981,12 @@ void GUIWindow_Shop::houseScreenClick() {
                         pParty->TakeGold(uPriceItemService);
                         item.uAttributes = (item.uAttributes & ~ITEM_BROKEN) | ITEM_IDENTIFIED;
                         pParty->activeCharacter().playReaction(SPEECH_SHOP_REPAIR);
-                        GameUI_SetStatusBar(LSTR_GOOD_AS_NEW);
+                        engine->_statusBar->setEvent(LSTR_GOOD_AS_NEW);
                         return;
                     }
 
                     playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
-                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                    engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                     return;
                 }
 
@@ -1107,7 +1107,7 @@ void GUIWindow_Shop::houseScreenClick() {
                 }
             } else if (pParty->GetGold() < uPriceItemService) {
                 playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
-                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                 return;
             }
 
@@ -1128,7 +1128,7 @@ void GUIWindow_Shop::houseScreenClick() {
                 return;
             } else {
                 pParty->activeCharacter().playReaction(SPEECH_NO_ROOM);
-                GameUI_SetStatusBar(LSTR_INVENTORY_IS_FULL);
+                engine->_statusBar->setEvent(LSTR_INVENTORY_IS_FULL);
                 return;
             }
             break;

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -129,7 +129,7 @@ void GUIWindow_Tavern::restDialogue() {
         window_SpeakInHouse = 0;
         return;
     }
-    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+    engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
     playHouseSound(houseId(), HOUSE_SOUND_TAVERN_NOT_ENOUGH_GOLD);
     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
 }
@@ -138,7 +138,7 @@ void GUIWindow_Tavern::buyFoodDialogue() {
     int pPriceFood = PriceCalculator::tavernFoodCostForPlayer(&pParty->activeCharacter(), buildingTable[houseId()]);
 
     if ((double)pParty->GetFood() >= buildingTable[houseId()].fPriceMultiplier) {
-        GameUI_SetStatusBar(LSTR_RATIONS_FULL);
+        engine->_statusBar->setEvent(LSTR_RATIONS_FULL);
         if (pParty->hasActiveCharacter()) {
             pParty->activeCharacter().playReaction(SPEECH_PACKS_FULL);
         }
@@ -152,7 +152,7 @@ void GUIWindow_Tavern::buyFoodDialogue() {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
         return;
     }
-    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+    engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
     playHouseSound(houseId(), HOUSE_SOUND_TAVERN_NOT_ENOUGH_GOLD);
     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
 }

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -34,7 +34,7 @@ void GUIWindow_Temple::healDialogue() {
 
     int price = PriceCalculator::templeHealingCostForPlayer(&pParty->activeCharacter(), buildingTable[houseId()].fPriceMultiplier);
     if (pParty->GetGold() < price) {
-        GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+        engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
         playHouseSound(houseId(), HOUSE_SOUND_GENERAL_NOT_ENOUGH_GOLD);
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
         return;
@@ -103,9 +103,9 @@ void GUIWindow_Temple::donateDialogue() {
         }
         _templeSpellCounter[pParty->activeCharacterIndex() - 1]++;
         pParty->activeCharacter().playReaction(SPEECH_TEMPLE_DONATE);
-        GameUI_SetStatusBar(LSTR_THANK_YOU);
+        engine->_statusBar->setEvent(LSTR_THANK_YOU);
     } else {
-        GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+        engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
     }
     engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
 }

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -86,14 +86,14 @@ void GUIWindow_Training::trainDialogue() {
                 }
                 pParty->activeCharacter().playReaction(SPEECH_LEVEL_UP);
 
-                GameUI_SetStatusBar(LSTR_FMT_S_NOW_LEVEL_D, pParty->activeCharacter().name,
+                engine->_statusBar->setEvent(LSTR_FMT_S_NOW_LEVEL_D, pParty->activeCharacter().name,
                                     pParty->activeCharacter().uLevel, pParty->activeCharacter().uLevel / 10 + 5);
 
                 engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
                 return;
             }
 
-            GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+            engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
             playHouseSound(houseId(), HOUSE_SOUND_TRAINING_NOT_ENOUGH_GOLD);
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
             return;

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -147,7 +147,7 @@ void GUIWindow_Transport::transportDialogue() {
     int pPrice = PriceCalculator::transportCostForPlayer(&pParty->activeCharacter(), buildingTable[houseId()]);
 
     if (pParty->GetGold() < pPrice) {
-        GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+        engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
         playHouseSound(houseId(), HOUSE_SOUND_TRANSPORT_NOT_ENOUGH_GOLD);
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
         return;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -497,6 +497,10 @@ void GUIWindow_GenericDialogue::Update() {
     pGUIWindow_BranchlessDialogue->DrawText(pFont, {12, 354 - pTextHeight}, colorTable.White,
         pFont->FitTextInAWindow(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12));
     render->DrawTextureNew(0, 352 / 480.0f, game_ui_statusbar);
+
+    // TODO(Nik-RE-dev): this code related to text input in MM6/MM8, revisit
+    // this functionality when it's time to support it.
+#if 0
     if (pGUIWindow_BranchlessDialogue->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS) {
         if (pGUIWindow_BranchlessDialogue->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
             pGUIWindow_BranchlessDialogue->keyboard_input_status = WINDOW_INPUT_NONE;
@@ -518,11 +522,11 @@ void GUIWindow_GenericDialogue::Update() {
         pGUIWindow_BranchlessDialogue->DrawFlashingInputCursor(pFontLucida->GetLineWidth(str) + 13, 357, pFontLucida);
         return;
     }
+#endif
 
     // Close branchless dialog on any keypress
     if (!keyboardInputHandler->GetTextInput().empty()) {
         keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_NONE);
-        GameUI_StatusBar_ClearInputString();
         ReleaseBranchlessDialogue();
         return;
     }
@@ -602,12 +606,12 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             return;
         }
         if (!pParty->pHirelings[0].pName.empty() && !pParty->pHirelings[1].pName.empty()) {
-            GameUI_SetStatusBar(LSTR_HIRE_NO_ROOM);
+            engine->_statusBar->setEvent(LSTR_HIRE_NO_ROOM);
         } else {
             if (speakingNPC->profession != Burglar) {
                 // burglars have no hiring price
                 if (pParty->GetGold() < pNPCStats->pProfessions[speakingNPC->profession].uHirePrice) {
-                    GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                    engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                     dialogue_show_profession_details = false;
                     uDialogueType = DIALOGUE_13_hiring_related;
                     if (pParty->hasActiveCharacter()) {
@@ -652,7 +656,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             }
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
         } else {
-            GameUI_SetStatusBar(LSTR_RATIONS_FULL);
+            engine->_statusBar->setEvent(LSTR_RATIONS_FULL);
         }
     } else if (option == DIALOGUE_13_hiring_related) {
         if (!speakingNPC->Hired()) {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -298,8 +298,7 @@ static constexpr IndexedArray<const char *, BUILDING_WEAPON_SHOP, BUILDING_MIRRO
 }};
 
 bool enterHouse(HOUSE_ID uHouseID) {
-    GameUI_StatusBar_Clear();
-    GameUI_SetStatusBar("");
+    engine->_statusBar->clearAll();
     engine->_messageQueue->clear();
     uDialogueType = DIALOGUE_NULL;
     keyboardInputHandler->SetWindowInputStatus(WINDOW_INPUT_CANCELLED);
@@ -342,7 +341,7 @@ bool enterHouse(HOUSE_ID uHouseID) {
             amPmClose = 1;
         }
 
-        GameUI_SetStatusBar(LSTR_FMT_OPEN_TIME, openHours, localization->GetAmPm(amPmOpen), closeHours, localization->GetAmPm(amPmClose));
+        engine->_statusBar->setEvent(LSTR_FMT_OPEN_TIME, openHours, localization->GetAmPm(amPmOpen), closeHours, localization->GetAmPm(amPmClose));
         if (pParty->hasActiveCharacter()) {
             pParty->activeCharacter().playReaction(SPEECH_STORE_CLOSED);
         }
@@ -354,7 +353,7 @@ bool enterHouse(HOUSE_ID uHouseID) {
         if (!(pParty->PartyTimes.shopBanTimes[uHouseID]) || (pParty->PartyTimes.shopBanTimes[uHouseID] <= pParty->GetPlayingTime())) {
             pParty->PartyTimes.shopBanTimes[uHouseID] = GameTime(0);
         } else {
-            GameUI_SetStatusBar(LSTR_BANNED_FROM_SHOP);
+            engine->_statusBar->setEvent(LSTR_BANNED_FROM_SHOP);
             return false;
         }
     }
@@ -528,7 +527,7 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
     }
 
     if (!pParty->pHirelings[0].pName.empty() && !pParty->pHirelings[1].pName.empty()) {
-        GameUI_SetStatusBar(LSTR_HIRE_NO_ROOM);
+        engine->_statusBar->setEvent(LSTR_HIRE_NO_ROOM);
         BackToHouseMenu();
         return;
     }
@@ -540,7 +539,7 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
         __debugbreak();
         int pPrice = pNPCStats->pProfessions[pCurrentNPCInfo->profession].uHirePrice;
         if (pParty->GetGold() < (unsigned int)pPrice) {
-            GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+            engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
             dialogue_show_profession_details = false;
             uDialogueType = DIALOGUE_13_hiring_related;
             current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
@@ -548,7 +547,7 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
             if (pParty->hasActiveCharacter()) {
                 pParty->activeCharacter().playReaction(SPEECH_NOT_ENOUGH_GOLD);
             }
-            GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+            engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
             BackToHouseMenu();
             return;
         } else {
@@ -1222,7 +1221,7 @@ void GUIWindow_House::learnSelectedSkill(CharacterSkillType skill) {
     if (skillMaxMasteryPerClass[pParty->activeCharacter().classType][skill] != CHARACTER_SKILL_MASTERY_NONE) {
         if (!pParty->activeCharacter().pActiveSkills[skill]) {
             if (pParty->GetGold() < pPrice) {
-                GameUI_SetStatusBar(LSTR_NOT_ENOUGH_GOLD);
+                engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                 if (buildingType() == BUILDING_TRAINING_GROUND) {
                     playHouseSound(houseId(), HOUSE_SOUND_TRAINING_NOT_ENOUGH_GOLD);
                 } else if (buildingType() == BUILDING_TAVERN) {

--- a/src/GUI/UI/UIInventory.cpp
+++ b/src/GUI/UI/UIInventory.cpp
@@ -1,5 +1,6 @@
 #include "GUI/UI/UIInventory.h"
 
+#include "Engine/Engine.h"
 #include "Engine/Localization.h"
 
 #include "Engine/Graphics/IRender.h"
@@ -39,7 +40,7 @@ GUIWindow_Inventory_CastSpell::GUIWindow_Inventory_CastSpell(Pointi position, Si
     GUIWindow(WINDOW_CastSpell_InInventory, position, dimensions, spellInfo, hint) {
     mouse->SetCursorImage("MICON2");
     pBtn_ExitCancel = CreateButton({392, 318}, {75, 33}, 1, 0, UIMSG_Escape, 0, Io::InputAction::Invalid, localization->GetString(LSTR_CANCEL), {ui_buttdesc2});
-    GameUI_SetStatusBar(LSTR_CHOOSE_TARGET);
+    engine->_statusBar->setEvent(LSTR_CHOOSE_TARGET);
     current_character_screen_window = WINDOW_CharacterWindow_Inventory;
     current_screen_type = SCREEN_CASTING;
 }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -47,6 +47,8 @@ std::array<GraphicsImage *, 22> ui_partycreation_portraits;
 std::array<GraphicsImage *, 19> ui_partycreation_arrow_r;
 std::array<GraphicsImage *, 19> ui_partycreation_arrow_l;
 
+int64_t errorMessageExpireTime; // expiration time (platform time) of error message
+
 static const int ARROW_SPIN_PERIOD_MS = 475;
 
 bool PartyCreationUI_LoopInternal();
@@ -192,12 +194,11 @@ void CreateParty_EventLoop() {
             break;
         case UIMSG_PlayerCreationClickOK:
             new OnButtonClick2({580, 431}, {0, 0}, pPlayerCreationUI_BtnOK);
-            if (CharacterCreation_GetUnspentAttributePointCount() ||
-                !PlayerCreation_Choose4Skills())
-                game_ui_status_bar_event_string_expiration_time =
-                    platform->tickCount() + 4000;
-            else
+            if (CharacterCreation_GetUnspentAttributePointCount() || !PlayerCreation_Choose4Skills()) {
+                errorMessageExpireTime = platform->tickCount() + 4000; // show message for 4 seconds
+            } else {
                 uGameState = GAME_STATE_STARTING_NEW_GAME;
+            }
             break;
         case UIMSG_PlayerCreationClickReset:
             new OnButtonClick2({527, 431}, {0, 0}, pPlayerCreationUI_BtnReset);
@@ -575,10 +576,10 @@ void GUIWindow_PartyCreation::Update() {
     pBonusNum = CharacterCreation_GetUnspentAttributePointCount();
 
     auto unspent_attribute_bonus_label = fmt::format("{}", pBonusNum);
-    pTextCenter =
-        pFontCreate->AlignText_Center(84, unspent_attribute_bonus_label);
+    pTextCenter = pFontCreate->AlignText_Center(84, unspent_attribute_bonus_label);
     pGUIWindow_CurrentMenu->DrawText(pFontCreate, {pTextCenter + 530, 410}, colorTable.White, unspent_attribute_bonus_label);
-    if (game_ui_status_bar_event_string_expiration_time > platform->tickCount()) {
+
+    if (errorMessageExpireTime > platform->tickCount()) {
         GUIWindow message_window;
         message_window.sHint = localization->GetString(LSTR_PARTY_UNASSIGNED_POINTS);
         if (pBonusNum < 0)

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -47,7 +47,7 @@ std::array<GraphicsImage *, 22> ui_partycreation_portraits;
 std::array<GraphicsImage *, 19> ui_partycreation_arrow_r;
 std::array<GraphicsImage *, 19> ui_partycreation_arrow_l;
 
-int64_t errorMessageExpireTime; // expiration time (platform time) of error message
+static int64_t errorMessageExpireTime; // expiration time (platform time) of error message
 
 static const int ARROW_SPIN_PERIOD_MS = 475;
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -258,7 +258,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
                 inspect_item->SetIdentified();
             CharacterSpeech speech = SPEECH_ID_ITEM_FAIL;
             if (!inspect_item->IsIdentified()) {
-                GameUI_SetStatusBar(LSTR_IDENTIFY_FAILED);
+                engine->_statusBar->setEvent(LSTR_IDENTIFY_FAILED);
             } else {
                 speech = SPEECH_ID_ITEM_STRONG;
                 if (inspect_item->GetValue() < 100 * (pParty->activeCharacter().uLevel + 5)) {
@@ -278,7 +278,7 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
             if (!inspect_item->IsBroken())
                 speech = SPEECH_REPAIR_SUCCESS;
             else
-                GameUI_SetStatusBar(LSTR_REPAIR_FAILED);
+                engine->_statusBar->setEvent(LSTR_REPAIR_FAILED);
             if (!identifyOrRepairReactionPlayed) {
                 pParty->activeCharacter().playReaction(speech);
                 identifyOrRepairReactionPlayed = true;
@@ -2234,7 +2234,7 @@ void Inventory_ItemPopupAndAlchemy() {
             if (pParty->activeCharacter().CanAct()) {
                 pParty->activeCharacter().playReaction(SPEECH_POTION_EXPLODE);
             }
-            GameUI_SetStatusBar(LSTR_OOPS);
+            engine->_statusBar->setEvent(LSTR_OOPS);
             mouse->RemoveHoldingItem();
             rightClickItemActionPerformed = true;
             return;

--- a/src/GUI/UI/UISpell.cpp
+++ b/src/GUI/UI/UISpell.cpp
@@ -5,6 +5,7 @@
 
 #include "Media/Audio/AudioPlayer.h"
 
+#include "Engine/Engine.h"
 #include "Engine/Spells/CastSpellInfo.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Localization.h"
@@ -16,7 +17,7 @@ TargetedSpellUI::TargetedSpellUI(Pointi position, Sizei dimensions, WindowData d
     : GUIWindow(WINDOW_CastSpell, position, dimensions, data, hint) {
     pEventTimer->Pause();
     mouse->SetCursorImage("MICON2");
-    GameUI_SetStatusBar(LSTR_CHOOSE_TARGET);
+    engine->_statusBar->setEvent(LSTR_CHOOSE_TARGET);
 }
 
 TargetedSpellUI_Hirelings::TargetedSpellUI_Hirelings(Pointi position, Sizei dimensions, WindowData data, const std::string &hint)

--- a/src/GUI/UI/UIStatusBar.h
+++ b/src/GUI/UI/UIStatusBar.h
@@ -7,29 +7,40 @@
 
 #include "Library/Color/Color.h"
 
-void GameUI_StatusBar_Draw();
-void GameUI_StatusBar_Set(const std::string &str);
-const std::string &GameUI_StatusBar_Get();
-void GameUI_StatusBar_Clear();
+class StatusBar {
+ public:
+    static const int EVENT_DURATION = 2000; // 2s
+    static const int EVENT_DURATION_SHORT = 500; // 0.5s
 
-void GameUI_StatusBar_Update(bool force_hide = false);
+    const std::string &get();
+    void draw();
+    void drawForced(const std::string &str, Color color);
+    void update();
+    void clearAll();
 
-void GameUI_SetStatusBar(const std::string &str);
+    void setPermanent(const std::string &str);
+    void clearPermanent();
 
-template<class... Args>
-void GameUI_SetStatusBar(int localization_string_id, Args &&... args) {
-    // TODO(captainurist): what if fmt throws?
-    GameUI_SetStatusBar(fmt::sprintf(localization->GetString(localization_string_id), std::forward<Args>(args)...));
-    // TODO(captainurist): there was also a call to sprintfex_internal here.
-}
+    void setEvent(const std::string &str);
+    void setEventShort(const std::string &str);
+    void clearEvent();
 
-void GameUI_SetStatusBarShortNotification(const std::string &str);
-void GameUI_StatusBar_ClearEventString();
+    template<class... Args> void setPermanent(int locId, Args &&... args) {
+        setPermanent(localization->FormatString(locId, std::forward<Args>(args)...));
+    }
 
-std::string GameUI_StatusBar_GetInput();
-void GameUI_StatusBar_OnInput(const std::string &str);
-void GameUI_StatusBar_ClearInputString();
+    template<class... Args> void setEvent(int locId, Args &&... args) {
+        setEvent(localization->FormatString(locId, std::forward<Args>(args)...));
+    }
 
-void GameUI_StatusBar_NothingHere();
+    template<class... Args> void setEventShort(int locId, Args &&... args) {
+        setEventShort(localization->FormatString(locId, std::forward<Args>(args)...));
+    }
 
-void GameUI_StatusBar_DrawImmediate(const std::string &str, Color color);
+    void nothingHere();
+
+ private:
+    std::string _statusString = "";
+    std::string _eventStatusString = "";
+    int _eventStatusExpireTime = 0;
+};

--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -113,7 +113,7 @@ static auto makeConfigTape(TestController *test, const ConfigEntry<T> &entry) {
 }
 
 static auto makeStatusBarTape(TestController *test) {
-    return test->tape([] { return GameUI_StatusBar_Get(); });
+    return test->tape([] { return engine->_statusBar->get(); });
 }
 
 static auto makeDialogueTypeTape(TestController *test) {
@@ -383,7 +383,7 @@ GAME_TEST(Issues, Issue272b) {
     // Check you cant leave menu with conflicting keys.
     test->playTraceFromTestData("issue_272b.mm7", "issue_272b.json");
     EXPECT_EQ(current_screen_type, SCREEN_KEYBOARD_OPTIONS);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Please resolve all key conflicts!");
+    EXPECT_EQ(engine->_statusBar->get(), "Please resolve all key conflicts!");
 }
 
 GAME_TEST(Issues, Issue290) {
@@ -1393,63 +1393,63 @@ GAME_TEST(Issues, Issue830) {
     // Mouseover hints for UI elements not showing
     game->startNewGame();
     game->tick(1);
-    game_ui_status_bar_event_string_expiration_time = 0;
+    engine->_statusBar->clearEvent();
     // Portrait: Name and conditions of the character
     game->moveMouse(65, 424);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Zoltan the Knight: Good");
+    EXPECT_EQ(engine->_statusBar->get(), "Zoltan the Knight: Good");
     //HP / SP Bar(either one) : Display current and max HP and SP both
     game->moveMouse(102, 426);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "45 / 45 Hit Points    0 / 0 Spell Points");
+    EXPECT_EQ(engine->_statusBar->get(), "45 / 45 Hit Points    0 / 0 Spell Points");
     // Minimap : Display time, day of the week and full date
     game->moveMouse(517, 111);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "9:00am Monday 1 January 1168");
+    EXPECT_EQ(engine->_statusBar->get(), "9:00am Monday 1 January 1168");
     //Zoom in / out minimap buttons : Display description of the button
     game->moveMouse(523, 140);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Zoom In");
+    EXPECT_EQ(engine->_statusBar->get(), "Zoom In");
     game->moveMouse(577, 140);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Zoom Out");
+    EXPECT_EQ(engine->_statusBar->get(), "Zoom Out");
     // Food : Display total amount of food(bit redundant, but it is there)
     game->moveMouse(520, 329);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "You have 7 food");
+    EXPECT_EQ(engine->_statusBar->get(), "You have 7 food");
     // Gold : Display amount of gold on party and in bank
     game->moveMouse(575, 327);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "You have 200 total gold, 0 in the Bank");
+    EXPECT_EQ(engine->_statusBar->get(), "You have 200 total gold, 0 in the Bank");
     // Books : Description of each book(journal, autonotes etc)
     game->moveMouse(513, 387);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Current Quests");
+    EXPECT_EQ(engine->_statusBar->get(), "Current Quests");
     game->moveMouse(540, 382);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Auto Notes");
+    EXPECT_EQ(engine->_statusBar->get(), "Auto Notes");
     game->moveMouse(556, 381);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Maps");
+    EXPECT_EQ(engine->_statusBar->get(), "Maps");
     game->moveMouse(586, 396);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Calendar");
+    EXPECT_EQ(engine->_statusBar->get(), "Calendar");
     game->moveMouse(611, 400);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "History");
+    EXPECT_EQ(engine->_statusBar->get(), "History");
     // Buttons : Description of the 4 buttons in the corner(cast spell, rest, quick ref, game options)
     game->moveMouse(494, 461);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Cast Spell");
+    EXPECT_EQ(engine->_statusBar->get(), "Cast Spell");
     game->moveMouse(541, 460);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Rest");
+    EXPECT_EQ(engine->_statusBar->get(), "Rest");
     game->moveMouse(585, 461);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Quick Reference");
+    EXPECT_EQ(engine->_statusBar->get(), "Quick Reference");
     game->moveMouse(621, 460);
     game->tick(1);
-    EXPECT_EQ(GameUI_StatusBar_Get(), "Game Options");
+    EXPECT_EQ(engine->_statusBar->get(), "Game Options");
 }
 
 GAME_TEST(Issues, Issue832) {


### PR DESCRIPTION
Refactor status bar.
Create class for status bar instead of collection of functions and place it's object into Engine class.

Changes from before:
- Remove code for `EVENT_InputString` in event processing and in branchless dialogue because it is unused in MM7 and not tested. It used status bar for intermediate string placement.
- Do not use status bar variables for showing error message in party creation.
- Increase duration of short status messages from 128ms to 0.5s (used when drowning for example).
- Remove `pEventTimer` check when updating event messages - it's redundant (in game loop status message already updated twice and second time without event timer check).