### PR TITLE
Resolve globals related to dialogue

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -767,7 +767,6 @@ void Game::processQueuedMessages() {
                                     current_screen_type = SCREEN_HOUSE;
                                     continue;
                                 case SCREEN_HOUSE:
-                                    uDialogueType = DIALOGUE_NULL;
                                     if (uGameState == GAME_STATE_CHANGE_LOCATION) {
                                         while (houseDialogPressEscape()) {}
                                     } else {

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -237,7 +237,6 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                 _mapExitTriggered = true;
                 if (current_screen_type == SCREEN_HOUSE) {
                     if (uGameState == GAME_STATE_CHANGE_LOCATION) {
-                        dialog_menu_id = DIALOGUE_NULL;
                         while (houseDialogPressEscape()) {}
                         pMediaPlayer->Unload();
                         window_SpeakInHouse->Release();
@@ -248,7 +247,6 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                             pDialogueWindow->Release();
                             pDialogueWindow = 0;
                         }
-                        dialog_menu_id = DIALOGUE_NULL;
                     }
                     return -1;
                 }

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2431,7 +2431,6 @@ unsigned int uIconIdx_FlySpell;
 unsigned int uIconIdx_WaterWalk;
 
 struct Actor *pDialogue_SpeakingActor;
-DIALOGUE_TYPE uDialogueType;
 int sDialogue_SpeakingActorNPC_ID;
 int uCurrentHouse_Animation;
 std::string Party_Teleport_Map_Name;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -99,7 +99,6 @@ extern unsigned int uIconIdx_FlySpell;
 extern unsigned int uIconIdx_WaterWalk;
 
 extern Actor *pDialogue_SpeakingActor;
-extern DIALOGUE_TYPE uDialogueType;
 extern signed int sDialogue_SpeakingActorNPC_ID;
 extern int uCurrentHouse_Animation;
 

--- a/src/GUI/UI/Houses/Bank.cpp
+++ b/src/GUI/UI/Houses/Bank.cpp
@@ -108,14 +108,14 @@ void GUIWindow_Bank::getGoldDialogue() {
 }
 
 void GUIWindow_Bank::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (option == DIALOGUE_BANK_PUT_GOLD || option == DIALOGUE_BANK_GET_GOLD) {
         keyboardInputHandler->StartTextInput(TextInputType::Number, 10, this);
     }
 }
 
 void GUIWindow_Bank::houseSpecificDialogue() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -131,7 +131,7 @@ void GUIWindow_Bank::houseSpecificDialogue() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Bank::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_BANK_PUT_GOLD, DIALOGUE_BANK_GET_GOLD};
       default:

--- a/src/GUI/UI/Houses/Bank.cpp
+++ b/src/GUI/UI/Houses/Bank.cpp
@@ -108,13 +108,14 @@ void GUIWindow_Bank::getGoldDialogue() {
 }
 
 void GUIWindow_Bank::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (option == DIALOGUE_BANK_PUT_GOLD || option == DIALOGUE_BANK_GET_GOLD) {
         keyboardInputHandler->StartTextInput(TextInputType::Number, 10, this);
     }
 }
 
 void GUIWindow_Bank::houseSpecificDialogue() {
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -129,8 +130,8 @@ void GUIWindow_Bank::houseSpecificDialogue() {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Bank::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Bank::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_BANK_PUT_GOLD, DIALOGUE_BANK_GET_GOLD};
       default:

--- a/src/GUI/UI/Houses/Bank.h
+++ b/src/GUI/UI/Houses/Bank.h
@@ -12,7 +12,7 @@ class GUIWindow_Bank : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
     virtual void playHouseGoodbyeSpeech() override;
 
  protected:

--- a/src/GUI/UI/Houses/Jail.cpp
+++ b/src/GUI/UI/Houses/Jail.cpp
@@ -15,5 +15,5 @@ void GUIWindow_Jail::houseSpecificDialogue() {
 }
 
 void GUIWindow_Jail::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    // Nothing
+    currentDialogue = option;
 }

--- a/src/GUI/UI/Houses/Jail.cpp
+++ b/src/GUI/UI/Houses/Jail.cpp
@@ -15,5 +15,5 @@ void GUIWindow_Jail::houseSpecificDialogue() {
 }
 
 void GUIWindow_Jail::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
 }

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -249,6 +249,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
 }
 
 void GUIWindow_MagicGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (option == DIALOGUE_GUILD_BUY_BOOKS) {
         if (pParty->PartyTimes.guildNextRefreshTime[houseId()] >= pParty->GetPlayingTime()) {
             for (int i = 0; i < itemAmountInShop[buildingType()]; ++i) {
@@ -266,7 +267,7 @@ void GUIWindow_MagicGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
 }
 
 void GUIWindow_MagicGuild::houseSpecificDialogue() {
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -279,10 +280,10 @@ void GUIWindow_MagicGuild::houseSpecificDialogue() {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions(DIALOGUE_TYPE option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions() {
     BuildingType guildType = buildingType();
 
-    switch (option) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         if (learnableAdditionalSkillDialogue[guildType] != DIALOGUE_NULL) {
             return {DIALOGUE_GUILD_BUY_BOOKS, learnableMagicSkillDialogue[guildType], learnableAdditionalSkillDialogue[guildType]};

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -249,7 +249,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
 }
 
 void GUIWindow_MagicGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (option == DIALOGUE_GUILD_BUY_BOOKS) {
         if (pParty->PartyTimes.guildNextRefreshTime[houseId()] >= pParty->GetPlayingTime()) {
             for (int i = 0; i < itemAmountInShop[buildingType()]; ++i) {
@@ -267,7 +267,7 @@ void GUIWindow_MagicGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
 }
 
 void GUIWindow_MagicGuild::houseSpecificDialogue() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -283,7 +283,7 @@ void GUIWindow_MagicGuild::houseSpecificDialogue() {
 std::vector<DIALOGUE_TYPE> GUIWindow_MagicGuild::listDialogueOptions() {
     BuildingType guildType = buildingType();
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         if (learnableAdditionalSkillDialogue[guildType] != DIALOGUE_NULL) {
             return {DIALOGUE_GUILD_BUY_BOOKS, learnableMagicSkillDialogue[guildType], learnableAdditionalSkillDialogue[guildType]};

--- a/src/GUI/UI/Houses/MagicGuild.h
+++ b/src/GUI/UI/Houses/MagicGuild.h
@@ -14,7 +14,7 @@ class GUIWindow_MagicGuild : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
     virtual void houseScreenClick() override;
 
  protected:

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -32,7 +32,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
      */
     int pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(), buildingTable[window_SpeakInHouse->houseId()]);
 
-    if (currentDialogue == DIALOGUE_MAIN) {
+    if (_currentDialogue == DIALOGUE_MAIN) {
         if (!pParty->activeCharacter()._achievedAwardsBits[word_4F0754[2 * window_SpeakInHouse->wData.val]]) {
             // 171 looks like Mercenary Stronghold message from NPCNews.txt in MM6
             int pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[171].pText, dialog_window.uFrameWidth, 0);
@@ -56,7 +56,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
         short *v6;
         if (false
             // if ( !*(&byte_4ED94C[37 * v1->uClass / 3] + dword_F8B19C)
-            || (v6 = (short *)(&pParty->activeCharacter().uIntelligence + currentDialogue),
+            || (v6 = (short *)(&pParty->activeCharacter().uIntelligence + _currentDialogue),
                 *(short *)v6)) {
             pAudioPlayer->playUISound(SOUND_error);
         } else {
@@ -76,5 +76,5 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
 }
 
 void GUIWindow_MercenaryGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
 }

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -32,7 +32,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
      */
     int pPrice = PriceCalculator::skillLearningCostForPlayer(&pParty->activeCharacter(), buildingTable[window_SpeakInHouse->houseId()]);
 
-    if (dialog_menu_id == DIALOGUE_MAIN) {
+    if (currentDialogue == DIALOGUE_MAIN) {
         if (!pParty->activeCharacter()._achievedAwardsBits[word_4F0754[2 * window_SpeakInHouse->wData.val]]) {
             // 171 looks like Mercenary Stronghold message from NPCNews.txt in MM6
             int pTextHeight = pFontArrus->CalcTextHeight(pNPCTopics[171].pText, dialog_window.uFrameWidth, 0);
@@ -56,7 +56,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
         short *v6;
         if (false
             // if ( !*(&byte_4ED94C[37 * v1->uClass / 3] + dword_F8B19C)
-            || (v6 = (short *)(&pParty->activeCharacter().uIntelligence + dialog_menu_id),
+            || (v6 = (short *)(&pParty->activeCharacter().uIntelligence + currentDialogue),
                 *(short *)v6)) {
             pAudioPlayer->playUISound(SOUND_error);
         } else {
@@ -76,5 +76,5 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
 }
 
 void GUIWindow_MercenaryGuild::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    // Nothing
+    currentDialogue = option;
 }

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -743,7 +743,7 @@ std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listShopLearnableSkills() {
 }
 
 void GUIWindow_Shop::houseSpecificDialogue() {
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -775,6 +775,7 @@ void GUIWindow_Shop::houseSpecificDialogue() {
 }
 
 void GUIWindow_Shop::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (option == DIALOGUE_SHOP_BUY_STANDARD || option == DIALOGUE_SHOP_BUY_SPECIAL) {
         if (pParty->PartyTimes.shopNextRefreshTime[houseId()] < pParty->GetPlayingTime()) {
             generateShopItems(false);
@@ -805,8 +806,8 @@ void GUIWindow_Shop::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Shop::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Shop::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_SHOP_BUY_STANDARD, DIALOGUE_SHOP_BUY_SPECIAL, DIALOGUE_SHOP_DISPLAY_EQUIPMENT, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_SHOP_DISPLAY_EQUIPMENT:
@@ -818,24 +819,27 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Shop::listDialogueOptions(DIALOGUE_TYPE opt
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listDialogueOptions(DIALOGUE_TYPE option) {
-    if (option == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
+std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listDialogueOptions() {
+    if (currentDialogue == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
         return {DIALOGUE_SHOP_SELL, DIALOGUE_SHOP_IDENTIFY};
     }
-    return GUIWindow_Shop::listDialogueOptions(option);
+    return GUIWindow_Shop::listDialogueOptions();
 }
 
-DIALOGUE_TYPE GUIWindow_Shop::getOptionOnEscape() {
-    if (IsSkillLearningDialogue(dialog_menu_id)) {
-        return DIALOGUE_LEARN_SKILLS;
+void GUIWindow_Shop::updateDialogueOnEscape() {
+    if (IsSkillLearningDialogue(currentDialogue)) {
+        currentDialogue = DIALOGUE_LEARN_SKILLS;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_SHOP_SELL || dialog_menu_id == DIALOGUE_SHOP_IDENTIFY || dialog_menu_id == DIALOGUE_SHOP_REPAIR) {
-        return DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
+    if (currentDialogue == DIALOGUE_SHOP_SELL || currentDialogue == DIALOGUE_SHOP_IDENTIFY || currentDialogue == DIALOGUE_SHOP_REPAIR) {
+        currentDialogue = DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_MAIN) {
-        return DIALOGUE_NULL;
+    if (currentDialogue == DIALOGUE_MAIN) {
+        currentDialogue = DIALOGUE_NULL;
+        return;
     }
-    return DIALOGUE_MAIN;
+    currentDialogue = DIALOGUE_MAIN;
 }
 
 void GUIWindow_Shop::playHouseGoodbyeSpeech() {
@@ -888,7 +892,7 @@ void GUIWindow_Shop::houseScreenClick() {
 
     Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
 
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
         case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             pParty->activeCharacter().OnInventoryLeftClick();
@@ -1009,7 +1013,7 @@ void GUIWindow_Shop::houseScreenClick() {
               case BUILDING_WEAPON_SHOP:
                 testx = (pt.x - 30) / 70;
                 if (testx >= 0 && testx < 6) {
-                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];
@@ -1032,7 +1036,7 @@ void GUIWindow_Shop::houseScreenClick() {
                         testx += 4;
                     }
 
-                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];
@@ -1062,7 +1066,7 @@ void GUIWindow_Shop::houseScreenClick() {
                         testx += 6;
                     }
 
-                    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -743,7 +743,7 @@ std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listShopLearnableSkills() {
 }
 
 void GUIWindow_Shop::houseSpecificDialogue() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -775,7 +775,7 @@ void GUIWindow_Shop::houseSpecificDialogue() {
 }
 
 void GUIWindow_Shop::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (option == DIALOGUE_SHOP_BUY_STANDARD || option == DIALOGUE_SHOP_BUY_SPECIAL) {
         if (pParty->PartyTimes.shopNextRefreshTime[houseId()] < pParty->GetPlayingTime()) {
             generateShopItems(false);
@@ -807,7 +807,7 @@ void GUIWindow_Shop::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Shop::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_SHOP_BUY_STANDARD, DIALOGUE_SHOP_BUY_SPECIAL, DIALOGUE_SHOP_DISPLAY_EQUIPMENT, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_SHOP_DISPLAY_EQUIPMENT:
@@ -820,26 +820,26 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Shop::listDialogueOptions() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_AlchemyShop::listDialogueOptions() {
-    if (currentDialogue == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
+    if (_currentDialogue == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
         return {DIALOGUE_SHOP_SELL, DIALOGUE_SHOP_IDENTIFY};
     }
     return GUIWindow_Shop::listDialogueOptions();
 }
 
 void GUIWindow_Shop::updateDialogueOnEscape() {
-    if (IsSkillLearningDialogue(currentDialogue)) {
-        currentDialogue = DIALOGUE_LEARN_SKILLS;
+    if (IsSkillLearningDialogue(_currentDialogue)) {
+        _currentDialogue = DIALOGUE_LEARN_SKILLS;
         return;
     }
-    if (currentDialogue == DIALOGUE_SHOP_SELL || currentDialogue == DIALOGUE_SHOP_IDENTIFY || currentDialogue == DIALOGUE_SHOP_REPAIR) {
-        currentDialogue = DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
+    if (_currentDialogue == DIALOGUE_SHOP_SELL || _currentDialogue == DIALOGUE_SHOP_IDENTIFY || _currentDialogue == DIALOGUE_SHOP_REPAIR) {
+        _currentDialogue = DIALOGUE_SHOP_DISPLAY_EQUIPMENT;
         return;
     }
-    if (currentDialogue == DIALOGUE_MAIN) {
-        currentDialogue = DIALOGUE_NULL;
+    if (_currentDialogue == DIALOGUE_MAIN) {
+        _currentDialogue = DIALOGUE_NULL;
         return;
     }
-    currentDialogue = DIALOGUE_MAIN;
+    _currentDialogue = DIALOGUE_MAIN;
 }
 
 void GUIWindow_Shop::playHouseGoodbyeSpeech() {
@@ -892,7 +892,7 @@ void GUIWindow_Shop::houseScreenClick() {
 
     Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
         case DIALOGUE_SHOP_DISPLAY_EQUIPMENT: {
             current_character_screen_window = WINDOW_CharacterWindow_Inventory;
             pParty->activeCharacter().OnInventoryLeftClick();
@@ -1013,7 +1013,7 @@ void GUIWindow_Shop::houseScreenClick() {
               case BUILDING_WEAPON_SHOP:
                 testx = (pt.x - 30) / 70;
                 if (testx >= 0 && testx < 6) {
-                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (_currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];
@@ -1036,7 +1036,7 @@ void GUIWindow_Shop::houseScreenClick() {
                         testx += 4;
                     }
 
-                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (_currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];
@@ -1066,7 +1066,7 @@ void GUIWindow_Shop::houseScreenClick() {
                         testx += 6;
                     }
 
-                    if (currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
+                    if (_currentDialogue == DIALOGUE_SHOP_BUY_STANDARD)
                         boughtItem = &pParty->standartItemsInShops[houseId()][testx];
                     else
                         boughtItem = &pParty->specialItemsInShops[houseId()][testx];

--- a/src/GUI/UI/Houses/Shops.h
+++ b/src/GUI/UI/Houses/Shops.h
@@ -14,8 +14,8 @@ class GUIWindow_Shop : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
-    virtual DIALOGUE_TYPE getOptionOnEscape() override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
+    virtual void updateDialogueOnEscape() override;
     virtual void houseScreenClick() override;
     virtual void playHouseGoodbyeSpeech() override;
 
@@ -82,7 +82,7 @@ class GUIWindow_AlchemyShop : public GUIWindow_MagicAlchemyShop {
     explicit GUIWindow_AlchemyShop(HOUSE_ID houseId) : GUIWindow_MagicAlchemyShop(houseId) {}
     virtual ~GUIWindow_AlchemyShop() {}
 
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
     virtual void playHouseGoodbyeSpeech() override;
 
  private:

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -119,7 +119,7 @@ void GUIWindow_Tavern::restDialogue() {
     if (pParty->GetGold() >= pPriceRoom) {
         pParty->TakeGold(pPriceRoom);
         playHouseSound(houseId(), HOUSE_SOUND_TAVERN_RENT_ROOM);
-        dialog_menu_id = DIALOGUE_NULL;
+        currentDialogue = DIALOGUE_NULL;
         houseDialogPressEscape();
         playHouseGoodbyeSpeech();
         pMediaPlayer->Unload();
@@ -158,6 +158,7 @@ void GUIWindow_Tavern::buyFoodDialogue() {
 }
 
 void GUIWindow_Tavern::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (option == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_PlayArcomage, 0, 0);
     } else if (IsSkillLearningDialogue(option)) {
@@ -171,7 +172,7 @@ void GUIWindow_Tavern::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -202,8 +203,8 @@ void GUIWindow_Tavern::houseSpecificDialogue() {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Tavern::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Tavern::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         if (houseId() == HOUSE_TAVERN_EMERALD_ISLE) {
             return {DIALOGUE_TAVERN_REST, DIALOGUE_TAVERN_BUY_FOOD, DIALOGUE_LEARN_SKILLS};
@@ -223,17 +224,20 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Tavern::listDialogueOptions(DIALOGUE_TYPE o
     }
 }
 
-DIALOGUE_TYPE GUIWindow_Tavern::getOptionOnEscape() {
-    if (IsSkillLearningDialogue(dialog_menu_id)) {
-        return DIALOGUE_LEARN_SKILLS;
+void GUIWindow_Tavern::updateDialogueOnEscape() {
+    if (IsSkillLearningDialogue(currentDialogue)) {
+        currentDialogue = DIALOGUE_LEARN_SKILLS;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_TAVERN_ARCOMAGE_RULES ||
-        dialog_menu_id == DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS ||
-        dialog_menu_id == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
-        return DIALOGUE_TAVERN_ARCOMAGE_MAIN;
+    if (currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RULES ||
+        currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS ||
+        currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
+        currentDialogue = DIALOGUE_TAVERN_ARCOMAGE_MAIN;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_MAIN) {
-        return DIALOGUE_NULL;
+    if (currentDialogue == DIALOGUE_MAIN) {
+        currentDialogue = DIALOGUE_NULL;
+        return;
     }
-    return DIALOGUE_MAIN;
+    currentDialogue = DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -119,7 +119,7 @@ void GUIWindow_Tavern::restDialogue() {
     if (pParty->GetGold() >= pPriceRoom) {
         pParty->TakeGold(pPriceRoom);
         playHouseSound(houseId(), HOUSE_SOUND_TAVERN_RENT_ROOM);
-        currentDialogue = DIALOGUE_NULL;
+        _currentDialogue = DIALOGUE_NULL;
         houseDialogPressEscape();
         playHouseGoodbyeSpeech();
         pMediaPlayer->Unload();
@@ -158,7 +158,7 @@ void GUIWindow_Tavern::buyFoodDialogue() {
 }
 
 void GUIWindow_Tavern::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (option == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_PlayArcomage, 0, 0);
     } else if (IsSkillLearningDialogue(option)) {
@@ -172,7 +172,7 @@ void GUIWindow_Tavern::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -204,7 +204,7 @@ void GUIWindow_Tavern::houseSpecificDialogue() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Tavern::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         if (houseId() == HOUSE_TAVERN_EMERALD_ISLE) {
             return {DIALOGUE_TAVERN_REST, DIALOGUE_TAVERN_BUY_FOOD, DIALOGUE_LEARN_SKILLS};
@@ -225,19 +225,19 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Tavern::listDialogueOptions() {
 }
 
 void GUIWindow_Tavern::updateDialogueOnEscape() {
-    if (IsSkillLearningDialogue(currentDialogue)) {
-        currentDialogue = DIALOGUE_LEARN_SKILLS;
+    if (IsSkillLearningDialogue(_currentDialogue)) {
+        _currentDialogue = DIALOGUE_LEARN_SKILLS;
         return;
     }
-    if (currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RULES ||
-        currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS ||
-        currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
-        currentDialogue = DIALOGUE_TAVERN_ARCOMAGE_MAIN;
+    if (_currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RULES ||
+        _currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_VICTORY_CONDITIONS ||
+        _currentDialogue == DIALOGUE_TAVERN_ARCOMAGE_RESULT) {
+        _currentDialogue = DIALOGUE_TAVERN_ARCOMAGE_MAIN;
         return;
     }
-    if (currentDialogue == DIALOGUE_MAIN) {
-        currentDialogue = DIALOGUE_NULL;
+    if (_currentDialogue == DIALOGUE_MAIN) {
+        _currentDialogue = DIALOGUE_NULL;
         return;
     }
-    currentDialogue = DIALOGUE_MAIN;
+    _currentDialogue = DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/Houses/Tavern.h
+++ b/src/GUI/UI/Houses/Tavern.h
@@ -12,8 +12,8 @@ class GUIWindow_Tavern : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
-    virtual DIALOGUE_TYPE getOptionOnEscape() override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
+    virtual void updateDialogueOnEscape() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -116,7 +116,7 @@ GUIWindow_Temple::GUIWindow_Temple(HOUSE_ID houseId) : GUIWindow_House(houseId) 
 }
 
 void GUIWindow_Temple::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (IsSkillLearningDialogue(option)) {
         learnSelectedSkill(GetLearningDialogueSkill(option));
     }
@@ -128,7 +128,7 @@ void GUIWindow_Temple::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -148,7 +148,7 @@ void GUIWindow_Temple::houseSpecificDialogue() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TEMPLE_HEAL, DIALOGUE_TEMPLE_DONATE, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_LEARN_SKILLS:
@@ -159,15 +159,15 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions() {
 }
 
 void GUIWindow_Temple::updateDialogueOnEscape() {
-    if (IsSkillLearningDialogue(currentDialogue)) {
-        currentDialogue = DIALOGUE_LEARN_SKILLS;
+    if (IsSkillLearningDialogue(_currentDialogue)) {
+        _currentDialogue = DIALOGUE_LEARN_SKILLS;
         return;
     }
-    if (currentDialogue == DIALOGUE_MAIN) {
-        currentDialogue = DIALOGUE_NULL;
+    if (_currentDialogue == DIALOGUE_MAIN) {
+        _currentDialogue = DIALOGUE_NULL;
         return;
     }
-    currentDialogue = DIALOGUE_MAIN;
+    _currentDialogue = DIALOGUE_MAIN;
 }
 
 void GUIWindow_Temple::playHouseGoodbyeSpeech() {

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -116,6 +116,7 @@ GUIWindow_Temple::GUIWindow_Temple(HOUSE_ID houseId) : GUIWindow_House(houseId) 
 }
 
 void GUIWindow_Temple::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (IsSkillLearningDialogue(option)) {
         learnSelectedSkill(GetLearningDialogueSkill(option));
     }
@@ -127,7 +128,7 @@ void GUIWindow_Temple::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -146,8 +147,8 @@ void GUIWindow_Temple::houseSpecificDialogue() {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TEMPLE_HEAL, DIALOGUE_TEMPLE_DONATE, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_LEARN_SKILLS:
@@ -157,14 +158,16 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Temple::listDialogueOptions(DIALOGUE_TYPE o
     }
 }
 
-DIALOGUE_TYPE GUIWindow_Temple::getOptionOnEscape() {
-    if (IsSkillLearningDialogue(dialog_menu_id)) {
-        return DIALOGUE_LEARN_SKILLS;
+void GUIWindow_Temple::updateDialogueOnEscape() {
+    if (IsSkillLearningDialogue(currentDialogue)) {
+        currentDialogue = DIALOGUE_LEARN_SKILLS;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_MAIN) {
-        return DIALOGUE_NULL;
+    if (currentDialogue == DIALOGUE_MAIN) {
+        currentDialogue = DIALOGUE_NULL;
+        return;
     }
-    return DIALOGUE_MAIN;
+    currentDialogue = DIALOGUE_MAIN;
 }
 
 void GUIWindow_Temple::playHouseGoodbyeSpeech() {

--- a/src/GUI/UI/Houses/Temple.h
+++ b/src/GUI/UI/Houses/Temple.h
@@ -13,8 +13,8 @@ class GUIWindow_Temple : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
-    virtual DIALOGUE_TYPE getOptionOnEscape() override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
+    virtual void updateDialogueOnEscape() override;
     virtual void playHouseGoodbyeSpeech() override;
 
  protected:

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -105,7 +105,7 @@ void GUIWindow_TownHall::payFineDialogue() {
 }
 
 void GUIWindow_TownHall::houseSpecificDialogue() {
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -121,6 +121,7 @@ void GUIWindow_TownHall::houseSpecificDialogue() {
 }
 
 void GUIWindow_TownHall::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (option == DIALOGUE_TOWNHALL_BOUNTY_HUNT) {
         bountyHuntingDialogueOptionClicked();
     } else if (option == DIALOGUE_TOWNHALL_PAY_FINE) {
@@ -128,8 +129,8 @@ void GUIWindow_TownHall::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_TownHall::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_TownHall::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         if (pParty->uFine) {
             return {DIALOGUE_TOWNHALL_BOUNTY_HUNT, DIALOGUE_TOWNHALL_PAY_FINE};

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -105,7 +105,7 @@ void GUIWindow_TownHall::payFineDialogue() {
 }
 
 void GUIWindow_TownHall::houseSpecificDialogue() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -121,7 +121,7 @@ void GUIWindow_TownHall::houseSpecificDialogue() {
 }
 
 void GUIWindow_TownHall::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (option == DIALOGUE_TOWNHALL_BOUNTY_HUNT) {
         bountyHuntingDialogueOptionClicked();
     } else if (option == DIALOGUE_TOWNHALL_PAY_FINE) {
@@ -130,7 +130,7 @@ void GUIWindow_TownHall::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_TownHall::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         if (pParty->uFine) {
             return {DIALOGUE_TOWNHALL_BOUNTY_HUNT, DIALOGUE_TOWNHALL_PAY_FINE};

--- a/src/GUI/UI/Houses/TownHall.h
+++ b/src/GUI/UI/Houses/TownHall.h
@@ -13,7 +13,7 @@ class GUIWindow_TownHall : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
 
     /**
      * @return   Text to show after the player has clicked on the "Bounty Hunt" dialogue option.

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -111,7 +111,7 @@ GUIWindow_Training::GUIWindow_Training(HOUSE_ID houseId) : GUIWindow_House(house
 }
 
 void GUIWindow_Training::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
     if (IsSkillLearningDialogue(option)) {
         learnSelectedSkill(GetLearningDialogueSkill(option));
     }
@@ -123,7 +123,7 @@ void GUIWindow_Training::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -140,7 +140,7 @@ void GUIWindow_Training::houseSpecificDialogue() {
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TRAINING_HALL_TRAIN, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_LEARN_SKILLS:
@@ -151,13 +151,13 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions() {
 }
 
 void GUIWindow_Training::updateDialogueOnEscape() {
-    if (IsSkillLearningDialogue(currentDialogue)) {
-        currentDialogue = DIALOGUE_LEARN_SKILLS;
+    if (IsSkillLearningDialogue(_currentDialogue)) {
+        _currentDialogue = DIALOGUE_LEARN_SKILLS;
         return;
     }
-    if (currentDialogue == DIALOGUE_MAIN) {
-        currentDialogue = DIALOGUE_NULL;
+    if (_currentDialogue == DIALOGUE_MAIN) {
+        _currentDialogue = DIALOGUE_NULL;
         return;
     }
-    currentDialogue = DIALOGUE_MAIN;
+    _currentDialogue = DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -111,6 +111,7 @@ GUIWindow_Training::GUIWindow_Training(HOUSE_ID houseId) : GUIWindow_House(house
 }
 
 void GUIWindow_Training::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
+    currentDialogue = option;
     if (IsSkillLearningDialogue(option)) {
         learnSelectedSkill(GetLearningDialogueSkill(option));
     }
@@ -122,7 +123,7 @@ void GUIWindow_Training::houseSpecificDialogue() {
         pParty->setActiveToFirstCanAct();
     }
 
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -138,8 +139,8 @@ void GUIWindow_Training::houseSpecificDialogue() {
     }
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TRAINING_HALL_TRAIN, DIALOGUE_LEARN_SKILLS};
       case DIALOGUE_LEARN_SKILLS:
@@ -149,12 +150,14 @@ std::vector<DIALOGUE_TYPE> GUIWindow_Training::listDialogueOptions(DIALOGUE_TYPE
     }
 }
 
-DIALOGUE_TYPE GUIWindow_Training::getOptionOnEscape() {
-    if (IsSkillLearningDialogue(dialog_menu_id)) {
-        return DIALOGUE_LEARN_SKILLS;
+void GUIWindow_Training::updateDialogueOnEscape() {
+    if (IsSkillLearningDialogue(currentDialogue)) {
+        currentDialogue = DIALOGUE_LEARN_SKILLS;
+        return;
     }
-    if (dialog_menu_id == DIALOGUE_MAIN) {
-        return DIALOGUE_NULL;
+    if (currentDialogue == DIALOGUE_MAIN) {
+        currentDialogue = DIALOGUE_NULL;
+        return;
     }
-    return DIALOGUE_MAIN;
+    currentDialogue = DIALOGUE_MAIN;
 }

--- a/src/GUI/UI/Houses/Training.h
+++ b/src/GUI/UI/Houses/Training.h
@@ -16,8 +16,8 @@ class GUIWindow_Training : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
-    virtual DIALOGUE_TYPE getOptionOnEscape() override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
+    virtual void updateDialogueOnEscape() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -153,7 +153,7 @@ void GUIWindow_Transport::transportDialogue() {
         return;
     }
 
-    int choice_id = dialog_menu_id - DIALOGUE_TRANSPORT_SCHEDULE_1;
+    int choice_id = currentDialogue - DIALOGUE_TRANSPORT_SCHEDULE_1;
     const TransportInfo *pTravel = &transportSchedule[transportRoutes[houseId()][choice_id]];
 
     if (pTravel->pSchedule[pParty->uCurrentDayOfMonth % 7]) {
@@ -204,7 +204,7 @@ void GUIWindow_Transport::transportDialogue() {
 void GUIWindow_Transport::houseSpecificDialogue() {
     assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->activeCharacterIndex() = 0 and crash
 
-    switch (dialog_menu_id) {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -220,11 +220,11 @@ void GUIWindow_Transport::houseSpecificDialogue() {
 }
 
 void GUIWindow_Transport::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    // Nothing
+    currentDialogue = option;
 }
 
-std::vector<DIALOGUE_TYPE> GUIWindow_Transport::listDialogueOptions(DIALOGUE_TYPE option) {
-    switch (option) {
+std::vector<DIALOGUE_TYPE> GUIWindow_Transport::listDialogueOptions() {
+    switch (currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TRANSPORT_SCHEDULE_1, DIALOGUE_TRANSPORT_SCHEDULE_2, DIALOGUE_TRANSPORT_SCHEDULE_3, DIALOGUE_TRANSPORT_SCHEDULE_4};
       default:

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -153,7 +153,7 @@ void GUIWindow_Transport::transportDialogue() {
         return;
     }
 
-    int choice_id = currentDialogue - DIALOGUE_TRANSPORT_SCHEDULE_1;
+    int choice_id = _currentDialogue - DIALOGUE_TRANSPORT_SCHEDULE_1;
     const TransportInfo *pTravel = &transportSchedule[transportRoutes[houseId()][choice_id]];
 
     if (pTravel->pSchedule[pParty->uCurrentDayOfMonth % 7]) {
@@ -204,7 +204,7 @@ void GUIWindow_Transport::transportDialogue() {
 void GUIWindow_Transport::houseSpecificDialogue() {
     assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->activeCharacterIndex() = 0 and crash
 
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         mainDialogue();
         break;
@@ -220,11 +220,11 @@ void GUIWindow_Transport::houseSpecificDialogue() {
 }
 
 void GUIWindow_Transport::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
 }
 
 std::vector<DIALOGUE_TYPE> GUIWindow_Transport::listDialogueOptions() {
-    switch (currentDialogue) {
+    switch (_currentDialogue) {
       case DIALOGUE_MAIN:
         return {DIALOGUE_TRANSPORT_SCHEDULE_1, DIALOGUE_TRANSPORT_SCHEDULE_2, DIALOGUE_TRANSPORT_SCHEDULE_3, DIALOGUE_TRANSPORT_SCHEDULE_4};
       default:

--- a/src/GUI/UI/Houses/Transport.h
+++ b/src/GUI/UI/Houses/Transport.h
@@ -12,7 +12,7 @@ class GUIWindow_Transport : public GUIWindow_House {
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option) override;
     virtual void houseSpecificDialogue() override;
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option) override;
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions() override;
 
  protected:
     void mainDialogue();

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -688,13 +688,11 @@ std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, 
     } else if (eventId >= 400 && eventId <= 410) {
         guildMembershipNPCTopicId = topic;
         uDialogueType = DIALOGUE_MAGIC_GUILD_OFFER;
-        dialog_menu_id = DIALOGUE_OTHER;
         current_npc_text = pNPCTopics[eventId - 301].pText;
         topicEventId = eventId;
         return {DIALOGUE_MAGIC_GUILD_JOIN};
     } else if (eventId >= 200 && eventId <= 310) {
         uDialogueType = DIALOGUE_MASTERY_TEACHER_OFFER;
-        dialog_menu_id = DIALOGUE_OTHER;
         current_npc_text = pNPCTopics[eventId + 168].pText;
         topicEventId = eventId;
         return {DIALOGUE_MASTERY_TEACHER_LEARN};

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -217,10 +217,10 @@ static constexpr std::array<std::pair<int16_t, ITEM_TYPE>, 27> _4F0882_evt_VAR_P
     {0x0F1, ITEM_RARE_THE_PERFECT_BOW}
 }};
 
-std::vector<DIALOGUE_TYPE> arenaMainDialogue() {
+DIALOGUE_TYPE arenaMainDialogue() {
     if (pParty->field_7B5_in_arena_quest) {
         if (pParty->field_7B5_in_arena_quest == -1) {
-            uDialogueType = DIALOGUE_ARENA_ALREADY_WON;
+            return DIALOGUE_ARENA_ALREADY_WON;
         } else {
             int killedMonsters = 0;
             for (Actor &actor : pActors) {
@@ -232,7 +232,6 @@ std::vector<DIALOGUE_TYPE> arenaMainDialogue() {
                 }
             }
             if (killedMonsters >= pActors.size() || pActors.size() <= 0) {
-                uDialogueType = DIALOGUE_ARENA_REWARD;
                 pParty->uNumArenaWins[pParty->field_7B5_in_arena_quest - DIALOGUE_ARENA_SELECT_PAGE]++;
                 for (Character &player : pParty->pCharacters) {
                     player.SetVariable(VAR_Award, (uint8_t)pParty->field_7B5_in_arena_quest + 3);
@@ -240,32 +239,32 @@ std::vector<DIALOGUE_TYPE> arenaMainDialogue() {
                 pParty->partyFindsGold(gold_transaction_amount, GOLD_RECEIVE_SHARE);
                 pAudioPlayer->playUISound(SOUND_51heroism03);
                 pParty->field_7B5_in_arena_quest = -1;
+                return DIALOGUE_ARENA_REWARD;
             } else {
-                uDialogueType = DIALOGUE_ARENA_WELCOME;
                 pParty->pos = Vec3i(3849, 5770, 1);
                 pParty->speed = Vec3i();
                 pParty->uFallStartZ = 1;
                 pParty->_viewYaw = 512;
                 pParty->_viewPitch = 0;
                 pAudioPlayer->playUISound(SOUND_51heroism03);
+                engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
+                return DIALOGUE_NULL;
             }
         }
-        return {};
     } else {
-        uDialogueType = DIALOGUE_ARENA_WELCOME;
-        return {DIALOGUE_ARENA_SELECT_PAGE, DIALOGUE_ARENA_SELECT_SQUIRE, DIALOGUE_ARENA_SELECT_KNIGHT, DIALOGUE_ARENA_SELECT_CHAMPION};
+        return DIALOGUE_ARENA_WELCOME;
     }
 }
 
 /**
  * @offset 0x4BC109
  */
-void prepareArenaFight() {
+void prepareArenaFight(DIALOGUE_TYPE dialogue) {
     const int LAST_ARENA_FIGHTER_TYPE = 258;
     std::vector<int> monsterIds;
     std::vector<int> monsterTypes;
 
-    pParty->field_7B5_in_arena_quest = uDialogueType;
+    pParty->field_7B5_in_arena_quest = dialogue;
     GUIWindow window = *pDialogueWindow;
     window.uFrameWidth = game_viewport_width;
     window.uFrameZ = 452;
@@ -301,18 +300,22 @@ void prepareArenaFight() {
     }
 
     int monsterMaxLevel = characterMaxLevel;
-
-    if (uDialogueType == DIALOGUE_ARENA_SELECT_PAGE) {
-        monsterMaxLevel = characterMaxLevel;
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_SQUIRE) {
-        monsterMaxLevel = characterMaxLevel * 1.5;
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_KNIGHT) {
-        monsterMaxLevel = 2 * characterMaxLevel;
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_CHAMPION) {
-        monsterMaxLevel = 2 * characterMaxLevel;
-    }
-
     int monsterMinLevel = characterMaxLevel / 2;
+
+    switch(dialogue) {
+      case DIALOGUE_ARENA_SELECT_PAGE:
+        monsterMaxLevel = characterMaxLevel;
+        break;
+      case DIALOGUE_ARENA_SELECT_SQUIRE:
+        monsterMaxLevel = characterMaxLevel * 1.5;
+        break;
+      case DIALOGUE_ARENA_SELECT_KNIGHT:
+      case DIALOGUE_ARENA_SELECT_CHAMPION:
+        monsterMaxLevel = characterMaxLevel * 2;
+        break;
+      default:
+        assert(false);
+    }
 
     if (monsterMinLevel < 2)
         monsterMinLevel = 2;
@@ -348,16 +351,16 @@ void prepareArenaFight() {
 
     int baseReward = 0, monstersNum = 0;
 
-    if (uDialogueType == DIALOGUE_ARENA_SELECT_PAGE) {
+    if (dialogue == DIALOGUE_ARENA_SELECT_PAGE) {
         baseReward = 50;
         monstersNum = grng->random(3) + 6; // [6:8] monsters
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_SQUIRE) {
+    } else if (dialogue == DIALOGUE_ARENA_SELECT_SQUIRE) {
         baseReward = 100;
         monstersNum = grng->random(7) + 6; // [6:12] monsters
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_KNIGHT) {
+    } else if (dialogue == DIALOGUE_ARENA_SELECT_KNIGHT) {
         baseReward = 200;
         monstersNum = grng->random(11) + 10; // [10:19] monsters
-    } else if (uDialogueType == DIALOGUE_ARENA_SELECT_CHAMPION) {
+    } else if (dialogue == DIALOGUE_ARENA_SELECT_CHAMPION) {
         baseReward = 500;
         monstersNum = 20;
     }
@@ -655,7 +658,7 @@ std::vector<DIALOGUE_TYPE> prepareScriptedNPCDialogueTopics(NPCData *npcData) {
     return optionList;
 }
 
-std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, NPCData *npcData) {
+DIALOGUE_TYPE handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, NPCData *npcData) {
     int eventId;
 
     if (topic == DIALOGUE_SCRIPTED_LINE_1) {
@@ -678,7 +681,7 @@ std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, 
         // Original code also listed this event which presumably opened bounty dialogue but MM7
         // use event 311 for some teleport in Bracada
         __debugbreak();
-        return {};
+        return DIALOGUE_MAIN;
     }
 
     if (eventId == 139) {
@@ -687,15 +690,13 @@ std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, 
         return arenaMainDialogue();
     } else if (eventId >= 400 && eventId <= 410) {
         guildMembershipNPCTopicId = topic;
-        uDialogueType = DIALOGUE_MAGIC_GUILD_OFFER;
         current_npc_text = pNPCTopics[eventId - 301].pText;
         topicEventId = eventId;
-        return {DIALOGUE_MAGIC_GUILD_JOIN};
+        return DIALOGUE_MAGIC_GUILD_OFFER;
     } else if (eventId >= 200 && eventId <= 310) {
-        uDialogueType = DIALOGUE_MASTERY_TEACHER_OFFER;
         current_npc_text = pNPCTopics[eventId + 168].pText;
         topicEventId = eventId;
-        return {DIALOGUE_MASTERY_TEACHER_LEARN};
+        return DIALOGUE_MASTERY_TEACHER_OFFER;
     } else {
         activeLevelDecoration = (LevelDecoration *)1;
         current_npc_text.clear();
@@ -703,8 +704,22 @@ std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, 
         activeLevelDecoration = nullptr;
     }
 
-    return {};
+    return DIALOGUE_MAIN;
 }
+
+std::vector<DIALOGUE_TYPE> listNPCDialogueOptions(DIALOGUE_TYPE topic) {
+    switch (topic) {
+      case DIALOGUE_MAGIC_GUILD_OFFER:
+        return {DIALOGUE_MAGIC_GUILD_JOIN};
+      case DIALOGUE_MASTERY_TEACHER_OFFER:
+        return {DIALOGUE_MASTERY_TEACHER_LEARN};
+      case DIALOGUE_ARENA_WELCOME:
+        return {DIALOGUE_ARENA_SELECT_PAGE, DIALOGUE_ARENA_SELECT_SQUIRE, DIALOGUE_ARENA_SELECT_KNIGHT, DIALOGUE_ARENA_SELECT_CHAMPION};
+      default:
+        return {};
+    }
+}
+
 
 void selectSpecialNPCTopicSelection(DIALOGUE_TYPE topic, NPCData* npcData) {
     if (topic == DIALOGUE_MASTERY_TEACHER_LEARN) {
@@ -765,7 +780,7 @@ void selectSpecialNPCTopicSelection(DIALOGUE_TYPE topic, NPCData* npcData) {
     } else if (topic == DIALOGUE_PROFESSION_DETAILS) {
         dialogue_show_profession_details = ~dialogue_show_profession_details;
     } else if (topic >= DIALOGUE_ARENA_SELECT_PAGE && topic <= DIALOGUE_ARENA_SELECT_CHAMPION) {
-        prepareArenaFight();
+        prepareArenaFight(topic);
     } else if (topic == DIALOGUE_USE_HIRED_NPC_ABILITY) {
         int hirelingId;
         for (hirelingId = 0; hirelingId < pParty->pHirelings.size(); hirelingId++) {
@@ -809,7 +824,7 @@ void selectSpecialNPCTopicSelection(DIALOGUE_TYPE topic, NPCData* npcData) {
                 if (pParty->GetGold() < pNPCStats->pProfessions[npcData->profession].uHirePrice) {
                     engine->_statusBar->setEvent(LSTR_NOT_ENOUGH_GOLD);
                     dialogue_show_profession_details = false;
-                    uDialogueType = DIALOGUE_13_hiring_related;
+                    //uDialogueType = DIALOGUE_13_hiring_related;
                     if (pParty->hasActiveCharacter()) {
                         pParty->activeCharacter().playReaction(SPEECH_NOT_ENOUGH_GOLD);
                     }

--- a/src/GUI/UI/NPCTopics.h
+++ b/src/GUI/UI/NPCTopics.h
@@ -15,7 +15,8 @@ std::string npcDialogueOptionString(DIALOGUE_TYPE topic, NPCData *npcData);
 
 std::vector<DIALOGUE_TYPE> prepareScriptedNPCDialogueTopics(NPCData *npcData);
 
-std::vector<DIALOGUE_TYPE> handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, NPCData *npcData);
+DIALOGUE_TYPE handleScriptedNPCTopicSelection(DIALOGUE_TYPE topic, NPCData *npcData);
+std::vector<DIALOGUE_TYPE> listNPCDialogueOptions(DIALOGUE_TYPE topic);
 
 void selectSpecialNPCTopicSelection(DIALOGUE_TYPE topic, NPCData* npcData);
 

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -11,8 +11,15 @@ class GUIWindow_Dialogue : public GUIWindow {
     explicit GUIWindow_Dialogue(WindowData data);
     virtual ~GUIWindow_Dialogue() {}
 
+    void setDisplayedDialogueType(DIALOGUE_TYPE type) {
+        _displayedDialogue = type;
+    }
+
     virtual void Update() override;
     virtual void Release() override;
+
+ protected:
+    DIALOGUE_TYPE _displayedDialogue = DIALOGUE_MAIN;
 };
 
 void initializeNPCDialogue(Actor *actor, int bPlayerSaysHello);

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -15,6 +15,10 @@ class GUIWindow_Dialogue : public GUIWindow {
         _displayedDialogue = type;
     }
 
+    DIALOGUE_TYPE getDisplayedDialogueType() {
+        return _displayedDialogue;
+    }
+
     virtual void Update() override;
     virtual void Release() override;
 

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -678,7 +678,8 @@ void GameUI_OnPlayerPortraitLeftClick(unsigned int uPlayerID) {
         return;
     }
 
-    if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD || dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL) {
+    if (window_SpeakInHouse->getCurrentDialogue() == DIALOGUE_SHOP_BUY_STANDARD ||
+        window_SpeakInHouse->getCurrentDialogue() == DIALOGUE_SHOP_BUY_SPECIAL) {
         current_character_screen_window = WINDOW_CharacterWindow_Inventory;
         pGUIWindow_CurrentMenu = new GUIWindow_CharacterRecord(pParty->activeCharacterIndex(), SCREEN_SHOP_INVENTORY);
         return;
@@ -1120,7 +1121,7 @@ void GameUI_WritePointedObjectStatusString() {
         /* if (current_screen_type == SCREEN_HOUSE)  // this is required
         when displaying inventory in a house/shop??
         {
-        if (dialog_menu_id != DIALOGUE_SHOP_BUY_STANDARD
+        if (window_SpeakInHouse->getCurrentDialogue() != DIALOGUE_SHOP_BUY_STANDARD
         || (v16 = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]], v16 ==
         0)
         || v16 == -65536)

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -471,7 +471,7 @@ void NPCHireableDialogPrepare() {
     pDialogueWindow->CreateButton({480, 30 * v0 + 160}, {140, 30}, 1, 0,
         UIMSG_SelectHouseNPCDialogueOption, DIALOGUE_HIRE_FIRE, Io::InputAction::Invalid, localization->GetString(LSTR_HIRE));
     pDialogueWindow->_41D08F_set_keyboard_control_group(v0 + 1, 1, 0, 2);
-    window_SpeakInHouse->setDialogueType(DIALOGUE_OTHER);
+    window_SpeakInHouse->setCurrentDialogue(DIALOGUE_OTHER);
 }
 
 void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
@@ -481,7 +481,7 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
         DIALOGUE_TYPE newTopic = handleScriptedNPCTopicSelection(topic, pCurrentNPCInfo);
 
         if (newTopic != DIALOGUE_MAIN) {
-            window_SpeakInHouse->setDialogueType(DIALOGUE_OTHER);
+            window_SpeakInHouse->setCurrentDialogue(DIALOGUE_OTHER);
             window_SpeakInHouse->reinitDialogueWindow();
             window_SpeakInHouse->initializeNPCDialogueButtons(listNPCDialogueOptions(newTopic));
         }
@@ -522,7 +522,6 @@ void selectHouseNPCDialogueOption(DIALOGUE_TYPE topic) {
     }
 
     prepareHouse(window_SpeakInHouse->houseId());
-    //window_SpeakInHouse->setDialogueType(DIALOGUE_MAIN);
     BackToHouseMenu();
 }
 
@@ -546,7 +545,7 @@ void updateHouseNPCTopics(int npc) {
                 houseNpcs[i].button = nullptr;
             }
         }
-        window_SpeakInHouse->setDialogueType(DIALOGUE_MAIN);
+        window_SpeakInHouse->setCurrentDialogue(DIALOGUE_MAIN);
         window_SpeakInHouse->reinitDialogueWindow();
         if (houseNpcs[npc].type == HOUSE_PROPRIETOR) {
             window_SpeakInHouse->initializeProprietorDialogue();

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -741,7 +741,7 @@ void GUIWindow_House::houseNPCDialogue() {
     house_window.DrawTitleText(pFontCreate, SIDE_TEXT_BOX_POS_X, SIDE_TEXT_BOX_POS_Y, colorTable.EasternBlue, NameAndTitle(pNPC), 3);
 
     if (houseNpcs[0].type != HOUSE_PROPRIETOR) {
-        if (current_npc_text.length() == 0 && currentDialogue == DIALOGUE_MAIN) {
+        if (current_npc_text.length() == 0 && _currentDialogue == DIALOGUE_MAIN) {
             if (pNPC->greet) {
                 std::string greetString;
 
@@ -1146,7 +1146,7 @@ void GUIWindow_House::Release() {
 }
 
 void GUIWindow_House::houseDialogueOptionSelected(DIALOGUE_TYPE option) {
-    currentDialogue = option;
+    _currentDialogue = option;
 }
 
 void GUIWindow_House::houseSpecificDialogue() {
@@ -1158,11 +1158,11 @@ std::vector<DIALOGUE_TYPE> GUIWindow_House::listDialogueOptions() {
 }
 
 void GUIWindow_House::updateDialogueOnEscape() {
-    if (currentDialogue == DIALOGUE_MAIN) {
-        currentDialogue = DIALOGUE_NULL;
+    if (_currentDialogue == DIALOGUE_MAIN) {
+        _currentDialogue = DIALOGUE_NULL;
         return;
     }
-    currentDialogue = DIALOGUE_MAIN;
+    _currentDialogue = DIALOGUE_MAIN;
 }
 
 void GUIWindow_House::houseScreenClick() {

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -89,11 +89,11 @@ class GUIWindow_House : public GUIWindow {
     }
 
     DIALOGUE_TYPE getCurrentDialogue() const {
-        return currentDialogue;
+        return _currentDialogue;
     }
 
     void setDialogueType(DIALOGUE_TYPE dialogue) {
-        currentDialogue = dialogue;
+        _currentDialogue = dialogue;
     }
 
     void houseDialogManager();
@@ -118,7 +118,7 @@ class GUIWindow_House : public GUIWindow {
  protected:
     void learnSkillsDialogue();
 
-    DIALOGUE_TYPE currentDialogue = DIALOGUE_NULL;
+    DIALOGUE_TYPE _currentDialogue = DIALOGUE_NULL;
     int _savedButtonsNum{};
     bool _transactionPerformed = false;
 };

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -92,7 +92,7 @@ class GUIWindow_House : public GUIWindow {
         return _currentDialogue;
     }
 
-    void setDialogueType(DIALOGUE_TYPE dialogue) {
+    void setCurrentDialogue(DIALOGUE_TYPE dialogue) {
         _currentDialogue = dialogue;
     }
 

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -88,6 +88,14 @@ class GUIWindow_House : public GUIWindow {
         return static_cast<HOUSE_ID>(wData.val); // TODO(captainurist): drop all direct accesses to wData.val.
     }
 
+    DIALOGUE_TYPE getCurrentDialogue() const {
+        return currentDialogue;
+    }
+
+    void setDialogueType(DIALOGUE_TYPE dialogue) {
+        currentDialogue = dialogue;
+    }
+
     void houseDialogManager();
     void houseNPCDialogue();
     void initializeProprietorDialogue();
@@ -101,16 +109,16 @@ class GUIWindow_House : public GUIWindow {
                      int topOptionShift = 0, bool denseSpacing = false);
 
     virtual void houseDialogueOptionSelected(DIALOGUE_TYPE option);
-    // TODO(Nik-RE-dev): add DIALOGUE_TYPE argument?
     virtual void houseSpecificDialogue();
-    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions(DIALOGUE_TYPE option);
-    virtual DIALOGUE_TYPE getOptionOnEscape();
+    virtual std::vector<DIALOGUE_TYPE> listDialogueOptions();
+    virtual void updateDialogueOnEscape();
     virtual void houseScreenClick();
     virtual void playHouseGoodbyeSpeech();
 
  protected:
     void learnSkillsDialogue();
 
+    DIALOGUE_TYPE currentDialogue = DIALOGUE_NULL;
     int _savedButtonsNum{};
     bool _transactionPerformed = false;
 };
@@ -124,9 +132,6 @@ struct HouseAnimDescr {
     uint8_t uRoomSoundId;
     uint16_t padding_e;
 };
-
-extern BuildingType in_current_building_type;  // 00F8B198
-extern DIALOGUE_TYPE dialog_menu_id;     // 00F8B19C
 
 extern class GraphicsImage *_591428_endcap;
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1405,36 +1405,33 @@ void ShowPopupShopItem() {
     ItemGen *item;  // ecx@13
     int invindex;
     int testpos;
+    BuildingType buildingType = window_SpeakInHouse->buildingType();
+    DIALOGUE_TYPE dialogue = window_SpeakInHouse->getCurrentDialogue();
 
-    if (in_current_building_type == BUILDING_INVALID) return;
-    if (dialog_menu_id < DIALOGUE_SHOP_BUY_STANDARD) return;
+    if (buildingType == BUILDING_INVALID)
+        return;
+
+    if (dialogue < DIALOGUE_SHOP_BUY_STANDARD)
+        return;
 
     Pointi pt = EngineIocContainer::ResolveMouse()->GetCursorPos();
     int testx;
 
-    if (in_current_building_type <= BUILDING_ALCHEMY_SHOP) {
-        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD ||
-            dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL) {
-            switch (in_current_building_type) {
+    if (buildingType <= BUILDING_ALCHEMY_SHOP) {
+        if (dialogue == DIALOGUE_SHOP_BUY_STANDARD || dialogue == DIALOGUE_SHOP_BUY_SPECIAL) {
+            switch (buildingType) {
                 case BUILDING_WEAPON_SHOP: {
                     testx = (pt.x - 30) / 70;
                     if (testx >= 0 && testx < 6) {
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        if (dialogue == DIALOGUE_SHOP_BUY_STANDARD)
                             item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
                         else
                             item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
 
                         if (item->uItemID != ITEM_NULL) {
-                            testpos =
-                                ((60 -
-                                  (shop_ui_items_in_store[testx]->width() /
-                                   2)) +
-                                 testx * 70);
-                            if (pt.x >= testpos &&
-                                pt.x <
-                                    (testpos + shop_ui_items_in_store[testx]->width())) {
-                                if (pt.y >= weaponYPos[testx] + 30 &&
-                                    pt.y < (weaponYPos[testx] + 30 + shop_ui_items_in_store[testx]->height())) {
+                            testpos = ((60 - (shop_ui_items_in_store[testx]->width() / 2)) + testx * 70);
+                            if (pt.x >= testpos && pt.x < (testpos + shop_ui_items_in_store[testx]->width())) {
+                                if (pt.y >= weaponYPos[testx] + 30 && pt.y < (weaponYPos[testx] + 30 + shop_ui_items_in_store[testx]->height())) {
                                     GameUI_DrawItemInfo(item);
                                 }
                             } else {
@@ -1455,31 +1452,21 @@ void ShowPopupShopItem() {
                             testx += 4;
                         }
 
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        if (dialogue == DIALOGUE_SHOP_BUY_STANDARD)
                             item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
                         else
                             item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
 
                         if (item->uItemID != ITEM_NULL) {
                             if (testx >= 4) {
-                                testpos = ((90 - (shop_ui_items_in_store[testx]->width() /
-                                                  2)) +
-                                           (testx * 105) - 420);  // low row
+                                testpos = ((90 - (shop_ui_items_in_store[testx]->width() / 2)) + (testx * 105) - 420);  // low row
                             } else {
-                                testpos = ((86 - (shop_ui_items_in_store[testx]->width() /
-                                                  2)) +
-                                           testx * 105);
+                                testpos = ((86 - (shop_ui_items_in_store[testx]->width() / 2)) + testx * 105);
                             }
 
-                            if (pt.x >= testpos &&
-                                pt.x <=
-                                    testpos + shop_ui_items_in_store[testx]->width()) {
-                                if ((pt.y >= 126 &&
-                                    pt.y <
-                                         (126 + shop_ui_items_in_store[testx]->height())) ||
-                                    (pt.y <= 98 &&
-                                        pt.y >=
-                                         (98 - shop_ui_items_in_store[testx]->height()))) {
+                            if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                                if ((pt.y >= 126 && pt.y < (126 + shop_ui_items_in_store[testx]->height())) ||
+                                    (pt.y <= 98 && pt.y >= (98 - shop_ui_items_in_store[testx]->height()))) {
                                     GameUI_DrawItemInfo(item);
                                 } else {
                                     return;
@@ -1500,33 +1487,21 @@ void ShowPopupShopItem() {
                             testx += 6;
                         }
 
-                        if (dialog_menu_id == DIALOGUE_SHOP_BUY_STANDARD)
+                        if (dialogue == DIALOGUE_SHOP_BUY_STANDARD)
                             item = &pParty->standartItemsInShops[window_SpeakInHouse->houseId()][testx];
                         else
                             item = &pParty->specialItemsInShops[window_SpeakInHouse->houseId()][testx];
 
                         if (item->uItemID != ITEM_NULL) {
                             if (pt.y > 152) {
-                                testpos =
-                                    75 * testx - shop_ui_items_in_store[testx]->width() /
-                                        2 +
-                                    40 - 450;
+                                testpos = 75 * testx - shop_ui_items_in_store[testx]->width() / 2 + 40 - 450;
                             } else {
-                                testpos =
-                                    75 * testx - shop_ui_items_in_store[testx]->width() /
-                                        2 +
-                                    40;
+                                testpos = 75 * testx - shop_ui_items_in_store[testx]->width() / 2 + 40;
                             }
 
-                            if (pt.x >= testpos &&
-                                pt.x <=
-                                    testpos + shop_ui_items_in_store[testx]->width()) {
-                                if ((pt.y <= 308 &&
-                                    pt.y >=
-                                         (308 - shop_ui_items_in_store[testx]->height())) ||
-                                    (pt.y <= 152 &&
-                                        pt.y >=
-                                         (152 - shop_ui_items_in_store[testx]->height()))) {
+                            if (pt.x >= testpos && pt.x <= testpos + shop_ui_items_in_store[testx]->width()) {
+                                if ((pt.y <= 308 && pt.y >= (308 - shop_ui_items_in_store[testx]->height())) ||
+                                    (pt.y <= 152 && pt.y >= (152 - shop_ui_items_in_store[testx]->height()))) {
                                     GameUI_DrawItemInfo(item);
                                 } else {
                                     return;
@@ -1544,7 +1519,7 @@ void ShowPopupShopItem() {
                     // return;
                     // v7 = &pParty->StandartItemsInShops[(unsigned
                     // int)window_SpeakInHouse->ptr_1C][v3 - 1]; if
-                    // (dialog_menu_id == DIALOGUE_SHOP_BUY_SPECIAL) v7 =
+                    // (dialogue == DIALOGUE_SHOP_BUY_SPECIAL) v7 =
                     // &pParty->SpecialItemsInShops[(unsigned
                     // int)window_SpeakInHouse->ptr_1C][v3 - 1];
                     // GameUI_DrawItemInfo(v7);
@@ -1553,22 +1528,17 @@ void ShowPopupShopItem() {
             }
         }
 
-        if (dialog_menu_id >= DIALOGUE_SHOP_SELL &&
-                dialog_menu_id <= DIALOGUE_SHOP_REPAIR ||
-            dialog_menu_id == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
+        if (dialogue >= DIALOGUE_SHOP_SELL && dialogue <= DIALOGUE_SHOP_REPAIR || dialogue == DIALOGUE_SHOP_DISPLAY_EQUIPMENT) {
             invindex = ((pt.x - 14) >> 5) + 14 * ((pt.y - 17) >> 5);
-            if (pt.x <= 13 || pt.x >= 462 ||
-                !pParty->activeCharacter().GetItemListAtInventoryIndex(
-                    invindex))
+            if (pt.x <= 13 || pt.x >= 462 || !pParty->activeCharacter().GetItemListAtInventoryIndex(invindex))
                 return;
 
-            GameUI_DrawItemInfo(
-                pParty->activeCharacter().GetItemAtInventoryIndex(invindex));
+            GameUI_DrawItemInfo(pParty->activeCharacter().GetItemAtInventoryIndex(invindex));
             return;
         }
     }
 
-    if (in_current_building_type <= BUILDING_MIRRORED_PATH_GUILD && dialog_menu_id == DIALOGUE_GUILD_BUY_BOOKS) {
+    if (buildingType <= BUILDING_MIRRORED_PATH_GUILD && dialogue == DIALOGUE_GUILD_BUY_BOOKS) {
         int testx = (pt.x - 32) / 70;
         if (testx >= 0 && testx < 6) {
             if (pt.y >= 250) {
@@ -1609,13 +1579,9 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Character *player) {
         if (player->pCharacterBuffs[i].Active()) ++numActivePlayerBuffs;
     }
 
-    window->uFrameHeight =
-        ((pFontArrus->GetHeight() + 162) +
-         ((numActivePlayerBuffs - 1) * pFontArrus->GetHeight()));
+    window->uFrameHeight = ((pFontArrus->GetHeight() + 162) + ((numActivePlayerBuffs - 1) * pFontArrus->GetHeight()));
     window->uFrameZ = window->uFrameWidth + window->uFrameX - 1;
-    window->uFrameW = ((pFontArrus->GetHeight() + 162) +
-                       ((numActivePlayerBuffs - 1) * pFontArrus->GetHeight())) +
-                      window->uFrameY - 1;
+    window->uFrameW = ((pFontArrus->GetHeight() + 162) + ((numActivePlayerBuffs - 1) * pFontArrus->GetHeight())) + window->uFrameY - 1;
     window->DrawMessageBox(0);
 
     if (player->IsEradicated()) {
@@ -1623,22 +1589,18 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, Character *player) {
     } else if (player->IsDead()) {
         v13 = game_ui_player_face_dead;
     } else {
-        uFramesetID =
-            pPlayerFrameTable->GetFrameIdByExpression(player->expression);
-        if (!uFramesetID) uFramesetID = 1;
+        uFramesetID = pPlayerFrameTable->GetFrameIdByExpression(player->expression);
+        if (!uFramesetID)
+            uFramesetID = 1;
         if (player->expression == CHARACTER_EXPRESSION_TALK)
-            v15 = pPlayerFrameTable->GetFrameBy_y(
-                &player->_expression21_frameset,
-                &player->_expression21_animtime, pMiscTimer->uTimeElapsed);
+            v15 = pPlayerFrameTable->GetFrameBy_y(&player->_expression21_frameset, &player->_expression21_animtime, pMiscTimer->uTimeElapsed);
         else
-            v15 = pPlayerFrameTable->GetFrameBy_x(uFramesetID,
-                                                  pMiscTimer->Time());
+            v15 = pPlayerFrameTable->GetFrameBy_x(uFramesetID, pMiscTimer->Time());
         player->uExpressionImageIndex = v15->uTextureID - 1;
         v13 = game_ui_player_faces[window->wData.val][v15->uTextureID - 1];
     }
 
-    render->DrawTextureNew((window->uFrameX + 24) / 640.0f,
-                                (window->uFrameY + 24) / 480.0f, v13);
+    render->DrawTextureNew((window->uFrameX + 24) / 640.0f, (window->uFrameY + 24) / 480.0f, v13);
 
     // TODO(captainurist): do a 2nd rewrite here
     auto str =

--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -116,9 +116,9 @@ static auto makeStatusBarTape(TestController &test) {
     return test.tape([] { return engine->_statusBar->get(); });
 }
 
-static auto makeDialogueTypeTape(TestController &test) {
-    return test.tape([] { return uDialogueType; });
-}
+//static auto makeDialogueTypeTape(TestController &test) {
+//    return test.tape([] { return uDialogueType; });
+//}
 
 static auto makeCharacterExperienceTape(TestController &test, int character) {
     return test.tape([character] { return pParty->pCharacters[character].experience; });
@@ -1651,11 +1651,9 @@ GAME_TEST(Issues, Issue1093) {
 GAME_TEST(Issues, Issue1115) {
     // Entering Arena on level 21 should not crash the game
     auto mapTape = makeMapTape(test);
-    auto dialogueTape = makeDialogueTypeTape(test);
     auto levelTape = makeCharacterLevelTape(test);
     test.playTraceFromTestData("issue_1115.mm7", "issue_1115.json");
     EXPECT_EQ(mapTape, tape("out02.odm", "d05.blv")); // Harmondale -> Arena.
-    EXPECT_TRUE(dialogueTape.contains(DIALOGUE_ARENA_SELECT_CHAMPION));
     EXPECT_EQ(levelTape, tape({21, 21, 21, 21}));
 }
 


### PR DESCRIPTION
Remove `in_current_building_type` - it can already be accessed using house window object.
Move `dialog_menu_id` to house window class, now it's `_currentDialogue` field. Tracks current dialogue option and used to view current dialogue state and calculate next state after escape.
Move `uDialogueType` to NPC window class, now it's `_displayedDialogue` field. Tracks selected option to show NPC dialogue text. No tracking is needed in this case because escape always closes whole dialogue for overworld NPC.

Small change in semantics: add escape message when selecting dialogue with arena master while fight is in process. Previously this causes party to be teleported to arena center and dialogue was still in effect. Now teleport also closes dialogue automatically.

Also remove dialogue type tape checking in test for 1115 because it's now not easily accessed.