### PR TITLE
Fix turn based combat

### DIFF
--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -737,20 +737,16 @@ void stru262_TurnBased::AI_Action_(int queue_index) {
                     default:
                         assert(false && "Unreachable");
                 }
-                // if (!pQueue[queue_index].AI_action_type)
+
                 if ((double)v9 < 307.2) {
                     Actor::AI_MeleeAttack(actor_id, v22, &v18);
                     pQueue[queue_index].AI_action_type = TE_AI_MELEE_ATTACK;
-                    pQueue[queue_index].uActionLength =
-                        pActors[actor_id].currentActionLength;
-                    return;
-                } else {
+                } else if (pQueue[queue_index].AI_action_type == TE_AI_STAND) {
                     Actor::AI_Stand(actor_id, v22, 64, &v18);
-                    pQueue[queue_index].AI_action_type = TE_AI_STAND;
-                    pQueue[queue_index].uActionLength =
-                        pActors[actor_id].currentActionLength;
-                    return;
                 }
+
+                pQueue[queue_index].uActionLength = pActors[actor_id].currentActionLength;
+                return;
             } else {
                 Actor::AI_Stand(actor_id, v22, 64, &v18);
                 pQueue[queue_index].AI_action_type = TE_AI_STAND;


### PR DESCRIPTION
This patch fixes a bug when monsters with ranged attacks do not attack in turn-based combat. I attach a save file where a party stands in a room filled with daemons. To check the fix, go back to the elevator so no daemon stands near you. Go to turn-based combat mode. Press `b` (skip step) repeatedly. No daemon will attack you ever. After the patch is applied they will attack you as in original MM7
[save005.mm7.gz](https://github.com/OpenEnroth/OpenEnroth/files/13361383/save005.mm7.gz)
