### PR TITLE
Fix house bugs

### DIFF
--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -1084,7 +1084,9 @@ void Party::placeHeldItemInInventoryOrDrop() {
         return;
     }
 
-    if (!addItemToParty(&pPickedItem, true)) {
+    if (addItemToParty(&pPickedItem, true)) {
+        mouse->RemoveHoldingItem();
+    } else {
         dropHeldItem();
     }
 }

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -1139,7 +1139,7 @@ void GUIWindow_Shop::houseScreenClick() {
         }
 
         default:
-            assert(false);
+            // Do nothing
             break;
     }
 }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -559,6 +559,8 @@ void selectProprietorDialogueOption(DIALOGUE_TYPE option) {
         return;
     }
 
+    pParty->placeHeldItemInInventoryOrDrop();
+
     render->ClearZBuffer();
 
     window_SpeakInHouse->houseDialogueOptionSelected(option);
@@ -572,6 +574,7 @@ bool houseDialogPressEscape() {
     keyboardInputHandler->ResetKeys();
     activeLevelDecoration = nullptr;
     current_npc_text.clear();
+    pParty->placeHeldItemInInventoryOrDrop();
 
     if (currentHouseNpc == -1) {
         return false;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1352,7 +1352,7 @@ void ShowPopupShopSkills() {
     int pY = 0;
     mouse->GetClickPos(&pX, &pY);
 
-    if (pDialogueWindow) {
+    if (pDialogueWindow && pDialogueWindow->pNumPresenceButton != 0) {
         for (GUIButton *pButton : pDialogueWindow->vButtons) {
             if (pX >= pButton->uX && pX < pButton->uZ && pY >= pButton->uY && pY < pButton->uW) {
                 if (IsSkillLearningDialogue((DIALOGUE_TYPE)pButton->msg_param)) {

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -19,7 +19,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 6f704038da9d73e3312d0d7039b978523d4221ac
+            GIT_TAG 65c9135178ff13d4005888daf87a4060453fae5d
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -1621,10 +1621,17 @@ GAME_TEST(Issues, Issue1196) {
 }
 
 GAME_TEST(Issues, Issue1197) {
-    //Assert on party death
+    // Assert on party death
     auto loc = tapes.map();
     auto deaths = tapes.custom([] { return pParty->uNumDeaths; });
     test.playTraceFromTestData("issue_1197.mm7", "issue_1197.json");
     EXPECT_TRUE(loc.contains("out01.odm")); // make it back to emerald
     EXPECT_EQ(deaths.delta(), 1);
+}
+
+GAME_TEST(Issues, Issue1273) {
+    // Assert when clicking on shop video area
+    auto dialogueTape = tapes.dialogueType();
+    test.playTraceFromTestData("issue_1273.mm7", "issue_1273.json");
+    EXPECT_EQ(dialogueTape, tape(DIALOGUE_NULL, DIALOGUE_MAIN));
 }

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -72,7 +72,7 @@ TestTape<DIALOGUE_TYPE> CommonTapeRecorder::dialogueType() {
     return custom([] {
         if (GUIWindow_Dialogue *dlg = dynamic_cast<GUIWindow_Dialogue*>(pDialogueWindow)) {
             return dlg->getDisplayedDialogueType();
-        } else if (GUIWindow_House *dlg = dynamic_cast<GUIWindow_House*>(pDialogueWindow)) {
+        } else if (GUIWindow_House *dlg = dynamic_cast<GUIWindow_House*>(window_SpeakInHouse)) {
             return dlg->getCurrentDialogue();
         } else {
             return DIALOGUE_NULL;


### PR DESCRIPTION
- Fix #1273. Assert in default case is unnecessary. Also add test.
- Fix #1274. Do not show popup if dialogue buttons are disabled.
- Fix #1275. Return held item in inventory when clicking changing current dialogue state.