### PR TITLE
Cleanup NPC dialogue

### DIFF
--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -685,13 +685,7 @@ std::string npcDialogueOptionString(DIALOGUE_TYPE topic, NPCData *npcData) {
       case DIALOGUE_USE_HIRED_NPC_ABILITY:
         return GetProfessionActionText(npcData->profession);
       default:
-        if (topic > DIALOGUE_NULL && topic < DIALOGUE_13_hiring_related) {
-            // TODO(Nik-RE-dev): wtf?
-            return localization->GetString(LSTR_JOIN);
-        } else {
-            // TODO(Nik-RE-dev): must never happen?
-            return "";
-        }
+        return "";
     }
 }
 

--- a/src/GUI/UI/NPCTopics.h
+++ b/src/GUI/UI/NPCTopics.h
@@ -33,9 +33,13 @@ const std::string &joinGuildOptionString();
  */
 void NPCHireableDialogPrepare();
 
+std::string npcDialogueOptionString(DIALOGUE_TYPE topic, NPCData *npcData);
+
+std::vector<DIALOGUE_TYPE> prepareScriptedNPCDialogueTopics(NPCData *npcData);
+
 // TODO(Nik-RE-dev): currently this function handles dialogue buttons creation etc,
 //                   need to move such functionality into UIHouses/UIDialogue
-std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, int eventId);
+std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, NPCData *npcData);
 void selectSpecialNPCTopicSelection(DIALOGUE_TYPE topic, NPCData* npcData);
 
 extern int gold_transaction_amount;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -130,6 +130,9 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(WindowData data) : GUIWindow(WINDOW_Dialo
                 speakingNPC->profession == Acolyte ||  // or Chaplain? mb discrepancy between game versions?
                 speakingNPC->profession == Piper || speakingNPC->profession == FallenWizard) {
                 optionList.push_back(DIALOGUE_USE_HIRED_NPC_ABILITY);
+                // TODO(Nik-RE-dev): this is for compatability. Previously when NPC can use ability, dialogue allocated 4 buttons unconditionally.
+                //                   Without it many test will fail because of changed buttons positions.
+                optionList.push_back(DIALOGUE_NULL);
             }
         }
     } else {

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -95,30 +95,7 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     if (sDialogue_SpeakingActorNPC_ID < 0) v9 = 4;
 #endif
 
-    pDialogueWindow = new GUIWindow_Dialogue({0, 0}, render->GetRenderDimensions(), 3);
-    if (pNPCInfo->Hired() && !pNPCInfo->bHasUsedTheAbility) {
-        if (pNPCInfo->profession == Healer ||
-            pNPCInfo->profession == ExpertHealer ||
-            pNPCInfo->profession == MasterHealer ||
-            pNPCInfo->profession == Cook ||
-            pNPCInfo->profession == Chef ||
-            pNPCInfo->profession == WindMaster ||
-            pNPCInfo->profession == WaterMaster ||
-            pNPCInfo->profession == GateMaster ||
-            pNPCInfo->profession == Acolyte ||  // or Chaplain? mb discrepancy between game versions?
-            pNPCInfo->profession == Piper ||
-            pNPCInfo->profession == FallenWizard
-        ) {
-            pDialogueWindow->CreateButton({480, 250}, {140, pFontArrus->GetHeight() - 3}, 1, 0,
-                UIMSG_SelectNPCDialogueOption, DIALOGUE_USE_HIRED_NPC_ABILITY);
-            pDialogueWindow->_41D08F_set_keyboard_control_group(4, 1, 0, 1);
-        }
-    }
-
-    pDialogueWindow->CreateButton({61, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1);
-    pDialogueWindow->CreateButton({177, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2);
-    pDialogueWindow->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, Io::InputAction::SelectChar3);
-    pDialogueWindow->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, Io::InputAction::SelectChar4);
+    pDialogueWindow = new GUIWindow_Dialogue(3);
 
     if (bPlayerSaysHello && pParty->hasActiveCharacter() && !pNPCInfo->Hired()) {
         if (pParty->uCurrentHour < 5 || pParty->uCurrentHour > 21) {
@@ -129,63 +106,49 @@ void GameUI_InitializeDialogue(Actor *actor, int bPlayerSaysHello) {
     }
 }
 
-
-GUIWindow_Dialogue::GUIWindow_Dialogue(Pointi position, Sizei dimensions, WindowData data, const std::string &hint)
-    : GUIWindow(WINDOW_Dialogue, position, dimensions, data, hint) {
+GUIWindow_Dialogue::GUIWindow_Dialogue(WindowData data) : GUIWindow(WINDOW_Dialogue, {0, 0}, render->GetRenderDimensions(), data) {
     prev_screen_type = current_screen_type;
     current_screen_type = SCREEN_NPC_DIALOGUE;
     pBtn_ExitCancel = CreateButton({0x1D7u, 0x1BDu}, {0xA9u, 0x23u}, 1, 0, UIMSG_Escape, 0, Io::InputAction::Invalid,
-        localization->GetString(LSTR_DIALOGUE_EXIT),
-        {ui_exit_cancel_button_background}
-    );
+                                   localization->GetString(LSTR_DIALOGUE_EXIT), {ui_exit_cancel_button_background});
+
+    int text_line_height = pFontArrus->GetHeight() - 3;
+    NPCData *speakingNPC = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    std::vector<DIALOGUE_TYPE> optionList;
+
     if (wData.val != 1) {
-        int num_dialugue_options = 0;
-        int text_line_height = pFontArrus->GetHeight() - 3;
-        NPCData *speakingNPC = GetNPCData(sDialogue_SpeakingActorNPC_ID);
         if (getNPCType(sDialogue_SpeakingActorNPC_ID) == NPC_TYPE_QUEST) {
-            if (speakingNPC->is_joinable) {
-                CreateButton({480, 130}, {140, text_line_height}, 1, 0, UIMSG_SelectNPCDialogueOption, DIALOGUE_13_hiring_related);
-                num_dialugue_options = 1;
-            }
-
-            #define AddScriptedDialogueLine(DIALOGUE_EVENT_ID, MSG_PARAM) \
-                if (DIALOGUE_EVENT_ID) { \
-                    if (num_dialugue_options < 4) { \
-                        int res = npcDialogueEventProcessor(DIALOGUE_EVENT_ID); \
-                        if (res == 1 || res == 2) \
-                            CreateButton({480, 130 + num_dialugue_options++ * text_line_height}, {140, text_line_height}, 1, 0, \
-                                UIMSG_SelectNPCDialogueOption, MSG_PARAM \
-                            ); \
-                    } \
-                }
-
-            AddScriptedDialogueLine(speakingNPC->dialogue_1_evt_id, DIALOGUE_SCRIPTED_LINE_1);
-            AddScriptedDialogueLine(speakingNPC->dialogue_2_evt_id, DIALOGUE_SCRIPTED_LINE_2);
-            AddScriptedDialogueLine(speakingNPC->dialogue_3_evt_id, DIALOGUE_SCRIPTED_LINE_3);
-            AddScriptedDialogueLine(speakingNPC->dialogue_4_evt_id, DIALOGUE_SCRIPTED_LINE_4);
-            AddScriptedDialogueLine(speakingNPC->dialogue_5_evt_id, DIALOGUE_SCRIPTED_LINE_5);
-            AddScriptedDialogueLine(speakingNPC->dialogue_6_evt_id, DIALOGUE_SCRIPTED_LINE_6);
-        } else {
-            if (speakingNPC->is_joinable) {
-                CreateButton({480, 0x82u}, {140, text_line_height}, 1, 0,
-                    UIMSG_SelectNPCDialogueOption, DIALOGUE_PROFESSION_DETAILS, Io::InputAction::Invalid,
-                    localization->GetString(LSTR_MORE_INFORMATION));
-                if (speakingNPC->Hired()) {
-                    CreateButton({480, 130 + text_line_height}, {140, text_line_height}, 1, 0,
-                        UIMSG_SelectNPCDialogueOption, DIALOGUE_HIRE_FIRE, Io::InputAction::Invalid,
-                        localization->FormatString(LSTR_HIRE_RELEASE, speakingNPC->pName)
-                    );
-                } else {
-                    CreateButton({480, 130 + text_line_height}, {140, text_line_height}, 1, 0,
-                                 UIMSG_SelectNPCDialogueOption, DIALOGUE_HIRE_FIRE, Io::InputAction::Invalid,
-                                 localization->GetString(LSTR_HIRE)
-                    );
-                }
-                num_dialugue_options = 2;
+            optionList = prepareScriptedNPCDialogueTopics(speakingNPC);
+        } else if (speakingNPC->is_joinable) {
+            optionList = {DIALOGUE_PROFESSION_DETAILS, DIALOGUE_HIRE_FIRE};
+        }
+        if (speakingNPC->Hired() && !speakingNPC->bHasUsedTheAbility) {
+            if (speakingNPC->profession == Healer || speakingNPC->profession == ExpertHealer ||
+                speakingNPC->profession == MasterHealer || speakingNPC->profession == Cook ||
+                speakingNPC->profession == Chef || speakingNPC->profession == WindMaster ||
+                speakingNPC->profession == WaterMaster || speakingNPC->profession == GateMaster ||
+                speakingNPC->profession == Acolyte ||  // or Chaplain? mb discrepancy between game versions?
+                speakingNPC->profession == Piper || speakingNPC->profession == FallenWizard) {
+                optionList.push_back(DIALOGUE_USE_HIRED_NPC_ABILITY);
             }
         }
-        _41D08F_set_keyboard_control_group(num_dialugue_options, 1, 0, 1);
+    } else {
+        assert(wData.val == 3);
+        if (!pNPCStats->pProfessions[speakingNPC->profession].pBenefits.empty()) {
+            optionList.push_back(DIALOGUE_PROFESSION_DETAILS);
+        }
+        optionList.push_back(DIALOGUE_HIRE_FIRE);
     }
+    for (int i = 0; i < optionList.size(); i++) {
+        CreateButton({480, 130 + i * text_line_height}, {140, text_line_height}, 1, 0, UIMSG_SelectNPCDialogueOption, optionList[i], Io::InputAction::Invalid, "");
+    }
+    _41D08F_set_keyboard_control_group(optionList.size(), 1, 0, 1);
+
+    CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1, "");
+    CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2, "");
+    CreateButton({292, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 3, Io::InputAction::SelectChar3, "");
+    CreateButton({407, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 4, Io::InputAction::SelectChar4, "");
+    CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, Io::InputAction::CharCycle, "");
 }
 
 void GUIWindow_Dialogue::Release() {
@@ -315,88 +278,22 @@ void GUIWindow_Dialogue::Update() {
     window.uFrameX = SIDE_TEXT_BOX_POS_X;
     window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
     window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
-    for (int i = window.pStartingPosActiveItem;
-         i < window.pStartingPosActiveItem + window.pNumPresenceButton; ++i) {
+    for (int i = window.pStartingPosActiveItem; i < window.pStartingPosActiveItem + window.pNumPresenceButton; ++i) {
         GUIButton *pButton = window.GetControl(i);
-        if (!pButton) break;
+        if (!pButton) {
+            break;
+        }
 
-        if (pButton->msg_param > DIALOGUE_ARENA_SELECT_CHAMPION) {
-            pButton->sLabel.clear();
-        } else if (pButton->msg_param == DIALOGUE_ARENA_SELECT_CHAMPION) {
-            pButton->sLabel = localization->GetString(LSTR_ARENA_DIFFICULTY_LORD);
-        } else if (pButton->msg_param == DIALOGUE_ARENA_SELECT_KNIGHT) {
-            pButton->sLabel = localization->GetString(LSTR_ARENA_DIFFICULTY_KNIGHT);
-        } else if (pButton->msg_param == DIALOGUE_ARENA_SELECT_SQUIRE) {
-            pButton->sLabel = localization->GetString(LSTR_ARENA_DIFFICULTY_SQUIRE);
-        } else if (pButton->msg_param == DIALOGUE_ARENA_SELECT_PAGE) {
-            pButton->sLabel = localization->GetString(LSTR_ARENA_DIFFICULTY_PAGE);
-        } else if (pButton->msg_param == DIALOGUE_PROFESSION_DETAILS) {
-            pButton->sLabel = localization->GetString(LSTR_MORE_INFORMATION);
-        } else if (pButton->msg_param == DIALOGUE_HIRE_FIRE) {
-            if (pNPC->Hired()) {
-                // TODO(captainurist): what if fmt throws?
-                pButton->sLabel = fmt::sprintf(localization->GetString(LSTR_HIRE_RELEASE), pNPC->pName);
-            } else {
-                pButton->sLabel = localization->GetString(LSTR_HIRE);
-            }
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_6) {
-            if (!pNPC->dialogue_6_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_6_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_USE_HIRED_NPC_ABILITY) {
-            pButton->sLabel = GetProfessionActionText(pNPC->profession);
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_1) {
-            if (!pNPC->dialogue_1_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_1_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_2) {
-            if (!pNPC->dialogue_2_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_2_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_3) {
-            if (!pNPC->dialogue_3_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_3_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_4) {
-            if (!pNPC->dialogue_4_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_4_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_SCRIPTED_LINE_5) {
-            if (!pNPC->dialogue_5_evt_id) {
-                pButton->sLabel.clear();
-                pButton->msg_param = 0;
-            } else {
-                pButton->sLabel = pNPCTopics[pNPC->dialogue_5_evt_id].pTopic;
-            }
-        } else if (pButton->msg_param == DIALOGUE_13_hiring_related) {
-            if (pNPC->Hired()) {
-                pButton->sLabel = localization->FormatString(LSTR_HIRE_RELEASE, pNPC->pName);
-            } else {
-                pButton->sLabel = localization->GetString(LSTR_JOIN);
-            }
-        } else {
-            pButton->sLabel.clear();
+        DIALOGUE_TYPE topic = (DIALOGUE_TYPE)pButton->msg_param;
+        pButton->sLabel = npcDialogueOptionString(topic, pNPC);
+        if (pButton->sLabel.empty() && topic >= DIALOGUE_SCRIPTED_LINE_1 && topic <= DIALOGUE_SCRIPTED_LINE_6) {
+            pButton->msg_param = 0;
         }
 
         if (pParty->field_7B5_in_arena_quest &&
             pParty->field_7B5_in_arena_quest != -1) {
             int num_dead_actors = 0;
-            for (uint i = 0; i < pActors.size(); ++i) {
+            for (int i = 0; i < pActors.size(); ++i) {
                 if (pActors[i].aiState == Dead ||
                     pActors[i].aiState == Removed ||
                     pActors[i].aiState == Disabled) {
@@ -543,6 +440,7 @@ void StartBranchlessDialogue(int eventid, int entryline, int event) {
         pGUIWindow_BranchlessDialogue->CreateButton({177, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2);
         pGUIWindow_BranchlessDialogue->CreateButton({292, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 3, Io::InputAction::SelectChar3);
         pGUIWindow_BranchlessDialogue->CreateButton({407, 424}, {31, 40}, 2, 94, UIMSG_SelectCharacter, 4, Io::InputAction::SelectChar4);
+        pGUIWindow_BranchlessDialogue->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, Io::InputAction::CharCycle, "");
     }
 }
 
@@ -560,21 +458,9 @@ void ReleaseBranchlessDialogue() {
 }
 
 void BuildHireableNpcDialogue() {
-    NPCData *v0 = GetNPCData(sDialogue_SpeakingActorNPC_ID);
-    int v1 = 0;
     pDialogueWindow->eWindowType = WINDOW_MainMenu;
     pDialogueWindow->Release();
-    pDialogueWindow = new GUIWindow_Dialogue({0, 0}, render->GetRenderDimensions(), 1);
-    if (!pNPCStats->pProfessions[v0->profession].pBenefits.empty()) {
-        pDialogueWindow->CreateButton({480, 160}, {140, 28}, 1, 0,
-            UIMSG_SelectNPCDialogueOption, DIALOGUE_PROFESSION_DETAILS, Io::InputAction::Invalid,
-            localization->GetString(LSTR_MORE_INFORMATION));
-        v1 = 1;
-    }
-    pDialogueWindow->CreateButton({480, 30 * v1 + 160}, {140, 30}, 1, 0,
-        UIMSG_SelectNPCDialogueOption, DIALOGUE_HIRE_FIRE, Io::InputAction::Invalid,
-        localization->GetString(LSTR_HIRE));
-    pDialogueWindow->_41D08F_set_keyboard_control_group(v1 + 1, 1, 0, 1);
+    pDialogueWindow = new GUIWindow_Dialogue(1);
 }
 
 void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
@@ -673,23 +559,7 @@ void OnSelectNPCDialogueOption(DIALOGUE_TYPE option) {
             return;
         }
     } else if (option >= DIALOGUE_SCRIPTED_LINE_1 && option <= DIALOGUE_SCRIPTED_LINE_6) {
-        int npc_event_id;
-        if (option == DIALOGUE_SCRIPTED_LINE_1) {
-            npc_event_id = speakingNPC->dialogue_1_evt_id;
-        } else if (option == DIALOGUE_SCRIPTED_LINE_2) {
-            npc_event_id = speakingNPC->dialogue_2_evt_id;
-        } else if (option == DIALOGUE_SCRIPTED_LINE_3) {
-            npc_event_id = speakingNPC->dialogue_3_evt_id;
-        } else if (option == DIALOGUE_SCRIPTED_LINE_4) {
-            npc_event_id = speakingNPC->dialogue_4_evt_id;
-        } else if (option == DIALOGUE_SCRIPTED_LINE_5) {
-            npc_event_id = speakingNPC->dialogue_5_evt_id;
-        } else {
-            assert(option == DIALOGUE_SCRIPTED_LINE_6);
-            npc_event_id = speakingNPC->dialogue_6_evt_id;
-        }
-
-        std::vector<DIALOGUE_TYPE> topics = handleScriptedNPCTopicSelection(option, npc_event_id);
+        std::vector<DIALOGUE_TYPE> topics = handleScriptedNPCTopicSelection(option, speakingNPC);
 
         // TODO(Nik-RE-dev): must create buttons when overworld NPC topics will be supported
         assert(topics.size() == 0);

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -8,7 +8,7 @@
 
 class GUIWindow_Dialogue : public GUIWindow {
  public:
-    GUIWindow_Dialogue(Pointi position, Sizei dimensions, WindowData data, const std::string &hint = std::string());
+    explicit GUIWindow_Dialogue(WindowData data);
     virtual ~GUIWindow_Dialogue() {}
 
     virtual void Update() override;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -457,33 +457,7 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
     NPCData *pCurrentNPCInfo = houseNpcs[currentHouseNpc].npc;
 
     if (topic >= DIALOGUE_SCRIPTED_LINE_1 && topic <= DIALOGUE_SCRIPTED_LINE_6) {
-        int pEventNumber;
-
-        switch (topic) {
-        case DIALOGUE_SCRIPTED_LINE_1:
-            pEventNumber = pCurrentNPCInfo->dialogue_1_evt_id;
-            break;
-        case DIALOGUE_SCRIPTED_LINE_2:
-            pEventNumber = pCurrentNPCInfo->dialogue_2_evt_id;
-            break;
-        case DIALOGUE_SCRIPTED_LINE_3:
-            pEventNumber = pCurrentNPCInfo->dialogue_3_evt_id;
-            break;
-        case DIALOGUE_SCRIPTED_LINE_4:
-            pEventNumber = pCurrentNPCInfo->dialogue_4_evt_id;
-            break;
-        case DIALOGUE_SCRIPTED_LINE_5:
-            pEventNumber = pCurrentNPCInfo->dialogue_5_evt_id;
-            break;
-        case DIALOGUE_SCRIPTED_LINE_6:
-            pEventNumber = pCurrentNPCInfo->dialogue_6_evt_id;
-            break;
-        default:
-            BackToHouseMenu();
-            return;
-        }
-
-        std::vector<DIALOGUE_TYPE> topics = handleScriptedNPCTopicSelection(topic, pEventNumber);
+        std::vector<DIALOGUE_TYPE> topics = handleScriptedNPCTopicSelection(topic, pCurrentNPCInfo);
 
         if (topics.size() != 0) {
             window_SpeakInHouse->reinitDialogueWindow();
@@ -732,11 +706,7 @@ void createHouseUI(HOUSE_ID houseId) {
         window_SpeakInHouse = new GUIWindow_House(houseId);
         break;
     }
-    window_SpeakInHouse->CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1, "");
-    window_SpeakInHouse->CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2, "");
-    window_SpeakInHouse->CreateButton({292, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 3, Io::InputAction::SelectChar3, "");
-    window_SpeakInHouse->CreateButton({407, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 4, Io::InputAction::SelectChar4, "");
-    window_SpeakInHouse->CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, Io::InputAction::CharCycle, "");
+
     if (houseNpcs.size() == 1) {
         updateHouseNPCTopics(0);
     }
@@ -831,81 +801,12 @@ void GUIWindow_House::houseNPCDialogue() {
     int buttonLimit = pDialogueWindow->pStartingPosActiveItem + pDialogueWindow->pNumPresenceButton;
     for (int i = pDialogueWindow->pStartingPosActiveItem; i < buttonLimit; ++i) {
         GUIButton *pButton = right_panel_window.GetControl(i);
-        switch (pButton->msg_param) {
-          case DIALOGUE_SCRIPTED_LINE_1:
-            if (pNPCTopics[pNPC->dialogue_1_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_1_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_SCRIPTED_LINE_2:
-            if (pNPCTopics[pNPC->dialogue_2_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_2_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_SCRIPTED_LINE_3:
-            if (pNPCTopics[pNPC->dialogue_3_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_3_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_SCRIPTED_LINE_4:
-            if (pNPCTopics[pNPC->dialogue_4_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_4_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_SCRIPTED_LINE_5:
-            if (pNPCTopics[pNPC->dialogue_5_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_5_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_SCRIPTED_LINE_6:
-            if (pNPCTopics[pNPC->dialogue_6_evt_id].pTopic.empty()) {
-                optionsText.push_back("");
-                pButton->msg_param = 0;
-            } else {
-                optionsText.push_back(pNPCTopics[pNPC->dialogue_6_evt_id].pTopic);
-            }
-            break;
-          case DIALOGUE_HIRE_FIRE:
-            optionsText.push_back(localization->GetString(LSTR_HIRE));
-            break;
-          case DIALOGUE_PROFESSION_DETAILS:
-            optionsText.push_back(localization->GetString(LSTR_MORE_INFORMATION));
-            break;
-          case DIALOGUE_MASTERY_TEACHER_LEARN:
-            optionsText.push_back(masteryTeacherOptionString());
-            break;
-          case DIALOGUE_MAGIC_GUILD_JOIN:
-            optionsText.push_back(joinGuildOptionString());
-            break;
-          case DIALOGUE_83_bounty_hunting:
-            current_npc_text = ((GUIWindow_TownHall*)window_SpeakInHouse)->bountyHuntingText();
-            optionsText.push_back("");
-            break;
-          default:
-            if (pButton->msg_param > 0 && pButton->msg_param < DIALOGUE_13_hiring_related) {
-                // TODO(Nik-RE-dev): wtf?
-                optionsText.push_back(localization->GetString(LSTR_JOIN));
-            } else {
-                // TODO(Nik-RE-dev): must never happen?
-                optionsText.push_back("");
-            }
-            break;
+        DIALOGUE_TYPE topic = (DIALOGUE_TYPE)pButton->msg_param;
+        std::string str = npcDialogueOptionString(topic, pNPC);
+        if (str.empty() && topic >= DIALOGUE_SCRIPTED_LINE_1 && topic <= DIALOGUE_SCRIPTED_LINE_6) {
+            pButton->msg_param = 0;
         }
+        optionsText.push_back(str);
     }
 
     if (optionsText.size()) {
@@ -1136,34 +1037,7 @@ void GUIWindow_House::initializeNPCDialogue(int npc) {
         return;
     }
 
-    NPCData *npcData = houseNpcs[npc].npc;
-    std::vector<DIALOGUE_TYPE> optionList;
-
-    if (npcData->is_joinable) {
-        optionList.push_back(DIALOGUE_13_hiring_related);
-    }
-
-    // TODO(Nik-RE-dev): place NPC events in array
-#define ADD_NPC_SCRIPTED_DIALOGUE(EVENT_ID, MSG_PARAM) \
-    if (EVENT_ID) { \
-        if (optionList.size() < 4) { \
-            int res = npcDialogueEventProcessor(EVENT_ID); \
-            if (res == 1 || res == 2) { \
-                optionList.push_back(MSG_PARAM); \
-            } \
-        } \
-    }
-
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_1_evt_id, DIALOGUE_SCRIPTED_LINE_1);
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_2_evt_id, DIALOGUE_SCRIPTED_LINE_2);
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_3_evt_id, DIALOGUE_SCRIPTED_LINE_3);
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_4_evt_id, DIALOGUE_SCRIPTED_LINE_4);
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_5_evt_id, DIALOGUE_SCRIPTED_LINE_5);
-    ADD_NPC_SCRIPTED_DIALOGUE(npcData->dialogue_6_evt_id, DIALOGUE_SCRIPTED_LINE_6);
-
-#undef ADD_NPC_SCRIPTED_DIALOGUE
-
-    initializeNPCDialogueButtons(optionList);
+    initializeNPCDialogueButtons(prepareScriptedNPCDialogueTopics(houseNpcs[npc].npc));
 }
 
 void GUIWindow_House::initializeNPCDialogueButtons(std::vector<DIALOGUE_TYPE> optionList) {
@@ -1256,6 +1130,12 @@ GUIWindow_House::GUIWindow_House(HOUSE_ID houseId) : GUIWindow(WINDOW_HouseInter
         houseNpcs[i].button = CreateButton(pos, {63, 73}, 1, 0, UIMSG_ClickHouseNPCPortrait, i,
                                                       Io::InputAction::Invalid, houseNpcs[i].label);
     }
+
+    CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1, "");
+    CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2, "");
+    CreateButton({292, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 3, Io::InputAction::SelectChar3, "");
+    CreateButton({407, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 4, Io::InputAction::SelectChar4, "");
+    CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_CycleCharacters, 0, Io::InputAction::CharCycle, "");
 }
 
 void GUIWindow_House::Update() {


### PR DESCRIPTION
Make common between house and overworld NPCs:
- Getting dialogue option title string.
- Listing scripted options.
- Preparing event ID of selected scripted option.

Also:
- Move character portraits button creation inside dialogue constructors.
- Add missing character cycling pseudo button.
- Do some cleanup of button creations in overworld NPC dialogue.