### PR TITLE
Fix release dependencies on macos

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -397,11 +397,6 @@ jobs:
         run: >
           cp -r resources/shaders OpenEnroth_GameData/mm7
 
-      - name: Install dependencies
-        run: |
-          brew install ffmpeg@4
-          brew install sdl2
-
       - name: ccache
         if: matrix.configuration == 'Debug'
         uses: botanicvelious/ccache-action@v1.2.10
@@ -465,6 +460,10 @@ jobs:
           files: >-
             ${{ runner.os }}_${{ env.TAG_NAME }}_${{ matrix.configuration }}_${{
             matrix.architecture }}.zip
+
+      - name: Check dependencies
+        run: |
+          otool -L build/src/Bin/OpenEnroth/OpenEnroth.app/Contents/MacOS/OpenEnroth
 
       - name: cleanup ccache
         run: >


### PR DESCRIPTION
Ref #1006.

Right now nightly macos builds somehow end up dynamically linked to ffmpeg.