### PR TITLE
fix item dupliction and crash when placing items. issue 680

### DIFF
--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -287,11 +287,11 @@ int Chest::CountChestItems(int uChestID) {
 
 int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
     int item_in_chest_count = CountChestItems(uChestID);
-    int test_pos = 0;
 
     int max_size = pChestWidthsByType[vChests[uChestID].uChestBitmapID] *
                    pChestHeightsByType[vChests[uChestID].uChestBitmapID];
     int chest_width = pChestWidthsByType[vChests[uChestID].uChestBitmapID];
+    int test_pos = max_size;
 
     if (item_in_chest_count == -1) return 0;
 
@@ -324,7 +324,6 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
     unsigned int slot_height = GetSizeInInventorySlots(texture->height());
 
     assert(slot_height > 0 && slot_width > 0 && "Items should have nonzero dimensions");
-
     // set inventory indices - memset was eratic??
     for (unsigned int x = 0; x < slot_width; x++) {
         for (unsigned int y = 0; y < slot_height; y++) {
@@ -334,6 +333,7 @@ int Chest::PutItemInChest(int position, ItemGen *put_item, int uChestID) {
 
     vChests[uChestID].pInventoryIndices[test_pos] = item_in_chest_count + 1;
     vChests[uChestID].igChestItems[item_in_chest_count] = *put_item;
+    vChests[uChestID].igChestItems[item_in_chest_count].placedInChest = true;
 
     return (test_pos + 1);
 }
@@ -364,6 +364,7 @@ void Chest::PlaceItemAt(unsigned int put_cell_pos, unsigned int item_at_cell, in
         chest_cell_row_pos += chest_cell_width;
     }
     vChests[uChestID].pInventoryIndices[put_cell_pos] = item_at_cell + 1;
+    vChests[uChestID].igChestItems[item_at_cell].placedInChest = true;
 }
 
 void Chest::PlaceItems(int uChestID) {  // only sued for setup
@@ -473,7 +474,7 @@ void Chest::OnChestLeftClick() {
 
             if (chestindex > 0) {
                 int itemindex = chestindex - 1;
-
+                chest->igChestItems[itemindex].placedInChest = false;
                 if (chest->igChestItems[itemindex].isGold()) {
                     pParty->partyFindsGold(chest->igChestItems[itemindex].special_enchantment, GOLD_RECEIVE_SHARE);
                 } else {
@@ -507,6 +508,7 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
 
         int itemindex = chestindex - 1;
         ItemGen chestitem = chest->igChestItems[itemindex];
+        chestitem.placedInChest = false;
         if (chestitem.isGold()) {
             pParty->partyFindsGold(chestitem.special_enchantment, GOLD_RECEIVE_SHARE);
             goldamount += chestitem.special_enchantment;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1580,6 +1580,20 @@ void reconstruct(const Chest_MM7 &src, Chest *dst) {
     dst->uFlags = ChestFlags(src.uFlags);
     reconstruct(src.igChestItems, &dst->igChestItems);
     reconstruct(src.pInventoryIndices, &dst->pInventoryIndices);
+
+    // fix placedInChest field for old saves
+    int chestArea = dst->pInventoryIndices.size();
+    for (int item = 0; item < chestArea; item++) {
+        if (dst->igChestItems[item].uItemID == ITEM_NULL) {
+            continue;
+        }
+        for (int position = 0; position < chestArea; position++) {
+            if (dst->pInventoryIndices[position] == item + 1) {
+                dst->igChestItems[item].placedInChest = true;
+                break;
+            }
+        }
+    }
 }
 
 void reconstruct(const BLVLight_MM7 &src, BLVLight *dst) {


### PR DESCRIPTION
I hope the patch may fix item duplication and crash when placing items in chests.