### PR TITLE
Style refactor keyboard control function and fix related issue #1277

### DIFF
--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -123,20 +123,16 @@ GUIButton *GUI_HandleHotkey(PlatformKey hotkey) {
     return 0;
 }
 
-//----- (0041D08F) --------------------------------------------------------
-void GUIWindow::_41D08F_set_keyboard_control_group(int num_buttons, int a3,
-    int a4, int a5) {
-    if (num_buttons) {
-        this->pNumPresenceButton = num_buttons;
-        this->field_30 = a3;
-        this->field_34 = a4;
-        this->pCurrentPosActiveItem = a5;
-        this->pStartingPosActiveItem = a5;
+void GUIWindow::setKeyboardControlGroup(int buttonsCount, int msgOnSelect, int selectStep, int initialPosition) {
+    this->pNumPresenceButton = buttonsCount;
+    this->_msgOnKeyboardSelect = msgOnSelect;
+    this->_selectStep = selectStep;
+
+    if (buttonsCount) {
+        this->pCurrentPosActiveItem = initialPosition;
+        this->pStartingPosActiveItem = initialPosition;
         this->receives_keyboard_input = true;
     } else {
-        this->pNumPresenceButton = 0;
-        this->field_30 = a3;
-        this->field_34 = a4;
         this->pCurrentPosActiveItem = 0;
         this->pStartingPosActiveItem = 0;
         this->receives_keyboard_input = false;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -123,7 +123,7 @@ GUIButton *GUI_HandleHotkey(PlatformKey hotkey) {
     return 0;
 }
 
-void GUIWindow::setKeyboardControlGroup(int buttonsCount, int msgOnSelect, int selectStep, int initialPosition) {
+void GUIWindow::setKeyboardControlGroup(int buttonsCount, bool msgOnSelect, int selectStep, int initialPosition) {
     this->pNumPresenceButton = buttonsCount;
     this->_msgOnKeyboardSelect = msgOnSelect;
     this->_selectStep = selectStep;

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -78,7 +78,7 @@ class GUIWindow {
     /**
      * @offset 0x41D08F
      */
-    void setKeyboardControlGroup(int buttonsCount, int msgOnSelect, int selectStep, int initialPosition);
+    void setKeyboardControlGroup(int buttonsCount, bool msgOnSelect, int selectStep, int initialPosition);
 
     virtual void Update() {}
     virtual void Release();

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -74,7 +74,11 @@ class GUIWindow {
     void DrawShops_next_generation_time_string(GameTime time);
     void DrawMessageBox(bool inside_game_viewport);
     GUIButton *GetControl(unsigned int uID);
-    void _41D08F_set_keyboard_control_group(int num_buttons, int a3, int a4, int a5);
+
+    /**
+     * @offset 0x41D08F
+     */
+    void setKeyboardControlGroup(int buttonsCount, int msgOnSelect, int selectStep, int initialPosition);
 
     virtual void Update() {}
     virtual void Release();
@@ -93,8 +97,8 @@ class GUIWindow {
     int field_24 = 0;
     int pNumPresenceButton = 0;
     int pCurrentPosActiveItem = 0;
-    int field_30 = 0;
-    int field_34 = 0;
+    bool _msgOnKeyboardSelect = true;
+    int _selectStep = 0;
     int pStartingPosActiveItem = 0;
     WindowInputStatus keyboard_input_status = WINDOW_INPUT_NONE;
     bool receives_keyboard_input = false;

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -635,7 +635,7 @@ void GUIWindow_CharacterRecord::releaseAwardsScrollBar() {
                 pButton->uY = savedInventoryLeftClickButtonY;
                 pButton->uZ = savedInventoryLeftClickButtonZ;
                 pButton->uW = savedInventoryLeftClickButtonW;
-                pGUIWindow_CurrentMenu->_41D08F_set_keyboard_control_group(1, 0, 0, 0);
+                pGUIWindow_CurrentMenu->setKeyboardControlGroup(1, true, 0, 0);
             }
         }
     }
@@ -1523,8 +1523,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
     }
 
     if (buttons_count) {
-        pGUIWindow_CurrentMenu->_41D08F_set_keyboard_control_group(
-            buttons_count, 1, 0, buttons_count);
+        pGUIWindow_CurrentMenu->setKeyboardControlGroup(buttons_count, false, 0, buttons_count);
     }
 }
 
@@ -2290,7 +2289,7 @@ void CharacterUI_ReleaseButtons() {
                 pButton->uY = savedInventoryLeftClickButtonY;
                 pButton->uZ = savedInventoryLeftClickButtonZ;
                 pButton->uW = savedInventoryLeftClickButtonW;
-                pGUIWindow_CurrentMenu->_41D08F_set_keyboard_control_group(1, 0, 0, 0);
+                pGUIWindow_CurrentMenu->setKeyboardControlGroup(1, true, 0, 0);
             }
         }
     }

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -635,7 +635,6 @@ void GUIWindow_CharacterRecord::releaseAwardsScrollBar() {
                 pButton->uY = savedInventoryLeftClickButtonY;
                 pButton->uZ = savedInventoryLeftClickButtonZ;
                 pButton->uW = savedInventoryLeftClickButtonW;
-                pGUIWindow_CurrentMenu->setKeyboardControlGroup(1, true, 0, 0);
             }
         }
     }
@@ -1521,10 +1520,6 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
             pGUIWindow_CurrentMenu->CreateButton({246, current_Y}, {width, uCurrFontHeght - 3}, 3, skill_id | 0x8000, UIMSG_SkillUp, skill_id);
         }
     }
-
-    if (buttons_count) {
-        pGUIWindow_CurrentMenu->setKeyboardControlGroup(buttons_count, false, 0, buttons_count);
-    }
 }
 
 void GUIWindow_CharacterRecord::CharacterUI_StatsTab_Draw(Character *player) {
@@ -2289,7 +2284,6 @@ void CharacterUI_ReleaseButtons() {
                 pButton->uY = savedInventoryLeftClickButtonY;
                 pButton->uZ = savedInventoryLeftClickButtonZ;
                 pButton->uW = savedInventoryLeftClickButtonW;
-                pGUIWindow_CurrentMenu->setKeyboardControlGroup(1, true, 0, 0);
             }
         }
     }

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -144,7 +144,7 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(WindowData data) : GUIWindow(WINDOW_Dialo
     for (int i = 0; i < optionList.size(); i++) {
         CreateButton({480, 130 + i * text_line_height}, {140, text_line_height}, 1, 0, UIMSG_SelectNPCDialogueOption, optionList[i], Io::InputAction::Invalid, "");
     }
-    _41D08F_set_keyboard_control_group(optionList.size(), 1, 0, 1);
+    setKeyboardControlGroup(optionList.size(), false, 0, 1);
 
     CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1, "");
     CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2, "");
@@ -364,7 +364,7 @@ void selectNPCDialogueOption(DIALOGUE_TYPE option) {
             for (int i = 0; i < topics.size(); i++) {
                 pDialogueWindow->CreateButton({480, 160 + i * 30}, {140, 30}, 1, 0, UIMSG_SelectNPCDialogueOption, topics[i], Io::InputAction::Invalid, "");
             }
-            pDialogueWindow->_41D08F_set_keyboard_control_group(topics.size(), 1, 0, 1);
+            pDialogueWindow->setKeyboardControlGroup(topics.size(), false, 0, 1);
 
             pDialogueWindow->CreateButton({61, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 1, Io::InputAction::SelectChar1, "");
             pDialogueWindow->CreateButton({177, 424}, {31, 0}, 2, 94, UIMSG_SelectCharacter, 2, Io::InputAction::SelectChar2, "");

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -196,7 +196,7 @@ GUIWindow_GameMenu::GUIWindow_GameMenu()
     pBtn_Resume = CreateButton({241, 263}, {214, 40}, 1, 0,
         UIMSG_GameMenu_ReturnToGame, 0, Io::InputAction::ReturnToGame, localization->GetString(LSTR_RETURN_TO_GAME), {game_ui_menu_resume});
 
-    _41D08F_set_keyboard_control_group(6, 1, 0, 0);
+    setKeyboardControlGroup(6, false, 0, 0);
 }
 
 void GUIWindow_GameMenu::Update() {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -469,7 +469,7 @@ void NPCHireableDialogPrepare() {
     }
     pDialogueWindow->CreateButton({480, 30 * v0 + 160}, {140, 30}, 1, 0,
         UIMSG_SelectHouseNPCDialogueOption, DIALOGUE_HIRE_FIRE, Io::InputAction::Invalid, localization->GetString(LSTR_HIRE));
-    pDialogueWindow->_41D08F_set_keyboard_control_group(v0 + 1, 1, 0, 2);
+    pDialogueWindow->setKeyboardControlGroup(v0 + 1, false, 0, 2);
     window_SpeakInHouse->setCurrentDialogue(DIALOGUE_OTHER);
 }
 
@@ -996,7 +996,8 @@ void GUIWindow_House::initializeProprietorDialogue() {
         for (int i = 0; i < optionList.size(); i++) {
             pDialogueWindow->CreateButton({480, 146 + 30 * i}, {140, 30}, 1, 0, UIMSG_SelectProprietorDialogueOption, optionList[i], Io::InputAction::Invalid, "");
         }
-        pDialogueWindow->_41D08F_set_keyboard_control_group(optionList.size(), 1, 0, 2);
+        pDialogueWindow->setKeyboardControlGroup(optionList.size(), false, 0, 2);
+
     }
     _savedButtonsNum = pDialogueWindow->pNumPresenceButton;
 }
@@ -1014,7 +1015,7 @@ void GUIWindow_House::initializeNPCDialogueButtons(std::vector<DIALOGUE_TYPE> op
         for (int i = 0; i < optionList.size(); i++) {
             pDialogueWindow->CreateButton({480, 160 + 30 * i}, {140, 30}, 1, 0, UIMSG_SelectHouseNPCDialogueOption, optionList[i], Io::InputAction::Invalid, "");
         }
-        pDialogueWindow->_41D08F_set_keyboard_control_group(optionList.size(), 1, 0, 2);
+        pDialogueWindow->setKeyboardControlGroup(optionList.size(), false, 0, 2);
     }
     _savedButtonsNum = pDialogueWindow->pNumPresenceButton;
 }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -997,7 +997,6 @@ void GUIWindow_House::initializeProprietorDialogue() {
             pDialogueWindow->CreateButton({480, 146 + 30 * i}, {140, 30}, 1, 0, UIMSG_SelectProprietorDialogueOption, optionList[i], Io::InputAction::Invalid, "");
         }
         pDialogueWindow->setKeyboardControlGroup(optionList.size(), false, 0, 2);
-
     }
     _savedButtonsNum = pDialogueWindow->pNumPresenceButton;
 }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -691,7 +691,7 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
         uX += 158;
     } while ((signed int)uControlParam < 30);
 
-    _41D08F_set_keyboard_control_group(28, 0, 7, 40);
+    setKeyboardControlGroup(28, true, 7, 40);
 
     CreateButton({323, 417}, {65, v0}, 1, 0, UIMSG_PlayerCreationSelectClass, 0);
     CreateButton({323, v0 + 417}, {65, v0}, 1, 0, UIMSG_PlayerCreationSelectClass, 0xC);

--- a/src/GUI/UI/UISpellbook.cpp
+++ b/src/GUI/UI/UISpellbook.cpp
@@ -90,7 +90,7 @@ void GUIWindow_Spellbook::openSpellbook() {
 
     CreateButton({0, 0}, {0, 0}, 1, 0, UIMSG_SpellBook_PressTab, 0, Io::InputAction::CharCycle);
     if (pageSpells) {
-        _41D08F_set_keyboard_control_group(pageSpells, 0, 0, 0);
+        setKeyboardControlGroup(pageSpells, true, 0, 0);
     }
 
     if (player.pActiveSkills[CHARACTER_SKILL_FIRE] || engine->config->debug.AllMagic.value())

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -347,32 +347,29 @@ bool UI_OnKeyDown(PlatformKey key) {
         }
 
         if (keyboardActionMapping->IsKeyMatchAction(Io::InputAction::DialogLeft, key)) {
-            int v12 = win->field_34;
-            if (win->pCurrentPosActiveItem - win->pStartingPosActiveItem - v12 >= 0) {
-                win->pCurrentPosActiveItem -= v12;
+            if (win->pCurrentPosActiveItem - win->pStartingPosActiveItem - win->_selectStep >= 0) {
+                win->pCurrentPosActiveItem -= win->_selectStep;
                 if (current_screen_type == SCREEN_PARTY_CREATION) {
                     pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
                 }
             }
-            if (win->field_30 != 0) {
-                break;
+            if (win->_msgOnKeyboardSelect) {
+                GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
+                engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
             }
-            GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
             break;
         } else if (keyboardActionMapping->IsKeyMatchAction(Io::InputAction::DialogRight, key)) {
-            int v7 = win->pCurrentPosActiveItem + win->field_34;
-            if (v7 < win->pNumPresenceButton + win->pStartingPosActiveItem) {
-                win->pCurrentPosActiveItem = v7;
+            int newPos = win->pCurrentPosActiveItem + win->_selectStep;
+            if (newPos < win->pNumPresenceButton + win->pStartingPosActiveItem) {
+                win->pCurrentPosActiveItem = newPos;
                 if (current_screen_type == SCREEN_PARTY_CREATION) {
                     pAudioPlayer->playUISound(SOUND_SelectingANewCharacter);
                 }
             }
-            if (win->field_30 != 0) {
-                break;
+            if (win->_msgOnKeyboardSelect) {
+                GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
+                engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
             }
-            GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
             break;
         } else if (keyboardActionMapping->IsKeyMatchAction(Io::InputAction::DialogDown, key)) {
             int v17 = win->pStartingPosActiveItem;
@@ -381,9 +378,10 @@ bool UI_OnKeyDown(PlatformKey key) {
                 win->pCurrentPosActiveItem = v17;
             else
                 win->pCurrentPosActiveItem = v18 + 1;
-            if (win->field_30 != 0) return true;
-            GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
+            if (win->_msgOnKeyboardSelect) {
+                GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
+                engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
+            }
             return true;
         } else if (key == PlatformKey::KEY_SELECT) {
             int uClickX;
@@ -421,22 +419,24 @@ bool UI_OnKeyDown(PlatformKey key) {
                     win->pNumPresenceButton + v23 - 1;
             else
                 win->pCurrentPosActiveItem = v22 - 1;
-            if (win->field_30 != 0) return true;
-            GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
-            engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
+            if (win->_msgOnKeyboardSelect) {
+                GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
+                engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
+            }
             return true;
         } else if (keyboardActionMapping->IsKeyMatchAction(Io::InputAction::DialogSelect, key)) {
             GUIButton *pButton = win->GetControl(win->pCurrentPosActiveItem);
             engine->_messageQueue->addMessageCurrentFrame(pButton->msg, pButton->msg_param, 0);
         } else if (key == PlatformKey::KEY_PAGEDOWN) { // not button event from user, but a call from GUI_UpdateWindows to track mouse
-            if (win->field_30 != 0) {
+            if (!win->_msgOnKeyboardSelect) {
                 int uClickX;
                 int uClickY;
                 EngineIocContainer::ResolveMouse()->GetClickPos(&uClickX, &uClickY);
                 int v29 = win->pStartingPosActiveItem + win->pNumPresenceButton;
                 for (int v4 = win->pStartingPosActiveItem; v4 < v29; ++v4) {
                     GUIButton *pButton = win->GetControl(v4);
-                    if (!pButton) continue;
+                    if (!pButton)
+                        continue;
                     if (uClickX >= pButton->uX && uClickX <= pButton->uZ &&
                         uClickY >= pButton->uY && uClickY <= pButton->uW) {
                         win->pCurrentPosActiveItem = v4;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -19,7 +19,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 6f704038da9d73e3312d0d7039b978523d4221ac
+            GIT_TAG 198d83c1329cd20c6597cfd90e4b33b8e634106f
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -1628,3 +1628,9 @@ GAME_TEST(Issues, Issue1197) {
     EXPECT_TRUE(loc.contains("out01.odm")); // make it back to emerald
     EXPECT_EQ(deaths.delta(), 1);
 }
+
+GAME_TEST(Issues, Issue1277) {
+    // Crash when press enter on character skills tab
+    test.playTraceFromTestData("issue_1277.mm7", "issue_1277.json");
+    EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
+}


### PR DESCRIPTION
- Rename `_41D08F_set_keyboard_control_group` and it's arguments. Also rearrange conde in the function a little.
- Rename related classes field.
- Invert boolean semantics of one of the function argument because `doSmth` makes more sense than `notDoSmth`.
- Fix #1277 - remove keyboard control from character screen. Not sure what it supposed to do there but as of now it is broken hard. Add test.