### PR TITLE
Fix buying price calculation for a character with GM merchant skill.

### DIFF
--- a/src/Engine/PriceCalculator.cpp
+++ b/src/Engine/PriceCalculator.cpp
@@ -69,7 +69,7 @@ int PriceCalculator::itemIdentificationPriceForPlayer(const Character *player, f
     return std::max(1, actualCost);
 }
 
-int PriceCalculator::itemBuyingPriceForPlayer(const Character *player, unsigned int uRealValue, float priceMultiplier) {
+int PriceCalculator::itemBuyingPriceForPlayer(const Character *player, int uRealValue, float priceMultiplier) {
     int price = applyMerchantDiscount(player, uRealValue * priceMultiplier);
 
     if (price < uRealValue) {  // price should always be at least item value

--- a/src/Engine/PriceCalculator.h
+++ b/src/Engine/PriceCalculator.h
@@ -76,7 +76,7 @@ class PriceCalculator {
      *
      * Note: originally method of Character class.
      */
-    static int itemBuyingPriceForPlayer(const Character *player, unsigned int uRealValue, float priceMultiplier);
+    static int itemBuyingPriceForPlayer(const Character *player, int uRealValue, float priceMultiplier);
 
     /**
      * @offset 0x4B8102


### PR DESCRIPTION
This PR fixes this situation (look at the cost) when merchant skill is trained to GM level.
![20231114_16h13m51s_grim](https://github.com/OpenEnroth/OpenEnroth/assets/812069/e8768b44-af3f-4b1f-b095-8c8321131197)
