### PR TITLE
Recharge non-decreasing #573

### DIFF
--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -72,6 +72,8 @@ bool Localization::Initialize() {
         this->localization_strings[LSTR_KEY_CONFLICT] = "Please resolve all key conflicts!";
     if (!this->localization_strings[LSTR_RECOVERY_TIME_NA])
         this->localization_strings[LSTR_RECOVERY_TIME_NA] = "Recovery time: N/A";
+    if (!this->localization_strings[LSTR_WAND_ALREADY_CHARGED])
+        this->localization_strings[LSTR_WAND_ALREADY_CHARGED] = "Wand already charged!";
 
     InitializeMm6ItemCategories();
 

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -434,8 +434,9 @@
 #define LSTR_NOBODY_IS_IN_CONDITION         680  // "Nobody is in a condition to do anything!"
 #define LSTR_KEY_CONFLICT                   681  // "Please resolve all key conflicts!"
 #define LSTR_RECOVERY_TIME_NA               682  // "Recovery time: N/A"
+#define LSTR_WAND_ALREADY_CHARGED           683  // "Wand already charged!"
 
-#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 6
+#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 7
 
 class Localization {
  public:

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1364,13 +1364,21 @@ void CastSpellInfoHelpers::castSpell() {
                     }
 
                     int uNewCharges = item->uMaxCharges * spell_recharge_factor;
-                    item->uMaxCharges = uNewCharges;
-                    item->uNumCharges = uNewCharges;
-                    if (uNewCharges <= 0) {
+
+                    // Disallow if wand will lose charges
+                    bool chargeFailed = false;
+                    if (uNewCharges < item->uNumCharges) {
+                        chargeFailed = true;
+                    } else {
+                        item->uMaxCharges = uNewCharges;
+                        item->uNumCharges = uNewCharges;
+                    }
+
+                    if (uNewCharges <= 0 || chargeFailed) {
                         AfterEnchClickEventId = UIMSG_Escape;
                         AfterEnchClickEventSecondParam = 0;
                         AfterEnchClickEventTimeout = Duration::fromRealtimeSeconds(1); // was 1 tick, increased to make message readable
-                        spellFailed(pCastSpell, LSTR_SPELL_FAILED);
+                        spellFailed(pCastSpell, chargeFailed ? LSTR_WAND_ALREADY_CHARGED : LSTR_SPELL_FAILED);
                         pPlayer->SpendMana(uRequiredMana); // decrease mana on failure
                         setSpellRecovery(pCastSpell, recoveryTime);
                         continue;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -2314,12 +2314,20 @@ void Inventory_ItemPopupAndAlchemy() {
             }
 
             float invMaxChargesDecrease = (100 - maxChargesDecreasePercent) * 0.01;
-            item->uMaxCharges = item->uNumCharges = item->uMaxCharges * invMaxChargesDecrease;
+            int newCharges = item->uMaxCharges * invMaxChargesDecrease;
 
-            // Effect and sound was not present previously
-            item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
-            ItemEnchantmentTimer = Duration::fromRealtimeSeconds(2);
-            pAudioPlayer->playSpellSound(SPELL_WATER_RECHARGE_ITEM, false, SOUND_MODE_UI);
+            // Disallow if wand will lose charges
+            if (newCharges < item->uNumCharges) {
+                engine->_statusBar->setEvent(LSTR_WAND_ALREADY_CHARGED);
+                pAudioPlayer->playUISound(SOUND_spellfail0201);
+            } else {
+                item->uMaxCharges = item->uNumCharges = newCharges;
+                // Effect and sound was not present previously
+                item->uAttributes |= ITEM_AURA_EFFECT_GREEN;
+                ItemEnchantmentTimer = Duration::fromRealtimeSeconds(2);
+                pAudioPlayer->playSpellSound(SPELL_WATER_RECHARGE_ITEM, false, SOUND_MODE_UI);
+            }
+
             mouse->RemoveHoldingItem();
             rightClickItemActionPerformed = true;
             return;


### PR DESCRIPTION
Fixes #573 

Wands will no longer lose available charges when being recharged - will cause error sound and message instead. Potion will still be used up/ mana will still be spent. 
