### PR TITLE
Use actions/setup-java@v3

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,7 +99,7 @@ jobs:
             sudo apt-get install -y gcc-13-multilib g++-13-multilib
           fi
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17.0.6


### PR DESCRIPTION
v2 gives this warning:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-java@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/Show less
```