### PR TITLE
Fix text colors for #995

### DIFF
--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -179,7 +179,7 @@ void GUIWindow_MagicGuild::mainDialogue() {
         working_window.DrawTitleText(pFontArrus, 0, 146, colorTable.White, skill_price_label, 3);
     }
 
-    drawOptions(optionsText, colorTable.Sunflower, 24);
+    drawOptions(optionsText, colorTable.PaleCanary, 24);
 }
 
 void GUIWindow_MagicGuild::buyBooksDialogue() {

--- a/src/GUI/UI/Houses/MercenaryGuild.cpp
+++ b/src/GUI/UI/Houses/MercenaryGuild.cpp
@@ -40,7 +40,7 @@ void GUIWindow_MercenaryGuild::houseSpecificDialogue() {
             pDialogueWindow->pNumPresenceButton = 0;
             return;
         }
-        learnSkillsDialogue();
+        learnSkillsDialogue(colorTable.PaleCanary);
         return;
     }
 

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -259,7 +259,7 @@ void GUIWindow_Shop::mainDialogue() {
     std::vector<std::string> optionsText = {localization->GetString(LSTR_STANDARD), localization->GetString(LSTR_SPECIAL),
                                             localization->GetString(LSTR_DISPLAY), localization->GetString(LSTR_LEARN_SKILLS)};
 
-    drawOptions(optionsText, colorTable.Jonquil);
+    drawOptions(optionsText, colorTable.Sunflower);
 }
 
 void GUIWindow_Shop::displayEquipmentDialogue() {
@@ -272,7 +272,7 @@ void GUIWindow_Shop::displayEquipmentDialogue() {
         optionsText.push_back(localization->GetString(LSTR_REPAIR));
     }
 
-    drawOptions(optionsText, colorTable.Jonquil);
+    drawOptions(optionsText, colorTable.Sunflower);
 }
 
 void GUIWindow_Shop::sellDialogue() {
@@ -766,7 +766,7 @@ void GUIWindow_Shop::houseSpecificDialogue() {
         repairDialogue();
         break;
       case DIALOGUE_LEARN_SKILLS:
-        learnSkillsDialogue();
+        learnSkillsDialogue(colorTable.Sunflower);
         break;
       default:
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -195,7 +195,7 @@ void GUIWindow_Tavern::houseSpecificDialogue() {
         buyFoodDialogue();
         break;
       case DIALOGUE_LEARN_SKILLS:
-        learnSkillsDialogue();
+        learnSkillsDialogue(colorTable.PaleCanary);
         break;
       default:
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -139,7 +139,7 @@ void GUIWindow_Temple::houseSpecificDialogue() {
         donateDialogue();
         break;
       case DIALOGUE_LEARN_SKILLS:
-        learnSkillsDialogue();
+        learnSkillsDialogue(colorTable.PaleCanary);
         break;
       default:
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -50,7 +50,7 @@ void GUIWindow_Training::mainDialogue() {
 
     std::vector<std::string> optionsText = {trainText, localization->GetString(LSTR_LEARN_SKILLS)};
 
-    drawOptions(optionsText, colorTable.Jonquil);
+    drawOptions(optionsText, colorTable.Sunflower);
 }
 
 void GUIWindow_Training::trainDialogue() {
@@ -131,7 +131,7 @@ void GUIWindow_Training::houseSpecificDialogue() {
         trainDialogue();
         break;
       case DIALOGUE_LEARN_SKILLS:
-        learnSkillsDialogue();
+        learnSkillsDialogue(colorTable.Sunflower);
         break;
       default:
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -402,7 +402,7 @@ void oracleDialogue() {
         pParty->pCharacters[0].AddVariable(VAR_PlayerItemInHands, std::to_underlying(item_id));
         // TODO(captainurist): what if fmt throws?
         current_npc_text = fmt::sprintf(pNPCTopics[666].pText, // "Here's %s that you lost. Be careful"
-                                        fmt::format("{::}{}\f00000", colorTable.Jonquil.tag(),
+                                        fmt::format("{::}{}\f00000", colorTable.Sunflower.tag(),
                                                     pItemTable->pItems[item_id].pUnidentifiedName));
     }
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -779,7 +779,7 @@ void GUIWindow_House::houseNPCDialogue() {
     }
 
     if (optionsText.size()) {
-        drawOptions(optionsText, colorTable.Jonquil);
+        drawOptions(optionsText, colorTable.Sunflower);
     }
 
     if (current_npc_text.length() > 0) {
@@ -1019,7 +1019,7 @@ void GUIWindow_House::initializeNPCDialogueButtons(std::vector<DIALOGUE_TYPE> op
     _savedButtonsNum = pDialogueWindow->pNumPresenceButton;
 }
 
-void GUIWindow_House::learnSkillsDialogue() {
+void GUIWindow_House::learnSkillsDialogue(Color selectColor) {
     if (!checkIfPlayerCanInteract()) {
         return;
     }
@@ -1057,7 +1057,7 @@ void GUIWindow_House::learnSkillsDialogue() {
     std::string skill_price_label = localization->FormatString(LSTR_FMT_SKILL_COST_D, cost);
     dialogue.DrawTitleText(pFontArrus, 0, 146, colorTable.White, skill_price_label, 3);
 
-    drawOptions(optionsText, colorTable.Sunflower, 18);
+    drawOptions(optionsText, selectColor, 18);
 }
 
 void GUIWindow_House::learnSelectedSkill(CharacterSkillType skill) {

--- a/src/GUI/UI/UIHouses.h
+++ b/src/GUI/UI/UIHouses.h
@@ -116,7 +116,7 @@ class GUIWindow_House : public GUIWindow {
     virtual void playHouseGoodbyeSpeech();
 
  protected:
-    void learnSkillsDialogue();
+    void learnSkillsDialogue(Color selectColor);
 
     DIALOGUE_TYPE _currentDialogue = DIALOGUE_NULL;
     int _savedButtonsNum{};


### PR DESCRIPTION
Fix #995.

- Refactor drawing monster popup text, split strings and draw them with different color. Draw seconds part using fixed x coordinate inside window, not using space characters.
- Fix focus colors inside buildings to match vanilla.