### PR TITLE
Fixes in data path resolution code

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -92,31 +92,27 @@
 #include "Media/MediaPlayer.h"
 
 #include "Library/Platform/Application/PlatformApplication.h"
-#include "Library/Environment/Interface/Environment.h"
 #include "Library/Random/Random.h"
 #include "Library/Logger/Logger.h"
 
 #include "Utility/Format.h"
 #include "Utility/DataPath.h"
 #include "Utility/Exception.h"
-#include "Utility/FileSystem.h"
 
 void ShowMM7IntroVideo_and_LoadingScreen();
 
 using Graphics::IRenderFactory;
 
-void initDataPath(Environment *environment, Platform *platform, const std::string &dataPath) {
+void initDataPath(Platform *platform, const std::string &dataPath) {
     std::string missing_file;
 
-    if (validateDataPath(dataPath, missing_file)) {
-        setDataPath(expandUserPath(dataPath, environment->path(PATH_HOME)));
+    if (validateDataPath(dataPath, &missing_file)) {
+        setDataPath(dataPath);
 
         std::string savesPath = makeDataPath("saves");
         if (!std::filesystem::exists(savesPath)) {
             std::filesystem::create_directory(savesPath);
         }
-
-        logger->info("Using MM7 directory: {}", dataPath);
     } else {
         std::string message = fmt::format(
             "Required file {} not found.\n"

--- a/src/Application/Game.h
+++ b/src/Application/Game.h
@@ -20,7 +20,6 @@ class PlatformApplication;
 class GameTraceHandler;
 class NuklearEventHandler;
 class Platform;
-class Environment;
 
 class Game {
  public:
@@ -50,6 +49,6 @@ class Game {
     std::shared_ptr<Nuklear> _nuklear = nullptr;
 };
 
-void initDataPath(Environment *environment, Platform *platform, const std::string &dataPath);
+void initDataPath(Platform *platform, const std::string &dataPath);
 
 extern class GraphicsImage *gamma_preview_image;  // 506E40

--- a/src/Application/GamePathResolver.cpp
+++ b/src/Application/GamePathResolver.cpp
@@ -14,10 +14,10 @@ std::string resolveMm6Path(Environment *environment) {
         {
             "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207661253/PATH",
             "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM6/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic\x00AE VI/1.0/AppPath",
+            "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath", // \xC2\xAE is (R) in utf-8.
             "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/Games/1207661253/PATH",
             "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM6/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic\x00AE VI/1.0/AppPath",
+            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath",
         }
     );
 }

--- a/src/Application/GamePathResolver.cpp
+++ b/src/Application/GamePathResolver.cpp
@@ -1,81 +1,95 @@
-#include <vector>
-
-#include "Application/GamePathResolver.h"
+#include "GamePathResolver.h"
 
 #include "Library/Logger/Logger.h"
 #include "Library/Environment/Interface/Environment.h"
 
-static std::string _resolvePath(Environment *environment, const char *envVarOverride, const std::vector<const char *> &registryKeys);
+struct PathResolutionConfig {
+    const char *overrideEnvKey = nullptr;
+    std::initializer_list<const char *> registryKeys;
+};
 
-std::string resolveMm6Path(Environment *environment) {
-    return _resolvePath(
-        environment,
-        mm6PathOverrideKey,
-        {
-            "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207661253/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM6/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath", // \xC2\xAE is (R) in utf-8.
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/Games/1207661253/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM6/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath",
-        }
-    );
-}
+static constexpr PathResolutionConfig mm6Config = {
+    mm6PathOverrideKey,
+    {
+        "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207661253/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM6/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath", // \xC2\xAE is (R) in utf-8.
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/Games/1207661253/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM6/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic\xC2\xAE VI/1.0/AppPath",
+    }
+};
 
+static constexpr PathResolutionConfig mm7Config = {
+    mm7PathOverrideKey,
+    {
+        "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207658916/Path",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM7/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic VII/1.0/AppPath",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/Games/1207658916/Path",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM7/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic VII/1.0/AppPath",
+    }
+};
 
-std::string resolveMm7Path(Environment *environment) {
-    return _resolvePath(
-        environment,
-        mm7PathOverrideKey,
-        {
-            "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207658916/Path",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM7/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic VII/1.0/AppPath",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/Games/1207658916/Path",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM7/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic VII/1.0/AppPath",
-        }
-    );
-}
+static constexpr PathResolutionConfig mm8Config = {
+    mm8PathOverrideKey,
+    {
+        "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM8/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic Day of the Destroyer/1.0/AppPath",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM8/PATH",
+        "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic Day of the Destroyer/1.0/AppPath",
+    }
+};
 
-
-std::string resolveMm8Path(Environment *environment) {
-    return _resolvePath(
-        environment,
-        mm8PathOverrideKey,
-        {
-            "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM8/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/New World Computing/Might and Magic Day of the Destroyer/1.0/AppPath",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/GOG.com/GOGMM8/PATH",
-            "HKEY_LOCAL_MACHINE/SOFTWARE/WOW6432Node/New World Computing/Might and Magic Day of the Destroyer/1.0/AppPath",
-        }
-    );
-}
-
-static std::string _resolvePath(Environment *environment, const char *envVarOverride, const std::vector<const char *> &registryKeys) {
-#ifdef __ANDROID__
-    // TODO: find a better way to deal with paths and remove this android specific block.
-    std::string result = environment->path(PATH_ANDROID_STORAGE_EXTERNAL);
-    if (result.empty())
-        result = environment->path(PATH_ANDROID_STORAGE_INTERNAL);
-    // TODO(captainurist): need a mechanism to show user-visible errors. Commenting out for now.
-    //if (result.empty())
-    //    platform->showMessageBox("Device currently unsupported", "Your device doesn't have any storage so it is unsupported!");
-    return result;
-#else
-    std::string envPath = environment->getenv(envVarOverride);
+static std::vector<std::string> resolvePaths(Environment *environment, const PathResolutionConfig &config) {
+    std::string envPath = environment->getenv(config.overrideEnvKey);
     if (!envPath.empty()) {
-        logger->info("Path override provided: {}={}", envVarOverride, envPath);
-        return envPath;
+        logger->info("Path override provided, '{}={}'.", config.overrideEnvKey, envPath);
+        return {envPath}; // Have path override => this is the only one we'll try.
     }
 
-    for (auto key : registryKeys) {
-        envPath = environment->queryRegistry(key);
-        if (!envPath.empty()) {
-            return envPath;
-        }
+    std::vector<std::string> result;
+
+    // Windows-specific.
+    for (const char *registryKey : config.registryKeys) {
+        std::string registryPath = environment->queryRegistry(registryKey);
+        if (!registryPath.empty())
+            result.push_back(registryPath);
     }
 
-    return "";
+    // Android-specific.
+    std::string externalPath = environment->path(PATH_ANDROID_STORAGE_EXTERNAL);
+    if (!externalPath.empty())
+        result.push_back(externalPath);
+    std::string internalPath = environment->path(PATH_ANDROID_STORAGE_INTERNAL);
+    if (!internalPath.empty())
+        result.push_back(internalPath);
+    // TODO(captainurist): need a mechanism to show user-visible errors. Commenting out for now.
+    //if (ANDROID && result.empty())
+    //    platform->showMessageBox("Device currently unsupported", "Your device doesn't have any storage so it is unsupported!");
+
+    // Mac-specific.
+#ifdef __APPLE__
+    std::string home = environment->path(PATH_HOME);
+    if (!home.empty())
+        result.push_back(home + "/Library/Application Support/OpenEnroth");
 #endif
+
+    // PWD.
+    result.push_back(".");
+
+    return result;
+}
+
+std::vector<std::string> resolveMm6Paths(Environment *environment) {
+    return resolvePaths(environment, mm6Config);
+}
+
+std::vector<std::string> resolveMm7Paths(Environment *environment) {
+    return resolvePaths(environment, mm7Config);
+}
+
+std::vector<std::string> resolveMm8Paths(Environment *environment) {
+    return resolvePaths(environment, mm8Config);
 }

--- a/src/Application/GamePathResolver.h
+++ b/src/Application/GamePathResolver.h
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <string>
+#include <vector>
 
 class Environment;
 
@@ -6,6 +9,6 @@ constexpr char mm6PathOverrideKey[] = "OPENENROTH_MM6_PATH";
 constexpr char mm7PathOverrideKey[] = "OPENENROTH_MM7_PATH";
 constexpr char mm8PathOverrideKey[] = "OPENENROTH_MM8_PATH";
 
-std::string resolveMm6Path(Environment *environment);
-std::string resolveMm7Path(Environment *environment);
-std::string resolveMm8Path(Environment *environment);
+std::vector<std::string> resolveMm6Paths(Environment *environment);
+std::vector<std::string> resolveMm7Paths(Environment *environment);
+std::vector<std::string> resolveMm8Paths(Environment *environment);

--- a/src/Application/GameStarter.h
+++ b/src/Application/GameStarter.h
@@ -29,7 +29,7 @@ class GameStarter {
     void run();
 
  private:
-    static void resolveDefaults(Environment *environment, GameStarterOptions* options);
+    static void resolvePaths(Environment *environment, GameStarterOptions* options, Logger *logger);
 
  private:
     GameStarterOptions _options;

--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -5,6 +5,11 @@
 
 #include "EnvironmentEnums.h"
 
+/**
+ * Base class akin to `Platform` that provides an abstraction for the process's environment.
+ *
+ * All strings accepted by and returned from methods of this class are UTF8-encoded.
+ */
 class Environment {
  public:
     virtual ~Environment() = default;
@@ -17,8 +22,8 @@ class Environment {
     /**
      * Windows-only function for querying the registry. Always returns an empty string on non-Windows systems.
      *
-     * @param path                      Registry path to query.
-     * @return                          Value at the given path, or an empty string in case of an error.
+     * @param path                      UTF8-encoded registry path to query.
+     * @return                          UTF8-encoded value at the given path, or an empty string in case of an error.
      */
     virtual std::string queryRegistry(const std::string &path) const = 0;
 
@@ -26,11 +31,15 @@ class Environment {
      * Accessor for various system paths.
      *
      * @param path                      Path to get.
+     * @return                          UTF8-encoded path, or an empty string in case of an error.
      */
     virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
      * Same as `std::getenv`, but takes & returns UTF8-encoded keys and values on all platforms.
+     *
+     * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
+     * (aka `std::setlocale(LC_ALL, ".UTF-8")`).
      *
      * Returns an empty string for non-existent environment variables, and thus doesn't distinguish between empty and
      * non-existent values (and you shouldn't, either).

--- a/src/Utility/DataPath.cpp
+++ b/src/Utility/DataPath.cpp
@@ -53,8 +53,7 @@ std::string makeDataPath(std::initializer_list<std::string_view> paths) {
     return makeCaseInsensitivePath(result).string();
 }
 
-bool validateDataPath(const std::string &data_path, std::string& missing_file) {
-    bool isGood = true;
+bool validateDataPath(const std::string &data_path, std::string *missing_file) {
     for (auto v : globalValidateList) {
         std::filesystem::path path = data_path;
         for (auto p : v) {
@@ -63,11 +62,10 @@ bool validateDataPath(const std::string &data_path, std::string& missing_file) {
         }
 
         if (!std::filesystem::exists(makeCaseInsensitivePath(path))) {
-            isGood = false;
-            missing_file = std::filesystem::absolute(path).string();
-            break;
+            *missing_file = std::filesystem::absolute(path).string();
+            return false;
         }
     }
 
-    return isGood;
+    return true;
 }

--- a/src/Utility/DataPath.h
+++ b/src/Utility/DataPath.h
@@ -17,4 +17,4 @@ std::string makeDataPath(Ts&&... paths) {
     return makeDataPath({paths...});
 }
 
-bool validateDataPath(const std::string &data_path, std::string& missing_file);
+bool validateDataPath(const std::string &data_path, std::string *missing_file);


### PR DESCRIPTION
Fixes #1335.

Data path resolution now works as follows:
* If `OPENENROTH_MM7_PATH` is set, then this is the path that's used.
* Otherwise, we first check if game data is in `pwd`.
* If it's not, we then check, one by one:
  * Paths from Windows registry on Windows.
  * Android internal & external storage.
  * `Library/Application Support/OpenEnroth` on macOS.