### PR TITLE
fix #1270

### DIFF
--- a/src/Library/Lod/LodReader.h
+++ b/src/Library/Lod/LodReader.h
@@ -84,6 +84,7 @@ class LodReader final {
 
  private:
     struct LodRegion {
+        std::string name{};
         size_t offset = 0;
         size_t size = 0;
     };
@@ -93,5 +94,5 @@ class LodReader final {
     std::string _path;
     std::string _description;
     std::string _rootName;
-    std::unordered_map<std::string, LodRegion> _files;
+    std::vector<LodRegion> _files{};
 };

--- a/src/Library/Lod/LodReader.h
+++ b/src/Library/Lod/LodReader.h
@@ -94,5 +94,9 @@ class LodReader final {
     std::string _path;
     std::string _description;
     std::string _rootName;
+    /**
+     * Vanilla save structure expects a certain order of the lod container. Using a vector here to maintain correct sequence.
+     * Maintain OE save backwards compatability - see #1270.
+     */
     std::vector<LodRegion> _files{};
 };


### PR DESCRIPTION
fix #1270 

Annoyingly it looks like vanilla expects a certain order of the lod container. Reverted our lod structure back to a vector.

Please test that this produces valid files you can load into vanilla without issue.