### PR TITLE
Fix #1282

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1007,7 +1007,7 @@ void Game::processQueuedMessages() {
                 current_screen_type = SCREEN_GAME;
                 continue;
             case UIMSG_CastSpell_Telekinesis: {
-                Pid pid = _vis->get_picked_object_zbuf_val().object_pid;
+                Pid pid = _vis->mousePickedObject().object_pid;
                 ObjectType type = pid.type();
                 int id = pid.id();
                 bool interactionPossible = false;
@@ -1187,8 +1187,8 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpell_TargetActorBuff:
             case UIMSG_CastSpell_TargetActor: {
-                Pid pid = _vis->get_picked_object_zbuf_val().object_pid;
-                int depth = _vis->get_picked_object_zbuf_val().depth;
+                Pid pid = _vis->mousePickedObject().object_pid;
+                int depth = _vis->mousePickedObject().depth;
                 if (pid.type() == OBJECT_Actor && depth < _engine->config->gameplay.RangedAttackDepth.value()) {
                     spellTargetPicked(pid, -1);
                     closeTargetedSpellWindow();
@@ -1933,7 +1933,7 @@ void Game::onPressSpace() {
                           keyboardInputHandler->IsKeyboardPickingOutlineToggled(),
                           &vis_decoration_noevent_filter, &vis_door_filter);
 
-    Pid pid = _vis->get_picked_object_zbuf_val().object_pid;
+    Pid pid = _vis->keyboardPickedObject().object_pid;
     if (pid) {
         DoInteractionWithTopmostZObject(pid);
     }

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1007,7 +1007,7 @@ void Game::processQueuedMessages() {
                 current_screen_type = SCREEN_GAME;
                 continue;
             case UIMSG_CastSpell_Telekinesis: {
-                Pid pid = _vis->mousePickedObject().object_pid;
+                Pid pid = _vis->mousePickedObject().pid;
                 ObjectType type = pid.type();
                 int id = pid.id();
                 bool interactionPossible = false;
@@ -1187,7 +1187,7 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpell_TargetActorBuff:
             case UIMSG_CastSpell_TargetActor: {
-                Pid pid = _vis->mousePickedObject().object_pid;
+                Pid pid = _vis->mousePickedObject().pid;
                 int depth = _vis->mousePickedObject().depth;
                 if (pid.type() == OBJECT_Actor && depth < _engine->config->gameplay.RangedAttackDepth.value()) {
                     spellTargetPicked(pid, -1);
@@ -1932,7 +1932,7 @@ void Game::onPressSpace() {
     _engine->PickKeyboard(_engine->config->gameplay.KeyboardInteractionDepth.value(),
                           &vis_decoration_noevent_filter, &vis_door_filter);
 
-    Pid pid = _vis->keyboardPickedObject().object_pid;
+    Pid pid = _vis->keyboardPickedObject().pid;
     if (pid) {
         DoInteractionWithTopmostZObject(pid);
     }

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1930,7 +1930,6 @@ void Game::processQueuedMessages() {
 //----- (0046A14B) --------------------------------------------------------
 void Game::onPressSpace() {
     _engine->PickKeyboard(_engine->config->gameplay.KeyboardInteractionDepth.value(),
-                          keyboardInputHandler->IsKeyboardPickingOutlineToggled(),
                           &vis_decoration_noevent_filter, &vis_door_filter);
 
     Pid pid = _vis->keyboardPickedObject().object_pid;

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1007,7 +1007,7 @@ void Game::processQueuedMessages() {
                 current_screen_type = SCREEN_GAME;
                 continue;
             case UIMSG_CastSpell_Telekinesis: {
-                Pid pid = _vis->mousePickedObject().pid;
+                Pid pid = engine->PickMouseTarget().pid;
                 ObjectType type = pid.type();
                 int id = pid.id();
                 bool interactionPossible = false;
@@ -1187,8 +1187,9 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpell_TargetActorBuff:
             case UIMSG_CastSpell_TargetActor: {
-                Pid pid = _vis->mousePickedObject().pid;
-                int depth = _vis->mousePickedObject().depth;
+                Vis_PIDAndDepth object = engine->PickMouseTarget();
+                Pid pid = object.pid;
+                int depth = object.depth;
                 if (pid.type() == OBJECT_Actor && depth < _engine->config->gameplay.RangedAttackDepth.value()) {
                     spellTargetPicked(pid, -1);
                     closeTargetedSpellWindow();
@@ -1929,10 +1930,8 @@ void Game::processQueuedMessages() {
 
 //----- (0046A14B) --------------------------------------------------------
 void Game::onPressSpace() {
-    _engine->PickKeyboard(_engine->config->gameplay.KeyboardInteractionDepth.value(),
-                          &vis_decoration_noevent_filter, &vis_door_filter);
-
-    Pid pid = _vis->keyboardPickedObject().pid;
+    Pid pid = _engine->PickKeyboard(_engine->config->gameplay.KeyboardInteractionDepth.value(),
+                                    &vis_decoration_noevent_filter, &vis_door_filter).pid;
     if (pid) {
         DoInteractionWithTopmostZObject(pid);
     }
@@ -1978,7 +1977,6 @@ void Game::gameLoop() {
             MessageLoopWithWait();
 
             _engine->particle_engine->UpdateParticles();
-            _engine->filterPickMouse();
             _engine->decal_builder->bloodsplat_container->uNumBloodsplats = 0;
             if (_engine->uNumStationaryLights_in_pStationaryLightsStack != pStationaryLightsStack->uNumLightsActive) {
                 _engine->uNumStationaryLights_in_pStationaryLightsStack = pStationaryLightsStack->uNumLightsActive;

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -206,7 +206,7 @@ void GameWindowHandler::OnMouseLeftClick(Pointi position) {
         }
 
         if (engine) {
-            engine->PickMouse(engine->config->gameplay.MouseInteractionDepth.value(), position.x, position.y, false,
+            engine->PickMouse(engine->config->gameplay.MouseInteractionDepth.value(), position.x, position.y,
                               &vis_decoration_noevent_filter, &vis_door_filter);
         }
 
@@ -223,7 +223,7 @@ void GameWindowHandler::OnMouseRightClick(Pointi position) {
         mouse->SetMouseClick(position.x, position.y);
 
         if (engine) {
-            engine->PickMouse(pCamera3D->GetMouseInfoDepth(), position.x, position.y, 0, &vis_allsprites_filter, &vis_door_filter);
+            engine->PickMouse(pCamera3D->GetMouseInfoDepth(), position.x, position.y, &vis_allsprites_filter, &vis_door_filter);
         }
 
         UI_OnMouseRightClick(position.x, position.y);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -557,7 +557,7 @@ void Engine::PickMouse(float fPickDepth, unsigned int uMouseX,
 bool Engine::PickKeyboard(float pick_depth, bool bOutline, Vis_SelectionFilter *sprite_filter,
                           Vis_SelectionFilter *face_filter) {
     if (current_screen_type == SCREEN_GAME) {
-        bool r = vis->PickKeyboard(pick_depth, &vis->default_list, sprite_filter, face_filter);
+        bool r = vis->PickKeyboard(pick_depth, &vis->_defaultList, sprite_filter, face_filter);
 
         if (bOutline)
             OutlineSelection();
@@ -582,10 +582,10 @@ return Result::Success;
 
 //----- (0044EB5A) --------------------------------------------------------
 void Engine::OutlineSelection() {
-    if (!vis->default_list.uSize)
+    if (!vis->_defaultList.uSize)
         return;
 
-    Vis_ObjectInfo *object_info = vis->default_list.object_pointers[0];
+    Vis_ObjectInfo *object_info = vis->_defaultList.object_pointers[0];
     if (object_info) {
         switch (object_info->object_type) {
             case VisObjectType_Sprite: {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -383,7 +383,7 @@ void Engine::filterPickMouse() {  // cursor picking
         depth = config->gameplay.RangedAttackDepth.value();
     }
     Pointi pt = mouse->GetCursorPos();
-    PickMouse(depth, pt.x, pt.y, false, sprite_filter, face_filter);
+    PickMouse(depth, pt.x, pt.y, sprite_filter, face_filter);
 }
 
 //----- (004645FA) --------------------------------------------------------
@@ -538,31 +538,20 @@ void Engine::LogEngineBuildInfo() {
 }
 
 //----- (0044EA5E) --------------------------------------------------------
-void Engine::PickMouse(float fPickDepth, unsigned int uMouseX,
-                       unsigned int uMouseY, bool bOutline,
-                       Vis_SelectionFilter *sprite_filter,
-                       Vis_SelectionFilter *face_filter) {
+void Engine::PickMouse(float fPickDepth, unsigned int uMouseX, unsigned int uMouseY,
+                       Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter) {
     if (uMouseX >= (signed int)pViewport->uScreen_TL_X &&
         uMouseX <= (signed int)pViewport->uScreen_BR_X &&
         uMouseY >= (signed int)pViewport->uScreen_TL_Y &&
         uMouseY <= (signed int)pViewport->uScreen_BR_Y) {
         vis->PickMouse(fPickDepth, uMouseX, uMouseY, sprite_filter, face_filter);
-
-        if (bOutline)
-            OutlineSelection(vis->mousePickedObject());
     }
 }
 
 //----- (0044EB12) --------------------------------------------------------
-bool Engine::PickKeyboard(float pick_depth, bool bOutline, Vis_SelectionFilter *sprite_filter,
-                          Vis_SelectionFilter *face_filter) {
-    if (current_screen_type == SCREEN_GAME) {
-        bool r = vis->PickKeyboard(pick_depth, sprite_filter, face_filter);
-
-        if (bOutline)
-            OutlineSelection(vis->keyboardPickedObject());
-        return r;
-    }
+bool Engine::PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter) {
+    if (current_screen_type == SCREEN_GAME)
+        return vis->PickKeyboard(pick_depth, sprite_filter, face_filter);
     return false;
 }
 /*
@@ -579,31 +568,6 @@ return Result::Success;
 }
 */
 // 4E28F8: using guessed type int current_screen_type;
-
-//----- (0044EB5A) --------------------------------------------------------
-void Engine::OutlineSelection(const Vis_PIDAndDepth &selection) {
-    if (!selection.object_pid)
-        return;
-
-    if (selection.object_pid.type() != OBJECT_Face)
-        return;
-
-    if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
-        ODMFace *face = &pOutdoor->face(selection.object_pid);
-        if (face->uAttributes & FACE_OUTLINED)
-            face->uAttributes &= ~FACE_OUTLINED;
-        else
-            face->uAttributes |= FACE_OUTLINED;
-    } else {
-        assert(uCurrentlyLoadedLevelType == LEVEL_INDOOR);
-
-        BLVFace *face = &pIndoor->pFaces[selection.object_pid.id()];
-        if (face->uAttributes & FACE_OUTLINED)
-            face->uAttributes &= ~FACE_OUTLINED;
-        else
-            face->uAttributes |= FACE_OUTLINED;
-    }
-}
 
 void PlayButtonClickSound() {
     pAudioPlayer->playNonResetableSound(SOUND_StartMainChoice02);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -537,7 +537,8 @@ Vis_PIDAndDepth Engine::PickKeyboard(float pick_depth, Vis_SelectionFilter *spri
 
 Vis_PIDAndDepth Engine::PickMouseInfoPopup() {
     Pointi pt = mouse->GetCursorPos();
-    // TODO(captainurist): having a different depth here makes no sense.
+    // TODO(captainurist): Right now we can have popups for monsters that are not reachable with a bow, and this is OK.
+    //                     However, such monsters also don't get a hint displayed on mouseover. Probably should fix this?
     return PickMouse(pCamera3D->GetMouseInfoDepth(), pt.x, pt.y, &vis_allsprites_filter, &vis_face_filter);
 }
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -120,8 +120,6 @@ class Engine {
     void _461103_load_level_sub();
     void MM7_Initialize();
 
-    inline bool IsTargetingMode() const { return is_targeting; }
-    inline void SetTargetingMode(bool is_targeting) { this->is_targeting = is_targeting; }
     inline bool IsUnderwater() const { return is_underwater; }
     inline void SetUnderwater(bool is_underwater) { this->is_underwater = is_underwater; }
     inline bool IsSaturateFaces() const { return is_saturate_faces; }
@@ -130,7 +128,6 @@ class Engine {
     inline void SetFog(bool is_fog) { this->is_fog = is_fog; } // fog off rather than on??
 
     bool is_underwater = false;
-    bool is_targeting = false;
     bool is_saturate_faces = false;
     bool is_fog = false; // keeps track of whether fog enabled in d3d
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -23,6 +23,7 @@ class KeyboardInputHandler;
 class KeyboardActionMapping;
 } // namespace Io
 
+struct Vis_PIDAndDepth;
 struct Polygon;
 class DecalBuilder;
 class BloodsplatContainer;
@@ -101,7 +102,7 @@ class Engine {
      * @offset 0x42213C
      */
     void onGameViewportClick();
-    void OutlineSelection();
+    void OutlineSelection(const Vis_PIDAndDepth &selection);
     int _44EC23_saturate_face_odm(struct Polygon *a2, int *a3, signed int a4); // TODO(captainurist): drop?
     int _44ED0A_saturate_face_blv(struct BLVFace *a2, int *a3, signed int a4);
     bool draw_debug_outlines();

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -23,8 +23,8 @@ class KeyboardInputHandler;
 class KeyboardActionMapping;
 } // namespace Io
 
-struct Vis_SelectionFilter;
 struct Vis_PIDAndDepth;
+struct Vis_SelectionFilter;
 struct Polygon;
 class DecalBuilder;
 class BloodsplatContainer;
@@ -93,9 +93,13 @@ class Engine {
     static void LogEngineBuildInfo();
 
     void Initialize();
-    void PickMouse(float fPickDepth, unsigned int uMouseX, unsigned int uMouseY,
-                   Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
-    bool PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
+    Vis_PIDAndDepth PickMouse(float fPickDepth, unsigned int uMouseX, unsigned int uMouseY,
+                              Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
+    Vis_PIDAndDepth PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
+
+    Vis_PIDAndDepth PickMouseInfoPopup();
+    Vis_PIDAndDepth PickMouseTarget();
+    Vis_PIDAndDepth PickMouseNormal();
 
     /**
      * @offset 0x42213C
@@ -104,7 +108,6 @@ class Engine {
     int _44EC23_saturate_face_odm(struct Polygon *a2, int *a3, signed int a4); // TODO(captainurist): drop?
     int _44ED0A_saturate_face_blv(struct BLVFace *a2, int *a3, signed int a4);
     bool draw_debug_outlines();
-    void filterPickMouse();
     void StackPartyTorchLight();
     void Deinitialize();
     void DrawParticles();

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -23,6 +23,7 @@ class KeyboardInputHandler;
 class KeyboardActionMapping;
 } // namespace Io
 
+struct Vis_SelectionFilter;
 struct Vis_PIDAndDepth;
 struct Polygon;
 class DecalBuilder;
@@ -93,16 +94,13 @@ class Engine {
 
     void Initialize();
     void PickMouse(float fPickDepth, unsigned int uMouseX, unsigned int uMouseY,
-                   bool bOutline, struct Vis_SelectionFilter *sprite_filter,
-                   struct Vis_SelectionFilter *face_filter);
-    bool PickKeyboard(float pick_depth, bool bOutline, struct Vis_SelectionFilter *sprite_filter,
-                      struct Vis_SelectionFilter *face_filter);
+                   Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
+    bool PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
 
     /**
      * @offset 0x42213C
      */
     void onGameViewportClick();
-    void OutlineSelection(const Vis_PIDAndDepth &selection);
     int _44EC23_saturate_face_odm(struct Polygon *a2, int *a3, signed int a4); // TODO(captainurist): drop?
     int _44ED0A_saturate_face_blv(struct BLVFace *a2, int *a3, signed int a4);
     bool draw_debug_outlines();

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -126,12 +126,12 @@ struct OutdoorLocation {
 
     static void LoadActualSkyFrame();
 
-    const ODMFace &face(Pid pid) {
+    ODMFace &face(Pid pid) {
         assert(pid.type() == OBJECT_Face);
         return pBModels[pid.id() >> 6].pFaces[pid.id() & 0x3F];
     }
 
-    const BSPModel &model(Pid pid) {
+    BSPModel &model(Pid pid) {
         assert(pid.type() == OBJECT_Face);
         return pBModels[pid.id() >> 6];
     }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -288,7 +288,7 @@ void Engine::onGameViewportClick() {
     }
 
     auto pidAndDepth = vis->mousePickedObject();
-    Pid pid = pidAndDepth.object_pid;
+    Pid pid = pidAndDepth.pid;
     int16_t distance = pidAndDepth.depth;
     bool in_range = distance < clickable_distance;
     // else

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -287,7 +287,7 @@ void Engine::onGameViewportClick() {
         return;
     }
 
-    auto pidAndDepth = vis->get_picked_object_zbuf_val();
+    auto pidAndDepth = vis->mousePickedObject();
     Pid pid = pidAndDepth.object_pid;
     int16_t distance = pidAndDepth.depth;
     bool in_range = distance < clickable_distance;

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -287,7 +287,7 @@ void Engine::onGameViewportClick() {
         return;
     }
 
-    auto pidAndDepth = vis->mousePickedObject();
+    auto pidAndDepth = engine->PickMouseNormal();
     Pid pid = pidAndDepth.pid;
     int16_t distance = pidAndDepth.depth;
     bool in_range = distance < clickable_distance;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -486,14 +486,14 @@ bool Vis::Intersect_Ray_Face(const Vec3f &origin, const Vec3f &step,
     // p(t) = p0 + tu;
     Intersection->vWorldPosition = origin + t * step;
 
-    if (!CheckIntersectBModel(pFace, Intersection->vWorldPosition.toInt(), pBModelID))
+    if (!CheckIntersectFace(pFace, Intersection->vWorldPosition.toInt(), pBModelID))
         return false;
 
     return true;
 }
 
 //----- (004C1D2B) --------------------------------------------------------
-bool Vis::CheckIntersectBModel(BLVFace *pFace, Vec3i IntersectPoint, signed int sModelID) {
+bool Vis::CheckIntersectFace(BLVFace *pFace, Vec3i IntersectPoint, signed int sModelID) {
     if (!pFace->pBounding.contains(IntersectPoint))
         return false;
 

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -444,16 +444,16 @@ Vis_PIDAndDepth Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
         }
 
         default:
-            log->warning("Undefined type requested for: CVis::get_object_zbuf_val()");
+            _log->warning("Undefined type requested for: CVis::get_object_zbuf_val()");
             return InvalidPIDAndDepth();
     }
 }
 
 //----- (004C1BF1) --------------------------------------------------------
 Vis_PIDAndDepth Vis::get_picked_object_zbuf_val() {
-    if (!default_list.uSize) return InvalidPIDAndDepth();
+    if (!_defaultList.uSize) return InvalidPIDAndDepth();
 
-    return get_object_zbuf_val(default_list.object_pointers[0]);
+    return get_object_zbuf_val(_defaultList.object_pointers[0]);
 }
 
 //----- (004C1C0C) --------------------------------------------------------
@@ -500,9 +500,9 @@ bool Vis::CheckIntersectBModel(BLVFace *pFace, Vec3i IntersectPoint, signed int 
         pFace->uAttributes |= FACE_IsPicked;
 
         // save debug pick line for later
-        debugpick.vWorldPosition.x = IntersectPoint.x;
-        debugpick.vWorldPosition.y = IntersectPoint.y;
-        debugpick.vWorldPosition.z = IntersectPoint.z;
+        _debugpick.vWorldPosition.x = IntersectPoint.x;
+        _debugpick.vWorldPosition.y = IntersectPoint.y;
+        _debugpick.vWorldPosition.z = IntersectPoint.z;
     }
 
 
@@ -692,14 +692,14 @@ void Vis::SortByScreenSpaceY(RenderVertexSoft *pArray, int start, int end) {
 
 //----- (004C04AF) --------------------------------------------------------
 Vis::Vis() {
-    this->log = EngineIocContainer::ResolveLogger();
+    this->_log = EngineIocContainer::ResolveLogger();
 }
 
 //----- (004C05CC) --------------------------------------------------------
 bool Vis::PickKeyboard(float pick_depth, Vis_SelectionList *list,
                        Vis_SelectionFilter *sprite_filter,
                        Vis_SelectionFilter *face_filter) {
-    if (!list) list = &default_list;
+    if (!list) list = &_defaultList;
     list->uSize = 0;
 
     PickBillboards_Keyboard(pick_depth, list, sprite_filter);
@@ -722,29 +722,29 @@ bool Vis::PickMouse(float fDepth, float fMouseX, float fMouseY,
                     Vis_SelectionFilter *face_filter) {
     Vec3f rayOrigin, rayStep;  // [sp+1Ch] [bp-60h]@1
 
-    default_list.uSize = 0;
+    _defaultList.uSize = 0;
     CastPickRay(fMouseX, fMouseY, fDepth, &rayOrigin, &rayStep);
 
     // log->Info("Sx: {}, Sy: {}, Sz: {} \n Fx: {}, Fy: {}, Fz: {}",
     //     pMouseRay->vWorldPosition.x, pMouseRay->vWorldPosition.y, pMouseRay->vWorldPosition.z,
     //     (pMouseRay+1)->vWorldPosition.x, (pMouseRay + 1)->vWorldPosition.y, (pMouseRay + 1)->vWorldPosition.z);
 
-    PickBillboards_Mouse(fDepth, fMouseX, fMouseY, &default_list, sprite_filter);
+    PickBillboards_Mouse(fDepth, fMouseX, fMouseY, &_defaultList, sprite_filter);
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-        PickIndoorFaces_Mouse(fDepth, rayOrigin, rayStep, &default_list, face_filter);
+        PickIndoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_defaultList, face_filter);
     } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
-        PickOutdoorFaces_Mouse(fDepth, rayOrigin, rayStep, &default_list, face_filter, false);
+        PickOutdoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_defaultList, face_filter, false);
     } else {
-        log->warning("Picking mouse in undefined level");  // picking in main menu is
+        _log->warning("Picking mouse in undefined level");  // picking in main menu is
                                                   // default (buggy) game
                                                   // behaviour. should've
                                                   // returned false in
                                                   // Game::PickMouse
         return false;
     }
-    default_list.create_object_pointers(Vis_SelectionList::All);
-    default_list.sort_object_pointers();
+    _defaultList.create_object_pointers(Vis_SelectionList::All);
+    _defaultList.sort_object_pointers();
 
     return true;
 }
@@ -791,7 +791,7 @@ bool Vis::is_part_of_selection(const Vis_Object &what, Vis_SelectionFilter *filt
             if (filter->select_flags & ExclusionIfNoEvent) {
                 if (object_type != filter->object_type) return true;
                 if (filter->object_type != OBJECT_Decoration) {
-                    log->warning("Unsupported \"exclusion if no event\" type in CVis::is_part_of_selection");
+                    _log->warning("Unsupported \"exclusion if no event\" type in CVis::is_part_of_selection");
                     return true;
                 }
                 if (pLevelDecorations[object_idx].uCog ||
@@ -801,7 +801,7 @@ bool Vis::is_part_of_selection(const Vis_Object &what, Vis_SelectionFilter *filt
             }
             if (object_type == filter->object_type) {
                 if (object_type != OBJECT_Actor) {
-                    log->warning("Default case reached in VIS");
+                    _log->warning("Default case reached in VIS");
                     return true;
                 }
 

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -425,7 +425,7 @@ void Vis::SortVectors_x(RenderVertexSoft *pArray, int start, int end) {
 Vis_PIDAndDepth InvalidPIDAndDepth() {
     Vis_PIDAndDepth result;
     result.depth = 0;
-    result.object_pid = Pid();
+    result.pid = Pid();
     return result;
 }
 
@@ -436,7 +436,7 @@ Vis_PIDAndDepth Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
         case VisObjectType_Face: {
             Vis_PIDAndDepth result;
             result.depth = info->depth;
-            result.object_pid = info->object_pid;
+            result.pid = info->object_pid;
             return result;
         }
 

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -484,15 +484,8 @@ bool Vis::CheckIntersectFace(BLVFace *pFace, Vec3i IntersectPoint, signed int sM
     if (!pFace->Contains(IntersectPoint, sModelID))
         return false;
 
-    if (engine->config->debug.ShowPickedFace.value()) {
+    if (engine->config->debug.ShowPickedFace.value())
         pFace->uAttributes |= FACE_IsPicked;
-
-        // save debug pick line for later
-        _debugpick.vWorldPosition.x = IntersectPoint.x;
-        _debugpick.vWorldPosition.y = IntersectPoint.y;
-        _debugpick.vWorldPosition.z = IntersectPoint.z;
-    }
-
 
     return true;
     /*

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -450,10 +450,18 @@ Vis_PIDAndDepth Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
 }
 
 //----- (004C1BF1) --------------------------------------------------------
-Vis_PIDAndDepth Vis::get_picked_object_zbuf_val() {
-    if (!_defaultList.uSize) return InvalidPIDAndDepth();
+Vis_PIDAndDepth Vis::mousePickedObject() {
+    if (!_mouseList.uSize)
+        return InvalidPIDAndDepth();
 
-    return get_object_zbuf_val(_defaultList.object_pointers[0]);
+    return get_object_zbuf_val(_mouseList.object_pointers[0]);
+}
+
+Vis_PIDAndDepth Vis::keyboardPickedObject() {
+    if (!_keyboardList.uSize)
+        return InvalidPIDAndDepth();
+
+    return get_object_zbuf_val(_keyboardList.object_pointers[0]);
 }
 
 //----- (004C1C0C) --------------------------------------------------------
@@ -696,22 +704,21 @@ Vis::Vis() {
 }
 
 //----- (004C05CC) --------------------------------------------------------
-bool Vis::PickKeyboard(float pick_depth, Vis_SelectionList *list,
+bool Vis::PickKeyboard(float pick_depth,
                        Vis_SelectionFilter *sprite_filter,
                        Vis_SelectionFilter *face_filter) {
-    if (!list) list = &_defaultList;
-    list->uSize = 0;
+    _keyboardList.uSize = 0;
 
-    PickBillboards_Keyboard(pick_depth, list, sprite_filter);
+    PickBillboards_Keyboard(pick_depth, &_keyboardList, sprite_filter);
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
-        PickIndoorFaces_Keyboard(pick_depth, list, face_filter);
+        PickIndoorFaces_Keyboard(pick_depth, &_keyboardList, face_filter);
     else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR)
-        PickOutdoorFaces_Keyboard(pick_depth, list, face_filter);
+        PickOutdoorFaces_Keyboard(pick_depth, &_keyboardList, face_filter);
     else
         assert(false);
 
-    list->create_object_pointers(Vis_SelectionList::Unique);
-    list->sort_object_pointers();
+    _keyboardList.create_object_pointers(Vis_SelectionList::Unique);
+    _keyboardList.sort_object_pointers();
 
     return true;
 }
@@ -722,19 +729,19 @@ bool Vis::PickMouse(float fDepth, float fMouseX, float fMouseY,
                     Vis_SelectionFilter *face_filter) {
     Vec3f rayOrigin, rayStep;  // [sp+1Ch] [bp-60h]@1
 
-    _defaultList.uSize = 0;
+    _mouseList.uSize = 0;
     CastPickRay(fMouseX, fMouseY, fDepth, &rayOrigin, &rayStep);
 
     // log->Info("Sx: {}, Sy: {}, Sz: {} \n Fx: {}, Fy: {}, Fz: {}",
     //     pMouseRay->vWorldPosition.x, pMouseRay->vWorldPosition.y, pMouseRay->vWorldPosition.z,
     //     (pMouseRay+1)->vWorldPosition.x, (pMouseRay + 1)->vWorldPosition.y, (pMouseRay + 1)->vWorldPosition.z);
 
-    PickBillboards_Mouse(fDepth, fMouseX, fMouseY, &_defaultList, sprite_filter);
+    PickBillboards_Mouse(fDepth, fMouseX, fMouseY, &_mouseList, sprite_filter);
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-        PickIndoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_defaultList, face_filter);
+        PickIndoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_mouseList, face_filter);
     } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
-        PickOutdoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_defaultList, face_filter, false);
+        PickOutdoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_mouseList, face_filter, false);
     } else {
         _log->warning("Picking mouse in undefined level");  // picking in main menu is
                                                   // default (buggy) game
@@ -743,8 +750,8 @@ bool Vis::PickMouse(float fDepth, float fMouseX, float fMouseY,
                                                   // Game::PickMouse
         return false;
     }
-    _defaultList.create_object_pointers(Vis_SelectionList::All);
-    _defaultList.sort_object_pointers();
+    _mouseList.create_object_pointers(Vis_SelectionList::All);
+    _mouseList.sort_object_pointers();
 
     return true;
 }

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -232,6 +232,10 @@ void Vis::PickBillboards_Mouse(float fPickDepth, float fX, float fY,
             if (DoesRayIntersectBillboard(fPickDepth, i)) {
                 RenderBillboard *billboard = &pBillboardRenderList[d3d_billboard->sParentBillboardID];
 
+                Pid pid = billboard->object_pid;
+                if (pid.type() == OBJECT_Item && pSpriteObjects[pid.id()].uObjectDescID == 0)
+                    continue; // Sprite object already removed.
+
                 list->AddObject(VisObjectType_Sprite, billboard->screen_space_z, billboard->object_pid);
             }
         }

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -87,23 +87,28 @@ struct Vis_SelectionList {
 class Vis {
  public:
     Vis();
-    //----- (004C05A2) --------------------------------------------------------
-    // virtual ~Vis() {}
-    //----- (004C05BE) --------------------------------------------------------
-    virtual ~Vis() {}
+
     bool PickKeyboard(float pick_depth, Vis_SelectionList *list,
                       Vis_SelectionFilter *sprite_filter,
                       Vis_SelectionFilter *face_filter);
+    bool PickMouse(float fDepth, float fMouseX, float fMouseY,
+                   Vis_SelectionFilter *sprite_filter,
+                   Vis_SelectionFilter *face_filter);
+
+    Vis_PIDAndDepth get_picked_object_zbuf_val();
+
+    bool DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx);
+
+    Pid PickClosestActor(ObjectType object_type, unsigned int pick_depth,
+                         VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
+
+private:
     void PickBillboards_Keyboard(float pick_depth, Vis_SelectionList *list,
                                  Vis_SelectionFilter *filter);
     void PickIndoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
                                   Vis_SelectionFilter *filter);
     void PickOutdoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
                                    Vis_SelectionFilter *filter);
-
-    bool PickMouse(float fDepth, float fMouseX, float fMouseY,
-                   Vis_SelectionFilter *sprite_filter,
-                   Vis_SelectionFilter *face_filter);
     void PickBillboards_Mouse(float fPickDepth, float fX, float fY,
                               Vis_SelectionList *list,
                               Vis_SelectionFilter *filter);
@@ -117,7 +122,6 @@ class Vis {
 
     bool is_part_of_selection(const Vis_Object &what,
                               Vis_SelectionFilter *filter);
-    bool DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx);
     Vis_ObjectInfo *DetermineFacetIntersection(struct BLVFace *face, Pid pid, float pick_depth);
     bool IsPolygonOccludedByBillboard(struct RenderVertexSoft *vertices,
                                       int num_vertices, float x, float y);
@@ -129,11 +133,8 @@ class Vis {
                                      float *out_center_y);
     bool IsPointInsideD3DBillboard(struct RenderBillboardD3D *billboard, float x,
                                    float y);
-    Pid PickClosestActor(ObjectType object_type, unsigned int pick_depth,
-                                    VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
     void SortVectors_x(RenderVertexSoft *pArray, int start, int end);
     Vis_PIDAndDepth get_object_zbuf_val(Vis_ObjectInfo *info);
-    Vis_PIDAndDepth get_picked_object_zbuf_val();
     bool Intersect_Ray_Face(const Vec3f &origin, const Vec3f &step,
                             RenderVertexSoft *Intersection, BLVFace *pFace,
                             signed int pBModelID);
@@ -148,10 +149,10 @@ class Vis {
     void SortByScreenSpaceY(struct RenderVertexSoft *pArray, int start,
                             int end);
 
-    Vis_SelectionList default_list;
-    RenderVertexSoft debugpick;
-
-    Logger *log = nullptr;
+public:
+    Vis_SelectionList _defaultList;
+    RenderVertexSoft _debugpick;
+    Logger *_log = nullptr;
 };
 
 

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -82,15 +82,9 @@ class Vis {
  public:
     Vis();
 
-    bool PickKeyboard(float pick_depth,
-                      Vis_SelectionFilter *sprite_filter,
-                      Vis_SelectionFilter *face_filter);
-    bool PickMouse(float fDepth, float fMouseX, float fMouseY,
-                   Vis_SelectionFilter *sprite_filter,
-                   Vis_SelectionFilter *face_filter);
-
-    Vis_PIDAndDepth mousePickedObject();
-    Vis_PIDAndDepth keyboardPickedObject();
+    Vis_PIDAndDepth PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
+    Vis_PIDAndDepth PickMouse(float fDepth, float fMouseX, float fMouseY,
+                              Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
 
     bool DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx);
 
@@ -146,8 +140,7 @@ private:
                             int end);
 
 private:
-    Vis_SelectionList _mouseList;
-    Vis_SelectionList _keyboardList;
+    Vis_SelectionList _selectionList;
     RenderVertexSoft _debugpick;
     Logger *_log = nullptr;
 };

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -141,7 +141,6 @@ private:
 
 private:
     Vis_SelectionList _selectionList;
-    RenderVertexSoft _debugpick;
     Logger *_log = nullptr;
 };
 

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -88,14 +88,15 @@ class Vis {
  public:
     Vis();
 
-    bool PickKeyboard(float pick_depth, Vis_SelectionList *list,
+    bool PickKeyboard(float pick_depth,
                       Vis_SelectionFilter *sprite_filter,
                       Vis_SelectionFilter *face_filter);
     bool PickMouse(float fDepth, float fMouseX, float fMouseY,
                    Vis_SelectionFilter *sprite_filter,
                    Vis_SelectionFilter *face_filter);
 
-    Vis_PIDAndDepth get_picked_object_zbuf_val();
+    Vis_PIDAndDepth mousePickedObject();
+    Vis_PIDAndDepth keyboardPickedObject();
 
     bool DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx);
 
@@ -149,8 +150,9 @@ private:
     void SortByScreenSpaceY(struct RenderVertexSoft *pArray, int start,
                             int end);
 
-public:
-    Vis_SelectionList _defaultList;
+private:
+    Vis_SelectionList _mouseList;
+    Vis_SelectionList _keyboardList;
     RenderVertexSoft _debugpick;
     Logger *_log = nullptr;
 };

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <variant>
-
 #include "Utility/Flags.h"
 #include "Utility/Geometry/Plane.h"
 
@@ -54,10 +52,7 @@ struct Vis_PIDAndDepth {
     int16_t depth;
 };
 
-using Vis_Object = std::variant<std::monostate, int /* index */, ODMFace *, BLVFace *>;
-
 struct Vis_ObjectInfo {
-    Vis_Object object;
     Pid object_pid = Pid();
     int16_t depth = -1;
     VisObjectType object_type = VisObjectType_Any;
@@ -71,8 +66,7 @@ struct Vis_SelectionList {
     void create_object_pointers(PointerCreationType type = All);
     void sort_object_pointers();
 
-    inline void AddObject(Vis_Object object, VisObjectType type, int depth, Pid pid) {
-        object_pool[uSize].object = object;
+    inline void AddObject(VisObjectType type, int depth, Pid pid) {
         object_pool[uSize].object_type = type;
         object_pool[uSize].depth = depth;
         object_pool[uSize].object_pid = pid;
@@ -121,8 +115,9 @@ private:
                                 Vis_SelectionFilter *filter,
                                 bool only_reachable);
 
-    bool is_part_of_selection(const Vis_Object &what,
-                              Vis_SelectionFilter *filter);
+    bool isBillboardPartOfSelection(int billboardId, Vis_SelectionFilter *filter);
+    bool isFacePartOfSelection(ODMFace *odmFace, BLVFace *bvlFace, Vis_SelectionFilter *filter);
+
     Vis_ObjectInfo *DetermineFacetIntersection(struct BLVFace *face, Pid pid, float pick_depth);
     bool IsPolygonOccludedByBillboard(struct RenderVertexSoft *vertices,
                                       int num_vertices, float x, float y);

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -91,7 +91,7 @@ class Vis {
     Pid PickClosestActor(ObjectType object_type, unsigned int pick_depth,
                          VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
 
-private:
+ private:
     void PickBillboards_Keyboard(float pick_depth, Vis_SelectionList *list,
                                  Vis_SelectionFilter *filter);
     void PickIndoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
@@ -139,7 +139,7 @@ private:
     void SortByScreenSpaceY(struct RenderVertexSoft *pArray, int start,
                             int end);
 
-private:
+ private:
     Vis_SelectionList _selectionList;
     Logger *_log = nullptr;
 };

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -134,7 +134,7 @@ private:
     bool Intersect_Ray_Face(const Vec3f &origin, const Vec3f &step,
                             RenderVertexSoft *Intersection, BLVFace *pFace,
                             signed int pBModelID);
-    bool CheckIntersectBModel(BLVFace *pFace, Vec3i IntersectPoint, signed int sModelID);
+    bool CheckIntersectFace(BLVFace *pFace, Vec3i IntersectPoint, signed int sModelID);
     void CastPickRay(float fMouseX, float fMouseY, float fPickDepth, Vec3f *origin, Vec3f *step);
     void SortVerticesByX(struct RenderVertexD3D3 *pArray, unsigned int uStart,
                          unsigned int uEnd);

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -48,8 +48,8 @@ extern Vis_SelectionFilter vis_decoration_noevent_filter;  // 00F93E6C
 extern Vis_SelectionFilter vis_items_filter;  // static to sub_44EEA7
 
 struct Vis_PIDAndDepth {
-    Pid object_pid;
-    int16_t depth;
+    Pid pid;
+    int depth = 0;
 };
 
 struct Vis_ObjectInfo {

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -68,7 +68,7 @@ struct SpriteObject {
 
     SPRITE_OBJECT_TYPE uType = SPRITE_NULL;
     // unsigned __int16 uType;
-    uint16_t uObjectDescID = 0; // Zero means free slot, can reuse.
+    uint16_t uObjectDescID = 0; // Index into pObjectList->pObjects. Zero means free slot, can reuse.
     Vec3i vPosition;
     Vec3i vVelocity;
     uint16_t uFacing = 0;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -903,9 +903,9 @@ void GameUI_WritePointedObjectStatusString() {
 
             // get_picked_object_zbuf_val contains both the pid and the depth
             pickedObject = vis->mousePickedObject();
-            mouse->uPointingObjectID = pickedObject.object_pid;
-            pickedObjectID = (signed)pickedObject.object_pid.id();
-            if (pickedObject.object_pid.type() == OBJECT_Item) {
+            mouse->uPointingObjectID = pickedObject.pid;
+            pickedObjectID = (signed)pickedObject.pid.id();
+            if (pickedObject.pid.type() == OBJECT_Item) {
                 if (pObjectList->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
                     mouse->uPointingObjectID = Pid();
                     engine->_statusBar->clearPermanent();
@@ -918,7 +918,7 @@ void GameUI_WritePointedObjectStatusString() {
                 } else {
                     engine->_statusBar->setPermanent(LSTR_FMT_GET_S, pSpriteObjects[pickedObjectID].containing_item.GetDisplayName());
                 }  // intentional fallthrough
-            } else if (pickedObject.object_pid.type() == OBJECT_Decoration) {
+            } else if (pickedObject.pid.type() == OBJECT_Decoration) {
                 if (!pLevelDecorations[pickedObjectID].uEventID) {
                     std::string pText;                 // ecx@79
                     if (pLevelDecorations[pickedObjectID].IsInteractive())
@@ -932,11 +932,11 @@ void GameUI_WritePointedObjectStatusString() {
                         engine->_statusBar->setPermanent(hintString);
                     }
                 }  // intentional fallthrough
-            } else if (pickedObject.object_pid.type() == OBJECT_Face) {
+            } else if (pickedObject.pid.type() == OBJECT_Face) {
                 if (pickedObject.depth < 0x200u) {
                     std::string newString;
                     if (uCurrentlyLoadedLevelType != LEVEL_INDOOR) {
-                        v18b = pickedObject.object_pid.id() >> 6;
+                        v18b = pickedObject.pid.id() >> 6;
                         short triggeredId = pOutdoor->pBModels[v18b].pFaces[pickedObjectID & 0x3F].sCogTriggeredID;
                         if (triggeredId != 0) {
                             newString = getEventHintString(pOutdoor->pBModels[v18b].pFaces[pickedObjectID & 0x3F]
@@ -966,7 +966,7 @@ void GameUI_WritePointedObjectStatusString() {
                 engine->_statusBar->clearPermanent();
                 uLastPointedObjectID = Pid();
                 return;
-            } else if (pickedObject.object_pid.type() == OBJECT_Actor) {
+            } else if (pickedObject.pid.type() == OBJECT_Actor) {
                 if (pickedObject.depth >= 0x2000u) {
                     mouse->uPointingObjectID = Pid();
                     if (uLastPointedObjectID) {

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -902,7 +902,7 @@ void GameUI_WritePointedObjectStatusString() {
             auto vis = EngineIocContainer::ResolveVis();
 
             // get_picked_object_zbuf_val contains both the pid and the depth
-            pickedObject = vis->mousePickedObject();
+            Vis_PIDAndDepth pickedObject = engine->PickMouseNormal();
             mouse->uPointingObjectID = pickedObject.pid;
             pickedObjectID = (signed)pickedObject.pid.id();
             if (pickedObject.pid.type() == OBJECT_Item) {
@@ -912,8 +912,7 @@ void GameUI_WritePointedObjectStatusString() {
                     uLastPointedObjectID = Pid();
                     return;
                 }
-                if (pickedObject.depth >= 0x200u ||
-                    pParty->pPickedItem.uItemID != ITEM_NULL) {
+                if (pickedObject.depth >= 0x200u || pParty->pPickedItem.uItemID != ITEM_NULL) {
                     engine->_statusBar->setPermanent(pSpriteObjects[pickedObjectID].containing_item.GetDisplayName());
                 } else {
                     engine->_statusBar->setPermanent(LSTR_FMT_GET_S, pSpriteObjects[pickedObjectID].containing_item.GetDisplayName());

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -902,7 +902,7 @@ void GameUI_WritePointedObjectStatusString() {
             auto vis = EngineIocContainer::ResolveVis();
 
             // get_picked_object_zbuf_val contains both the pid and the depth
-            pickedObject = vis->get_picked_object_zbuf_val();
+            pickedObject = vis->mousePickedObject();
             mouse->uPointingObjectID = pickedObject.object_pid;
             pickedObjectID = (signed)pickedObject.object_pid.id();
             if (pickedObject.object_pid.type() == OBJECT_Item) {

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1668,10 +1668,7 @@ void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
 
 //----- (00416D62) --------------------------------------------------------
 void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
-    Pid v5;                  // esi@62
-    // GUIButton *pButton;      // esi@84
     std::string pStr;        // edi@85
-    // const char *pHint;       // edx@113
     GUIWindow popup_window;  // [sp+4h] [bp-74h]@32
 
     if (current_screen_type == SCREEN_VIDEO || GetCurrentMenuID() == MENU_MAIN)
@@ -1802,8 +1799,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                 popup_window.uFrameY = 40;
                 // if ( render->pRenderD3D )
 
-                auto vis = EngineIocContainer::ResolveVis();
-                v5 = vis->mousePickedObject().pid;
+                Pid v5 = engine->PickMouseInfoPopup().pid;
                 /*else
                 v5 = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]];*/
                 if (v5.type() == OBJECT_Actor) {

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1803,7 +1803,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                 // if ( render->pRenderD3D )
 
                 auto vis = EngineIocContainer::ResolveVis();
-                v5 = vis->get_picked_object_zbuf_val().object_pid;
+                v5 = vis->mousePickedObject().object_pid;
                 /*else
                 v5 = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]];*/
                 if (v5.type() == OBJECT_Actor) {

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1803,7 +1803,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                 // if ( render->pRenderD3D )
 
                 auto vis = EngineIocContainer::ResolveVis();
-                v5 = vis->mousePickedObject().object_pid;
+                v5 = vis->mousePickedObject().pid;
                 /*else
                 v5 = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]];*/
                 if (v5.type() == OBJECT_Actor) {

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -449,10 +449,6 @@ bool Io::KeyboardInputHandler::IsTurnStrafingToggled() const {
     return controller->IsKeyDown(PlatformKey::KEY_CONTROL);
 }
 
-bool Io::KeyboardInputHandler::IsKeyboardPickingOutlineToggled() const {
-    return controller->IsKeyDown(PlatformKey::KEY_CONTROL);
-}
-
 bool Io::KeyboardInputHandler::IsStealingToggled() const {
     return controller->IsKeyDown(PlatformKey::KEY_CONTROL);
 }

--- a/src/Io/KeyboardInputHandler.h
+++ b/src/Io/KeyboardInputHandler.h
@@ -36,7 +36,6 @@ class KeyboardInputHandler {
         ResetKeys();
     }
 
-    bool IsKeyboardPickingOutlineToggled() const;
     bool IsRunKeyToggled() const;
     bool IsTurnStrafingToggled() const;
     bool IsStealingToggled() const;

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -320,7 +320,7 @@ void Io::Mouse::UI_OnMouseLeftClick() {
         return;
     }
 
-    Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->get_picked_object_zbuf_val();
+    Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->mousePickedObject();
 
     ObjectType type = picked_object.object_pid.type();
     if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -51,8 +51,6 @@ void Io::Mouse::SetCursorImage(const std::string &name) {
     if (this->cursor_name != name)
         this->cursor_name = name;
 
-    engine->SetTargetingMode(name == "MICON2");
-
     ClearCursor();
     if (name == "MICON1") {  // arrow
         this->bActive = false;

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -322,13 +322,13 @@ void Io::Mouse::UI_OnMouseLeftClick() {
 
     Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->mousePickedObject();
 
-    ObjectType type = picked_object.object_pid.type();
+    ObjectType type = picked_object.pid.type();
     if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&
         pParty->activeCharacter().CanAct() &&
         pParty->activeCharacter().CanSteal()) {
         engine->_messageQueue->addMessageCurrentFrame(
             UIMSG_STEALFROMACTOR,
-            picked_object.object_pid.id(),
+            picked_object.pid.id(),
             0
         );
 

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -320,7 +320,7 @@ void Io::Mouse::UI_OnMouseLeftClick() {
         return;
     }
 
-    Vis_PIDAndDepth picked_object = EngineIocContainer::ResolveVis()->mousePickedObject();
+    Vis_PIDAndDepth picked_object = engine->PickMouseNormal();
 
     ObjectType type = picked_object.pid.type();
     if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -19,7 +19,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 198d83c1329cd20c6597cfd90e4b33b8e634106f
+            GIT_TAG bb572ff1eff5897a59c28e6d6437492ac918ac0a
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests.cpp
+++ b/test/Bin/GameTest/GameTests.cpp
@@ -1641,3 +1641,18 @@ GAME_TEST(Issues, Issue1277) {
     test.playTraceFromTestData("issue_1277.mm7", "issue_1277.json");
     EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
 }
+
+GAME_TEST(Issues, Issue1282) {
+    // Picking up an item asserts.
+    auto itemTape = tapes.hasItem(ITEM_LEATHER_ARMOR);
+    auto totalObjectsTape = tapes.custom([] {
+        int result = 0;
+        for (const SpriteObject &spriteObject : pSpriteObjects)
+            if (spriteObject.containing_item.uItemID != ITEM_NULL)
+                result++;
+        return result;
+    });
+    test.playTraceFromTestData("issue_1282.mm7", "issue_1282.json");
+    EXPECT_EQ(itemTape, tape(false, true));
+    EXPECT_EQ(totalObjectsTape.delta(), -1);
+}


### PR DESCRIPTION
Ref #1282 

Changes:
* `Vis::PickMouse` / `Vis::PickKeyboard` returns the resulting item instead of caching it inside the `Vis` object.
* Since nothing is cached, `PickMouse` / `PickKeyboard` is called whenever a pick result is needed.
* Dropped `Engine::OutlineSelection` and related code.
* Moved most of `Vis` code to `private`.