### PR TITLE
Remove a redundant autosave overwrite

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1969,8 +1969,6 @@ void Game::gameLoop() {
         // = 0;
         current_screen_type = SCREEN_GAME;
 
-        SaveGame(1, 0);
-
         bool game_finished = false;
         do {
             MessageLoopWithWait();


### PR DESCRIPTION
When you save & load a game, the autosave becomes overwritten. Remove a redundant call to `SaveGame` to stop it. Why was it introduced in cb6abcc anyway?