### PR TITLE
Check sound needs decompressing

### DIFF
--- a/src/Library/Snd/SndReader.cpp
+++ b/src/Library/Snd/SndReader.cpp
@@ -69,7 +69,7 @@ Blob SndReader::read(const std::string &filename) const {
     const SndEntry &entry = pos->second;
 
     Blob result = _snd.subBlob(entry.offset, entry.size);
-    if (entry.decompressedSize)
+    if (entry.decompressedSize && entry.decompressedSize != entry.size)
         result = zlib::uncompress(result, entry.decompressedSize);
     return result;
 }


### PR DESCRIPTION
Minor fix from  f6effbf3d529870666454a61b807ccedcb0a9475 - needs to check if data need decompressing before calling into zlib.
StartMainChoice02 soundID as example.