### PR TITLE
fix assert for wand of charms

### DIFF
--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -619,6 +619,11 @@ void CastSpellInfoHelpers::castSpell() {
                         GameTime spell_duration;
 
                         switch (spell_mastery) {
+                            case CHARACTER_SKILL_MASTERY_NOVICE: // MM6 have different durations
+                                // the only way to cast novice charm in MM7 is Wand of Charms
+                                assert(pCastSpell->overrideSkillValue && "SPELL_MIND_CHARM override");
+                                spell_duration = GameTime::FromMinutes(5 * spell_level);
+                                break;
                             case CHARACTER_SKILL_MASTERY_EXPERT:
                                 spell_duration = GameTime::FromMinutes(5 * spell_level);
                                 break;
@@ -629,7 +634,6 @@ void CastSpellInfoHelpers::castSpell() {
                                 // Time must be infinite until the player leaves the map
                                 spell_duration = GameTime::FromYears(1);
                                 break;
-                            case CHARACTER_SKILL_MASTERY_NOVICE: // MM6 have different durations
                             default:
                                 assert(false);
                         }


### PR DESCRIPTION
Using the wand of charms activates this assert.

I'm too lazy to post a bug for this fix.

In the savefile from https://github.com/OpenEnroth/OpenEnroth/issues/1246 the 4-th knight has this wand ready.

I made a save with all wands...
<strike>[wands.zip](https://github.com/OpenEnroth/OpenEnroth/files/12387883/wands.zip)</strike>
[all_wands.zip](https://github.com/OpenEnroth/OpenEnroth/files/12387918/all_wands.zip)

But you might prefer creating all wands from debug menu:
Game.cpp:
```
            case UIMSG_DebugGenItem: {
                if (!pParty->hasActiveCharacter())
                    continue;

                for (int a=135;a<150;a++) {
                    ITEM_TYPE pItemID = (ITEM_TYPE)a;
                    Character &c = pParty->pCharacters[0];
                    int slot_no_plus1 = c.AddItem(-1, pItemID);
                    if (!slot_no_plus1) {
                        pAudioPlayer->playUISound(SOUND_error);
                        break;
                    }
                    c.pInventoryItemList[slot_no_plus1-1].uNumCharges = 100;
                    c.pInventoryItemList[slot_no_plus1-1].uMaxCharges = 100;
                    c.pInventoryItemList[slot_no_plus1-1].SetIdentified();
                }


                for (int a=150;a<=159;a++) {
                    ITEM_TYPE pItemID = (ITEM_TYPE)a;
                    Character &c = pParty->pCharacters[1];
                    int slot_no_plus1 = c.AddItem(-1, pItemID);
                    if (!slot_no_plus1) {
                        pAudioPlayer->playUISound(SOUND_error);
                        break;
                    }
                    c.pInventoryItemList[slot_no_plus1-1].uNumCharges = 100;
                    c.pInventoryItemList[slot_no_plus1-1].uMaxCharges = 100;
                    c.pInventoryItemList[slot_no_plus1-1].SetIdentified();
                }
```
