### PR TITLE
full path in error message about missing data files

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -101,7 +101,9 @@ using Graphics::IRenderFactory;
 
 
 void initDataPath(const std::string &dataPath) {
-    if (validateDataPath(dataPath)) {
+    std::string missing_file;
+
+    if (validateDataPath(dataPath, missing_file)) {
         setDataPath(dataPath);
 
         std::string savesPath = makeDataPath("saves");
@@ -112,11 +114,13 @@ void initDataPath(const std::string &dataPath) {
         EngineIocContainer::ResolveLogger()->info("Using MM7 directory: {}", dataPath);
     } else {
         std::string message = fmt::format(
-            "Required resources aren't found!\n"
-            "You should acquire licensed copy of M&M VII and copy its resources to \n{}\n\n"
+            "Required file {} not found.\n"
+            "You should acquire licensed copy of M&M VII and copy its resources to \n{}{}\n\n"
             "Additionally you should also copy the content from\n"
-            "resources directory from our repository there as well!",
-            !dataPath.empty() ? dataPath : "current directory"
+            "resources directory from our repository there as well.",
+            missing_file,
+            !dataPath.empty() ? dataPath : std::filesystem::current_path().string(),
+            !dataPath.empty() ? "" :      " (current directory)"
         );
         EngineIocContainer::ResolveLogger()->critical("{}", message);
         platform->showMessageBox("CRITICAL ERROR: missing resources", message);

--- a/src/Utility/DataPath.cpp
+++ b/src/Utility/DataPath.cpp
@@ -53,7 +53,7 @@ std::string makeDataPath(std::initializer_list<std::string_view> paths) {
     return makeCaseInsensitivePath(result).string();
 }
 
-bool validateDataPath(const std::string &data_path) {
+bool validateDataPath(const std::string &data_path, std::string& missing_file) {
     bool isGood = true;
     for (auto v : globalValidateList) {
         std::filesystem::path path = data_path;
@@ -64,6 +64,7 @@ bool validateDataPath(const std::string &data_path) {
 
         if (!std::filesystem::exists(makeCaseInsensitivePath(path))) {
             isGood = false;
+            missing_file = std::filesystem::absolute(path).string();
             break;
         }
     }

--- a/src/Utility/DataPath.h
+++ b/src/Utility/DataPath.h
@@ -14,4 +14,4 @@ std::string makeDataPath(Ts&&... paths) {
     return makeDataPath({paths...});
 }
 
-bool validateDataPath(const std::string &data_path);
+bool validateDataPath(const std::string &data_path, std::string& missing_file);


### PR DESCRIPTION
The message would look like
```
Required file /home/user/build/OpenEnroth/anims/magic7.vid not found.
You should acquire licensed copy of M&M VII and copy its resources to
/home/user/build/OpenEnroth (current directory)

Additionally you should also copy the content from
resources directory from our repository there as well.

```