### PR TITLE
test for 1191

### DIFF
--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -1579,6 +1579,38 @@ GAME_TEST(Issues, Issue1164) {
     EXPECT_GE(ticks, 144 - frameTicks);
 }
 
+GAME_TEST(Issues, Issue1191) {
+    auto foodTape = tapes.food();
+    test.playTraceFromTestData("issue_1191.mm7", "issue_1191.json");
+
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_FIRE).level(), 10);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_AIR).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_WATER).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_EARTH).level(), 4);
+
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_SPIRIT).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_MIND).level(), 9); // 4, +3 dragon, +2 Ruler's ring
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_BODY).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_DARK).level(), 0);
+    EXPECT_EQ(pParty->pCharacters[0].getActualSkillValue(CHARACTER_SKILL_LIGHT).level(), 0);
+
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_FIRE).level(), 4);
+    EXPECT_LE(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_AIR).level(), 3); // She has no skill. 0 or 3 skill level is fine
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_WATER).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_EARTH).level(), 18); // 10, +3 dragon, +5 ring
+
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_SPIRIT).level(), 13);
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_MIND).level(), 4);
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_BODY).level(), 18); // 10, +3 dragon, +5 ring
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_DARK).level(), 0);
+    EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_LIGHT).level(), 0);
+
+    // Uncomment when food issues (1226) resolved
+    // EXPECT_EQ(foodTape.delta(), -3);
+    // EXPECT_EQ(pParty->GetFood(), 7);
+}
+
+
 GAME_TEST(Issues, Issue1197) {
     //Assert on party death
     auto loc = tapes.map();


### PR DESCRIPTION
Test for https://github.com/OpenEnroth/OpenEnroth/issues/1191

Test data already committed.

By the way. I ran the tests and get these errors:
```
[ RUN      ] Issues.Issue735a
OpenEnroth/test/Testing/Game/GameTest.cpp:42: Failure
Exception thrown in test body: Random state desynchronized when playing back trace 'OpenEnroth_TestData/data/issue_735a.json' at 39700ms: expected 843, got 844
[  FAILED  ] Issues.Issue735a (4339 ms)
[ RUN      ] Issues.Issue735b
[       OK ] Issues.Issue735b (4146 ms)
[ RUN      ] Issues.Issue735c
OpenEnroth/test/Testing/Game/GameTest.cpp:42: Failure
Exception thrown in test body: Random state desynchronized when playing back trace 'OpenEnroth_TestData/data/issue_735c.json' at 17000ms: expected 358, got 369
[  FAILED  ] Issues.Issue735c (1945 ms)
[ RUN      ] Issues.Issue735d
[       OK ] Issues.Issue735d (4835 ms)
[ RUN      ] Issues.Issue755
OpenEnroth/test/Testing/Game/GameTest.cpp:42: Failure
Exception thrown in test body: Random state desynchronized when playing back trace 'OpenEnroth_TestData/data/issue_755.json' at 1200ms: expected 197, got 199
[  FAILED  ] Issues.Issue755 (715 ms)
[ RUN      ] Issues.Issue1051
OpenEnroth/test/Testing/Game/GameTest.cpp:42: Failure
Exception thrown in test body: Random state desynchronized when playing back trace 'OpenEnroth_TestData/data/issue_1051.json' at 1005ms: expected 138, got 139
[  FAILED  ] Issues.Issue1051 (1092 ms)
...
[  FAILED  ] Issues.Issue735a
[  FAILED  ] Issues.Issue735c
[  FAILED  ] Issues.Issue755
[  FAILED  ] Issues.Issue1051
```