### PR TITLE
Replace x/y/z coords with Vec3i in some cases

### DIFF
--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -194,7 +194,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
         {
             if (ir.data.move_map_descr.house_id || ir.data.move_map_descr.exit_pic_id) {
                 pDialogueWindow = new GUIWindow_Transition(ir.data.move_map_descr.house_id, ir.data.move_map_descr.exit_pic_id,
-                                                           ir.data.move_map_descr.x, ir.data.move_map_descr.y, ir.data.move_map_descr.z,
+                                                           Vec3i(ir.data.move_map_descr.x, ir.data.move_map_descr.y, ir.data.move_map_descr.z),
                                                            ir.data.move_map_descr.yaw, ir.data.move_map_descr.pitch, ir.data.move_map_descr.zspeed, ir.str);
                 savedEventID = _eventId;
                 savedEventStep = step + 1;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1303,9 +1303,9 @@ bool Check_LOS_Obscurred_Indoors(const Vec3i &target, const Vec3i &from) {  // t
     for (int sectargetrflip = 0; sectargetrflip < 2; sectargetrflip++) {
         int SectargetrID = 0;
         if (sectargetrflip)
-            SectargetrID = pIndoor->GetSector(target.x, target.y, target.z);
+            SectargetrID = pIndoor->GetSector(target);
         else
-            SectargetrID = pIndoor->GetSector(from.x, from.y, from.z);
+            SectargetrID = pIndoor->GetSector(from);
 
         // loop over sectargetr faces
         for (int FaceLoop = 0; FaceLoop < pIndoor->pSectors[SectargetrID].uNumFaces; ++FaceLoop) {
@@ -1963,7 +1963,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
             enc_spawn_point.uMonsterIndex = enc_index;
 
             // get proposed sector
-            mon_sectorID = pIndoor->GetSector(enc_spawn_point.vPosition.x, enc_spawn_point.vPosition.y, pParty->pos.z);
+            mon_sectorID = pIndoor->GetSector(enc_spawn_point.vPosition);
             if (mon_sectorID == party_sectorID) {
                 // check proposed floor level
                 indoor_floor_level = BLV_GetFloorLevel(enc_spawn_point.vPosition, mon_sectorID);
@@ -1987,17 +1987,15 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
 }
 
 //----- (00450521) --------------------------------------------------------
-int DropTreasureAt(ITEM_TREASURE_LEVEL trs_level, int trs_type, int x, int y, int z, uint16_t facing) {
+int DropTreasureAt(ITEM_TREASURE_LEVEL trs_level, int trs_type, Vec3i pos, uint16_t facing) {
     SpriteObject a1;
     pItemTable->generateItem(trs_level, trs_type, &a1.containing_item);
     a1.uType = (SPRITE_OBJECT_TYPE)pItemTable->pItems[a1.containing_item.uItemID].uSpriteID;
     a1.uObjectDescID = pObjectList->ObjectIDByItemID(a1.uType);
-    a1.vPosition.x = x;
-    a1.vPosition.y = y;
-    a1.vPosition.z = z;
+    a1.vPosition = pos;
     a1.uFacing = facing;
     a1.uAttributes = 0;
-    a1.uSectorID = pIndoor->GetSector(x, y, z);
+    a1.uSectorID = pIndoor->GetSector(a1.vPosition);
     a1.uSpriteFrameID = 0;
     return a1.Create(0, 0, 0, 0);
 }
@@ -2020,9 +2018,7 @@ void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2) {
             return;
 
         if (v5 >= 60) {
-            DropTreasureAt(v13, grng->random(27) + 20, a2->vPosition.x,
-                           a2->vPosition.y,
-                           a2->vPosition.z, 0);
+            DropTreasureAt(v13, grng->random(27) + 20, a2->vPosition, 0);
             return;
         }
 
@@ -2056,19 +2052,17 @@ void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2) {
         a1a.uObjectDescID = pObjectList->ObjectIDByItemID(a1a.uType);
         a1a.containing_item.Reset();  // TODO(captainurist): this needs checking
     }
-    a1a.vPosition.y = a2->vPosition.y;
     a1a.uAttributes = 0;
     a1a.uSoundID = 0;
     a1a.uFacing = 0;
-    a1a.vPosition.z = a2->vPosition.z;
-    a1a.vPosition.x = a2->vPosition.x;
+    a1a.vPosition = a2->vPosition;
     a1a.spell_skill = CHARACTER_SKILL_MASTERY_NONE;
     a1a.spell_level = 0;
     a1a.uSpellID = SPELL_NONE;
     a1a.spell_target_pid = Pid();
     a1a.spell_caster_pid = Pid();
     a1a.uSpriteFrameID = 0;
-    a1a.uSectorID = pIndoor->GetSector(a2->vPosition.x, a2->vPosition.y, a2->vPosition.z);
+    a1a.uSectorID = pIndoor->GetSector(a2->vPosition);
     a1a.Create(0, 0, 0, 0);
 }
 

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -321,7 +321,7 @@ int CalcDistPointToLine(int a1, int a2, int a3, int a4, int a5, int a6);
 void PrepareDrawLists_BLV();
 void PrepareToLoadBLV(bool bLoading);
 int SpawnEncounterMonsters(struct MapInfo *a1, int a2);
-int DropTreasureAt(ITEM_TREASURE_LEVEL trs_level, signed int trs_type, int x, int y, int z, uint16_t facing);
+int DropTreasureAt(ITEM_TREASURE_LEVEL trs_level, signed int trs_type, Vec3i pos, uint16_t facing);
 void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2);
 
 void FindBillboardsLightLevels_BLV();

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3335,14 +3335,14 @@ void Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
 }
 
 //----- (004BBF61) --------------------------------------------------------
-void Actor::Arena_summon_actor(int monster_id, int x, int y, int z) {
+void Actor::Arena_summon_actor(int monster_id, Vec3i pos) {
     Actor *actor = AllocateActor(true);
     if (!actor)
         return;
 
     int v16 = 0;
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
-        v16 = pIndoor->GetSector(x, y, z);
+        v16 = pIndoor->GetSector(pos);
 
     actor->name = pMonsterStats->pInfos[monster_id].pName;
     actor->currentHP = (short)pMonsterStats->pInfos[monster_id].uHP;
@@ -3351,18 +3351,14 @@ void Actor::Arena_summon_actor(int monster_id, int x, int y, int z) {
     actor->radius = pMonsterList->pMonsters[monster_id - 1].uMonsterRadius;
     actor->height = pMonsterList->pMonsters[monster_id - 1].uMonsterHeight;
     actor->moveSpeed = pMonsterList->pMonsters[monster_id - 1].uMovementSpeed;
-    actor->initialPosition.x = x;
-    actor->pos.x = x;
+    actor->initialPosition = Vec3s(pos.x, pos.y, pos.z);
+    actor->pos = Vec3s(pos.x, pos.y, pos.z);
     actor->attributes |= ACTOR_AGGRESSOR;
     actor->monsterInfo.uTreasureType = 0;
     actor->monsterInfo.uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID;
     actor->monsterInfo.uTreasureDiceSides = 0;
     actor->monsterInfo.uTreasureDiceRolls = 0;
     actor->monsterInfo.uTreasureDropChance = 0;
-    actor->initialPosition.y = y;
-    actor->pos.y = y;
-    actor->initialPosition.z = z;
-    actor->pos.z = z;
     actor->tetherDistance = 256;
     actor->sectorId = v16;
     actor->group = 1;

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -159,7 +159,7 @@ class Actor {
     int _43B3E0_CalcDamage(ABILITY_INDEX dmgSource);
     static void AddOnDamageOverlay(unsigned int uActorID, int overlayType, int damage);
 
-    static void Arena_summon_actor(int monster_id, int x, int y, int z);
+    static void Arena_summon_actor(int monster_id, Vec3i pos);
     static void DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster,
                                        Vec3i *pVelocity);
     static void MakeActorAIList_ODM();

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -7576,9 +7576,7 @@ bool Character::setBeacon(int index, GameTime duration) {
 
     beacon.image = render->TakeScreenshot(92, 68);
     beacon.uBeaconTime = pParty->GetPlayingTime() + duration;
-    beacon.PartyPos_X = pParty->pos.x;
-    beacon.PartyPos_Y = pParty->pos.y;
-    beacon.PartyPos_Z = pParty->pos.z;
+    beacon._partyPos = pParty->pos;
     beacon._partyViewYaw = pParty->_viewYaw;
     beacon._partyViewPitch = pParty->_viewPitch;
     beacon.mapId = file_index;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -7171,10 +7171,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
                                       target_id, &a3);
         if (character->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_MAIN_HAND) ||
             character->WearsItem(ITEM_ARTIFACT_SPLITTER, ITEM_SLOT_OFF_HAND))
-            _42FA66_do_explosive_impact(
-                actor->pos.x, actor->pos.y,
-                actor->pos.z + actor->height / 2, 0, 512,
-                pParty->activeCharacterIndex());
+            _42FA66_do_explosive_impact(actor->pos + Vec3i(0, 0, actor->height / 2), 0, 512, pParty->activeCharacterIndex());
     } else if (bow_idx) {
         shooting_bow = true;
         pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0, 0);
@@ -7237,8 +7234,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
 }
 
 //----- (0042FA66) --------------------------------------------------------
-void Character::_42FA66_do_explosive_impact(int xpos, int ypos, int zpos, int a4,
-                                         int16_t a5, signed int actchar) {
+void Character::_42FA66_do_explosive_impact(Vec3i pos, int a4, int16_t a5, signed int actchar) {
         // EXPLOSIVE IMPACT OF ARTIFACT SPLITTER
 
     // a5 is range?
@@ -7250,11 +7246,9 @@ void Character::_42FA66_do_explosive_impact(int xpos, int ypos, int zpos, int a4
     a1a.spell_level = 8;
     a1a.spell_skill = CHARACTER_SKILL_MASTERY_MASTER;
     a1a.uObjectDescID = pObjectList->ObjectIDByItemID(a1a.uType);
-    a1a.vPosition.x = xpos;
-    a1a.vPosition.y = ypos;
-    a1a.vPosition.z = zpos;
+    a1a.vPosition = pos;
     a1a.uAttributes = 0;
-    a1a.uSectorID = pIndoor->GetSector(xpos, ypos, zpos);
+    a1a.uSectorID = pIndoor->GetSector(pos);
     a1a.uSpriteFrameID = 0;
     a1a.spell_target_pid = Pid();
     a1a.field_60_distance_related_prolly_lod = 0;

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -28,18 +28,6 @@ class Actor;
 class GraphicsImage;
 
 struct LloydBeacon {
-    LloydBeacon() {
-        uBeaconTime = GameTime(0);
-        PartyPos_X = 0;
-        PartyPos_Y = 0;
-        PartyPos_Z = 0;
-        _partyViewYaw = 0;
-        _partyViewPitch = 0;
-        unknown = 0;
-        mapId = MAP_INVALID;
-        image = nullptr;
-    }
-
     ~LloydBeacon() {
         // if (image != nullptr) {
         //    image->Release();
@@ -48,15 +36,13 @@ struct LloydBeacon {
         image = nullptr;
     }
 
-    GameTime uBeaconTime;
-    int32_t PartyPos_X;
-    int32_t PartyPos_Y;
-    int32_t PartyPos_Z;
-    int16_t _partyViewYaw;
-    int16_t _partyViewPitch;
-    uint16_t unknown;
-    MAP_TYPE mapId;
-    GraphicsImage *image;
+    GameTime uBeaconTime = GameTime(0);
+    Vec3i _partyPos = Vec3i(0, 0, 0);
+    int16_t _partyViewYaw = 0;
+    int16_t _partyViewPitch = 0;
+    uint16_t unknown = 0;
+    MAP_TYPE mapId = MAP_INVALID;
+    GraphicsImage *image = nullptr;
 };
 
 struct CharacterSpellbookChapter {

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -430,9 +430,7 @@ class Character {
     int getCharacterIndex();
 
     static void _42ECB5_CharacterAttacksActor();
-    static void _42FA66_do_explosive_impact(int xpos, int ypos, int zpos,
-                                            int a4, int16_t a5,
-                                            signed int actchar);
+    static void _42FA66_do_explosive_impact(Vec3i pos, int a4, int16_t a5, signed int actchar);
     void cleanupBeacons();
     bool setBeacon(int index, GameTime duration);
 

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -728,9 +728,9 @@ void snapshot(const Character &src, Player_MM7 *dst) {
             continue;
         }
         dst->installedBeacons[i].beaconTime = src.vBeacons[i].uBeaconTime.value;
-        dst->installedBeacons[i].partyPosX = src.vBeacons[i].PartyPos_X;
-        dst->installedBeacons[i].partyPosY = src.vBeacons[i].PartyPos_Y;
-        dst->installedBeacons[i].partyPosZ = src.vBeacons[i].PartyPos_Z;
+        dst->installedBeacons[i].partyPosX = src.vBeacons[i]._partyPos.x;
+        dst->installedBeacons[i].partyPosY = src.vBeacons[i]._partyPos.y;
+        dst->installedBeacons[i].partyPosZ = src.vBeacons[i]._partyPos.z;
         dst->installedBeacons[i].partyViewYaw = src.vBeacons[i]._partyViewYaw;
         dst->installedBeacons[i].partyViewPitch = src.vBeacons[i]._partyViewPitch;
         dst->installedBeacons[i].mapIndexInGamesLod = valueOr(gamesLodIndexByMapId, src.vBeacons[i].mapId, -1);
@@ -982,9 +982,9 @@ void reconstruct(const Player_MM7 &src, Character *dst) {
         if (src.installedBeacons[i].beaconTime != 0) {
             LloydBeacon beacon;
             beacon.uBeaconTime = GameTime(src.installedBeacons[i].beaconTime);
-            beacon.PartyPos_X = src.installedBeacons[i].partyPosX;
-            beacon.PartyPos_Y = src.installedBeacons[i].partyPosY;
-            beacon.PartyPos_Z = src.installedBeacons[i].partyPosZ;
+            beacon._partyPos.x = src.installedBeacons[i].partyPosX;
+            beacon._partyPos.y = src.installedBeacons[i].partyPosY;
+            beacon._partyPos.z = src.installedBeacons[i].partyPosZ;
             beacon._partyViewYaw = src.installedBeacons[i].partyViewYaw;
             beacon._partyViewPitch = src.installedBeacons[i].partyViewPitch;
             beacon.mapId = valueOr(mapIdByGamesLodIndex, src.installedBeacons[i].mapIndexInGamesLod, MAP_INVALID);

--- a/src/Engine/TeleportPoint.h
+++ b/src/Engine/TeleportPoint.h
@@ -22,7 +22,7 @@ class TeleportPoint {
 
     /**
      * Set teleportation target within the map.
-     * Updates teleportation point validity if
+     * Updates teleportation point validity if any of the set values is not zero (or -1 for yaw).
      *
      * @param pos     Party position after teleportation.
      * @param yaw     Camera yaw after teleportation, if set to -1 then yaw will not be changed after teleport.

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -203,11 +203,9 @@ void GUIWindow_LloydsBook::installOrRecallBeacon(int beaconId) {
             pCurrentMapName = pMapStats->pInfos[character.vBeacons[beaconId].mapId].pFilename;
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
             uGameState = GAME_STATE_CHANGE_LOCATION;
-            engine->_teleportPoint.setTeleportTarget(Vec3i(character.vBeacons[beaconId].PartyPos_X, character.vBeacons[beaconId].PartyPos_Y, character.vBeacons[beaconId].PartyPos_Z), character.vBeacons[beaconId]._partyViewYaw, character.vBeacons[beaconId]._partyViewPitch, 0);
+            engine->_teleportPoint.setTeleportTarget(character.vBeacons[beaconId]._partyPos, character.vBeacons[beaconId]._partyViewYaw, character.vBeacons[beaconId]._partyViewPitch, 0);
         } else {
-            pParty->pos.x = character.vBeacons[beaconId].PartyPos_X;
-            pParty->pos.y = character.vBeacons[beaconId].PartyPos_Y;
-            pParty->pos.z = character.vBeacons[beaconId].PartyPos_Z;
+            pParty->pos = character.vBeacons[beaconId]._partyPos;
             pParty->uFallStartZ = pParty->pos.z;
             pParty->_viewYaw = character.vBeacons[beaconId]._partyViewYaw;
             pParty->_viewPitch = character.vBeacons[beaconId]._partyViewPitch;

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -23,53 +23,51 @@
 
 struct TransportInfo {
     MAP_TYPE uMapInfoID;
-    unsigned char pSchedule[7];
+    std::array<unsigned char, 7> pSchedule;
     unsigned int uTravelTime; // In days.
-    int arrival_x;
-    int arrival_y;
-    int arrival_z;
+    Vec3i arrivalPos;
     int arrival_view_yaw;
     unsigned int uQuestBit;  // quest bit required to set for this travel option to be enabled; otherwise 0
 };
 
 // 004F09B0
 static constexpr std::array<TransportInfo, 35> transportSchedule = {{
-    // location name   days    x        y       z
-    { MAP_ERATHIA, {1, 0, 1, 0, 1, 0, 0 }, 2, -18048, 4636, 833, 1536, 0 },  // for stable
-    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0 }, 2, -2527, -6773, 1153, 896, 0 },
-    { MAP_TATALIA, { 1, 0, 1, 0, 1, 0, 0 }, 2, 4730, -10580, 320, 1024, 0 },
-    { MAP_HARMONDALE, { 0, 1, 0, 1, 0, 1, 0 }, 2, -5692, 11137, 1, 1024, 0 },
-    { MAP_DEYJA, { 1, 0, 0, 1, 0, 0, 0 }, 3, 7227, -16007, 2625, 640, 0 },
-    { MAP_BRACADA_DESERT, {0, 0, 1, 0, 0, 1, 0 }, 3, 8923, 17191, 1, 512, 0 },
-    { MAP_AVLEE, { 1, 0, 1, 0, 1, 0, 0 }, 3, 17059, 12331, 512, 1152, 0 },
-    { MAP_DEYJA, { 0, 1, 0, 0, 1, 0, 1 }, 2, 7227, -16007, 2625, 640, 0 },
-    { MAP_HARMONDALE, { 0, 1, 0, 1, 0, 1, 0 }, 2, -5692, 11137, 1, 1024, 0 },
-    { MAP_ERATHIA, {1, 0, 1, 0, 1, 0, 0 }, 3, -18048, 4636, 833, 1536, 0 },
-    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0 }, 2, -2527, -6773, 1153, 896, 0 },
-    { MAP_ERATHIA, {1, 0, 1, 0, 1, 0, 1 }, 3, -18048, 4636, 833, 1536, 0 },
-    { MAP_HARMONDALE, { 0, 1, 0, 0, 0, 1, 0 }, 5, -5692, 11137, 1, 1024, 0 },
-    { MAP_ERATHIA, {0, 1, 0, 1, 0, 1, 0 }, 2, -18048, 4636, 833, 1536, 0 },
-    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0 }, 3, -2527, -6773, 1153, 896, 0 },
-    { MAP_DEYJA, { 0, 0, 1, 0, 0, 0, 1 }, 5, 7227, -16007, 2625, 640, 0 },
-    { MAP_TATALIA, { 0, 1, 0, 1, 0, 1, 0 }, 2, -2183, -6941, 97, 0, 0 },
-    { MAP_AVLEE, { 1, 0, 0, 0, 1, 0, 0 }, 4, 7913, 9476, 193, 0, 0 },
-    { MAP_EVENMORN_ISLAND, {0, 0, 0, 0, 0, 0, 1 }, 7, 15616, 6390, 193, 1536, QBIT_EVENMORN_MAP_FOUND },
-    { MAP_BRACADA_DESERT, {0, 0, 1, 0, 0, 0, 0 }, 6, 19171, -19722, 193, 1024, 0 },
-    { MAP_AVLEE, { 0, 1, 0, 1, 0, 1, 0 }, 3, 7913, 9476, 193, 0, 0 },
-    { MAP_BRACADA_DESERT, {1, 0, 1, 0, 0, 0, 0 }, 6, 19171, -19722, 193, 1024, 0 },
-    { MAP_TATALIA, { 1, 0, 1, 0, 1, 0, 0 }, 4, -2183, -6941, 97, 0, 0 },
-    { MAP_TULAREAN_FOREST, {0, 0, 0, 0, 0, 1, 0 }, 6, -709, -14087, 193, 1024, 0 },  // for boat
-    { MAP_ERATHIA, {0, 0, 0, 0, 0, 0, 1 }, 6, -10471, 13497, 193, 1536, 0 },
-    { MAP_EVENMORN_ISLAND, {0, 1, 0, 1, 0, 0, 0 }, 1, 15616, 6390, 193, 1536, QBIT_EVENMORN_MAP_FOUND },
-    { MAP_BRACADA_DESERT, {0, 1, 0, 1, 0, 0, 0 }, 1, 19171, -19722, 193, 1024, 0 },
-    { MAP_ERATHIA, {0, 1, 0, 1, 0, 1, 0 }, 2, -10471, 13497, 193, 1536, 0 },
-    { MAP_BRACADA_DESERT, {1, 0, 1, 0, 0, 0, 0 }, 4, 19171, -19722, 193, 1024, 0 },
-    { MAP_EVENMORN_ISLAND, {0, 0, 0, 0, 0, 0, 1 }, 5, 15616, 6390, 193, 1536, QBIT_EVENMORN_MAP_FOUND },
-    { MAP_AVLEE, { 0, 0, 0, 0, 1, 0, 0 }, 5, 7913, 9476, 193, 0, 0 },
-    { MAP_ERATHIA, {0, 1, 0, 0, 0, 1, 0 }, 4, -10471, 13497, 193, 1536, 0 },
-    { MAP_TULAREAN_FOREST, {1, 0, 1, 0, 1, 0, 0 }, 3, -709, -14087, 193, 1024, 0 },
-    { MAP_TATALIA, { 0, 0, 0, 1, 0, 0, 0 }, 5, -2183, -6941, 97, 0, 0 },
-    { MAP_ARENA, { 0, 0, 0, 0, 0, 0, 1 }, 4, 3844, 2906, 193, 512, 0 }
+//    location name        schedule            days  pos                     yaw   qbit
+    { MAP_ERATHIA,         {1, 0, 1, 0, 1, 0, 0}, 2, {-18048,  4636,  833},  1536, 0 },  // for stable
+    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0}, 2, {-2527,  -6773,  1153}, 896,  0 },
+    { MAP_TATALIA,         {1, 0, 1, 0, 1, 0, 0}, 2, { 4730,  -10580, 320},  1024, 0 },
+    { MAP_HARMONDALE,      {0, 1, 0, 1, 0, 1, 0}, 2, {-5692,   11137, 1},    1024, 0 },
+    { MAP_DEYJA,           {1, 0, 0, 1, 0, 0, 0}, 3, { 7227,  -16007, 2625}, 640,  0 },
+    { MAP_BRACADA_DESERT,  {0, 0, 1, 0, 0, 1, 0}, 3, { 8923,   17191, 1},    512,  0 },
+    { MAP_AVLEE,           {1, 0, 1, 0, 1, 0, 0}, 3, { 17059,  12331, 512},  1152, 0 },
+    { MAP_DEYJA,           {0, 1, 0, 0, 1, 0, 1}, 2, { 7227,  -16007, 2625}, 640,  0 },
+    { MAP_HARMONDALE,      {0, 1, 0, 1, 0, 1, 0}, 2, {-5692,   11137, 1},    1024, 0 },
+    { MAP_ERATHIA,         {1, 0, 1, 0, 1, 0, 0}, 3, {-18048,  4636,  833},  1536, 0 },
+    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0}, 2, {-2527,  -6773,  1153}, 896,  0 },
+    { MAP_ERATHIA,         {1, 0, 1, 0, 1, 0, 1}, 3, {-18048,  4636,  833},  1536, 0 },
+    { MAP_HARMONDALE,      {0, 1, 0, 0, 0, 1, 0}, 5, {-5692,   11137, 1},    1024, 0 },
+    { MAP_ERATHIA,         {0, 1, 0, 1, 0, 1, 0}, 2, {-18048,  4636,  833},  1536, 0 },
+    { MAP_TULAREAN_FOREST, {0, 1, 0, 1, 0, 1, 0}, 3, {-2527,  -6773,  1153}, 896,  0 },
+    { MAP_DEYJA,           {0, 0, 1, 0, 0, 0, 1}, 5, { 7227,  -16007, 2625}, 640,  0 },
+    { MAP_TATALIA,         {0, 1, 0, 1, 0, 1, 0}, 2, {-2183,  -6941,  97},   0,    0 },
+    { MAP_AVLEE,           {1, 0, 0, 0, 1, 0, 0}, 4, { 7913,   9476,  193},  0,    0 },
+    { MAP_EVENMORN_ISLAND, {0, 0, 0, 0, 0, 0, 1}, 7, { 15616,  6390,  193},  1536, QBIT_EVENMORN_MAP_FOUND },
+    { MAP_BRACADA_DESERT,  {0, 0, 1, 0, 0, 0, 0}, 6, { 19171, -19722, 193},  1024, 0 },
+    { MAP_AVLEE,           {0, 1, 0, 1, 0, 1, 0}, 3, { 7913,   9476,  193},  0,    0 },
+    { MAP_BRACADA_DESERT,  {1, 0, 1, 0, 0, 0, 0}, 6, { 19171, -19722, 193},  1024, 0 },
+    { MAP_TATALIA,         {1, 0, 1, 0, 1, 0, 0}, 4, {-2183,  -6941,  97},   0,    0 },
+    { MAP_TULAREAN_FOREST, {0, 0, 0, 0, 0, 1, 0}, 6, {-709,   -14087, 193},  1024, 0 },  // for boat
+    { MAP_ERATHIA,         {0, 0, 0, 0, 0, 0, 1}, 6, {-10471,  13497, 193},  1536, 0 },
+    { MAP_EVENMORN_ISLAND, {0, 1, 0, 1, 0, 0, 0}, 1, { 15616,  6390,  193},  1536, QBIT_EVENMORN_MAP_FOUND },
+    { MAP_BRACADA_DESERT,  {0, 1, 0, 1, 0, 0, 0}, 1, { 19171, -19722, 193},  1024, 0 },
+    { MAP_ERATHIA,         {0, 1, 0, 1, 0, 1, 0}, 2, {-10471,  13497, 193},  1536, 0 },
+    { MAP_BRACADA_DESERT,  {1, 0, 1, 0, 0, 0, 0}, 4, { 19171, -19722, 193},  1024, 0 },
+    { MAP_EVENMORN_ISLAND, {0, 0, 0, 0, 0, 0, 1}, 5, { 15616,  6390,  193},  1536, QBIT_EVENMORN_MAP_FOUND },
+    { MAP_AVLEE,           {0, 0, 0, 0, 1, 0, 0}, 5, { 7913,   9476,  193},  0,    0 },
+    { MAP_ERATHIA,         {0, 1, 0, 0, 0, 1, 0}, 4, {-10471,  13497, 193},  1536, 0 },
+    { MAP_TULAREAN_FOREST, {1, 0, 1, 0, 1, 0, 0}, 3, {-709,   -14087, 193},  1024, 0 },
+    { MAP_TATALIA,         {0, 0, 0, 1, 0, 0, 0}, 5, {-2183,  -6941,  97},   0,    0 },
+    { MAP_ARENA,           {0, 0, 0, 0, 0, 0, 1}, 4, { 3844,   2906,  193},  512,  0 }
 }};
 
 static constexpr IndexedArray<std::array<int, 4>, HOUSE_FIRST_TRANSPORT, HOUSE_LAST_TRANSPORT> transportRoutes = {
@@ -163,13 +161,11 @@ void GUIWindow_Transport::transportDialogue() {
 
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
             uGameState = GAME_STATE_CHANGE_LOCATION;
-            engine->_teleportPoint.setTeleportTarget(Vec3i(pTravel->arrival_x, pTravel->arrival_y, pTravel->arrival_z), pTravel->arrival_view_yaw, 0, 0);
+            engine->_teleportPoint.setTeleportTarget(pTravel->arrivalPos, pTravel->arrival_view_yaw, 0, 0);
         } else {
             // travelling to map we are already in
             pCamera3D->_viewYaw = 0;
-            pParty->pos.x = pTravel->arrival_x;
-            pParty->pos.y = pTravel->arrival_y;
-            pParty->pos.z = pTravel->arrival_z;
+            pParty->pos = pTravel->arrivalPos;
             pParty->uFallStartZ = pParty->pos.z;
             pParty->_viewPitch = 0;
             pParty->_viewYaw = pTravel->arrival_view_yaw;

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -367,7 +367,8 @@ void prepareArenaFight(DIALOGUE_TYPE dialogue) {
     gold_transaction_amount = characterMaxLevel * baseReward;
 
     for (int i = 0; i < monstersNum; ++i) {
-        Actor::Arena_summon_actor(monsterIds[grng->random(monsterIds.size())], pMonsterArenaPlacements[i].x, pMonsterArenaPlacements[i].y, 1);
+        Vec2i pos = pMonsterArenaPlacements[i];
+        Actor::Arena_summon_actor(monsterIds[grng->random(monsterIds.size())], Vec3i(pos.x, pos.y, 1));
     }
     pAudioPlayer->playUISound(SOUND_51heroism03);
 }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -67,11 +67,11 @@ void GUIWindow_Transition::Release() {
 
 //----- (00444839) --------------------------------------------------------
 GUIWindow_Transition::GUIWindow_Transition(HOUSE_ID transitionHouse, uint exit_pic_id,
-                                           int x, int y, int z, int directiony,
-                                           int directionx, int a8,
+                                           Vec3i pos, int yaw,
+                                           int pitch, int zspeed,
                                            const std::string &locationName)
     : GUIWindow(WINDOW_Transition, {0, 0}, render->GetRenderDimensions(), 0) {
-    engine->_teleportPoint.setTeleportTarget(Vec3i(x, y, z), directiony, directionx, a8);
+    engine->_teleportPoint.setTeleportTarget(pos, yaw, pitch, zspeed);
     engine->_teleportPoint.setTeleportMap(locationName);
     uCurrentHouse_Animation = std::to_underlying(transitionHouse); // TODO(Nik-RE-dev): is this correct?
     pEventTimer->Pause();

--- a/src/GUI/UI/UITransition.h
+++ b/src/GUI/UI/UITransition.h
@@ -16,7 +16,7 @@ class GUIWindow_Travel : public GUIWindow {
 
 class GUIWindow_Transition : public GUIWindow {
  public:
-    GUIWindow_Transition(HOUSE_ID transitionHouse, uint32_t exit_pic_id, int x, int y, int z, int directiony, int directionx, int a8, const std::string &locationName);
+    GUIWindow_Transition(HOUSE_ID transitionHouse, uint32_t exit_pic_id, Vec3i pos, int yaw, int pitch, int zspeed, const std::string &locationName);
     virtual ~GUIWindow_Transition() {}
 
     virtual void Update() override;


### PR DESCRIPTION
Replace 3 ints with Vec3i mainly in cases that I noticed while doing previous PR for teleport target.
Also use Vec3i in more cases for GetSector function.