### PR TITLE
Fixing problems with returning a local address

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,17 +57,30 @@ check_linker_flag(CXX "-fuse-ld=mold" COMPILER_RT_HAS_FUSE_LD_MOLD_FLAG)
 check_linker_flag(CXX "-fuse-ld=lld" COMPILER_RT_HAS_FUSE_LD_LLD_FLAG)
 check_linker_flag(CXX "-fuse-ld=gold" COMPILER_RT_HAS_FUSE_LD_GOLD_FLAG)
 
-# Set compiler options.
-# We do a lot of tweaks here.
-add_compile_definitions(FMT_USE_NONTYPE_TEMPLATE_ARGS) # Enable _cf literals
+# Set up warnings-as-errors for all compilers.
+if (BUILD_COMPILER STREQUAL "gcc" OR BUILD_COMPILER STREQUAL "clang")
+    add_compile_options(-Werror=return-type) # Control reaches the end of non-void function. This is an error on MSVC.
+    add_compile_options(-Werror=unused-result) # Ignoring return value of function declared with 'nodiscard' attribute.
+    add_compile_options(-Werror=unused-value) # Expression result unused.
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=suggest-override>) # 'func' overrides a member function but is not marked 'override'.
+endif ()
+if(BUILD_COMPILER STREQUAL "gcc")
+    add_compile_options(-Werror=return-local-addr) # Returning reference to temporary.
+elseif(BUILD_COMPILER STREQUAL "clang")
+    add_compile_options(-Werror=return-stack-address) # Returning reference to temporary.
+    add_compile_options(-Werror=unused-comparison) # Comparison result unused.
+    add_compile_options(-Werror=inconsistent-missing-override) # 'override' only used on some of the overridden functions.
+    add_compile_options(-Werror=invalid-noreturn) # function declared 'noreturn' should not return.
+    add_compile_options(-Werror=uninitialized) # variable 'x' is used uninitialized.
+elseif(BUILD_COMPILER STREQUAL "msvc")
+    add_compile_options(/we4834) # Discarding return value of function with 'nodiscard' attribute.
+    add_compile_options(/we4172) # Returning address of local variable or temporary.
+    add_compile_options(/we26433) # Function should be marked with 'override'.
+endif()
 
+# Set compiler options. We do a lot of tweaks here.
 if(BUILD_COMPILER STREQUAL "gcc" OR BUILD_COMPILER STREQUAL "clang")
-    add_compile_options(-Werror=return-type) # Control reaches the end of non-void function, this is an error on MSVC
-    add_compile_options(-Werror=unused-result) # Ignoring return value of function declared with 'nodiscard' attribute
-    add_compile_options(-Werror=unused-value) # Expression result unused
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=suggest-override>) # 'func' overrides a member function but is not marked 'override'
-
-    # -Og is a better choice than -O0 for producing debuggable code because some compiler passes that collect debug information are disabled at -O0. 
+    # -Og is a better choice than -O0 for producing debuggable code because some compiler passes that collect debug information are disabled at -O0.
     string(REPLACE " -O0 " "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
     string(REPLACE " -O0 " "" CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     string(REPLACE " -g " " -g -Og " CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
@@ -107,18 +120,9 @@ if(BUILD_COMPILER STREQUAL "gcc" OR BUILD_COMPILER STREQUAL "clang")
     # Clang & gcc implementations of fp-contract differ, and we are getting diffs in tests. Better to disable it.
     add_compile_options(-ffp-contract=off)
 endif()
-
 if(BUILD_COMPILER STREQUAL "gcc")
-    # Flags that are available only in gcc but not in clang go here.
-    add_compile_options(-Werror=return-local-addr) # Returning reference to temporary
     add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>) # Enable assertions in libstdc++.
 elseif(BUILD_COMPILER STREQUAL "clang")
-    # Flags that are available only in clang but not in gcc go here.
-    add_compile_options(-Werror=return-stack-address) # Returning reference to temporary
-    add_compile_options(-Werror=unused-comparison) # Comparison result unused.
-    add_compile_options(-Werror=inconsistent-missing-override) # 'override' only used on some of the overridden functions.
-    add_compile_options(-Werror=invalid-noreturn) # function declared 'noreturn' should not return.
-    add_compile_options(-Werror=uninitialized) # variable 'x' is used uninitialized.
     add_compile_definitions($<$<CONFIG:Debug>:_LIBCPP_ENABLE_ASSERTIONS=1>) # Enable assertions in libcxx.
 elseif(BUILD_COMPILER STREQUAL "msvc")
     # /Zi -> /Z7: Pack debug info into .obj files, this is needed for ccache to work. Note that pdb for the binary
@@ -127,22 +131,23 @@ elseif(BUILD_COMPILER STREQUAL "msvc")
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-    add_compile_definitions(NOMINMAX) # please don't pull in these macros from <Windows.h>
+    add_compile_definitions(NOMINMAX) # Please don't pull in these macros from <Windows.h>
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS) # STL security warnings are just noise
     add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE) # POSIX deprecation warnings are also just noise
     add_compile_definitions(_USE_MATH_DEFINES) # Pull in M_PI and other <cmath> defines
     add_compile_definitions(FMT_CONSTEVAL=) # MSVC chokes on fmt consteval formatting, so we define FMT_CONSTEVAL=<empty>
     add_compile_options(/MP) # Multi-threaded build
     add_compile_options(/Zc:preprocessor) # Use standard compliant preprocessor
-    add_compile_options(/we4834) # Discarding return value of function with 'nodiscard' attribute
     add_link_options(/OPT:REF) # Eliminate unreferenced data & functions.
     add_link_options(/OPT:ICF) # Enable COMDAT folding, should decrease binary sizes?
     if (BUILD_ARCHITECTURE STREQUAL "x86")
         add_link_options(/LARGEADDRESSAWARE) # Enable heap size over 2gb for x86 builds
         add_link_options(/SAFESEH:NO) # /SAFESEH is x86-only, don't produce safe exception handler tables
     endif()
+
     # Allow the compiler to package individual functions in the form of packaged functions (COMDATs)
     add_compile_options("$<$<CONFIG:RELEASE>:/Gy>")
+
     # Retains almost all relevant debug information for debugging, but makes a very big difference in performance and is debug safe
     # /Ob controls inline expansions and /Ob2 expands any function not explicitly marked for no inlining.
     string(REPLACE "/Ob0" "/Ob2" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,9 +110,11 @@ endif()
 
 if(BUILD_COMPILER STREQUAL "gcc")
     # Flags that are available only in gcc but not in clang go here.
+    add_compile_options(-Werror=return-local-addr) # Returning reference to temporary
     add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>) # Enable assertions in libstdc++.
 elseif(BUILD_COMPILER STREQUAL "clang")
     # Flags that are available only in clang but not in gcc go here.
+    add_compile_options(-Werror=return-stack-address) # Returning reference to temporary
     add_compile_options(-Werror=unused-comparison) # Comparison result unused.
     add_compile_options(-Werror=inconsistent-missing-override) # 'override' only used on some of the overridden functions.
     add_compile_options(-Werror=invalid-noreturn) # function declared 'noreturn' should not return.

--- a/test/Testing/Game/AccessibleVector.h
+++ b/test/Testing/Game/AccessibleVector.h
@@ -46,7 +46,9 @@ class Accessible : public Base {
     using Base::Base;
     using Base::begin;
     using Base::end;
-    using value_type = std::iter_value_t<decltype(std::declval<const Base *>()->begin())>;
+    using const_iterator = decltype(std::declval<const Base *>()->begin());
+    using value_type = std::iter_value_t<const_iterator>;
+    using const_reference = std::iter_reference_t<const_iterator>; // Need this typedef b/c of std::vector<bool>.
 
     friend AccessibleVector<value_type> calculateDelta(const Accessible &l, const Accessible &r) {
         AccessibleVector<value_type> result;
@@ -62,12 +64,12 @@ class Accessible : public Base {
         return end() - begin();
     }
 
-    const value_type &front() const {
+    const_reference front() const {
         assert(begin() != end());
         return *begin();
     }
 
-    const value_type &back() const {
+    const_reference back() const {
         assert(begin() != end());
         return *std::prev(end());
     }
@@ -96,12 +98,12 @@ class Accessible : public Base {
         return result;
     }
 
-    value_type min() const {
+    const_reference min() const {
         assert(begin() != end());
         return *std::min_element(begin(), end());
     }
 
-    value_type max() const {
+    const_reference max() const {
         assert(begin() != end());
         return *std::max_element(begin(), end());
     }

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -7,13 +7,19 @@ set(BUILD_TESTING OFF CACHE BOOL "Don't build tests for subprojects. Value is fo
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 add_subdirectory(fast_float)
-add_subdirectory(fmt)
 add_subdirectory(glm)
 add_subdirectory(magic_enum)
 add_subdirectory(nuklear)
 add_subdirectory(cli11)
 add_subdirectory(nlohmann_json)
 add_subdirectory(mio)
+
+# fmt
+add_subdirectory(fmt)
+target_compile_definitions(fmt INTERFACE FMT_USE_NONTYPE_TEMPLATE_ARGS) # Enable _cf literals.
+if (BUILD_COMPILER STREQUAL "msvc")
+    target_compile_definitions(fmt INTERFACE FMT_CONSTEVAL=) # MSVC chokes on fmt consteval formatting, so we define FMT_CONSTEVAL=<empty>.
+endif ()
 
 # glad
 add_subdirectory(glad)


### PR DESCRIPTION
* `-Werror` when returning a temporary.
* Fixed the problem with returning a reference to temporary in `class Accessible`.
* Reorganized `CMakeLists.txt` a bit.