### PR TITLE
Duration work & some fixes

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1031,7 +1031,7 @@ void Game::processQueuedMessages() {
                 uGameState = GAME_STATE_PLAYING;
 
                 for (Character &character : pParty->pCharacters) {
-                    character.playEmotion(CHARACTER_EXPRESSION_WIDE_SMILE, Duration::zero());
+                    character.playEmotion(CHARACTER_EXPRESSION_WIDE_SMILE, 0_ticks);
                 }
 
                 // strcpy((char *)userInputHandler->pPressedKeysBuffer, "2");

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2035,7 +2035,7 @@ void Game::gameLoop() {
 
                 Actor::InitializeActors();
 
-                int playerId = pParty->getRandomActiveCharacterId(vrng.get());
+                int playerId = pParty->getRandomActiveCharacterId(vrng);
 
                 if (playerId != -1) {
                     pParty->pCharacters[playerId].playReaction(SPEECH_CHEATED_DEATH);

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -618,12 +618,12 @@ void Game::processQueuedMessages() {
                                         }
                                         AfterEnchClickEventId = UIMSG_0;
                                         AfterEnchClickEventSecondParam = 0;
-                                        AfterEnchClickEventTimeout = Duration::zero();
+                                        AfterEnchClickEventTimeout = 0_ticks;
                                     }
                                     if (ptr_50C9A4_ItemToEnchant &&
                                         ptr_50C9A4_ItemToEnchant->uItemID != ITEM_NULL) {
                                         ptr_50C9A4_ItemToEnchant->uAttributes &= ~ITEM_ENCHANT_ANIMATION_MASK;
-                                        ItemEnchantmentTimer = Duration::zero();
+                                        ItemEnchantmentTimer = 0_ticks;
                                         ptr_50C9A4_ItemToEnchant = nullptr;
                                     }
                                     onEscape();
@@ -1836,7 +1836,7 @@ void Game::processQueuedMessages() {
     engine->_messageQueue->swapFrames();
 
     if (AfterEnchClickEventId != UIMSG_0) {
-        AfterEnchClickEventTimeout = std::max(Duration::zero(), AfterEnchClickEventTimeout - pEventTimer->uTimeElapsed);
+        AfterEnchClickEventTimeout = std::max(0_ticks, AfterEnchClickEventTimeout - pEventTimer->uTimeElapsed);
         if (!AfterEnchClickEventTimeout) {
             engine->_messageQueue->addMessageCurrentFrame(AfterEnchClickEventId, AfterEnchClickEventSecondParam, 0);
             AfterEnchClickEventId = UIMSG_0;

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -284,7 +284,7 @@ void Game_StartDialogue(unsigned int actor_id) {
     }
 }
 
-void Game_StartHirelingDialogue(unsigned int hireling_id) {
+void Game_StartHirelingDialogue(int hireling_id) {
     assert(hireling_id == 0 || hireling_id == 1);
 
     if (bNoNPCHiring || current_screen_type != SCREEN_GAME) return;
@@ -294,7 +294,11 @@ void Game_StartHirelingDialogue(unsigned int hireling_id) {
     FlatHirelings buf;
     buf.Prepare();
 
-    if ((signed int)hireling_id + (signed int)pParty->hirelingScrollPosition < buf.Size()) {
+    int index = hireling_id + pParty->hirelingScrollPosition;
+    if (index < buf.Size()) {
+        if (!buf.IsFollower(index) && buf.Get(index)->dialogue_1_evt_id == 1)
+            return; // Hireling is being dark sacrificed.
+
         Actor actor;
         actor.npcId += -1 - pParty->hirelingScrollPosition - hireling_id;
         initializeNPCDialogue(&actor, true);

--- a/src/Engine/Components/Trace/EngineTraceRecorder.cpp
+++ b/src/Engine/Components/Trace/EngineTraceRecorder.cpp
@@ -35,6 +35,9 @@ void EngineTraceRecorder::startRecording(EngineController *game, const std::stri
     _trace = std::make_unique<EventTrace>();
     _configSnapshot = std::make_unique<ConfigPatch>(ConfigPatch::fromConfig(engine->config.get()));
 
+    game->resizeWindow(640, 480);
+    game->tick();
+
     int frameTimeMs = engine->config->debug.TraceFrameTimeMs.value();
     RandomEngineType rngType = engine->config->debug.TraceRandomEngine.value();
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1489,7 +1489,7 @@ void RegeneratePartyHealthMana() {
                 spellSprite.field_60_distance_related_prolly_lod = 0;
                 spellSprite.uAttributes = 0;
                 spellSprite.uSectorID = 0;
-                spellSprite.uSpriteFrameID = 0_ticks;
+                spellSprite.timeSinceCreated = 0_ticks;
                 spellSprite.spell_caster_pid = Pid(OBJECT_Character, pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].caster);
                 spellSprite.uFacing = 0;
                 spellSprite.uSoundID = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -801,7 +801,7 @@ void Engine::SecondaryInitialization() {
         // pUIAnims[i]->uIconID = pIconsFrameTable->FindIcon(pUIAnimNames[i]);
         pUIAnims[i]->icon = pIconsFrameTable->GetIcon(pUIAnimNames[i]);
 
-        pUIAnims[i]->uAnimLength = Duration::zero();
+        pUIAnims[i]->uAnimLength = 0_ticks;
         pUIAnims[i]->uAnimTime = 0;
         pUIAnims[i]->x = _4E98D0[i][0];
         pUIAnims[i]->y = _4E98D0[i][2];
@@ -956,7 +956,7 @@ void Engine::ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows() {
     pAudioPlayer->stopSounds();
     uCurrentlyLoadedLevelType = LEVEL_NULL;
     pSpriteFrameTable->ResetLoadedFlags();
-    pParty->armageddon_timer = Duration::zero();
+    pParty->armageddon_timer = 0_ticks;
 
     windowManager.DeleteAllVisibleWindows();
 }
@@ -1283,7 +1283,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
     // TODO(captainurist): #time drop once we move to msecs in duration.
     Duration recoveryTimeDt = pEventTimer->uTimeElapsed;
     recoveryTimeDt += pParty->_roundingDt;
-    pParty->_roundingDt = Duration::zero();
+    pParty->_roundingDt = 0_ticks;
     if (pParty->uFlags2 & PARTY_FLAGS_2_RUNNING && recoveryTimeDt > Duration::zero()) {  // half recovery speed if party is running
         pParty->_roundingDt = recoveryTimeDt % 2_ticks;
         recoveryTimeDt /= 2;
@@ -1489,7 +1489,7 @@ void RegeneratePartyHealthMana() {
                 spellSprite.field_60_distance_related_prolly_lod = 0;
                 spellSprite.uAttributes = 0;
                 spellSprite.uSectorID = 0;
-                spellSprite.uSpriteFrameID = Duration::zero();
+                spellSprite.uSpriteFrameID = 0_ticks;
                 spellSprite.spell_caster_pid = Pid(OBJECT_Character, pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].caster);
                 spellSprite.uFacing = 0;
                 spellSprite.uSoundID = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1252,7 +1252,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
             if (character.WearsItem(ITEM_RELIC_HARECKS_LEATHER, ITEM_SLOT_ARMOUR) ||
                 character.HasEnchantedItemEquipped(ITEM_ENCHANTMENT_OF_WATER_WALKING) ||
                 character.pCharacterBuffs[CHARACTER_BUFF_WATER_WALK].Active()) {
-                character.playEmotion(CHARACTER_EXPRESSION_SMILE, Duration::zero());
+                character.playEmotion(CHARACTER_EXPRESSION_SMILE, 0_ticks);
             } else {
                 if (!character.hasUnderwaterSuitEquipped()) {
                     character.receiveDamage((int64_t)character.GetMaxHealth() * 0.1, DAMAGE_FIRE);
@@ -1260,7 +1260,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
                         engine->_statusBar->setEventShort(LSTR_YOURE_DROWNING);
                     }
                 } else {
-                    character.playEmotion(CHARACTER_EXPRESSION_SMILE, Duration::zero());
+                    character.playEmotion(CHARACTER_EXPRESSION_SMILE, 0_ticks);
                 }
             }
         }
@@ -1284,14 +1284,14 @@ void _494035_timed_effects__water_walking_damage__etc() {
     Duration recoveryTimeDt = pEventTimer->uTimeElapsed;
     recoveryTimeDt += pParty->_roundingDt;
     pParty->_roundingDt = 0_ticks;
-    if (pParty->uFlags2 & PARTY_FLAGS_2_RUNNING && recoveryTimeDt > Duration::zero()) {  // half recovery speed if party is running
+    if (pParty->uFlags2 & PARTY_FLAGS_2_RUNNING && recoveryTimeDt > 0_ticks) {  // half recovery speed if party is running
         pParty->_roundingDt = recoveryTimeDt % 2_ticks;
         recoveryTimeDt /= 2;
     }
 
     unsigned numPlayersCouldAct = pParty->pCharacters.size();
     for (Character &character : pParty->pCharacters) {
-        if (character.timeToRecovery && recoveryTimeDt > Duration::zero())
+        if (character.timeToRecovery && recoveryTimeDt > 0_ticks)
             character.Recover(recoveryTimeDt);
 
         if (character.GetItemsBonus(CHARACTER_ATTRIBUTE_ENDURANCE) +

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -876,16 +876,6 @@ void MM6_Initialize() {
     pODMRenderParams->shading_dist_shade = 2048;
     pODMRenderParams->shading_dist_shademist = 4096;
 
-    // pODMRenderParams->shading_dist_mist = 0x2000;//drawing dist 0x2000
-
-    debug_non_combat_recovery_mul = 1.0f;
-    debug_combat_recovery_mul = 1.0f;
-
-    // this makes very little sense, but apparently this is how it was done in the original binary.
-    debug_turn_based_monster_movespeed_mul = debug_non_combat_recovery_mul * 1.666666666666667f;
-
-    flt_debugrecmod3 = 2.133333333333333f;
-
     MM7Initialization();
 }
 

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -234,7 +234,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             }
             break;
         case EVENT_ShowFace:
-            doForChosenPlayer(ir.who, vrng, [&] (Character &player) { player.playEmotion(ir.data.expr_id, Duration::zero()); return false; });
+            doForChosenPlayer(ir.who, vrng, [&] (Character &player) { player.playEmotion(ir.data.expr_id, 0_ticks); return false; });
             break;
         case EVENT_ReceiveDamage:
             doForChosenPlayer(ir.who, grng, [&] (Character &player) { player.receiveDamage(ir.data.damage_descr.damage, ir.data.damage_descr.damage_type); return false; });

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -234,10 +234,10 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             }
             break;
         case EVENT_ShowFace:
-            doForChosenPlayer(ir.who, vrng.get(), [&] (Character &player) { player.playEmotion(ir.data.expr_id, Duration::zero()); return false; });
+            doForChosenPlayer(ir.who, vrng, [&] (Character &player) { player.playEmotion(ir.data.expr_id, Duration::zero()); return false; });
             break;
         case EVENT_ReceiveDamage:
-            doForChosenPlayer(ir.who, grng.get(), [&] (Character &player) { player.receiveDamage(ir.data.damage_descr.damage, ir.data.damage_descr.damage_type); return false; });
+            doForChosenPlayer(ir.who, grng, [&] (Character &player) { player.receiveDamage(ir.data.damage_descr.damage, ir.data.damage_descr.damage_type); return false; });
             break;
         case EVENT_SetSnow:
             if (!ir.data.snow_descr.is_nop) {
@@ -288,7 +288,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             break;
         case EVENT_Compare:
         {
-            bool res = doForChosenPlayer(_who, grng.get(), [&] (Character &player) { return player.CompareVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); });
+            bool res = doForChosenPlayer(_who, grng, [&] (Character &player) { return player.CompareVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); });
             if (res) {
                 return ir.target_step;
             }
@@ -298,7 +298,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             switchDoorAnimation(ir.data.door_descr.door_id, ir.data.door_descr.door_action);
             break;
         case EVENT_Add:
-            doForChosenPlayer(_who, grng.get(), [&] (Character &player) { player.AddVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
+            doForChosenPlayer(_who, grng, [&] (Character &player) { player.AddVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
             break;
         case EVENT_Substract:
             if (ir.data.variable_descr.type == VAR_PlayerItemInHands && _who == CHOOSE_PARTY) {
@@ -309,11 +309,11 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
                     }
                 }
             } else {
-                doForChosenPlayer(_who, grng.get(), [&] (Character &player) { player.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
+                doForChosenPlayer(_who, grng, [&] (Character &player) { player.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
             }
             break;
         case EVENT_Set:
-            doForChosenPlayer(_who, grng.get(), [&] (Character &player) { player.SetVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
+            doForChosenPlayer(_who, grng, [&] (Character &player) { player.SetVariable(ir.data.variable_descr.type, ir.data.variable_descr.value); return false; });
             break;
         case EVENT_SummonMonsters:
             spawnMonsters(ir.data.monster_descr.type, ir.data.monster_descr.level, ir.data.monster_descr.count,
@@ -462,10 +462,10 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
         case EVENT_CheckSkill:
         {
             assert(_who != CHOOSE_PARTY); // TODO(Nik-RE-dev): original code for this option is dubious
-            bool res = doForChosenPlayer(_who, grng.get(), [&] (Character &player) {
-                                         CombinedSkillValue val = player.getSkillValue(ir.data.check_skill_descr.skill_type);
-                                         return val.level() >= ir.data.check_skill_descr.skill_level && val.mastery() == ir.data.check_skill_descr.skill_mastery;
-                                         });
+            bool res = doForChosenPlayer(_who, grng, [&] (Character &player) {
+                CombinedSkillValue val = player.getSkillValue(ir.data.check_skill_descr.skill_type);
+                return val.level() >= ir.data.check_skill_descr.skill_level && val.mastery() == ir.data.check_skill_descr.skill_mastery;
+            });
             if (res) {
                 return ir.target_step;
             }
@@ -536,7 +536,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             Chest::toggleFlag(ir.data.chest_flag_descr.chest_id, ir.data.chest_flag_descr.flag, ir.data.chest_flag_descr.is_set);
             break;
         case EVENT_CharacterAnimation:
-            doForChosenPlayer(ir.who, vrng.get(), [&] (Character &player) { player.playReaction(ir.data.speech_id); return false; });
+            doForChosenPlayer(ir.who, vrng, [&] (Character &player) { player.playReaction(ir.data.speech_id); return false; });
             break;
         case EVENT_SetActorItem:
             Actor::giveItem(ir.data.npc_item_descr.id, ir.data.npc_item_descr.item, ir.data.npc_item_descr.is_give);

--- a/src/Engine/Events/Processor.cpp
+++ b/src/Engine/Events/Processor.cpp
@@ -134,7 +134,7 @@ static void registerTimerTriggers(EventType triggerType, std::vector<MapTimer> *
                 }
             }
 
-            assert(timer.interval > Duration::zero());
+            assert(timer.interval > 0_ticks);
         }
         timer.eventId = trigger.eventId;
         timer.eventStep = trigger.eventStep;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1188,7 +1188,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
         particle.g = 0.0;
         particle.b = 0.0;
         particle.particle_size = 1.0;
-        particle.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128); // was rand() & 0x80
+        particle.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2); // was either 1 or 2 secs, we made it into [1, 2).
         particle.texture = spell_fx_renderer->effpar01;
         particle_engine->AddParticle(&particle);
         return;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1058,7 +1058,7 @@ void PrepareToLoadBLV(bool bLoading) {
 
     // Active character speaks.
     if (!bLoading && indoor_was_respawned) {
-        int id = pParty->getRandomActiveCharacterId(vrng.get());
+        int id = pParty->getRandomActiveCharacterId(vrng);
 
         if (id != -1) {
             pParty->setDelayedReaction(SPEECH_ENTER_DUNGEON, id);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1831,7 +1831,7 @@ void switchDoorAnimation(unsigned int uDoorID, DoorAction a2) {
         if (door.uState == DOOR_CLOSING || door.uState == DOOR_OPENING)
             return;
 
-        door.uTimeSinceTriggered = Duration::zero();
+        door.uTimeSinceTriggered = 0_ticks;
 
         if (door.uState == DOOR_OPEN) {
             door.uState = DOOR_CLOSING;
@@ -1844,7 +1844,7 @@ void switchDoorAnimation(unsigned int uDoorID, DoorAction a2) {
             return;
 
         if (door.uState == DOOR_OPEN) {
-            door.uTimeSinceTriggered = Duration::zero();
+            door.uTimeSinceTriggered = 0_ticks;
         } else if (door.uTimeSinceTriggered != 15360_ticks) {
             assert(door.uState == DOOR_OPENING);
             int totalTimeMs = 1000 * door.uMoveLength / door.uCloseSpeed;
@@ -1857,7 +1857,7 @@ void switchDoorAnimation(unsigned int uDoorID, DoorAction a2) {
             return;
 
         if (door.uState == DOOR_CLOSED) {
-            door.uTimeSinceTriggered = Duration::zero();
+            door.uTimeSinceTriggered = 0_ticks;
         } else if (door.uTimeSinceTriggered != 15360_ticks) {
             assert(door.uState == DOOR_CLOSING);
             int totalTimeMs = 1000 * door.uMoveLength / door.uOpenSpeed;
@@ -1983,7 +1983,7 @@ int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3i p
     a1.uFacing = facing;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = Duration::zero();
+    a1.uSpriteFrameID = 0_ticks;
     return a1.Create(0, 0, 0, 0);
 }
 
@@ -2028,7 +2028,7 @@ void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2) {
     a1a.uSpellID = SPELL_NONE;
     a1a.spell_target_pid = Pid();
     a1a.spell_caster_pid = Pid();
-    a1a.uSpriteFrameID = Duration::zero();
+    a1a.uSpriteFrameID = 0_ticks;
     a1a.uSectorID = pIndoor->GetSector(a2->vPosition);
     a1a.Create(0, 0, 0, 0);
 }

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1706,7 +1706,7 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
             for (Character &character : pParty->pCharacters) {
                 if (!character.HasEnchantedItemEquipped(ITEM_ENCHANTMENT_OF_FEATHER_FALLING) &&
                     !character.WearsItem(ITEM_ARTIFACT_HERMES_SANDALS, ITEM_SLOT_BOOTS)) {  // was 8
-                    character.playEmotion(CHARACTER_EXPRESSION_SCARED, Duration::zero());
+                    character.playEmotion(CHARACTER_EXPRESSION_SCARED, 0_ticks);
                 }
             }
         }

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1983,7 +1983,7 @@ int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3i p
     a1.uFacing = facing;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = 0_ticks;
+    a1.timeSinceCreated = 0_ticks;
     return a1.Create(0, 0, 0, 0);
 }
 
@@ -2028,7 +2028,7 @@ void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2) {
     a1a.uSpellID = SPELL_NONE;
     a1a.spell_target_pid = Pid();
     a1a.spell_caster_pid = Pid();
-    a1a.uSpriteFrameID = 0_ticks;
+    a1a.timeSinceCreated = 0_ticks;
     a1a.uSectorID = pIndoor->GetSector(a2->vPosition);
     a1a.Create(0, 0, 0, 0);
 }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1204,8 +1204,8 @@ bool OutdoorLocation::InitalizeActors(MapId a1) {
     for (int i = 0; i < pActors.size(); ++i) {
         if (!(pActors[i].attributes & ACTOR_UNKNOW7)) {
             if (!alert_status) {
-                pActors[i].currentActionTime = Duration::zero();
-                pActors[i].currentActionLength = Duration::zero();
+                pActors[i].currentActionTime = 0_ticks;
+                pActors[i].currentActionLength = 0_ticks;
                 if (pActors[i].attributes & ACTOR_UNKNOW11)
                     pActors[i].aiState = AIState::Disabled;
                 if (pActors[i].aiState != AIState::Removed &&
@@ -1228,8 +1228,8 @@ bool OutdoorLocation::InitalizeActors(MapId a1) {
             pActors[i].aiState = AIState::Disabled;
             pActors[i].attributes |= ACTOR_UNKNOW11;
         } else if (alert_status) {
-            pActors[i].currentActionTime = Duration::zero();
-            pActors[i].currentActionLength = Duration::zero();
+            pActors[i].currentActionTime = 0_ticks;
+            pActors[i].currentActionLength = 0_ticks;
             if (pActors[i].attributes & ACTOR_UNKNOW11)
                 pActors[i].aiState = AIState::Disabled;
             if (pActors[i].aiState != AIState::Removed &&
@@ -1328,7 +1328,7 @@ void OutdoorLocation::PrepareActorsDrawList() {
 
         if (pActors[i].buffs[ACTOR_BUFF_STONED].Active() ||
             pActors[i].buffs[ACTOR_BUFF_PARALYZED].Active())
-            Cur_Action_Time = Duration::zero();
+            Cur_Action_Time = 0_ticks;
 
         int v49 = 0;
         float v4 = 0.0f;
@@ -2429,7 +2429,7 @@ void UpdateActors_ODM() {
                 // approaching water - turn away
                 if (pActors[Actor_ITR].CanAct()) {
                     pActors[Actor_ITR].yawAngle -= 32;
-                    pActors[Actor_ITR].currentActionTime = Duration::zero();
+                    pActors[Actor_ITR].currentActionTime = 0_ticks;
                     pActors[Actor_ITR].currentActionLength = 128_ticks;
                     pActors[Actor_ITR].aiState = Fleeing;
                 }
@@ -2449,7 +2449,7 @@ void UpdateActors_ODM() {
                             if (pActors[Actor_ITR].CanAct()) {  // head to land
                                 pActors[Actor_ITR].yawAngle = TrigLUT.atan2(target_x - pActors[Actor_ITR].pos.x,
                                                                              target_y - pActors[Actor_ITR].pos.y);
-                                pActors[Actor_ITR].currentActionTime = Duration::zero();
+                                pActors[Actor_ITR].currentActionTime = 0_ticks;
                                 pActors[Actor_ITR].currentActionLength = 128_ticks;
                                 pActors[Actor_ITR].aiState = Fleeing;
                                 break;

--- a/src/Engine/Graphics/Overlays.cpp
+++ b/src/Engine/Graphics/Overlays.cpp
@@ -22,7 +22,7 @@ void ActiveOverlayList::Reset() {
 }
 
 //----- (004418B6) --------------------------------------------------------
-int ActiveOverlayList::_4418B6(int uOverlayID, Pid pid, int animLength, int fpDamageMod, int16_t projSize) {
+int ActiveOverlayList::_4418B6(int uOverlayID, Pid pid, Duration animLength, int fpDamageMod, int16_t projSize) {
     Duration v11;    // dx@11
 
     for (unsigned int i = 0; i < 50; ++i) {
@@ -37,7 +37,7 @@ int ActiveOverlayList::_4418B6(int uOverlayID, Pid pid, int animLength, int fpDa
             this->pOverlays[i].indexToOverlayList = indexer;
             this->pOverlays[i].spriteFrameTime = 0;
             if (animLength)
-                v11 = Duration::fromTicks(animLength);
+                v11 = animLength;
             else
                 v11 = pSpriteFrameTable->pSpriteSFrames[pOverlayList->pOverlays[indexer].uSpriteFramesetID].uAnimLength;
             this->pOverlays[i].animLength = v11.ticks();

--- a/src/Engine/Graphics/Overlays.h
+++ b/src/Engine/Graphics/Overlays.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "Engine/Pid.h"
+#include "Engine/Time/Duration.h"
 
 #include "Utility/Memory/Blob.h"
 
@@ -26,7 +27,7 @@ struct ActiveOverlay {
 
 struct ActiveOverlayList {
     void Reset();
-    int _4418B6(int uOverlayID, Pid pid, int animLength, int fpDamageMod, int16_t projSize);
+    int _4418B6(int uOverlayID, Pid pid, Duration animLength, int fpDamageMod, int16_t projSize);
 
     std::array<ActiveOverlay, 50> pOverlays;
 };

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -19,7 +19,7 @@ void TrailParticleGenerator::AddParticle(int x, int y, int z, Color color) {
     particles[num_particles].x = x;
     particles[num_particles].y = y;
     particles[num_particles].z = z;
-    particles[num_particles].time_to_live = Duration::fromTicks(vrng->random(64) + 256);
+    particles[num_particles].time_to_live = Duration::randomRealtimeMilliseconds(vrng, 500, 2500);
     particles[num_particles].time_left = particles[num_particles].time_to_live;
     particles[num_particles].color = color;
 

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -54,7 +54,7 @@ void ParticleEngine::ResetParticles() {
     pParticles.fill({});
     uStartParticle = PARTICLES_ARRAY_SIZE;
     uEndParticle = 0;
-    uTimeElapsed = Duration::zero();
+    uTimeElapsed = 0_ticks;
 }
 
 void ParticleEngine::AddParticle(Particle_sw *particle) {
@@ -118,7 +118,7 @@ void ParticleEngine::UpdateParticles() {
     unsigned uCurrentBegin = PARTICLES_ARRAY_SIZE;
 
     // TODO(captainurist): checking pMiscTimer->bPaused, then using pEventTimer->uTimeElapsed?
-    Duration time = pMiscTimer->bPaused == 0 ? pEventTimer->uTimeElapsed : Duration::zero();
+    Duration time = pMiscTimer->bPaused == 0 ? pEventTimer->uTimeElapsed : 0_ticks;
 
     if (!time) {
         return;
@@ -132,7 +132,7 @@ void ParticleEngine::UpdateParticles() {
         }
 
         if (p->timeToLive <= time) {
-            p->timeToLive = Duration::zero();
+            p->timeToLive = 0_ticks;
             p->type = ParticleType_Invalid;
             continue;
         }

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -37,7 +37,7 @@ void TrailParticleGenerator::GenerateTrailParticles(int x, int y, int z,
 //----- (00440F07) --------------------------------------------------------
 void TrailParticleGenerator::UpdateParticles() {
     for (unsigned int i = 0; i < 100; ++i) {
-        if (particles[i].time_left > Duration::zero()) {
+        if (particles[i].time_left > 0_ticks) {
             particles[i].x += vrng->random(5) + 4;
             particles[i].y += vrng->random(5) - 2;
             particles[i].z += vrng->random(5) - 2;

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -373,7 +373,7 @@ void BaseRenderer::PrepareDecorationsRenderList_ODM() {
                 local_0.g = 0.0f;
                 local_0.b = 0.0f;
                 local_0.particle_size = 1.0f;
-                local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128); // was rand() & 0x80
+                local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2); // was either 1 or 2 secs, we made it into [1, 2).
                 local_0.texture = spell_fx_renderer->effpar01;
                 particle_engine->AddParticle(&local_0);
             }

--- a/src/Engine/Graphics/TurnBasedOverlay.cpp
+++ b/src/Engine/Graphics/TurnBasedOverlay.cpp
@@ -37,7 +37,7 @@ void TurnBasedOverlay::update(Duration dt, TurnEngineStep newStep) {
     if (_state == TURN_BASED_OVERLAY_NONE) {
         assert(newStep == TE_WAIT);
         _state = TURN_BASED_OVERLAY_INITIAL;
-        _currentTime = Duration::zero();
+        _currentTime = 0_ticks;
         _currentEnd = pIconsFrameTable->GetIcon(_initialIconId)->GetAnimLength();
         return;
     }

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1167,41 +1167,41 @@ void Actor::AddOnDamageOverlay(unsigned int uActorID, int overlayType, signed in
     switch (overlayType) {
         case 1:
             if (damage)
-                pActiveOverlayList->_4418B6(904, actorPID, 0,
+                pActiveOverlayList->_4418B6(904, actorPID, 0_ticks,
                                            (int)(sub_43AE12(damage) * 65536.0), 0);
             return;
         case 2:
             if (damage)
-                pActiveOverlayList->_4418B6(905, actorPID, 0,
+                pActiveOverlayList->_4418B6(905, actorPID, 0_ticks,
                                            (int)(sub_43AE12(damage) * 65536.0), 0);
             return;
         case 3:
             if (damage)
-                pActiveOverlayList->_4418B6(906, actorPID, 0,
+                pActiveOverlayList->_4418B6(906, actorPID, 0_ticks,
                                            (int)(sub_43AE12(damage) * 65536.0), 0);
             return;
         case 4:
             if (damage)
-                pActiveOverlayList->_4418B6(907, actorPID, 0,
+                pActiveOverlayList->_4418B6(907, actorPID, 0_ticks,
                                            (int)(sub_43AE12(damage) * 65536.0), 0);
             return;
         case 5:
-            pActiveOverlayList->_4418B6(901, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(901, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         case 6:
-            pActiveOverlayList->_4418B6(902, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(902, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         case 7:
-            pActiveOverlayList->_4418B6(903, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(903, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         case 8:
-            pActiveOverlayList->_4418B6(900, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(900, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         case 9:
-            pActiveOverlayList->_4418B6(909, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(909, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         case 10:
-            pActiveOverlayList->_4418B6(908, actorPID, 0, 0, 0); // 4th param was actorPID.
+            pActiveOverlayList->_4418B6(908, actorPID, 0_ticks, 0, 0); // 4th param was actorPID.
             return;
         default:
             return;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2767,7 +2767,7 @@ void Actor::UpdateActorAI() {
                 v45 = pActor->special_ability_use_check(actor_id);
                 if (v45 == ABILITY_ATTACK1) {
                     if (pActor->monsterInfo.attack1MissileType) {
-                        if (pActor->monsterInfo.recoveryTime <= Duration::zero()) {
+                        if (pActor->monsterInfo.recoveryTime <= 0_ticks) {
                             Actor::AI_MissileAttack1(actor_id, target_pid, pDir);
                         } else if (pActor->monsterInfo.movementType == MONSTER_MOVEMENT_TYPE_STATIONARY) {
                             Actor::AI_Stand(actor_id, target_pid, v47, pDir);
@@ -2790,7 +2790,7 @@ void Actor::UpdateActorAI() {
                                 // follow player
                                 Actor::AI_Pursue2(actor_id, target_pid, 0_ticks, pDir, v70);
                             }
-                        } else if (pActor->monsterInfo.recoveryTime > Duration::zero()) {
+                        } else if (pActor->monsterInfo.recoveryTime > 0_ticks) {
                             Actor::AI_Stand(actor_id, target_pid, v47, pDir);
                         } else {
                             // monsters
@@ -2804,7 +2804,7 @@ void Actor::UpdateActorAI() {
                     else
                         v46 = pActor->monsterInfo.spell2Id;
                     if (v46 != SPELL_NONE) {
-                        if (pActor->monsterInfo.recoveryTime <= Duration::zero()) {
+                        if (pActor->monsterInfo.recoveryTime <= 0_ticks) {
                             if (v45 == ABILITY_SPELL1)
                                 Actor::AI_SpellAttack1(actor_id, target_pid, pDir);
                             else
@@ -2825,7 +2825,7 @@ void Actor::UpdateActorAI() {
                                 v70 = (radiusMultiplier * 307.2);
                                 Actor::AI_Pursue2(actor_id, target_pid, 0_ticks, pDir, v70);
                             }
-                        } else if (pActor->monsterInfo.recoveryTime > Duration::zero()) {
+                        } else if (pActor->monsterInfo.recoveryTime > 0_ticks) {
                             Actor::AI_Stand(actor_id, target_pid, v47, pDir);
                         } else {
                             Actor::AI_MeleeAttack(actor_id, target_pid, pDir);
@@ -2861,12 +2861,12 @@ void Actor::UpdateActorAI() {
                     v70 = (radiusMultiplier * 307.2);
                     Actor::AI_Pursue2(actor_id, target_pid, 0_ticks, pDir, v70);
                 }
-            } else if (pActor->monsterInfo.recoveryTime > Duration::zero()) {
+            } else if (pActor->monsterInfo.recoveryTime > 0_ticks) {
                 Actor::AI_Stand(actor_id, target_pid, v47, pDir);
             } else {
                 Actor::AI_MeleeAttack(actor_id, target_pid, pDir);
             }
-        } else if (pActor->monsterInfo.recoveryTime > Duration::zero()) {
+        } else if (pActor->monsterInfo.recoveryTime > 0_ticks) {
             if (radiusMultiplier * 307.2 > v81 || pActor->monsterInfo.movementType == MONSTER_MOVEMENT_TYPE_STATIONARY)
                 Actor::AI_Stand(actor_id, target_pid, v47, pDir);
             else

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -258,7 +258,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uSoundID = 0;
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
-            sprite.uSpriteFrameID = 0_ticks;
+            sprite.timeSinceCreated = 0_ticks;
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = distancemod;
@@ -337,7 +337,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 sprite.uSpellID = SPELL_FIRE_METEOR_SHOWER;
                 sprite.uAttributes = 0;
                 sprite.uSectorID = 0;
-                sprite.uSpriteFrameID = 0_ticks;
+                sprite.timeSinceCreated = 0_ticks;
                 sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
                 sprite.spell_target_pid = Pid();
                 sprite.uFacing = yaw;
@@ -388,7 +388,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
-            sprite.uSpriteFrameID = 0_ticks;
+            sprite.timeSinceCreated = 0_ticks;
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = 3;
 
@@ -641,7 +641,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
-            sprite.uSpriteFrameID = 0_ticks;
+            sprite.timeSinceCreated = 0_ticks;
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = 3;
 
@@ -800,7 +800,7 @@ void Actor::AI_RangedAttack(unsigned int uActorID, struct AIDirection *pDir,
     a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = 0_ticks;
+    a1.timeSinceCreated = 0_ticks;
     a1.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
     a1.spell_target_pid = Pid();
     if (pDir->uDistance < 307.2)
@@ -852,7 +852,7 @@ void Actor::Explode(unsigned int uActorID) {  // death explosion for some actors
     a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = 0_ticks;
+    a1.timeSinceCreated = 0_ticks;
     a1.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
     a1.spell_target_pid = Pid();
     a1.field_60_distance_related_prolly_lod = 3;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -258,7 +258,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uSoundID = 0;
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
-            sprite.uSpriteFrameID = Duration::zero();
+            sprite.uSpriteFrameID = 0_ticks;
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = distancemod;
@@ -337,7 +337,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 sprite.uSpellID = SPELL_FIRE_METEOR_SHOWER;
                 sprite.uAttributes = 0;
                 sprite.uSectorID = 0;
-                sprite.uSpriteFrameID = Duration::zero();
+                sprite.uSpriteFrameID = 0_ticks;
                 sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
                 sprite.spell_target_pid = Pid();
                 sprite.uFacing = yaw;
@@ -388,7 +388,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
-            sprite.uSpriteFrameID = Duration::zero();
+            sprite.uSpriteFrameID = 0_ticks;
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = 3;
 
@@ -641,7 +641,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
-            sprite.uSpriteFrameID = Duration::zero();
+            sprite.uSpriteFrameID = 0_ticks;
             sprite.spell_target_pid = Pid();
             sprite.field_60_distance_related_prolly_lod = 3;
 
@@ -800,7 +800,7 @@ void Actor::AI_RangedAttack(unsigned int uActorID, struct AIDirection *pDir,
     a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = Duration::zero();
+    a1.uSpriteFrameID = 0_ticks;
     a1.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
     a1.spell_target_pid = Pid();
     if (pDir->uDistance < 307.2)
@@ -852,7 +852,7 @@ void Actor::Explode(unsigned int uActorID) {  // death explosion for some actors
     a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
-    a1.uSpriteFrameID = Duration::zero();
+    a1.uSpriteFrameID = 0_ticks;
     a1.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
     a1.spell_target_pid = Pid();
     a1.field_60_distance_related_prolly_lod = 3;
@@ -1000,7 +1000,7 @@ void Actor::AI_FaceObject(unsigned int uActorID, Pid uObjID,
         }
 
         pActors[uActorID].yawAngle = Dir_Out->uYawAngle;
-        pActors[uActorID].currentActionTime = Duration::zero();
+        pActors[uActorID].currentActionTime = 0_ticks;
         pActors[uActorID].speed.z = 0;
         pActors[uActorID].speed.y = 0;
         pActors[uActorID].speed.x = 0;
@@ -1040,7 +1040,7 @@ void Actor::AI_Stand(unsigned int uActorID, Pid object_to_face_pid,
         pActors[uActorID].currentActionLength = Duration::fromTicks(grng->random(256) + 256);  // от 256 до 256 + 256
     else
         pActors[uActorID].currentActionLength = uActionLength;
-    pActors[uActorID].currentActionTime = Duration::zero();
+    pActors[uActorID].currentActionTime = 0_ticks;
     pActors[uActorID].yawAngle = a4->uYawAngle;
     pActors[uActorID].pitchAngle = a4->uPitchAngle;
     pActors[uActorID].speed.z = 0;
@@ -1052,7 +1052,7 @@ void Actor::AI_Stand(unsigned int uActorID, Pid object_to_face_pid,
 //----- (00403E61) --------------------------------------------------------
 void Actor::StandAwhile(unsigned int uActorID) {
     pActors[uActorID].currentActionLength = Duration::fromTicks(grng->random(128) + 128);
-    pActors[uActorID].currentActionTime = Duration::zero();
+    pActors[uActorID].currentActionTime = 0_ticks;
     pActors[uActorID].aiState = Standing;
     pActors[uActorID].speed.z = 0;
     pActors[uActorID].speed.y = 0;
@@ -1113,7 +1113,7 @@ void Actor::AI_MeleeAttack(unsigned int uActorID, Pid sTargetPid,
             pSpriteFrameTable
                 ->pSpriteSFrames[pActors[uActorID].spriteIds[ANIM_AtkMelee]]
                 .uAnimLength;
-        pActors[uActorID].currentActionTime = Duration::zero();
+        pActors[uActorID].currentActionTime = 0_ticks;
         pActors[uActorID].aiState = AttackingMelee;
         Actor::playSound(uActorID, ACTOR_ATTACK_SOUND);
         v25 = pMonsterStats->infos[pActors[uActorID].monsterInfo.id]
@@ -1345,7 +1345,7 @@ void Actor::AI_SpellAttack2(unsigned int uActorID, Pid edx0,
         v13 = pSpriteFrameTable->pSpriteSFrames[v3->spriteIds[ANIM_AtkRanged]]
                   .uAnimLength;
         v3->currentActionLength = v13;
-        v3->currentActionTime = Duration::zero();
+        v3->currentActionTime = 0_ticks;
         v3->aiState = AttackingRanged4;
         Actor::playSound(uActorID, ACTOR_ATTACK_SOUND);
         pDira = pMonsterStats->infos[v3->monsterInfo.id].recoveryTime;
@@ -1360,7 +1360,7 @@ void Actor::AI_SpellAttack2(unsigned int uActorID, Pid edx0,
         v3->speed.x = 0;
         if (ShouldMonsterPlayAttackAnim(v3->monsterInfo.spell2Id)) {
             v3->currentActionLength = 64_ticks;
-            v3->currentActionTime = Duration::zero();
+            v3->currentActionTime = 0_ticks;
             v3->aiState = Fidgeting;
             v3->UpdateAnimation();
             v3->aiState = AttackingRanged4;
@@ -1419,7 +1419,7 @@ void Actor::AI_SpellAttack1(unsigned int uActorID, Pid sTargetPid,
         v13 = pSpriteFrameTable->pSpriteSFrames[v3->spriteIds[ANIM_AtkRanged]]
                   .uAnimLength;
         v3->currentActionLength = v13;
-        v3->currentActionTime = Duration::zero();
+        v3->currentActionTime = 0_ticks;
         v3->aiState = AttackingRanged3;
         Actor::playSound(uActorID, ACTOR_ATTACK_SOUND);
         pDira = pMonsterStats->infos[v3->monsterInfo.id].recoveryTime;
@@ -1435,7 +1435,7 @@ void Actor::AI_SpellAttack1(unsigned int uActorID, Pid sTargetPid,
         v3->speed.x = 0;
         if (ShouldMonsterPlayAttackAnim(v3->monsterInfo.spell1Id)) {
             v3->currentActionLength = 64_ticks;
-            v3->currentActionTime = Duration::zero();
+            v3->currentActionTime = 0_ticks;
             v3->aiState = Fidgeting;
             v3->UpdateAnimation();
             v3->aiState = AttackingRanged3;
@@ -1494,7 +1494,7 @@ void Actor::AI_MissileAttack2(unsigned int uActorID, Pid sTargetPid,
         v13 = pSpriteFrameTable->pSpriteSFrames[v3->spriteIds[ANIM_AtkRanged]]
                   .uAnimLength;
         v3->currentActionLength = v13;
-        v3->currentActionTime = Duration::zero();
+        v3->currentActionTime = 0_ticks;
         v3->aiState = AttackingRanged2;
         Actor::playSound(uActorID, ACTOR_ATTACK_SOUND);
         pDira = pMonsterStats->infos[v3->monsterInfo.id].recoveryTime;
@@ -1565,7 +1565,7 @@ void Actor::AI_MissileAttack1(unsigned int uActorID, Pid sTargetPid,
         v14 = pSpriteFrameTable->pSpriteSFrames[v3->spriteIds[ANIM_AtkRanged]]
                   .uAnimLength;
         v3->currentActionLength = v14;
-        v3->currentActionTime = Duration::zero();
+        v3->currentActionTime = 0_ticks;
         v3->aiState = AttackingRanged1;
         Actor::playSound(uActorID, ACTOR_ATTACK_SOUND);
         pDira = pMonsterStats->infos[v3->monsterInfo.id].recoveryTime;
@@ -1635,8 +1635,8 @@ void Actor::AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,
         pActors[uActor_id].currentActionLength = Duration::fromTicks(
             32 * absx / pActors[uActor_id].moveSpeed);
     else
-        pActors[uActor_id].currentActionLength = Duration::zero();
-    pActors[uActor_id].currentActionTime = Duration::zero();
+        pActors[uActor_id].currentActionLength = 0_ticks;
+    pActors[uActor_id].currentActionTime = 0_ticks;
     pActors[uActor_id].aiState = Tethered;
     if (vrng->random(100) < 2) {
         Actor::playSound(uActor_id, ACTOR_BORED_SOUND);
@@ -1734,7 +1734,7 @@ void Actor::AI_Stun(unsigned int uActorID, Pid edx0,
         v7 = pSpriteFrameTable
                  ->pSpriteSFrames[pActors[uActorID].spriteIds[ANIM_GotHit]]
                  .uAnimLength;
-        pActors[uActorID].currentActionTime = Duration::zero();
+        pActors[uActorID].currentActionTime = 0_ticks;
         pActors[uActorID].aiState = Stunned;
         pActors[uActorID].currentActionLength = v7;
         Actor::playSound(uActorID, ACTOR_STUNNED_SOUND);
@@ -1768,7 +1768,7 @@ void Actor::AI_Bored(unsigned int uActorID, Pid uObjID,
         Actor::AI_Stand(uActorID, uObjID, actor->currentActionLength, a4);
     } else {  // facing player - play bored anim
         actor->aiState = Fidgeting;
-        actor->currentActionTime = Duration::zero();
+        actor->currentActionTime = 0_ticks;
         actor->yawAngle = a4->uYawAngle;
         actor->speed.z = 0;
         actor->speed.y = 0;
@@ -1784,7 +1784,7 @@ void Actor::AI_Bored(unsigned int uActorID, Pid uObjID,
 void Actor::resurrect(unsigned int uActorID) {
     assert(uActorID < pActors.size());
     Actor *pActor = &pActors[uActorID];
-    pActor->currentActionTime = Duration::zero();
+    pActor->currentActionTime = 0_ticks;
     pActor->aiState = Resurrected;
     pActor->currentActionAnimation = ANIM_Dying;
     pActor->currentActionLength =
@@ -1813,7 +1813,7 @@ void Actor::resurrect(unsigned int uActorID) {
 void Actor::Die(unsigned int uActorID) {
     Actor *actor = &pActors[uActorID];
 
-    actor->currentActionTime = Duration::zero();
+    actor->currentActionTime = 0_ticks;
     actor->aiState = Dying;
     actor->currentActionAnimation = ANIM_Dying;
     actor->currentHP = 0;
@@ -1954,14 +1954,14 @@ void Actor::AI_Flee(unsigned int uActorID, Pid sTargetPid,
                 v5->currentActionLength = Duration::fromTicks(
                     (signed int)(a4->uDistanceXZ << 7) / v5->moveSpeed);
             else
-                v5->currentActionLength = Duration::zero();
+                v5->currentActionLength = 0_ticks;
             if (v5->currentActionLength > 256_ticks) v5->currentActionLength = 256_ticks;
             v5->yawAngle =
                 (short)TrigLUT.uIntegerHalfPi + (short)a4->uYawAngle;
             v5->yawAngle =
                 (short)TrigLUT.uDoublePiMask &
                 (v5->yawAngle + grng->random(TrigLUT.uIntegerPi));
-            v5->currentActionTime = Duration::zero();
+            v5->currentActionTime = 0_ticks;
             v5->pitchAngle = (short)a4->uPitchAngle;
             v5->aiState = Fleeing;
             v5->UpdateAnimation();
@@ -2014,12 +2014,12 @@ void Actor::AI_Pursue2(unsigned int uActorID, Pid a2,
             v7->currentActionLength = Duration::fromTicks(
                 (signed int)(v10->uDistanceXZ << 7) / v13);
         else
-            v7->currentActionLength = Duration::zero();
+            v7->currentActionLength = 0_ticks;
         if (v7->currentActionLength > 32_ticks) v7->currentActionLength = 32_ticks;
     }
     v7->yawAngle = (short)v10->uYawAngle;
     v14 = (short)v10->uPitchAngle;
-    v7->currentActionTime = Duration::zero();
+    v7->currentActionTime = 0_ticks;
     v7->pitchAngle = v14;
     v7->aiState = Pursuing;
     v7->UpdateAnimation();
@@ -2066,7 +2066,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
         if (v12)
             v6->currentActionLength = Duration::fromTicks((a4->uDistanceXZ << 7) / v12);
         else
-            v6->currentActionLength = Duration::zero();
+            v6->currentActionLength = 0_ticks;
         if (v6->currentActionLength > 128_ticks) v6->currentActionLength = 128_ticks;
     }
     v14 = (short)a4->uYawAngle;
@@ -2076,7 +2076,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
         v14 -= 256;
     v6->yawAngle = v14;
     v16 = (short)a4->uPitchAngle;
-    v6->currentActionTime = Duration::zero();
+    v6->currentActionTime = 0_ticks;
     v6->pitchAngle = v16;
     v6->aiState = Pursuing;
     if (vrng->random(100) < 2) {
@@ -2503,7 +2503,7 @@ void Actor::SummonMinion(int summonerId) {
     actor->PrepareSprites(0);
     actor->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
     actor->ally = v19;
-    actor->currentActionTime = Duration::zero();
+    actor->currentActionTime = 0_ticks;
     actor->group = this->group;
     actor->aiState = Summoned;
     actor->currentActionLength = 256_ticks;
@@ -2607,8 +2607,8 @@ void Actor::UpdateActorAI() {
             pActor->aiState = Standing;
         }
 
-        pActor->currentActionTime = Duration::zero();
-        pActor->currentActionLength = Duration::zero();
+        pActor->currentActionTime = 0_ticks;
+        pActor->currentActionLength = 0_ticks;
         pActor->UpdateAnimation();
     }
 
@@ -4264,7 +4264,7 @@ void Spawn_Light_Elemental(int spell_power, CharacterSkillMastery caster_skill_m
     actor->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
     actor->ally = MONSTER_TYPE_9999;
     actor->group = 0;
-    actor->currentActionTime = Duration::zero();
+    actor->currentActionTime = 0_ticks;
     actor->aiState = Summoned;
     actor->currentActionLength = 256_ticks;
     actor->UpdateAnimation();

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1037,7 +1037,7 @@ void Actor::AI_Stand(unsigned int uActorID, Pid object_to_face_pid,
 
     pActors[uActorID].aiState = Standing;
     if (!uActionLength)
-        pActors[uActorID].currentActionLength = Duration::fromTicks(grng->random(256) + 256);  // от 256 до 256 + 256
+        pActors[uActorID].currentActionLength = Duration::randomRealtimeSeconds(grng, 2, 4);
     else
         pActors[uActorID].currentActionLength = uActionLength;
     pActors[uActorID].currentActionTime = 0_ticks;
@@ -1051,7 +1051,7 @@ void Actor::AI_Stand(unsigned int uActorID, Pid object_to_face_pid,
 
 //----- (00403E61) --------------------------------------------------------
 void Actor::StandAwhile(unsigned int uActorID) {
-    pActors[uActorID].currentActionLength = Duration::fromTicks(grng->random(128) + 128);
+    pActors[uActorID].currentActionLength = Duration::randomRealtimeSeconds(grng, 1, 2);
     pActors[uActorID].currentActionTime = 0_ticks;
     pActors[uActorID].aiState = Standing;
     pActors[uActorID].speed.z = 0;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2060,7 +2060,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
         return Actor::AI_StandOrBored(uActorID, a2, uActionLength, a4);
     }
     if (uActionLength) {
-        v6->currentActionLength = uActionLength + Duration::fromTicks(grng->random(uActionLength.ticks()));
+        v6->currentActionLength = uActionLength + Duration::random(grng, uActionLength);
     } else {
         v12 = v6->moveSpeed;
         if (v12)

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -215,7 +215,7 @@ class Actor {
     uint16_t yawAngle = 0;
     uint16_t pitchAngle = 0;
     int sectorId = 0;
-    Duration currentActionLength = Duration::zero();
+    Duration currentActionLength = 0_ticks;
     Vec3i initialPosition;
     Vec3i guardingPosition;
     uint16_t tetherDistance = 256;
@@ -223,7 +223,7 @@ class Actor {
     ActorAnimation currentActionAnimation = ANIM_Standing;
     ItemId carriedItemId = ITEM_NULL; // carried items are special items the
                                          // ncp carries (ie lute from bard)
-    Duration currentActionTime = Duration::zero();
+    Duration currentActionTime = 0_ticks;
     IndexedArray<uint16_t, ANIM_First, ANIM_Last> spriteIds = {{}};
     IndexedArray<SoundId, ACTOR_SOUND_FIRST, ACTOR_SOUND_LAST> soundSampleIds = {{}};
     IndexedArray<SpellBuff, ACTOR_BUFF_FIRST, ACTOR_BUFF_LAST> buffs;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -2348,7 +2348,7 @@ bool Character::Recover(Duration dt) {
         timeToRecovery -= timepassed;
         return true;
     } else {
-        timeToRecovery = Duration::zero();  // recovered
+        timeToRecovery = 0_ticks;  // recovered
 
         if (!pParty->hasActiveCharacter())  // set recoverd char as active
             pParty->switchToNextActiveCharacter();
@@ -7153,7 +7153,7 @@ void Character::_42FA66_do_explosive_impact(Vec3i pos, int a4, int16_t a5, signe
     a1a.vPosition = pos;
     a1a.uAttributes = 0;
     a1a.uSectorID = pIndoor->GetSector(pos);
-    a1a.uSpriteFrameID = Duration::zero();
+    a1a.uSpriteFrameID = 0_ticks;
     a1a.spell_target_pid = Pid();
     a1a.field_60_distance_related_prolly_lod = 0;
     a1a.uFacing = 0;
@@ -7241,7 +7241,7 @@ void Character::playEmotion(CharacterExpressionID new_expression, Duration durat
         }
     }
 
-    this->uExpressionTimePassed = Duration::zero();
+    this->uExpressionTimePassed = 0_ticks;
 
     if (!duration) {
         this->uExpressionTimeLength = pPlayerFrameTable->GetDurationByExpression(new_expression);
@@ -7402,7 +7402,7 @@ Character::Character() {
     sResLightBase = sResLightBonus = 0;
     sResDarkBase = sResDarkBonus = 0;
 
-    timeToRecovery = Duration::zero();
+    timeToRecovery = 0_ticks;
 
     uSkillPoints = 0;
 
@@ -7422,8 +7422,8 @@ Character::Character() {
     _ranged_dmg_bonus = 0;
 
     expression = CHARACTER_EXPRESSION_INVALID;
-    uExpressionTimePassed = Duration::zero();
-    uExpressionTimeLength = Duration::zero();
+    uExpressionTimePassed = 0_ticks;
+    uExpressionTimeLength = 0_ticks;
 
     uNumDivineInterventionCastsThisDay = 0;
     uNumArmageddonCasts = 0;
@@ -7431,7 +7431,7 @@ Character::Character() {
 
     _characterEventBits.reset();
 
-    _expression21_animtime = Duration::zero();
+    _expression21_animtime = 0_ticks;
     _expression21_frameset = 0;
 
     lastOpenedSpellbookPage = MAGIC_SCHOOL_FIRE;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -2360,7 +2360,7 @@ bool Character::Recover(Duration dt) {
 //----- (0048E96A) --------------------------------------------------------
 void Character::SetRecoveryTime(Duration rec) {
     // to avoid switching characters if endurance eliminates hit recovery
-    if (rec <= Duration::zero()) return;
+    if (rec <= 0_ticks) return;
 
     if (rec > timeToRecovery) timeToRecovery = rec;
 

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6539,7 +6539,7 @@ void DamageCharacterFromMonster(Pid uObjID, ActorAbility dmgSource, Vec3i *pPos,
             if (targetchar != -1) {
                 playerPtr = &pParty->pCharacters[targetchar];
             } else {
-                int id = pParty->getRandomActiveCharacterId(grng.get());
+                int id = pParty->getRandomActiveCharacterId(grng);
 
                 if (id != -1) {
                     playerPtr = &pParty->pCharacters[id];

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -7153,7 +7153,7 @@ void Character::_42FA66_do_explosive_impact(Vec3i pos, int a4, int16_t a5, signe
     a1a.vPosition = pos;
     a1a.uAttributes = 0;
     a1a.uSectorID = pIndoor->GetSector(pos);
-    a1a.uSpriteFrameID = 0_ticks;
+    a1a.timeSinceCreated = 0_ticks;
     a1a.spell_target_pid = Pid();
     a1a.field_60_distance_related_prolly_lod = 0;
     a1a.uFacing = 0;

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -123,7 +123,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
             pSpellObject.uSoundID = 0;
             pSpellObject.uAttributes = SPRITE_IGNORE_RANGE | SPRITE_NO_Z_BUFFER;
             pSpellObject.uSectorID = pIndoor->GetSector(pOut);
-            pSpellObject.uSpriteFrameID = 0_ticks;
+            pSpellObject.timeSinceCreated = 0_ticks;
             pSpellObject.spell_caster_pid = Pid();
             pSpellObject.spell_target_pid = Pid();
             pSpellObject.uFacing = 0;

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -123,7 +123,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
             pSpellObject.uSoundID = 0;
             pSpellObject.uAttributes = SPRITE_IGNORE_RANGE | SPRITE_NO_Z_BUFFER;
             pSpellObject.uSectorID = pIndoor->GetSector(pOut);
-            pSpellObject.uSpriteFrameID = Duration::zero();
+            pSpellObject.uSpriteFrameID = 0_ticks;
             pSpellObject.spell_caster_pid = Pid();
             pSpellObject.spell_target_pid = Pid();
             pSpellObject.uFacing = 0;

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -121,7 +121,7 @@ static void createSpriteTrailParticle(Vec3i pos, ObjectDescFlags flags) {
     if (flags & OBJECT_DESC_TRIAL_FIRE) {
         particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
         particle.uDiffuse = colorTable.OrangeyRed;
-        particle.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128); // was rand() & 0x80
+        particle.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2); // was either 1 or 2 secs, we made it into [1, 2).
         particle.texture = spell_fx_renderer->effpar01;
         particle.particle_size = 1.0f;
         particle_engine->AddParticle(&particle);
@@ -135,7 +135,7 @@ static void createSpriteTrailParticle(Vec3i pos, ObjectDescFlags flags) {
     } else if (flags & OBJECT_DESC_TRIAL_PARTICLE) {
         particle.type = ParticleType_Bitmap | ParticleType_Ascending;
         particle.uDiffuse = Color(vrng->random(0x100), vrng->random(0x100), 0, 0); // TODO(captainurist): TBH this makes no sense, investigate
-        particle.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128); // was rand() & 0x80
+        particle.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2); // was either 1 or 2 secs, we made it into [1, 2).
         particle.texture = spell_fx_renderer->effpar03;
         particle.particle_size = 1.0f;
         particle_engine->AddParticle(&particle);

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -1313,7 +1313,7 @@ void UpdateObjects() {
                 if (!(object->uFlags & OBJECT_DESC_TEMPORARY)) {
                     continue;
                 }
-                if (pSpriteObjects[i].timeSinceCreated >= Duration::zero()) {
+                if (pSpriteObjects[i].timeSinceCreated >= 0_ticks) {
                     Duration lifetime = object->uLifetime;
                     if (pSpriteObjects[i].uAttributes & SPRITE_TEMPORARY) {
                         lifetime = pSpriteObjects[i].tempLifetime;
@@ -1329,7 +1329,7 @@ void UpdateObjects() {
                 Duration lifetime;
                 pSpriteObjects[i].timeSinceCreated += pEventTimer->uTimeElapsed;
                 if (object->uFlags & OBJECT_DESC_TEMPORARY) {
-                    if (pSpriteObjects[i].timeSinceCreated < Duration::zero()) {
+                    if (pSpriteObjects[i].timeSinceCreated < 0_ticks) {
                         SpriteObject::OnInteraction(i);
                         continue;
                     }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -585,7 +585,7 @@ Duration SpriteObject::GetLifetime() {
 
 SpriteFrame *SpriteObject::getSpriteFrame() {
     ObjectDesc *pObjectDesc = &pObjectList->pObjects[uObjectDescID];
-    return pSpriteFrameTable->GetFrame(pObjectDesc->uSpriteID, uSpriteFrameID);
+    return pSpriteFrameTable->GetFrame(pObjectDesc->uSpriteID, timeSinceCreated);
 }
 
 bool SpriteObject::IsUnpickable() {
@@ -1309,16 +1309,16 @@ void UpdateObjects() {
                 if (!pSpriteObjects[i].uObjectDescID) {
                     continue;
                 }
-                pSpriteObjects[i].uSpriteFrameID += pEventTimer->uTimeElapsed;
+                pSpriteObjects[i].timeSinceCreated += pEventTimer->uTimeElapsed;
                 if (!(object->uFlags & OBJECT_DESC_TEMPORARY)) {
                     continue;
                 }
-                if (pSpriteObjects[i].uSpriteFrameID >= Duration::zero()) {
+                if (pSpriteObjects[i].timeSinceCreated >= Duration::zero()) {
                     Duration lifetime = object->uLifetime;
                     if (pSpriteObjects[i].uAttributes & SPRITE_TEMPORARY) {
                         lifetime = pSpriteObjects[i].tempLifetime;
                     }
-                    if (pSpriteObjects[i].uSpriteFrameID < lifetime) {
+                    if (pSpriteObjects[i].timeSinceCreated < lifetime) {
                         continue;
                     }
                 }
@@ -1327,9 +1327,9 @@ void UpdateObjects() {
             }
             if (pSpriteObjects[i].uObjectDescID) {
                 Duration lifetime;
-                pSpriteObjects[i].uSpriteFrameID += pEventTimer->uTimeElapsed;
+                pSpriteObjects[i].timeSinceCreated += pEventTimer->uTimeElapsed;
                 if (object->uFlags & OBJECT_DESC_TEMPORARY) {
-                    if (pSpriteObjects[i].uSpriteFrameID < Duration::zero()) {
+                    if (pSpriteObjects[i].timeSinceCreated < Duration::zero()) {
                         SpriteObject::OnInteraction(i);
                         continue;
                     }
@@ -1339,7 +1339,7 @@ void UpdateObjects() {
                     }
                 }
                 if (!(object->uFlags & OBJECT_DESC_TEMPORARY) ||
-                    pSpriteObjects[i].uSpriteFrameID < lifetime) {
+                    pSpriteObjects[i].timeSinceCreated < lifetime) {
                     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
                         SpriteObject::updateObjectBLV(i);
                     } else {

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -34,7 +34,7 @@ struct SpriteObject {
     Color GetParticleTrailColor();
 
     inline void spellSpriteStop() {
-        uSpriteFrameID = Duration::zero();
+        uSpriteFrameID = 0_ticks;
         vVelocity = Vec3i(0, 0, 0);
     }
 

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -34,7 +34,7 @@ struct SpriteObject {
     Color GetParticleTrailColor();
 
     inline void spellSpriteStop() {
-        uSpriteFrameID = 0_ticks;
+        timeSinceCreated = 0_ticks;
         vVelocity = Vec3i(0, 0, 0);
     }
 
@@ -74,7 +74,7 @@ struct SpriteObject {
     uint16_t uSoundID = 0;
     SpriteAttributes uAttributes = 0;
     int uSectorID = 0;
-    Duration uSpriteFrameID;
+    Duration timeSinceCreated;
     Duration tempLifetime;
     int16_t field_22_glow_radius_multiplier = 1;
     ItemGen containing_item;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -157,7 +157,7 @@ void Party::Zero() {
     pHireling2Name[0] = 0;
     armageddon_timer = 0_ticks;
     armageddonDamage = 0;
-    pTurnBasedCharacterRecoveryTimes.fill(Duration::zero());
+    pTurnBasedCharacterRecoveryTimes.fill(0_ticks);
     InTheShopFlags.fill(0);
     uFine = 0;
     TorchLightLastIntensity = 0.0f;
@@ -248,7 +248,7 @@ void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems enteri
 void Party::switchToNextActiveCharacter() {
     // avoid switching away from char that can act
     if (hasActiveCharacter() && this->pCharacters[_activeCharacter - 1].CanAct() &&
-        this->pCharacters[_activeCharacter - 1].timeToRecovery <= Duration::zero())
+        this->pCharacters[_activeCharacter - 1].timeToRecovery <= 0_ticks)
         return;
 
     if (pParty->bTurnBasedModeOn) {
@@ -266,7 +266,7 @@ void Party::switchToNextActiveCharacter() {
 
     for (int i = 0; i < this->pCharacters.size(); i++) {
         if (!this->pCharacters[i].CanAct() ||
-            this->pCharacters[i].timeToRecovery > Duration::zero()) {
+            this->pCharacters[i].timeToRecovery > 0_ticks) {
             playerAlreadyPicked[i] = true;
         } else if (!playerAlreadyPicked[i]) {
             playerAlreadyPicked[i] = true;
@@ -951,7 +951,7 @@ void Party::restOneFrame() {
     if (restTick) {
         Rest(restTick);
         remainingRestTime -= restTick;
-        assert(remainingRestTime >= Duration::zero());
+        assert(remainingRestTime >= 0_ticks);
         OutdoorLocation::LoadActualSkyFrame();
     }
 

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -669,7 +669,7 @@ void Party::Reset() {
 
         player.expression = CHARACTER_EXPRESSION_NORMAL;
         player.uExpressionTimePassed = 0_ticks;
-        player.uExpressionTimeLength = Duration::fromTicks(vrng->random(256) + 128);
+        player.uExpressionTimeLength = Duration::randomRealtimeSeconds(vrng, 1, 3);
     }
 
     for (SpellBuff &buff : this->pPartyBuffs) {
@@ -774,7 +774,7 @@ void Party::updateCharactersAndHirelingsEmotions() {
             player.uExpressionTimePassed = 0_ticks;
             if (player.expression != CHARACTER_EXPRESSION_NORMAL || vrng->random(5)) {
                 player.expression = CHARACTER_EXPRESSION_NORMAL;
-                player.uExpressionTimeLength = Duration::fromTicks(vrng->random(256) + 32);
+                player.uExpressionTimeLength = Duration::randomRealtimeMilliseconds(vrng, 250, 2250);
             } else {
                 int randomVal = vrng->random(100);
                 if (randomVal < 25)

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -155,14 +155,14 @@ void Party::Zero() {
 
     pHireling1Name[0] = 0;
     pHireling2Name[0] = 0;
-    armageddon_timer = Duration::zero();
+    armageddon_timer = 0_ticks;
     armageddonDamage = 0;
     pTurnBasedCharacterRecoveryTimes.fill(Duration::zero());
     InTheShopFlags.fill(0);
     uFine = 0;
     TorchLightLastIntensity = 0.0f;
 
-    _roundingDt = Duration::zero();
+    _roundingDt = 0_ticks;
 
     // players
     for (Character &player : this->pCharacters) {
@@ -511,7 +511,7 @@ void Party::createDefaultParty(bool bDebugGiveItems) {
             }
         }
 
-        pCharacter.uExpressionTimePassed = Duration::zero();
+        pCharacter.uExpressionTimePassed = 0_ticks;
 
         if (bDebugGiveItems) {
             Dst.Reset();
@@ -660,7 +660,7 @@ void Party::Reset() {
     pCharacters[3].name = localization->GetString(LSTR_PC_NAME_ALEXIS);
 
     for (Character &player : this->pCharacters) {
-        player.timeToRecovery = Duration::zero();
+        player.timeToRecovery = 0_ticks;
         player.conditions.ResetAll();
 
         for (SpellBuff &buff : player.pCharacterBuffs) {
@@ -668,7 +668,7 @@ void Party::Reset() {
         }
 
         player.expression = CHARACTER_EXPRESSION_NORMAL;
-        player.uExpressionTimePassed = Duration::zero();
+        player.uExpressionTimePassed = 0_ticks;
         player.uExpressionTimeLength = Duration::fromTicks(vrng->random(256) + 128);
     }
 
@@ -751,8 +751,8 @@ void Party::resetCharacterEmotions() {
             player.uExpressionTimeLength = 32_ticks;
             player.expression = CHARACTER_EXPRESSION_NORMAL;
         } else {
-            player.uExpressionTimeLength = Duration::zero();
-            player.uExpressionTimePassed = Duration::zero();
+            player.uExpressionTimeLength = 0_ticks;
+            player.uExpressionTimePassed = 0_ticks;
             player.expression = expressionForCondition(condition);
         }
     }
@@ -771,7 +771,7 @@ void Party::updateCharactersAndHirelingsEmotions() {
             if (player.uExpressionTimePassed < player.uExpressionTimeLength)
                 continue;
 
-            player.uExpressionTimePassed = Duration::zero();
+            player.uExpressionTimePassed = 0_ticks;
             if (player.expression != CHARACTER_EXPRESSION_NORMAL || vrng->random(5)) {
                 player.expression = CHARACTER_EXPRESSION_NORMAL;
                 player.uExpressionTimeLength = Duration::fromTicks(vrng->random(256) + 32);
@@ -816,8 +816,8 @@ void Party::updateCharactersAndHirelingsEmotions() {
                    player.expression != CHARACTER_EXPRESSION_DMGRECVD_MODERATE &&
                    player.expression != CHARACTER_EXPRESSION_DMGRECVD_MAJOR ||
                    player.uExpressionTimePassed >= player.uExpressionTimeLength) {
-            player.uExpressionTimeLength = Duration::zero();
-            player.uExpressionTimePassed = Duration::zero();
+            player.uExpressionTimeLength = 0_ticks;
+            player.uExpressionTimePassed = 0_ticks;
             player.expression = expressionForCondition(condition);
         }
     }
@@ -864,7 +864,7 @@ void Party::restAndHeal() {
         pPlayer->conditions.Reset(CONDITION_SLEEP);
         pPlayer->conditions.Reset(CONDITION_WEAK);
 
-        pPlayer->timeToRecovery = Duration::zero();
+        pPlayer->timeToRecovery = 0_ticks;
         pPlayer->health = pPlayer->GetMaxHealth();
         pPlayer->mana = pPlayer->GetMaxMana();
         if (pPlayer->classType == CLASS_LICH) {
@@ -931,7 +931,7 @@ void restAndHeal(Duration restTime) {
     pParty->restAndHeal();
 
     for (Character &player : pParty->pCharacters) {
-        player.timeToRecovery = Duration::zero();
+        player.timeToRecovery = 0_ticks;
         player.uNumDivineInterventionCastsThisDay = 0;
         player.uNumArmageddonCasts = 0;
         player.uNumFireSpikeCasts = 0;
@@ -1070,7 +1070,7 @@ void Party::dropHeldItem() {
     sprite.uFacing = 0;
     sprite.uAttributes = SPRITE_DROPPED_BY_PLAYER;
     sprite.uSectorID = pBLVRenderParams->uPartyEyeSectorID;
-    sprite.uSpriteFrameID = Duration::zero();
+    sprite.uSpriteFrameID = 0_ticks;
     sprite.containing_item = pPickedItem;
 
     // extern int UnprojectX(int);

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -1070,7 +1070,7 @@ void Party::dropHeldItem() {
     sprite.uFacing = 0;
     sprite.uAttributes = SPRITE_DROPPED_BY_PLAYER;
     sprite.uSectorID = pBLVRenderParams->uPartyEyeSectorID;
-    sprite.uSpriteFrameID = 0_ticks;
+    sprite.timeSinceCreated = 0_ticks;
     sprite.containing_item = pPickedItem;
 
     // extern int UnprojectX(int);

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -289,7 +289,7 @@ struct Party {
     Time _6FC_water_lava_timer;
     int uFallStartZ;
     unsigned int bFlying;
-    uint8_t hirelingScrollPosition;
+    int hirelingScrollPosition;
     char cNonHireFollowers;  // number of non hireling party guests
 
     // TODO(captainurist): #time drop all of these?

--- a/src/Engine/Random/Random.h
+++ b/src/Engine/Random/Random.h
@@ -18,7 +18,7 @@ class RandomEnginePtr {
         return *_ptr;
     }
 
-    RandomEngine *get() const {
+    operator RandomEngine *() const {
         return _ptr;
     }
 

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1465,7 +1465,7 @@ void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->uSoundID = src.uSoundID;
     dst->uAttributes = std::to_underlying(src.uAttributes);
     dst->uSectorID = src.uSectorID;
-    dst->uSpriteFrameID = src.uSpriteFrameID.ticks();
+    dst->uTimeSinceCreated = src.timeSinceCreated.ticks();
     dst->tempLifetime = src.tempLifetime.ticks();
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
     snapshot(src.containing_item, &dst->containing_item);
@@ -1489,7 +1489,7 @@ void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->uSoundID = src.uSoundID;
     dst->uAttributes = SpriteAttributes(src.uAttributes);
     dst->uSectorID = src.uSectorID;
-    dst->uSpriteFrameID = Duration::fromTicks(src.uSpriteFrameID);
+    dst->timeSinceCreated = Duration::fromTicks(src.uTimeSinceCreated);
     dst->tempLifetime = Duration::fromTicks(src.tempLifetime);
     dst->field_22_glow_radius_multiplier = src.field_22_glow_radius_multiplier;
     reconstruct(src.containing_item, &dst->containing_item);

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -966,7 +966,7 @@ struct SpriteObject_MM7 {
     uint16_t uSoundID;
     uint16_t uAttributes;
     int16_t uSectorID;
-    uint16_t uSpriteFrameID;
+    uint16_t uTimeSinceCreated;
     int16_t tempLifetime;
     int16_t field_22_glow_radius_multiplier;
     ItemGen_MM7 containing_item;

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -354,7 +354,7 @@ void SpellFxRenderer::_4A75CC_single_spell_collision_particle(
 }
 
 void SpellFxRenderer::_4A7688_fireball_collision_particle(SpriteObject *a2) {
-    double v3 = (double)a2->uSpriteFrameID.ticks() / (double)a2->GetLifetime().ticks();
+    double v3 = (double)a2->timeSinceCreated.ticks() / (double)a2->GetLifetime().ticks();
     double v4;
     if (v3 >= 0.75)
         v4 = (1.0 - v3) * 4.0;
@@ -387,7 +387,7 @@ void SpellFxRenderer::_4A7688_fireball_collision_particle(SpriteObject *a2) {
 }
 
 void SpellFxRenderer::_4A77FD_implosion_particle_d3d(SpriteObject *a1) {
-    double v4 = (double)a1->uSpriteFrameID.ticks() / (double)a1->GetLifetime().ticks();
+    double v4 = (double)a1->timeSinceCreated.ticks() / (double)a1->GetLifetime().ticks();
     double v5;
     if (v4 >= 0.75) {
         v5 = v4 * 4.0;

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -1215,7 +1215,7 @@ void SpellFxRenderer::RenderSpecialEffects() {
     }
 
     field_204 = 0;
-    if (uFadeTime > Duration::zero()) {
+    if (uFadeTime > 0_ticks) {
         v4 = (double)uFadeTime.ticks() / (double)uFadeLength.ticks();
         v5 = 1.0 - v4 * v4;
         // v6 = v5;
@@ -1225,7 +1225,7 @@ void SpellFxRenderer::RenderSpecialEffects() {
         uFadeTime -= pEventTimer->uTimeElapsed;
     }
 
-    if (uAnimLength > Duration::zero()) {
+    if (uAnimLength > 0_ticks) {
         // prismatic light
         v8 = pSpriteFrameTable->pSpriteSFrames[pSpriteFrameTable->FastFindSprite("spell84")].uAnimLength - uAnimLength;
         v10 = pSpriteFrameTable->GetFrame(pSpriteFrameTable->FastFindSprite("spell84"), v8);

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -1068,7 +1068,7 @@ void SpellFxRenderer::SetPlayerBuffAnim(SpellId uSpellID,
     const char *v6;      // [sp-4h] [bp-10h]@2
 
     v4 = &pCharacterBuffs[uPlayerID];
-    v4->uSpellAnimTimeElapsed = Duration::zero();
+    v4->uSpellAnimTimeElapsed = 0_ticks;
     v4->bRender = uSpellID != SPELL_NONE;
 
     switch (uSpellID) {

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -288,7 +288,7 @@ void SpellFxRenderer::_4A73AA_hanging_trace_particles___like_fire_strike_ice_bla
         local_0.r = 0.0;
         local_0.g = 0.0;
         local_0.b = 0.0;
-        local_0.timeToLive = Duration::fromTicks(vrng->random(0x40) + 96); // was rand() & 0x40
+        local_0.timeToLive = Duration::randomRealtimeMilliseconds(vrng, 750, 1250); // was either 750 or 1250 ms, we made it into [750, 1250).
         local_0.texture = texture;
         local_0.particle_size = 1.0f;
         particle_engine->AddParticle(&local_0);
@@ -318,7 +318,7 @@ void SpellFxRenderer::_4A73AA_hanging_trace_particles___like_fire_strike_ice_bla
         local_0.g = 0.0f;
         local_0.b = 0.0f;
         local_0.particle_size = 1.0f;
-        local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+        local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
         local_0.texture = texture;
         particle_engine->AddParticle(&local_0);
         local_0.x = (float)a2->vPosition.x - 4.0f;
@@ -341,7 +341,7 @@ void SpellFxRenderer::_4A75CC_single_spell_collision_particle(
     local_0.uDiffuse = uDiffuse;
     local_0.z = v4;
     v5 = 10;
-    local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+    local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     local_0.texture = texture;
     local_0.particle_size = 1.0f;
     do {
@@ -367,7 +367,7 @@ void SpellFxRenderer::_4A7688_fireball_collision_particle(SpriteObject *a2) {
     local_0.x = (float)a2->vPosition.x;
     local_0.y = (float)a2->vPosition.y;
     local_0.z = (float)a2->vPosition.z;
-    local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+    local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     local_0.texture = this->effpar01;
     local_0.particle_size = 1.0;
 
@@ -412,7 +412,7 @@ void SpellFxRenderer::_4A7948_mind_blast_after_effect(SpriteObject *a1) {
     Dst.z = (float)a1->vPosition.z;
     Dst.texture = a1->getSpriteFrame()->hw_sprites[0]->texture;
     Dst.particle_size = 1.0;
-    Dst.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+    Dst.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     for (int i = 0; i < 10; i++) {
         Dst.r = (float) vrng->random(0x200) - 255.0f;
         Dst.g = (float) vrng->random(0x200) - 255.0f;
@@ -452,7 +452,7 @@ void SpellFxRenderer::
     local_0.z = (float)(v5 + 32);
     local_0.particle_size = 1.0;
     v7 = 0.0 * a4;
-    local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+    local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     local_0.texture = texture;
     a1a = v7;
     local_0.r = v7;
@@ -510,7 +510,7 @@ void SpellFxRenderer::_4A7C07_stun_spell_fx(SpriteObject *a2) {
         local_0.b = 0.0f;
 
         local_0.particle_size = 3.0;
-        local_0.timeToLive = Duration::fromTicks(vrng->random(0x40) + 64);
+        local_0.timeToLive = Duration::randomRealtimeMilliseconds(vrng, 500, 1000);
         local_0.texture = a2->getSpriteFrame()->hw_sprites[0]->texture;
         local_0.paletteID = a2->getSpriteFrame()->uPaletteID;
         particle_engine->AddParticle(&local_0);
@@ -518,7 +518,7 @@ void SpellFxRenderer::_4A7C07_stun_spell_fx(SpriteObject *a2) {
         local_0.x = (float)a2->vPosition.x;
         local_0.y = (float)a2->vPosition.y;
         local_0.z = (float)a2->vPosition.z;
-        local_0.timeToLive = Duration::fromTicks(vrng->random(0x40) + 64);
+        local_0.timeToLive = Duration::randomRealtimeMilliseconds(vrng, 500, 1000);
         particle_engine->AddParticle(&local_0);
         v6->flt_0_x = (float)a2->vPosition.x;
         v6->flt_4_y = (float)a2->vPosition.y;
@@ -537,7 +537,7 @@ void SpellFxRenderer::_4A7C07_stun_spell_fx(SpriteObject *a2) {
         local_0.r = 0.0f;
         local_0.g = 0.0f;
         local_0.b = 0.0f;
-        local_0.timeToLive = Duration::fromTicks(vrng->random(0x40) + 64);
+        local_0.timeToLive = Duration::randomRealtimeMilliseconds(vrng, 500, 1000);
         local_0.texture = a2->getSpriteFrame()->hw_sprites[0]->texture;
         local_0.paletteID = a2->getSpriteFrame()->uPaletteID;
         particle_engine->AddParticle(&local_0);
@@ -565,7 +565,7 @@ void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, Color uDiff
 
     memset(&particle, 0, sizeof(Particle_sw));
     particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
-    particle.timeToLive = Duration::fromTicks(vrng->random(128) + 128);
+    particle.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     particle.texture = this->effpar02;
     particle.particle_size = 1.0;
 
@@ -596,7 +596,7 @@ void SpellFxRenderer::_4A7F74(int x, int y, int z) {
     local_0.uDiffuse = colorTable.MediumGrey;
     local_0.particle_size = 1.0;
     v6 = 8;
-    local_0.timeToLive = Duration::fromTicks(vrng->random(0x80) + 128);
+    local_0.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
 
     v12 = (float)x;
     local_0.texture = this->effpar01;

--- a/src/Engine/SpellFxRenderer.h
+++ b/src/Engine/SpellFxRenderer.h
@@ -94,10 +94,10 @@ struct SpellFxRenderer {
         this->particle_engine = particle_engine;
 
         this->field_204 = 0;
-        this->uFadeTime = Duration::zero();
+        this->uFadeTime = 0_ticks;
         this->uNumProjectiles = 0;
         this->field_0 = 0;
-        this->uAnimLength = Duration::zero();
+        this->uAnimLength = 0_ticks;
 
         pStru1 = new SpellFX_Billboard();
         pStru1->Initialize(colorTable.OrangeyRed.c32());

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1099,7 +1099,7 @@ void CastSpellInfoHelpers::castSpell() {
                     int spell_spray_angle_start = ONE_THIRD_PI / -2;
                     int spell_spray_angle_end = ONE_THIRD_PI / 2;
                     while (spell_spray_angle_start <= spell_spray_angle_end) {
-                        pSpellSprite.timeSinceCreated = Duration::fromTicks(grng->random(64));
+                        pSpellSprite.timeSinceCreated = Duration::randomRealtimeMilliseconds(grng, 500);
                         pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
                         int spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
                         int yaw = spell_spray_angle_start + target_direction.uYawAngle;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -91,7 +91,7 @@ static void setSpellRecovery(CastSpellInfo *pCastSpell,
     }
 
     if (recoveryTime < Duration::zero()) {
-        recoveryTime = Duration::zero();
+        recoveryTime = 0_ticks;
     }
 
     Character *pPlayer = &pParty->pCharacters[pCastSpell->casterCharacterIndex];
@@ -1236,7 +1236,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1557,7 +1557,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1690,7 +1690,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1791,7 +1791,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1861,7 +1861,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1905,7 +1905,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -1938,7 +1938,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -2146,7 +2146,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -2233,7 +2233,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -2303,7 +2303,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);
@@ -2342,7 +2342,7 @@ void CastSpellInfoHelpers::castSpell() {
                             spell_duration = Duration::fromDays(spell_level);
                             break;
                         case CHARACTER_SKILL_MASTERY_GRANDMASTER:
-                            spell_duration = Duration::zero();
+                            spell_duration = 0_ticks;
                             break;
                         default:
                             assert(false);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1099,7 +1099,7 @@ void CastSpellInfoHelpers::castSpell() {
                     int spell_spray_angle_start = ONE_THIRD_PI / -2;
                     int spell_spray_angle_end = ONE_THIRD_PI / 2;
                     while (spell_spray_angle_start <= spell_spray_angle_end) {
-                        pSpellSprite.uSpriteFrameID = Duration::fromTicks(grng->random(64)); // TODO(captainurist): this doesn't look like a frame id initialization
+                        pSpellSprite.timeSinceCreated = Duration::fromTicks(grng->random(64));
                         pSpellSprite.uFacing = spell_spray_angle_start + (short)target_direction.uYawAngle;
                         int spell_speed = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
                         int yaw = spell_spray_angle_start + target_direction.uYawAngle;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -90,7 +90,7 @@ static void setSpellRecovery(CastSpellInfo *pCastSpell,
         return;
     }
 
-    if (recoveryTime < Duration::zero()) {
+    if (recoveryTime < 0_ticks) {
         recoveryTime = 0_ticks;
     }
 

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -567,7 +567,7 @@ void eventCastSpell(SpellId uSpellID, CharacterSkillMastery skillMastery, int sk
             spell_sprites.uAttributes = SPRITE_IGNORE_RANGE;
             spell_sprites.uSectorID = pIndoor->GetSector(from);
             spell_sprites.field_60_distance_related_prolly_lod = distance_to_target;
-            spell_sprites.uSpriteFrameID = Duration::zero();
+            spell_sprites.uSpriteFrameID = 0_ticks;
             spell_sprites.spell_caster_pid = Pid(OBJECT_Item, 1000); // 8000 | OBJECT_Item;
             spell_sprites.uSoundID = 0;
             break;
@@ -820,7 +820,7 @@ void armageddonProgress() {
     assert(uCurrentlyLoadedLevelType == LEVEL_OUTDOOR && pParty->armageddon_timer > Duration::zero());
 
     if (pParty->armageddon_timer > 417_ticks) {
-        pParty->armageddon_timer = Duration::zero();
+        pParty->armageddon_timer = 0_ticks;
         return; // TODO(captainurist): wtf? Looks like a quick hack for some bug.
     }
 
@@ -830,7 +830,7 @@ void armageddonProgress() {
 
     pParty->_viewYaw = TrigLUT.uDoublePiMask & (pParty->_viewYaw + grng->randomInSegment(-8, 8)); // Was RandomInSegment(-8, 7)
     pParty->_viewPitch = std::clamp(pParty->_viewPitch + grng->randomInSegment(-8, 8), -128, 128); // Was RandomInSegment(-8, 7)
-    pParty->armageddon_timer = std::max(Duration::zero(), pParty->armageddon_timer - pEventTimer->uTimeElapsed); // Was pMiscTimer
+    pParty->armageddon_timer = std::max(0_ticks, pParty->armageddon_timer - pEventTimer->uTimeElapsed); // Was pMiscTimer
 
     // TODO(pskelton): ignore if pEventTimer->uTimeElapsed is zero?
     // TODO(captainurist): See the logic in Outdoor.cpp, right now the force is applied in fixed amounts per frame,

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -567,7 +567,7 @@ void eventCastSpell(SpellId uSpellID, CharacterSkillMastery skillMastery, int sk
             spell_sprites.uAttributes = SPRITE_IGNORE_RANGE;
             spell_sprites.uSectorID = pIndoor->GetSector(from);
             spell_sprites.field_60_distance_related_prolly_lod = distance_to_target;
-            spell_sprites.uSpriteFrameID = 0_ticks;
+            spell_sprites.timeSinceCreated = 0_ticks;
             spell_sprites.spell_caster_pid = Pid(OBJECT_Item, 1000); // 8000 | OBJECT_Item;
             spell_sprites.uSoundID = 0;
             break;

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -817,7 +817,7 @@ int CalcSpellDamage(SpellId uSpellID, int spellLevel, CharacterSkillMastery skil
 }
 
 void armageddonProgress() {
-    assert(uCurrentlyLoadedLevelType == LEVEL_OUTDOOR && pParty->armageddon_timer > Duration::zero());
+    assert(uCurrentlyLoadedLevelType == LEVEL_OUTDOOR && pParty->armageddon_timer > 0_ticks);
 
     if (pParty->armageddon_timer > 417_ticks) {
         pParty->armageddon_timer = 0_ticks;

--- a/src/Engine/Tables/CharacterFrameTable.cpp
+++ b/src/Engine/Tables/CharacterFrameTable.cpp
@@ -14,7 +14,7 @@ unsigned int PlayerFrameTable::GetFrameIdByExpression(CharacterExpressionID expr
 Duration PlayerFrameTable::GetDurationByExpression(CharacterExpressionID expression) {
     int index = GetFrameIdByExpression(expression);
     if (index == 0)
-        return Duration::zero();
+        return 0_ticks;
     return this->pFrames[index].uAnimLength;
 }
 

--- a/src/Engine/Time/CMakeLists.txt
+++ b/src/Engine/Time/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 set(ENGINE_TIME_SOURCES
+        Duration.cpp
         Timer.cpp)
 
 set(ENGINE_TIME_HEADERS

--- a/src/Engine/Time/Duration.cpp
+++ b/src/Engine/Time/Duration.cpp
@@ -1,0 +1,20 @@
+#include "Duration.h"
+
+#include "Library/Random/RandomEngine.h"
+
+Duration Duration::randomRealtimeMilliseconds(RandomEngine *rng, int64_t hi) {
+    return Duration::fromTicks(rng->random(Duration::fromRealtimeMilliseconds(hi).ticks()));
+}
+
+Duration Duration::randomRealtimeMilliseconds(RandomEngine *rng, int64_t lo, int64_t hi) {
+    return Duration::fromRealtimeMilliseconds(lo) + Duration::randomRealtimeMilliseconds(rng, hi - lo);
+}
+
+Duration Duration::randomRealtimeSeconds(RandomEngine *rng, int64_t hi) {
+    return Duration::fromTicks(rng->random(Duration::fromRealtimeSeconds(hi).ticks()));
+}
+
+Duration Duration::randomRealtimeSeconds(RandomEngine *rng, int64_t lo, int64_t hi) {
+    return Duration::fromRealtimeSeconds(lo) + Duration::randomRealtimeSeconds(rng, hi - lo);
+}
+

--- a/src/Engine/Time/Duration.cpp
+++ b/src/Engine/Time/Duration.cpp
@@ -2,19 +2,23 @@
 
 #include "Library/Random/RandomEngine.h"
 
+Duration Duration::random(RandomEngine *rng, Duration hi) {
+    return fromTicks(rng->random(hi.ticks()));
+}
+
 Duration Duration::randomRealtimeMilliseconds(RandomEngine *rng, int64_t hi) {
-    return Duration::fromTicks(rng->random(Duration::fromRealtimeMilliseconds(hi).ticks()));
+    return random(rng, fromRealtimeMilliseconds(hi));
 }
 
 Duration Duration::randomRealtimeMilliseconds(RandomEngine *rng, int64_t lo, int64_t hi) {
-    return Duration::fromRealtimeMilliseconds(lo) + Duration::randomRealtimeMilliseconds(rng, hi - lo);
+    return fromRealtimeMilliseconds(lo) + randomRealtimeMilliseconds(rng, hi - lo);
 }
 
 Duration Duration::randomRealtimeSeconds(RandomEngine *rng, int64_t hi) {
-    return Duration::fromTicks(rng->random(Duration::fromRealtimeSeconds(hi).ticks()));
+    return random(rng, fromRealtimeSeconds(hi));
 }
 
 Duration Duration::randomRealtimeSeconds(RandomEngine *rng, int64_t lo, int64_t hi) {
-    return Duration::fromRealtimeSeconds(lo) + Duration::randomRealtimeSeconds(rng, hi - lo);
+    return fromRealtimeSeconds(lo) + randomRealtimeSeconds(rng, hi - lo);
 }
 

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -4,6 +4,8 @@
 #include <compare>
 #include <type_traits>
 
+class RandomEngine;
+
 struct CivilDuration {
     int days = 0;
     int hours = 0;
@@ -59,6 +61,14 @@ class Duration {
     [[nodiscard]] constexpr int64_t toRealtimeSeconds() const { return ticks() / TICKS_PER_REALTIME_SECOND; }
     [[nodiscard]] constexpr int64_t toRealtimeMilliseconds() const { return ticks() * 1000 / TICKS_PER_REALTIME_SECOND; }
     [[nodiscard]] constexpr float toFloatRealtimeSeconds() const { return ticks() / static_cast<float>(TICKS_PER_REALTIME_SECOND); }
+
+    // Unlike with RandomEngine::randomInSegment, two-arg functions below generate a duration in [lo, hi) open interval,
+    // not in [lo, hi] segment.
+
+    [[nodiscard]] static Duration randomRealtimeMilliseconds(RandomEngine *rng, int64_t hi);
+    [[nodiscard]] static Duration randomRealtimeMilliseconds(RandomEngine *rng, int64_t lo, int64_t hi);
+    [[nodiscard]] static Duration randomRealtimeSeconds(RandomEngine *rng, int64_t hi);
+    [[nodiscard]] static Duration randomRealtimeSeconds(RandomEngine *rng, int64_t lo, int64_t hi);
 
     [[nodiscard]] constexpr CivilDuration toCivilDuration() const {
         CivilDuration result;

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -65,6 +65,7 @@ class Duration {
     // Unlike with RandomEngine::randomInSegment, two-arg functions below generate a duration in [lo, hi) open interval,
     // not in [lo, hi] segment.
 
+    [[nodiscard]] static Duration random(RandomEngine *rng, Duration hi);
     [[nodiscard]] static Duration randomRealtimeMilliseconds(RandomEngine *rng, int64_t hi);
     [[nodiscard]] static Duration randomRealtimeMilliseconds(RandomEngine *rng, int64_t lo, int64_t hi);
     [[nodiscard]] static Duration randomRealtimeSeconds(RandomEngine *rng, int64_t hi);

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -90,7 +90,7 @@ void stru262_TurnBased::SortTurnQueue() {
         if (pQueue[i].uPackedID.type() ==
             OBJECT_Character)  // set recovery times
             pParty->pCharacters[pQueue[i].uPackedID.id()].timeToRecovery =
-                Duration::fromTicks((double)pQueue[i].actor_initiative * 0.46875);
+                Duration::fromTicks((double)pQueue[i].actor_initiative / flt_debugrecmod3); // Was * 0.46875, 0.46875 = 1 / 2.133333333333333.
     }
 }
 //----- (0040471C) --------------------------------------------------------

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -279,7 +279,7 @@ void stru262_TurnBased::AITurnBasedAction() {
     if (turn_stage == TE_WAIT) {
         if (ai_turn_timer == 64_ticks) {
             ActorAISetMovementDecision();
-        } else if (ai_turn_timer > Duration::zero()) {
+        } else if (ai_turn_timer > 0_ticks) {
             ActorAIDoAdditionalMove();
         } else {
             ActorAIStopMovement();
@@ -545,7 +545,7 @@ void stru262_TurnBased::_4065B0() {
             if ((pQueue[i].uPackedID.type() == OBJECT_Character) ||
                 (pQueue[i].actor_initiative > 0))
                 break;
-            if ((pQueue[i].uActionLength <= Duration::zero()) &&
+            if ((pQueue[i].uActionLength <= 0_ticks) &&
                 (pQueue[i].uPackedID.type() == OBJECT_Actor))
                 AI_Action_(i);
         }

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -127,8 +127,8 @@ void stru262_TurnBased::Start() {
             TurnBased_QueueElem &element = this->pQueue.emplace_back();
             element.uPackedID = Pid(OBJECT_Character, pl_id);
             element.AI_action_type = TE_AI_PURSUE;
-            element.uActionLength = Duration::zero();
-            pParty->pTurnBasedCharacterRecoveryTimes[this->pQueue.size() - 1] = Duration::zero();
+            element.uActionLength = 0_ticks;
+            pParty->pTurnBasedCharacterRecoveryTimes[this->pQueue.size() - 1] = 0_ticks;
         }
     }
 
@@ -147,7 +147,7 @@ void stru262_TurnBased::Start() {
                 TurnBased_QueueElem &element = this->pQueue.emplace_back();
                 element.uPackedID = Pid(OBJECT_Actor, ai_near_actors_ids[i]);
                 element.AI_action_type = TE_AI_PURSUE;
-                element.uActionLength = Duration::zero();
+                element.uActionLength = 0_ticks;
             }
         }
     }
@@ -265,8 +265,8 @@ void stru262_TurnBased::AITurnBasedAction() {
                 v15 = v6;
                 v14 = v15;
                 if (curr_actor->aiState == Dying) {
-                    curr_actor->currentActionTime = Duration::zero();
-                    curr_actor->currentActionLength = Duration::zero();
+                    curr_actor->currentActionTime = 0_ticks;
+                    curr_actor->currentActionLength = 0_ticks;
                     curr_actor->aiState = Dead;
                     curr_actor->UpdateAnimation();
                 } else if ((curr_actor->aiState > Removed) &&
@@ -328,7 +328,7 @@ void stru262_TurnBased::StartTurn() {
             TurnBased_QueueElem &element = this->pQueue.emplace_back();
             element.uPackedID = Pid(OBJECT_Character, player_num);
             element.actor_initiative = 100;
-            element.uActionLength = Duration::zero();
+            element.uActionLength = 0_ticks;
             element.AI_action_type = TE_AI_STAND;
         }
     }
@@ -343,7 +343,7 @@ void stru262_TurnBased::StartTurn() {
             TurnBased_QueueElem &element = this->pQueue.emplace_back();
             element.uPackedID = Pid(OBJECT_Actor, ai_near_actors_ids[actor_num]);
             element.actor_initiative = 1;
-            element.uActionLength = Duration::zero();
+            element.uActionLength = 0_ticks;
             element.AI_action_type = TE_AI_STAND;
         }
     }
@@ -398,8 +398,8 @@ void stru262_TurnBased::NextTurn() {
                     v13 = 1;
                 } else if (pActors[monster_id].aiState == Dying) {  // Dying
                     pActors[monster_id].aiState = Dead;
-                    pActors[monster_id].currentActionTime = Duration::zero();
-                    pActors[monster_id].currentActionLength = Duration::zero();
+                    pActors[monster_id].currentActionTime = 0_ticks;
+                    pActors[monster_id].currentActionLength = 0_ticks;
                     pActors[monster_id].UpdateAnimation();
                 } else {
                     if (pActors[monster_id].aiState == Stunned)  // Stunned
@@ -425,7 +425,7 @@ void stru262_TurnBased::NextTurn() {
                 (pActors[monster_id].aiState != Removed) &&
                 (pActors[monster_id].aiState != Summoned) &&
                 (pActors[monster_id].aiState != Disabled)) {
-                pQueue[i].uActionLength = Duration::zero();
+                pQueue[i].uActionLength = 0_ticks;
                 Actor::AI_StandOrBored(monster_id,
                                        ai_near_actors_targets_pid[monster_id],
                                        32_ticks, nullptr);
@@ -463,7 +463,7 @@ bool stru262_TurnBased::StepTurnQueue() {
                         for (j = 0; j < this->pQueue.size(); ++j) {
                             --pQueue[j].actor_initiative;
                             if (pQueue[j].actor_initiative == 0)
-                                pQueue[j].uActionLength = Duration::zero();
+                                pQueue[j].uActionLength = 0_ticks;
                         }
                         --turn_initiative;
                         if (turn_initiative == 0) return true;
@@ -484,7 +484,7 @@ void stru262_TurnBased::_406457(int a2) {
         v4 = pQueue[a2].uPackedID.id();
         if (pParty->pTurnBasedCharacterRecoveryTimes[v4]) {
             v6 = pParty->pTurnBasedCharacterRecoveryTimes[v4];
-            pParty->pTurnBasedCharacterRecoveryTimes[v4] = Duration::zero();
+            pParty->pTurnBasedCharacterRecoveryTimes[v4] = 0_ticks;
         } else {
             v6 = pParty->pCharacters[v4].GetAttackRecoveryTime(false);
         }
@@ -505,7 +505,7 @@ void stru262_TurnBased::_406457(int a2) {
     while ((pQueue[0].actor_initiative > 0) && (turn_initiative > 0)) {
         for (i = 0; i < this->pQueue.size(); ++i) {
             --pQueue[i].actor_initiative;
-            if (pQueue[i].actor_initiative == 0) pQueue[i].uActionLength = Duration::zero();
+            if (pQueue[i].actor_initiative == 0) pQueue[i].uActionLength = 0_ticks;
         }
         --turn_initiative;
     }
@@ -599,8 +599,8 @@ void stru262_TurnBased::AIAttacks(unsigned int queue_index) {
                         Actor::AI_Stand(actor_id, ai_near_actors_targets_pid[actor_id], 0_ticks, &a4);
                         break;
                     case Dying:
-                        pActors[actor_id].currentActionTime = Duration::zero();
-                        pActors[actor_id].currentActionLength = Duration::zero();
+                        pActors[actor_id].currentActionTime = 0_ticks;
+                        pActors[actor_id].currentActionLength = 0_ticks;
                         pActors[actor_id].aiState = Dead;
                         pActors[actor_id].UpdateAnimation();
                         break;
@@ -643,7 +643,7 @@ void stru262_TurnBased::AI_Action_(int queue_index) {
     AIDirection v18;        // [sp+28h] [bp-28h]@10
     Pid v22;         // [sp+58h] [bp+8h]@10
 
-    pQueue[queue_index].uActionLength = Duration::zero();
+    pQueue[queue_index].uActionLength = 0_ticks;
     if (pQueue[queue_index].uPackedID.type() == OBJECT_Actor) {
         actor_id = pQueue[queue_index].uPackedID.id();
         if (!(pActors[actor_id].aiState == Dying ||
@@ -782,7 +782,7 @@ void stru262_TurnBased::ActorAIStopMovement() {
             Actor::GetDirectionInfo(pQueue[i].uPackedID, target_pid, &v7, 0);
             Actor::AI_Stand(pQueue[i].uPackedID.id(), target_pid, 32_ticks, &v7);
             pQueue[i].AI_action_type = TE_AI_STAND;
-            pQueue[i].uActionLength = Duration::zero();
+            pQueue[i].uActionLength = 0_ticks;
         }
     }
     turn_stage = TE_ATTACK;
@@ -817,8 +817,8 @@ void stru262_TurnBased::ActorAIDoAdditionalMove() {
                     if (pActors[monster_id].currentActionTime >
                         pActors[monster_id].currentActionLength) {
                         if (pActors[monster_id].aiState == Dying) {
-                            pActors[monster_id].currentActionTime = Duration::zero();
-                            pActors[monster_id].currentActionLength = Duration::zero();
+                            pActors[monster_id].currentActionTime = 0_ticks;
+                            pActors[monster_id].currentActionLength = 0_ticks;
                             pActors[monster_id].aiState = Dead;
                             pActors[monster_id].UpdateAnimation();
                         }
@@ -996,8 +996,8 @@ void stru262_TurnBased::ActorAIChooseNewTargets() {
                 if (curr_acror->currentActionTime >
                     curr_acror->currentActionLength) {
                     if (curr_acror->aiState == Dying) {
-                        curr_acror->currentActionTime = Duration::zero();
-                        curr_acror->currentActionLength = Duration::zero();
+                        curr_acror->currentActionTime = 0_ticks;
+                        curr_acror->currentActionLength = 0_ticks;
                         curr_acror->aiState = Dead;
                         curr_acror->UpdateAnimation();
                         break;

--- a/src/Engine/TurnEngine/TurnEngine.h
+++ b/src/Engine/TurnEngine/TurnEngine.h
@@ -10,7 +10,7 @@ struct TurnBased_QueueElem {
     inline TurnBased_QueueElem() {
         uPackedID = Pid();
         actor_initiative = 0;
-        uActionLength = Duration::zero();
+        uActionLength = 0_ticks;
         AI_action_type = TE_AI_STAND;
     }
     Pid uPackedID;
@@ -23,7 +23,7 @@ struct stru262_TurnBased {
     inline stru262_TurnBased() {
         turns_count = 0;
         turn_stage = TE_NONE;
-        ai_turn_timer = Duration::zero();
+        ai_turn_timer = 0_ticks;
         turn_initiative = 0;
         uActionPointsLeft = 0;
         flags = 0;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2450,11 +2450,6 @@ std::string pCurrentMapName;
 MapId uLevelMapStatsID;
 int dword_6BE364_game_settings_1 = 0;
 
-float debug_non_combat_recovery_mul;
-float debug_combat_recovery_mul;
-float debug_turn_based_monster_movespeed_mul;
-float flt_debugrecmod3;
-
 std::string s_SavedMapName;  // idb
 char bNoNPCHiring = false;
 std::vector<Vec3f> pTerrainNormals;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -130,17 +130,16 @@ extern int dword_6BE364_game_settings_1;  // GAME_SETTINGS_*
 
 /** Recovery multiplier for non-combat actions, e.g. receiving fall damage, casting buffs,
  * and receiving damage from monsters. */
-extern float debug_non_combat_recovery_mul;
+constexpr float debug_non_combat_recovery_mul = 1.0f;
 
 /** Recovery multiplier for combat actions, e.g. hand-to-hand and ranged attacks and combat spells. */
-extern float debug_combat_recovery_mul;
+constexpr float debug_combat_recovery_mul = 1.0f;
 
 /** Speed multiplier for monsters in turn-based mode. It does affect actual move distance, but setting a high value
  * doesn't make monsters dart like crazy because monster speed is capped at 1000. Doh. */
-extern float debug_turn_based_monster_movespeed_mul;
+constexpr float debug_turn_based_monster_movespeed_mul = 1.666666666666667f;
 
-// 2.1333
-extern float flt_debugrecmod3;
+constexpr float flt_debugrecmod3 = 2.133333333333333f;
 
 extern std::string s_SavedMapName;
 extern char bNoNPCHiring;

--- a/src/GUI/GUIProgressBar.cpp
+++ b/src/GUI/GUIProgressBar.cpp
@@ -98,7 +98,7 @@ void GUIProgressBar::Draw() {
         pParty->updateCharactersAndHirelingsEmotions();
 
         render->DrawTextureNew(80 / 640.0f, 122 / 480.0f, progressbar_dungeon);
-        render->DrawTextureNew(100 / 640.0f, 146 / 480.0f, pIconsFrameTable->GetFrame(uIconID_TurnHour, Duration::zero())->GetTexture());
+        render->DrawTextureNew(100 / 640.0f, 146 / 480.0f, pIconsFrameTable->GetFrame(uIconID_TurnHour, 0_ticks)->GetTexture());
         render->FillRectFast(174, 164, floorf(((double)(113 * uProgressCurrent) / (double)uProgressMax) + 0.5f), 16, colorTable.Red);
     } else {
         if (loading_bg) {

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -856,7 +856,7 @@ void GUIWindow_Shop::playHouseGoodbyeSpeech() {
         rudeReaction = !_transactionPerformed;
     }
     if (rudeReaction && !pParty->_delayedReactionTimer) {
-        int id = pParty->getRandomActiveCharacterId(vrng.get());
+        int id = pParty->getRandomActiveCharacterId(vrng);
 
         if (id != -1) {
             pParty->setDelayedReaction(SPEECH_SHOP_RUDE, id);
@@ -871,7 +871,7 @@ void GUIWindow_AlchemyShop::playHouseGoodbyeSpeech() {
     if (pParty->PartyTimes.shopBanTimes[houseId()] <= pParty->GetPlayingTime()) {
         playHouseSound(houseId(), _transactionPerformed ? HOUSE_SOUND_ALCHEMY_SHOP_GOODBYE_BOUGHT : HOUSE_SOUND_ALCHEMY_SHOP_GOODBYE_REGULAR);
     } else if (!pParty->_delayedReactionTimer) {
-        int id = pParty->getRandomActiveCharacterId(vrng.get());
+        int id = pParty->getRandomActiveCharacterId(vrng);
 
         if (id != -1) {
             pParty->setDelayedReaction(SPEECH_SHOP_RUDE, id);

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -1314,7 +1314,7 @@ static void CharacterUI_DrawItem(int x, int y, ItemGen *item, int id, GraphicsIm
         else
             assert(false);
 
-        ItemEnchantmentTimer = std::max(Duration::zero(), ItemEnchantmentTimer - pEventTimer->uTimeElapsed);
+        ItemEnchantmentTimer = std::max(0_ticks, ItemEnchantmentTimer - pEventTimer->uTimeElapsed);
         if (!ItemEnchantmentTimer) {
             item->ResetEnchantAnimation();
             ptr_50C9A4_ItemToEnchant = nullptr;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1242,20 +1242,21 @@ void GameUI_DrawCharacterSelectionFrame() {
 
 //----- (0044162D) --------------------------------------------------------
 void GameUI_DrawPartySpells() {
-    // TODO(pskelton): check tickcount usage here
-    // TODO(captainurist): #time we have relativistic time dilation here, / 20 doesn't give us Duration ticks.
-    Duration frameNum = Duration::fromTicks(platform->tickCount() / 20);
-    GraphicsImage *spell_texture;  // [sp-4h] [bp-1Ch]@12
-
     for (int i = 0; i < spellBuffsAtRightPanel.size(); ++i) {
         if (pParty->pPartyBuffs[spellBuffsAtRightPanel[i]].Active()) {
-            render->TexturePixelRotateDraw(pPartySpellbuffsUI_XYs[i][0] / 640., pPartySpellbuffsUI_XYs[i][1] / 480.,
-                                           party_buff_icons[i], frameNum.ticks() + 20 * pPartySpellbuffsUI_smthns[i]);
+            render->TexturePixelRotateDraw(pPartySpellbuffsUI_XYs[i][0] / 640.,
+                                           pPartySpellbuffsUI_XYs[i][1] / 480.,
+                                           party_buff_icons[i],
+                                           pMiscTimer->uTotalTimeElapsed.toRealtimeMilliseconds() / 20 + 20 * pPartySpellbuffsUI_smthns[i]);
         }
     }
 
-    if (current_screen_type == SCREEN_GAME ||
-        current_screen_type == SCREEN_NPC_DIALOGUE) {
+    if (current_screen_type == SCREEN_GAME || current_screen_type == SCREEN_NPC_DIALOGUE) {
+        // Flight / water walk animation is purposefully slowed down compared to what's in the data files.
+        Duration frameNum = pMiscTimer->uTotalTimeElapsed * 50 / 128;
+
+        GraphicsImage *spell_texture;  // [sp-4h] [bp-1Ch]@12
+
         if (pParty->FlyActive()) {
             if (pParty->bFlying)
                 spell_texture = pIconsFrameTable->GetFrame(uIconIdx_FlySpell, frameNum)->GetTexture();
@@ -1263,6 +1264,7 @@ void GameUI_DrawPartySpells() {
                 spell_texture = pIconsFrameTable->GetFrame(uIconIdx_FlySpell, 0_ticks)->GetTexture();
             render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, spell_texture);
         }
+
         if (pParty->WaterWalkActive()) {
             if (pParty->uFlags & PARTY_FLAG_STANDING_ON_WATER)
                 spell_texture = pIconsFrameTable->GetFrame(uIconIdx_WaterWalk, frameNum)->GetTexture();

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1260,14 +1260,14 @@ void GameUI_DrawPartySpells() {
             if (pParty->bFlying)
                 spell_texture = pIconsFrameTable->GetFrame(uIconIdx_FlySpell, frameNum)->GetTexture();
             else
-                spell_texture = pIconsFrameTable->GetFrame(uIconIdx_FlySpell, Duration::zero())->GetTexture();
+                spell_texture = pIconsFrameTable->GetFrame(uIconIdx_FlySpell, 0_ticks)->GetTexture();
             render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, spell_texture);
         }
         if (pParty->WaterWalkActive()) {
             if (pParty->uFlags & PARTY_FLAG_STANDING_ON_WATER)
                 spell_texture = pIconsFrameTable->GetFrame(uIconIdx_WaterWalk, frameNum)->GetTexture();
             else
-                spell_texture = pIconsFrameTable->GetFrame(uIconIdx_WaterWalk, Duration::zero())->GetTexture();
+                spell_texture = pIconsFrameTable->GetFrame(uIconIdx_WaterWalk, 0_ticks)->GetTexture();
             render->DrawTextureNew(396 / 640.0f, 8 / 480.0f, spell_texture);
         }
     }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -360,7 +360,7 @@ bool enterHouse(HouseId uHouseID) {
         ++pParty->uNumPrisonTerms;
         pParty->uFine = 0;
         for (Character &player : pParty->pCharacters) {
-            player.timeToRecovery = Duration::zero();
+            player.timeToRecovery = 0_ticks;
             player.uNumDivineInterventionCastsThisDay = 0;
             player.SetVariable(VAR_Award, Award_PrisonTerms);
         }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1723,7 +1723,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, int characterIndex) {
     window->DrawText(assets->pFontArrus.get(), {14, 114}, colorTable.White, active_spells);
 }
 
-void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
+void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
     NPCData *pNPC;           // eax@16
     std::string pText;       // eax@18
     int a2;                  // [sp+60h] [bp-Ch]@16
@@ -1732,8 +1732,8 @@ void GameUI_DrawNPCPopup(void *_this) {  // PopupWindowForBenefitAndJoinText
         FlatHirelings buf;
         buf.Prepare();
 
-        if ((int64_t)((char *)_this + pParty->hirelingScrollPosition) < buf.Size()) {
-            sDialogue_SpeakingActorNPC_ID = -1 - pParty->hirelingScrollPosition - (int64_t)_this;
+        if (_this + pParty->hirelingScrollPosition < buf.Size()) {
+            sDialogue_SpeakingActorNPC_ID = -1 - pParty->hirelingScrollPosition - _this;
             pNPC = GetNewNPCData(sDialogue_SpeakingActorNPC_ID, &a2);
             if (pNPC) {
                 if (a2 == 57)
@@ -1882,7 +1882,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                                (int)pY < 156 || (int)pY > 229) {  // NPC zone
                         if (!((signed int)pX < 566 || (signed int)pX > 629 ||
                               (signed int)pY < 156 || (signed int)pY > 229)) {
-                            GameUI_DrawNPCPopup((void *)1);  // NPC 2
+                            GameUI_DrawNPCPopup(1);  // NPC 2
                         }
                     } else {
                         GameUI_DrawNPCPopup(0);  // NPC 1

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -664,7 +664,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         if (pMonsterInfoUI_Doll.currentActionAnimation == ANIM_Bored ||
             pMonsterInfoUI_Doll.currentActionAnimation == ANIM_AtkMelee) {
             pMonsterInfoUI_Doll.currentActionAnimation = ANIM_Standing;
-            pMonsterInfoUI_Doll.currentActionLength = Duration::fromTicks(vrng->random(128) + 128);
+            pMonsterInfoUI_Doll.currentActionLength = Duration::randomRealtimeSeconds(vrng, 1, 2);
         } else {
             // rand();
             pMonsterInfoUI_Doll.currentActionAnimation = ANIM_Bored;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -654,13 +654,13 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         // copy actor info if different
         pMonsterInfoUI_Doll = pActors[uActorID];
         pMonsterInfoUI_Doll.currentActionAnimation = ANIM_Bored;
-        pMonsterInfoUI_Doll.currentActionTime = Duration::zero();
+        pMonsterInfoUI_Doll.currentActionTime = 0_ticks;
         actionLen = Duration::fromTicks(vrng->random(256) + 128);
         pMonsterInfoUI_Doll.currentActionLength = actionLen;
     }
 
     if (pMonsterInfoUI_Doll.currentActionTime > actionLen) {
-        pMonsterInfoUI_Doll.currentActionTime = Duration::zero();
+        pMonsterInfoUI_Doll.currentActionTime = 0_ticks;
         if (pMonsterInfoUI_Doll.currentActionAnimation == ANIM_Bored ||
             pMonsterInfoUI_Doll.currentActionAnimation == ANIM_AtkMelee) {
             pMonsterInfoUI_Doll.currentActionAnimation = ANIM_Standing;

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -78,7 +78,7 @@ GUIWindow_Rest::GUIWindow_Rest()
 
     current_screen_type = SCREEN_REST;
 
-    hourglassLoopTimer = Duration::zero();
+    hourglassLoopTimer = 0_ticks;
     rest_ui_restmain = assets->getImage_Alpha("restmain");
     rest_ui_btn_1 = assets->getImage_Alpha("restb1");
     rest_ui_btn_2 = assets->getImage_Alpha("restb2");
@@ -126,7 +126,7 @@ void GUIWindow_Rest::Update() {
 
         hourglassLoopTimer += pEventTimer->uTimeElapsed;
         if (hourglassLoopTimer >= Duration::fromRealtimeSeconds(4)) {
-            hourglassLoopTimer = Duration::zero();
+            hourglassLoopTimer = 0_ticks;
         }
 
         int hourglass_icon_idx = (int)floorf(((double)hourglassLoopTimer.ticks() / 512.0 * 120.0) + 0.5f) % 256 + 1;

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -330,7 +330,7 @@ void Io::KeyboardInputHandler::GenerateGameplayActions() {
     }
 
     if (resettimer == true) {
-        this->keydelaytimer = Duration::zero();
+        this->keydelaytimer = 0_ticks;
     } else {
         // use timer so pacing is consistent across framerates
         if (this->keydelaytimer < DELAY_TOGGLE_TIME_FIRST) this->keydelaytimer += pEventTimer->uTimeElapsed;

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 97f3b1aa9ed93714b91e7efe362cad24f7102add
+            GIT_TAG bc6a2d26267565ad5142eef5cb2948487796b59c
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTestMain.cpp
+++ b/test/Bin/GameTest/GameTestMain.cpp
@@ -43,7 +43,7 @@ int platformMain(int argc, char **argv) {
 
         int exitCode = 0;
         starter.runInstrumented([&] (EngineController *game) {
-            TestController test(game, opts.testPath);
+            TestController test(game, opts.testPath, opts.speed);
             GameTest::init(game, &test);
             exitCode = RUN_ALL_TESTS();
         });

--- a/test/Bin/GameTest/GameTestOptions.cpp
+++ b/test/Bin/GameTest/GameTestOptions.cpp
@@ -25,6 +25,9 @@ GameTestOptions GameTestOptions::parse(int argc, char **argv) {
     app->add_flag(
         "--headless", result.headless,
         "Run in headless mode.")->group(otherOptions);
+    app->add_option(
+        "--speed", result.speed,
+        "Playback speed, default is infinite, use '1.0' for realtime playback.")->option_text("SPEED");
     app->add_flag(
         "--tracing-rng", result.tracingRng,
         "Use random number generators that print stack trace on each call.")->group(otherOptions);

--- a/test/Bin/GameTest/GameTestOptions.h
+++ b/test/Bin/GameTest/GameTestOptions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cfloat>
 #include <string>
 
 #include "Application/GameStarterOptions.h"
@@ -7,6 +8,7 @@
 
 struct GameTestOptions : GameStarterOptions {
     std::string testPath;
+    float speed = FLT_MAX; // Test playback speed.
     bool helpPrinted = false;
     bool listRequested = false;
 

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -466,8 +466,9 @@ GAME_TEST(Issues, Issue1383) {
     character.pActiveSkills[CHARACTER_SKILL_MERCHANT] = CombinedSkillValue();
     int noobPrice = PriceCalculator::itemBuyingPriceForPlayer(&character, item.GetValue(), 10.0f);
     EXPECT_EQ(noobPrice, 75000);
-    // Reset level type to avoid state errors in future tests
-    uCurrentlyLoadedLevelType = LevelType::LEVEL_NULL;
+
+    // Restore level type.
+    uCurrentlyLoadedLevelType = LEVEL_NULL;
 }
 
 // 1400
@@ -485,7 +486,7 @@ GAME_TEST(Prs, Pr1440) {
 
     TextureFrame frame1;
     frame1.name = "dec33d";
-    frame1.animationDuration = Duration::zero();
+    frame1.animationDuration = 0_ticks;
     frame1.frameDuration = 8_ticks;
     frame1.flags = 0;
     GraphicsImage *tex1 = frame1.GetTexture();

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -526,3 +526,13 @@ GAME_TEST(Issues, Issue1457) {
     EXPECT_EQ(itemsTape.size(), 1);
     EXPECT_EQ(mapItemsTape.size(), 1);
 }
+
+GAME_TEST(Issues, Issue1464) {
+    // Can talk to the npc being dark-sacrificed.
+    // Talking to the last NPC while he's being dark-sacrificed asserts.
+    auto screenTape = tapes.screen();
+    auto hirelingsTape = tapes.totalHirelings();
+    test.playTraceFromTestData("issue_1464.mm7", "issue_1464.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
+    EXPECT_EQ(screenTape, tape(SCREEN_GAME)); // No SCREEN_NPC_DIALOG.
+    EXPECT_EQ(hirelingsTape, tape(1, 0)); // We did sacrifice the last one.
+}

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -6,6 +6,7 @@
 #include "Engine/Objects/Character.h"
 #include "Engine/Objects/Actor.h"
 #include "Engine/Objects/SpriteObject.h"
+#include "Engine/Objects/NPC.h"
 #include "Engine/mm7_data.h"
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
@@ -46,6 +47,14 @@ TestTape<int> CommonTapeRecorder::totalItemCount() {
                 result += item.uItemID != ITEM_NULL;
         result += pParty->pPickedItem.uItemID != ITEM_NULL;
         return result;
+    });
+}
+
+TestTape<int> CommonTapeRecorder::totalHirelings() {
+    return custom([] {
+        FlatHirelings hirelings;
+        hirelings.Prepare();
+        return static_cast<int>(hirelings.Size());
     });
 }
 

--- a/test/Testing/Game/CommonTapeRecorder.h
+++ b/test/Testing/Game/CommonTapeRecorder.h
@@ -45,6 +45,8 @@ class CommonTapeRecorder {
 
     TestTape<int> totalItemCount();
 
+    TestTape<int> totalHirelings();
+
     TestTape<bool> hasItem(ItemId itemId);
 
     TestTape<int> gold();

--- a/test/Testing/Game/TestController.h
+++ b/test/Testing/Game/TestController.h
@@ -17,7 +17,7 @@ class EngineController;
 
 class TestController {
  public:
-    TestController(EngineController *controller, const std::string &testDataPath);
+    TestController(EngineController *controller, const std::string &testDataPath, float playbackSpeed);
 
     std::string fullPathInTestData(const std::string &fileName);
 
@@ -48,5 +48,6 @@ class TestController {
  private:
     EngineController *_controller;
     std::filesystem::path _testDataPath;
+    float _playbackSpeed;
     std::vector<std::function<void()>> _tapeCallbacks;
 };


### PR DESCRIPTION
* Using `0_ticks` instead of `Duration::zero()`.
* Added `Duration::random*` functions & using them everywhere.
* Resolved some `Duration`-related TODOs.
* `float` debug recovery multipliers are now constexpr.
* Game window is resized to 640x480 before trace recording – otherwise trace recording fails if the window has non-default size.
* Added `--speed` option to GameTests binary, handy for debugging.
* Fix & test #1464.