### PR TITLE
More Time work & issue fixes

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1693,7 +1693,7 @@ void Game::processQueuedMessages() {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 continue;
             }
-            case UIMSG_DebugGenItem: {
+            case UIMSG_DebugGenItem:
                 if (!pParty->hasActiveCharacter())
                     continue;
 
@@ -1709,6 +1709,21 @@ void Game::processQueuedMessages() {
                 }
 
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
+                continue;
+            case UIMSG_DebugLich: {
+                if (!pParty->hasActiveCharacter())
+                    continue;
+
+                Character &character = pParty->activeCharacter();
+                if (character.classType == CLASS_LICH)
+                    continue;
+
+                character.classType = CLASS_LICH;
+
+                ItemGen jar;
+                jar.uItemID = ITEM_QUEST_LICH_JAR_FULL;
+                jar.uHolderPlayer = character.getCharacterIndex();
+                character.AddItem2(-1, &jar);
                 continue;
             }
             case UIMSG_DebugKillChar:

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -296,7 +296,7 @@ void Game_StartHirelingDialogue(int hireling_id) {
 
     int index = hireling_id + pParty->hirelingScrollPosition;
     if (index < buf.Size()) {
-        if (!buf.IsFollower(index) && buf.Get(index)->dialogue_1_evt_id == 1)
+        if (buf.GetSacrificeStatus(index) && buf.GetSacrificeStatus(index)->inProgress)
             return; // Hireling is being dark sacrificed.
 
         Actor actor;

--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -11,7 +11,6 @@
 
 #include "Library/Trace/EventTrace.h"
 
-#include "Utility/Exception.h"
 #include "Utility/String.h"
 
 static bool shouldSkip(const GameConfig *config, const ConfigSection *section, const AnyConfigEntry *entry) {
@@ -22,7 +21,8 @@ static bool shouldSkip(const GameConfig *config, const ConfigSection *section, c
         entry == &config->settings.VoiceLevel ||
         entry == &config->settings.SoundLevel ||
         entry == &config->debug.LogLevel ||
-        entry == &config->debug.NoVideo;
+        entry == &config->debug.NoVideo ||
+        entry == &config->gameplay.QuickSavesCount;
 }
 
 static bool shouldTake(const GameConfig *config, const ConfigSection *section, const AnyConfigEntry *entry) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1610,13 +1610,9 @@ void RegeneratePartyHealthMana() {
 }
 
 Duration timeUntilDawn() {
-    const Duration dawnHour = Duration::fromHours(5);
-    Duration currentTimeInDay = Duration::fromHours(pParty->uCurrentHour) + Duration::fromMinutes(pParty->uCurrentMinute);
-
-    if (currentTimeInDay < dawnHour) {
-        return dawnHour - currentTimeInDay;
-    }
-    return Duration::fromDays(1) + dawnHour - currentTimeInDay;
+    Time now = pParty->GetPlayingTime();
+    Time next5am = Time::fromDurationSinceSilence((now.toDurationSinceSilence() - Duration::fromHours(5) + 1_ticks).roundedUp(Duration::fromDays(1)) + Duration::fromHours(5));
+    return next5am - now;
 }
 
 void initLevelStrings(const Blob &blob) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1586,7 +1586,7 @@ void RegeneratePartyHealthMana() {
         }
 
         // for warlock
-        if (PartyHasDragon() && character.classType == CLASS_WARLOCK) {
+        if (PartyHasDragon() && character.classType == CLASS_WARLOCK && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
             character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
         }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1593,12 +1593,13 @@ void RegeneratePartyHealthMana() {
         // for lich
         if (character.classType == CLASS_LICH) {
             bool lich_has_jar = false;
-            for (int idx = 0; idx < Character::INVENTORY_SLOT_COUNT; ++idx) {
-                if (character.pInventoryItemList[idx].uItemID == ITEM_QUEST_LICH_JAR_FULL)
+            for (const ItemGen &item : character.pInventoryItemList)
+                if (item.uItemID == ITEM_QUEST_LICH_JAR_FULL && item.uHolderPlayer == character.getCharacterIndex())
                     lich_has_jar = true;
-            }
 
-            if (character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+            if (lich_has_jar) {
+                character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
+            } else if (character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
                 if (character.health > character.GetMaxHealth() / 2) {
                     character.health = std::max(character.GetMaxHealth() / 2, character.health - 2 * ticks5);
                 }
@@ -1606,9 +1607,6 @@ void RegeneratePartyHealthMana() {
                     character.mana = std::max(character.GetMaxMana() / 2, character.mana - 2 * ticks5);
                 }
             }
-
-            if (lich_has_jar)
-                character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
         }
 
         // for zombie

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1507,6 +1507,9 @@ void RegeneratePartyHealthMana() {
 
     // HP/SP regeneration and HP deterioration.
     for (Character &character : pParty->pCharacters) {
+        if (character.conditions.HasAny({CONDITION_DEAD, CONDITION_ERADICATED}))
+            continue; // No HP/MP regen/drain for dead characters.
+
         for (ItemSlot idx : allItemSlots()) {
             bool recovery_HP = false;
             bool decrease_HP = false;
@@ -1549,18 +1552,18 @@ void RegeneratePartyHealthMana() {
                     }
                 }
 
-                if (recovery_HP && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+                if (recovery_HP) {
                     character.health = std::min(character.GetMaxHealth(), character.health + ticks5);
                     if (character.conditions.Has(CONDITION_UNCONSCIOUS) && character.health > 0) {
                         character.conditions.Reset(CONDITION_UNCONSCIOUS);
                     }
                 }
 
-                if (recovery_SP && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+                if (recovery_SP) {
                     character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
                 }
 
-                if (decrease_HP && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+                if (decrease_HP) {
                     character.health -= ticks5;
                     if (!(character.conditions.Has(CONDITION_UNCONSCIOUS)) && character.health < 0) {
                         character.conditions.Set(CONDITION_UNCONSCIOUS, pParty->GetPlayingTime());
@@ -1578,7 +1581,7 @@ void RegeneratePartyHealthMana() {
         }
 
         // regeneration buff
-        if (character.pCharacterBuffs[CHARACTER_BUFF_REGENERATION].Active() && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+        if (character.pCharacterBuffs[CHARACTER_BUFF_REGENERATION].Active()) {
             character.health = std::min(character.GetMaxHealth(), ticks5 * 5 * character.pCharacterBuffs[CHARACTER_BUFF_REGENERATION].power);
             if (character.conditions.Has(CONDITION_UNCONSCIOUS) && character.health > 0) {
                 character.conditions.Reset(CONDITION_UNCONSCIOUS);
@@ -1586,7 +1589,7 @@ void RegeneratePartyHealthMana() {
         }
 
         // for warlock
-        if (PartyHasDragon() && character.classType == CLASS_WARLOCK && character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+        if (PartyHasDragon() && character.classType == CLASS_WARLOCK) {
             character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
         }
 
@@ -1599,7 +1602,7 @@ void RegeneratePartyHealthMana() {
 
             if (lich_has_jar) {
                 character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
-            } else if (character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+            } else {
                 if (character.health > character.GetMaxHealth() / 2) {
                     character.health = std::max(character.GetMaxHealth() / 2, character.health - 2 * ticks5);
                 }
@@ -1610,8 +1613,7 @@ void RegeneratePartyHealthMana() {
         }
 
         // for zombie
-        if (character.conditions.Has(CONDITION_ZOMBIE) &&
-            character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
+        if (character.conditions.Has(CONDITION_ZOMBIE)) {
             if (character.health > character.GetMaxHealth() / 2) {
                 character.health = std::max(character.GetMaxHealth() / 2, character.health - ticks5);
             }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1607,22 +1607,17 @@ void RegeneratePartyHealthMana() {
                 }
             }
 
-            if (lich_has_jar) {
-                if (character.mana < character.GetMaxMana()) {
-                    character.mana++;
-                }
-            }
+            if (lich_has_jar)
+                character.mana = std::min(character.GetMaxMana(), character.mana + ticks5);
         }
 
         // for zombie
         if (character.conditions.Has(CONDITION_ZOMBIE) &&
             character.conditions.HasNone({ CONDITION_DEAD, CONDITION_ERADICATED })) {
-            if (character.health > (character.GetMaxHealth() / 2)) {
-                character.health = character.health--;
+            if (character.health > character.GetMaxHealth() / 2) {
+                character.health = std::max(character.GetMaxHealth() / 2, character.health - ticks5);
             }
-            if (character.mana > 0) {
-                character.mana = character.mana--;
-            }
+            character.mana = std::max(0, character.mana - ticks5);
         }
     }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1181,7 +1181,9 @@ void _494035_timed_effects__water_walking_damage__etc() {
     int old_hour = pParty->uCurrentHour;
     int old_year = pParty->uCurrentYear;
 
-    pParty->GetPlayingTime() += pEventTimer->dt();
+    Time oldTime = pParty->GetPlayingTime();
+    Time newTime = oldTime + pEventTimer->dt();
+    pParty->GetPlayingTime() = newTime;
 
     CivilTime time = pParty->GetPlayingTime().toCivilTime();
     pParty->uCurrentTimeSecond = time.second;
@@ -1192,10 +1194,9 @@ void _494035_timed_effects__water_walking_damage__etc() {
     pParty->uCurrentMonth = time.month - 1;
     pParty->uCurrentYear = time.year;
 
-    // New day dawns
-    // TODO(pskelton): ticks over at 3 in the morning?? check
-    // TODO(pskelton): store GetDays() somewhere for a neater check here
-    if ((pParty->uCurrentYear > old_year) || pParty->uCurrentHour >= 3 && (old_hour < 3 || pParty->uCurrentDayOfMonth > old_day)) {
+    // New day dawns at 3am.
+    Time next3am = Time::fromDurationSinceSilence((oldTime.toDurationSinceSilence() - Duration::fromHours(3)).roundedUp(Duration::fromDays(1)) + Duration::fromHours(3));
+    if (oldTime < next3am && newTime >= next3am) {
         pParty->pHirelings[0].bHasUsedTheAbility = false;
         pParty->pHirelings[1].bHasUsedTheAbility = false;
 

--- a/src/Engine/Events/Processor.cpp
+++ b/src/Engine/Events/Processor.cpp
@@ -237,7 +237,6 @@ static void checkTimer(MapTimer &timer) {
                 // Initial firing of daily timers, next alarm must be configured to fire on exact time of day
                 timer.alarmTime = Time() + timer.timeInsideDay;
             }
-            // TODO(captainurist): #time
             while (pParty->GetPlayingTime() >= timer.alarmTime) {
                 timer.alarmTime += timer.interval;
             }

--- a/src/Engine/Graphics/BSPModel.cpp
+++ b/src/Engine/Graphics/BSPModel.cpp
@@ -10,6 +10,7 @@
 
 GraphicsImage *ODMFace::GetTexture() {
     if (this->IsTextureFrameTable()) {
+        // TODO(captainurist): probably should be pMiscTimer, not pEventTimer.
         return pTextureFrameTable->GetFrameTexture(
             (int64_t)this->resource, pEventTimer->time());
     } else {

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -205,33 +205,25 @@ void Localization::InitializeNpcProfessionNames() {
 }
 
 void Localization::InitializeCharacterConditionNames() {
-    this->character_conditions[0] = this->localization_strings[52];  // Cursed
-    this->character_conditions[1] = this->localization_strings[241];
-    this->character_conditions[2] = this->localization_strings[14];   // Asleep
-    this->character_conditions[3] = this->localization_strings[4];    // Fear
-    this->character_conditions[4] = this->localization_strings[69];   // Drunk
-    this->character_conditions[5] = this->localization_strings[117];  // Insane
-    this->character_conditions[6] =
-        this->localization_strings[166];                             // Poisoned
-    this->character_conditions[7] = this->localization_strings[65];  // Diseased
-    this->character_conditions[8] =
-        this->localization_strings[166];                             // Poisoned
-    this->character_conditions[9] = this->localization_strings[65];  // Diseased
-    this->character_conditions[10] =
-        this->localization_strings[166];  // Poisoned
-    this->character_conditions[11] =
-        this->localization_strings[65];  // Diseased
-    this->character_conditions[12] =
-        this->localization_strings[162];  // Paralyzed
-    this->character_conditions[13] =
-        this->localization_strings[231];  // Unconcious
-    this->character_conditions[14] = this->localization_strings[58];  // Dead
-    this->character_conditions[15] =
-        this->localization_strings[220];  // Petrified
-    this->character_conditions[16] =
-        this->localization_strings[76];  // Eradicated
-    this->character_conditions[17] = this->localization_strings[601];  // Zombie
-    this->character_conditions[18] = this->localization_strings[98];   // Good
+    this->character_conditions[CONDITION_CURSED]            = this->localization_strings[52];
+    this->character_conditions[CONDITION_WEAK]              = this->localization_strings[241];
+    this->character_conditions[CONDITION_SLEEP]             = this->localization_strings[14];
+    this->character_conditions[CONDITION_FEAR]              = this->localization_strings[4];
+    this->character_conditions[CONDITION_DRUNK]             = this->localization_strings[69];
+    this->character_conditions[CONDITION_INSANE]            = this->localization_strings[117];
+    this->character_conditions[CONDITION_POISON_WEAK]       = this->localization_strings[166];
+    this->character_conditions[CONDITION_DISEASE_WEAK]      = this->localization_strings[65];
+    this->character_conditions[CONDITION_POISON_MEDIUM]     = this->localization_strings[166];
+    this->character_conditions[CONDITION_DISEASE_MEDIUM]    = this->localization_strings[65];
+    this->character_conditions[CONDITION_POISON_SEVERE]     = this->localization_strings[166];
+    this->character_conditions[CONDITION_DISEASE_SEVERE]    = this->localization_strings[65];
+    this->character_conditions[CONDITION_PARALYZED]         = this->localization_strings[162];
+    this->character_conditions[CONDITION_UNCONSCIOUS]       = this->localization_strings[231];
+    this->character_conditions[CONDITION_DEAD]              = this->localization_strings[58];
+    this->character_conditions[CONDITION_PETRIFIED]         = this->localization_strings[220];
+    this->character_conditions[CONDITION_ERADICATED]        = this->localization_strings[76];
+    this->character_conditions[CONDITION_ZOMBIE]            = this->localization_strings[601];
+    this->character_conditions[CONDITION_GOOD]              = this->localization_strings[98];
 }
 
 void Localization::InitializeSkillNames() {

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <string>
 #include <utility>
 
@@ -544,7 +545,7 @@ class Localization {
     }
 
     const char *GetCharacterConditionName(Condition index) const {
-        return this->character_conditions[std::to_underlying(index)];
+        return this->character_conditions[index];
     }
 
     const char *GetAmPm(unsigned int index) const {
@@ -658,10 +659,10 @@ class Localization {
     std::string attribute_desc_raw;
     std::string skill_desc_raw;
 
-    const char *mm6_item_categories[14]{};
-    const char *month_names[12]{};
-    const char *day_names[7]{};
-    const char *moon_phase_names[5]{};
+    std::array<const char *, 14> mm6_item_categories = {{}};
+    std::array<const char *, 12> month_names = {{}};
+    std::array<const char *, 7> day_names = {{}};
+    std::array<const char *, 5> moon_phase_names = {{}};
     IndexedArray<const char *, MAGIC_SCHOOL_FIRST, MAGIC_SCHOOL_LAST> spell_school_names = {{}};
     IndexedArray<const char *, PARTY_BUFF_FIRST, PARTY_BUFF_LAST> party_buff_names = {{}};
     IndexedArray<const char *, CHARACTER_BUFF_FIRST, CHARACTER_BUFF_LAST> character_buff_names = {{}};
@@ -675,7 +676,7 @@ class Localization {
     IndexedArray<const char *, CHARACTER_SKILL_INVALID, CHARACTER_SKILL_LAST_VISIBLE> skill_descriptions_expert = {{}};
     IndexedArray<const char *, CHARACTER_SKILL_INVALID, CHARACTER_SKILL_LAST_VISIBLE> skill_descriptions_master = {{}};
     IndexedArray<const char *, CHARACTER_SKILL_INVALID, CHARACTER_SKILL_LAST_VISIBLE> skill_descriptions_grand = {{}};
-    const char *character_conditions[19]{};
+    IndexedArray<const char *, CONDITION_FIRST, CONDITION_LAST> character_conditions = {{}};
     IndexedArray<const char *, NPC_PROFESSION_FIRST, NPC_PROFESSION_LAST> npc_profession_names = {{}};
     const char *hp_description{};
     const char *sp_description{};

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -122,7 +122,6 @@ class Character {
      * @offset 0x4680ED
      */
     void useItem(int targetCharacter, bool isPortraitClick);
-    bool AddItem(ItemGen *pItem);
     int GetActualAttribute(CharacterAttributeType attrId,
                            unsigned short Character::*attrValue,
                            unsigned short Character::*attrBonus) const;

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -311,3 +311,13 @@ NPCData *FlatHirelings::Get(size_t index) const {
     else
         return &pNPCStats->pNewNPCData[id - 2];
 }
+
+NPCSacrificeStatus *FlatHirelings::GetSacrificeStatus(size_t index) const {
+    assert(index < count);
+
+    uint8_t id = ids[index];
+    if (id < 2)
+        return &pParty->pHirelingsSacrifice[id];
+    else
+        return nullptr;
+}

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -10,6 +10,7 @@
 #include "Engine/Objects/CharacterEnums.h"
 
 struct NPCData;
+struct NPCSacrificeStatus;
 
 enum class NpcType {
     NPC_TYPE_QUEST = 1,
@@ -61,6 +62,12 @@ class FlatHirelings {
      * @return                          Associated `NPCData`.
      */
     NPCData *Get(size_t index) const;
+
+    /**
+     * @param index                     Hireling index.
+     * @return                          Associated `NPCDarkSacrificeStatus`. Returns null for followers.
+     */
+    NPCSacrificeStatus *GetSacrificeStatus(size_t index) const;
 
  private:
     /** Hireling / follower NPC ids.

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -187,6 +187,7 @@ void Party::Zero() {
 
     // hirelings
     pHirelings.fill(NPCData());
+    pHirelingsSacrifice.fill(NPCSacrificeStatus());
 
     playerAlreadyPicked.fill(false); // TODO(captainurist): belongs in a different place?
 }
@@ -430,6 +431,7 @@ void Party::createDefaultParty(bool bDebugGiveItems) {
     pHireling2Name[0] = 0;
     this->hirelingScrollPosition = 0;
     pHirelings.fill(NPCData());
+    pHirelingsSacrifice.fill(NPCSacrificeStatus());
 
     this->pCharacters[0].name = localization->GetString(LSTR_PC_NAME_ZOLTAN);
     this->pCharacters[0].uPrevFace = 17;
@@ -823,17 +825,13 @@ void Party::updateCharactersAndHirelingsEmotions() {
     }
 
     for (int i = 0; i < 2; ++i) {
-        NPCData *hireling = &pParty->pHirelings[i];
-        if (!hireling->dialogue_3_evt_id) continue;
+        if (!pHirelingsSacrifice[i].inProgress)
+            continue;
 
-        hireling->dialogue_2_evt_id += pMiscTimer->dt().ticks();
-        if (hireling->dialogue_2_evt_id >= hireling->dialogue_3_evt_id) {
-            hireling->dialogue_1_evt_id = 0;
-            hireling->dialogue_2_evt_id = 0;
-            hireling->dialogue_3_evt_id = 0;
-
-            *hireling = NPCData();
-
+        pHirelingsSacrifice[i].elapsedTime += pMiscTimer->dt();
+        if (pHirelingsSacrifice[i].elapsedTime >= pHirelingsSacrifice[i].endTime) {
+            pHirelings[i] = NPCData();
+            pHirelingsSacrifice[i] = NPCSacrificeStatus();
             pParty->hirelingScrollPosition = 0;
             pParty->CountHirelings();
         }

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -272,7 +272,7 @@ struct Party {
     int _yawRotationSpeed;  // deg/s
     int jump_strength; // jump strength, higher value => higher jumps, default 5.
     Time playing_time;  // uint64_t uTimePlayed;
-    Time last_regenerated; // Timestamp when HP/MP regeneration was checked last time (using 5 minutes granularity)
+    Time last_regenerated; // Timestamp when HP/MP regeneration was done last time.
     PartyTimeStruct PartyTimes;
     Vec3f pos;
     Vec3f speed; // Party speed, negative z => falling, positive z => jumping.

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -324,6 +324,7 @@ struct Party {
     IndexedArray<SpellBuff, PARTY_BUFF_FIRST, PARTY_BUFF_LAST> pPartyBuffs;
     std::array<Character, 4> pCharacters;
     std::array<NPCData, 2> pHirelings;
+    std::array<NPCSacrificeStatus, 2> pHirelingsSacrifice;
     ItemGen pPickedItem;
     PartyFlags uFlags;
     IndexedArray<std::array<ItemGen, 12>, HOUSE_FIRST_SHOP, HOUSE_LAST_SHOP> standartItemsInShops;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -533,6 +533,15 @@ void snapshot(const Party &src, Party_MM7 *dst) {
     snapshot(src.pCharacters, &dst->players);
     snapshot(src.pHirelings, &dst->hirelings);
 
+    // Vanilla stored NPC sacrifice status in NPC evt values.
+    for (int i = 0; i < 2; i++) {
+        if (src.pHirelingsSacrifice[i].inProgress) {
+            dst->hirelings[i].evt_A = 1;
+            dst->hirelings[i].evt_B = src.pHirelingsSacrifice[i].elapsedTime.ticks();
+            dst->hirelings[i].evt_C = src.pHirelingsSacrifice[i].endTime.ticks();
+        }
+    }
+
     snapshot(src.pPickedItem, &dst->pickedItem);
 
     dst->flags = std::to_underlying(src.uFlags);
@@ -638,6 +647,18 @@ void reconstruct(const Party_MM7 &src, Party *dst) {
     reconstruct(src.partyBuffs, &dst->pPartyBuffs);
     reconstruct(src.players, &dst->pCharacters);
     reconstruct(src.hirelings, &dst->pHirelings);
+
+    // Vanilla stored NPC sacrifice status in NPC evt values.
+    for (int i = 0; i < 2; i++) {
+        if (src.hirelings[i].evt_A) {
+            dst->pHirelings[i].dialogue_1_evt_id = 0;
+            dst->pHirelings[i].dialogue_2_evt_id = 0;
+            dst->pHirelings[i].dialogue_3_evt_id = 0;
+            dst->pHirelingsSacrifice[i].inProgress = true;
+            dst->pHirelingsSacrifice[i].elapsedTime = Duration::fromTicks(src.hirelings[i].evt_B);
+            dst->pHirelingsSacrifice[i].endTime = Duration::fromTicks(src.hirelings[i].evt_C);
+        }
+    }
 
     reconstruct(src.pickedItem, &dst->pPickedItem);
 

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -363,7 +363,8 @@ struct Player_MM7 {
     /* 1928 */ int32_t prevFace;
     /* 192C */ int32_t field_192C;
     /* 1930 */ int32_t field_1930;
-    /* 1934 */ uint16_t timeToRecovery;
+    /* 1934 */ int16_t timeToRecovery; // Time left for the character to recover, in game ticks. Will overflow if
+                                       // recovery is around 1 in-game hour, which never happens.
     /* 1936 */ char field_1936;
     /* 1937 */ char field_1937;
     /* 1938 */ uint32_t skillPoints;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2797,20 +2797,19 @@ void CastSpellInfoHelpers::castSpell() {
 
                     // TODO(captainurist): reimplement this in a saner way.
                     int flatHirelingId = pParty->hirelingScrollPosition + pCastSpell->targetCharacterIndex;
+                    NPCSacrificeStatus *sacrifice = buf.GetSacrificeStatus(flatHirelingId);
 
-                    if (buf.IsFollower(flatHirelingId) || buf.Get(flatHirelingId)->dialogue_1_evt_id == 1) {
+                    if (buf.IsFollower(flatHirelingId) || (sacrifice && sacrifice->inProgress)) {
                         spellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         pPlayer->SpendMana(uRequiredMana); // decrease mana on failure
                         setSpellRecovery(pCastSpell, recoveryTime);
                         continue;
                     }
 
-                    NPCData *npcData = buf.Get(flatHirelingId);
-                    npcData->dialogue_1_evt_id = 1;
-                    npcData->dialogue_2_evt_id = 0;
-                    // TODO(captainurist): #time that's the timer for dark sacrifice.
-                    //                     It's processed in Party::updateCharactersAndHirelingsEmotions. Redo properly?
-                    npcData->dialogue_3_evt_id = pIconsFrameTable->GetIcon("spell96")->GetAnimLength().ticks();
+                    sacrifice->inProgress = true;
+                    sacrifice->elapsedTime = 0_ticks;
+                    sacrifice->endTime = pIconsFrameTable->GetIcon("spell96")->GetAnimLength();
+
                     for (Character &character : pParty->pCharacters) {
                         character.health = character.GetMaxHealth();
                         character.mana = character.GetMaxMana();

--- a/src/Engine/Tables/NPCTable.h
+++ b/src/Engine/Tables/NPCTable.h
@@ -6,6 +6,7 @@
 #include "Engine/Objects/NPCEnums.h"
 #include "Engine/Objects/CharacterEnums.h"
 #include "Engine/Objects/MonsterEnums.h"
+#include "Engine/Time/Duration.h"
 #include "Engine/MapEnums.h"
 
 #include "GUI/UI/UIHouseEnums.h"
@@ -56,6 +57,12 @@ struct NPCData {  // 4Ch
     CharacterSex uSex = SEX_MALE;       // 40
     int bHasUsedTheAbility = 0;  // 44
     int news_topic = 0;          // 48
+};
+
+struct NPCSacrificeStatus {
+    bool inProgress = false; // Dark sacrifice is in progress for this hired NPC?
+    Duration elapsedTime; // Time elapsed since the spell was cast.
+    Duration endTime; // Total time of the animation - NPC will be removed once this time is reached.
 };
 
 struct NPCProfession {

--- a/src/Engine/Time/CMakeLists.txt
+++ b/src/Engine/Time/CMakeLists.txt
@@ -10,5 +10,5 @@ set(ENGINE_TIME_HEADERS
         Duration.h)
 
 add_library(engine_time STATIC ${ENGINE_TIME_SOURCES} ${ENGINE_TIME_HEADERS})
-target_link_libraries(engine_time PUBLIC engine)
+target_link_libraries(engine_time PUBLIC engine library_snapshots)
 target_check_style(engine_time)

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -133,6 +133,10 @@ class Duration {
         return Duration::fromTicks(l._ticks / r);
     }
 
+    [[nodiscard]] constexpr friend int64_t operator/(Duration l, Duration r) {
+        return l._ticks / r._ticks;
+    }
+
     [[nodiscard]] constexpr friend Duration operator%(Duration l, Duration r) {
         return Duration::fromTicks(l._ticks % r._ticks);
     }

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -29,13 +29,13 @@ class Duration {
 
     constexpr Duration() = default;
     constexpr Duration(int seconds, int minutes, int hours, int days, int weeks, int months, int years) {
-        value = seconds + 60ll * minutes + 3600ll * hours + 86400ll * days + 604800ll * weeks + 2419200ll * months + 29030400ll * years;
-        value = value * TICKS_PER_REALTIME_SECOND / GAME_SECONDS_IN_REALTIME_SECOND;
+        _ticks = seconds + 60ll * minutes + 3600ll * hours + 86400ll * days + 604800ll * weeks + 2419200ll * months + 29030400ll * years;
+        _ticks = _ticks * TICKS_PER_REALTIME_SECOND / GAME_SECONDS_IN_REALTIME_SECOND;
     }
 
     [[nodiscard]] constexpr static Duration fromTicks(int64_t ticks) {
         Duration result;
-        result.value = ticks;
+        result._ticks = ticks;
         return result;
     }
 
@@ -46,8 +46,8 @@ class Duration {
     [[nodiscard]] constexpr static Duration fromMonths(int months) { return Duration(0, 0, 0, 0, 0, months, 0); }
     [[nodiscard]] constexpr static Duration fromYears(int years) { return Duration(0, 0, 0, 0, 0, 0, years); }
 
-    [[nodiscard]] constexpr int64_t ticks() const { return value; }
-    [[nodiscard]] constexpr int64_t toSeconds() const { return value * GAME_SECONDS_IN_REALTIME_SECOND / TICKS_PER_REALTIME_SECOND; }
+    [[nodiscard]] constexpr int64_t ticks() const { return _ticks; }
+    [[nodiscard]] constexpr int64_t toSeconds() const { return _ticks * GAME_SECONDS_IN_REALTIME_SECOND / TICKS_PER_REALTIME_SECOND; }
     [[nodiscard]] constexpr int64_t toMinutes() const { return toSeconds() / 60; }
     [[nodiscard]] constexpr int64_t toHours() const { return toMinutes() / 60; }
     [[nodiscard]] constexpr int toDays() const { return toHours() / 24; }
@@ -92,51 +92,51 @@ class Duration {
     }
 
     [[nodiscard]] constexpr friend Duration operator+(const Duration &l, const Duration &r) {
-        return Duration::fromTicks(l.value + r.value);
+        return Duration::fromTicks(l._ticks + r._ticks);
     }
 
     [[nodiscard]] constexpr friend Duration operator-(const Duration &l, const Duration &r) {
-        return Duration::fromTicks(l.value - r.value);
+        return Duration::fromTicks(l._ticks - r._ticks);
     }
 
     template<class L> requires std::is_arithmetic_v<L>
     [[nodiscard]] constexpr friend Duration operator*(L l, const Duration &r) {
-        return Duration::fromTicks(l * r.value);
+        return Duration::fromTicks(l * r._ticks);
     }
 
     template<class R> requires std::is_arithmetic_v<R>
     [[nodiscard]] constexpr friend Duration operator*(const Duration &l, R r) {
-        return Duration::fromTicks(l.value * r);
+        return Duration::fromTicks(l._ticks * r);
     }
 
     template<class R> requires std::is_arithmetic_v<R>
     [[nodiscard]] constexpr friend Duration operator/(const Duration &l, R r) {
-        return Duration::fromTicks(l.value / r);
+        return Duration::fromTicks(l._ticks / r);
     }
 
     [[nodiscard]] constexpr friend Duration operator%(const Duration &l, const Duration &r) {
-        return Duration::fromTicks(l.value % r.value);
+        return Duration::fromTicks(l._ticks % r._ticks);
     }
 
     constexpr Duration &operator+=(const Duration &rhs) {
-        value += rhs.value;
+        _ticks += rhs._ticks;
         return *this;
     }
 
     constexpr Duration &operator-=(const Duration &rhs) {
-        value -= rhs.value;
+        _ticks -= rhs._ticks;
         return *this;
     }
 
     template<class R> requires std::is_arithmetic_v<R>
     constexpr Duration &operator*=(R r) {
-        value *= r;
+        _ticks *= r;
         return *this;
     }
 
     template<class R> requires std::is_arithmetic_v<R>
     constexpr Duration &operator/=(R r) {
-        value /= r;
+        _ticks /= r;
         return *this;
     }
 
@@ -144,7 +144,7 @@ class Duration {
     [[nodiscard]] constexpr friend auto operator<=>(const Duration &l, const Duration &r) = default;
 
     [[nodiscard]] constexpr explicit operator bool() const {
-        return value != 0;
+        return _ticks != 0;
     }
 
     [[nodiscard]] constexpr static Duration zero() {
@@ -152,7 +152,7 @@ class Duration {
     }
 
  private:
-    int64_t value = 0;
+    int64_t _ticks = 0;
 };
 
 constexpr Duration operator""_ticks(unsigned long long ticks) {

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cassert>
 #include <compare>
 #include <type_traits>
 
@@ -89,6 +90,24 @@ class Duration {
         result.minutes = toMinutes() % 60;
         result.seconds = toSeconds() % 60;
         return result;
+    }
+
+    // TODO(captainurist): #time add unit tests.
+
+    [[nodiscard]] constexpr Duration roundedUp(Duration period) const {
+        assert(period.ticks() > 0);
+
+        int64_t t = ticks();
+        int64_t p = period.ticks();
+        return Duration::fromTicks((t + p - 1) / p * p);
+    }
+
+    [[nodiscard]] constexpr Duration roundedDown(Duration period) const {
+        assert(period.ticks() > 0);
+
+        int64_t t = ticks();
+        int64_t p = period.ticks();
+        return Duration::fromTicks(t / p * p);
     }
 
     [[nodiscard]] constexpr friend Duration operator+(const Duration &l, const Duration &r) {

--- a/src/Engine/Time/Duration.h
+++ b/src/Engine/Time/Duration.h
@@ -110,39 +110,39 @@ class Duration {
         return Duration::fromTicks(t / p * p);
     }
 
-    [[nodiscard]] constexpr friend Duration operator+(const Duration &l, const Duration &r) {
+    [[nodiscard]] constexpr friend Duration operator+(Duration l, Duration r) {
         return Duration::fromTicks(l._ticks + r._ticks);
     }
 
-    [[nodiscard]] constexpr friend Duration operator-(const Duration &l, const Duration &r) {
+    [[nodiscard]] constexpr friend Duration operator-(Duration l, Duration r) {
         return Duration::fromTicks(l._ticks - r._ticks);
     }
 
     template<class L> requires std::is_arithmetic_v<L>
-    [[nodiscard]] constexpr friend Duration operator*(L l, const Duration &r) {
+    [[nodiscard]] constexpr friend Duration operator*(L l, Duration r) {
         return Duration::fromTicks(l * r._ticks);
     }
 
     template<class R> requires std::is_arithmetic_v<R>
-    [[nodiscard]] constexpr friend Duration operator*(const Duration &l, R r) {
+    [[nodiscard]] constexpr friend Duration operator*(Duration l, R r) {
         return Duration::fromTicks(l._ticks * r);
     }
 
     template<class R> requires std::is_arithmetic_v<R>
-    [[nodiscard]] constexpr friend Duration operator/(const Duration &l, R r) {
+    [[nodiscard]] constexpr friend Duration operator/(Duration l, R r) {
         return Duration::fromTicks(l._ticks / r);
     }
 
-    [[nodiscard]] constexpr friend Duration operator%(const Duration &l, const Duration &r) {
+    [[nodiscard]] constexpr friend Duration operator%(Duration l, Duration r) {
         return Duration::fromTicks(l._ticks % r._ticks);
     }
 
-    constexpr Duration &operator+=(const Duration &rhs) {
+    constexpr Duration &operator+=(Duration rhs) {
         _ticks += rhs._ticks;
         return *this;
     }
 
-    constexpr Duration &operator-=(const Duration &rhs) {
+    constexpr Duration &operator-=(Duration rhs) {
         _ticks -= rhs._ticks;
         return *this;
     }
@@ -159,8 +159,8 @@ class Duration {
         return *this;
     }
 
-    [[nodiscard]] constexpr friend bool operator==(const Duration &l, const Duration &r) = default;
-    [[nodiscard]] constexpr friend auto operator<=>(const Duration &l, const Duration &r) = default;
+    [[nodiscard]] constexpr friend bool operator==(Duration l, Duration r) = default;
+    [[nodiscard]] constexpr friend auto operator<=>(Duration l, Duration r) = default;
 
     [[nodiscard]] constexpr explicit operator bool() const {
         return _ticks != 0;

--- a/src/Engine/Time/Time.h
+++ b/src/Engine/Time/Time.h
@@ -21,13 +21,13 @@ class Time {
  public:
     Time() = default;
     Time(int seconds, int minutes, int hours = 0, int days = 0, int weeks = 0, int months = 0, int years = 0) {
-        value = seconds + 60ll * minutes + 3600ll * hours + 86400ll * days + 604800ll * weeks + 2419200ll * months + 29030400ll * years;
-        value = value * Duration::TICKS_PER_REALTIME_SECOND / Duration::GAME_SECONDS_IN_REALTIME_SECOND;
+        _ticks = seconds + 60ll * minutes + 3600ll * hours + 86400ll * days + 604800ll * weeks + 2419200ll * months + 29030400ll * years;
+        _ticks = _ticks * Duration::TICKS_PER_REALTIME_SECOND / Duration::GAME_SECONDS_IN_REALTIME_SECOND;
     }
 
     static Time fromTicks(int64_t ticks) {
         Time result;
-        result.value = ticks;
+        result._ticks = ticks;
         return result;
     }
 
@@ -38,8 +38,8 @@ class Time {
     static Time fromMonths(int months) { return Time(0, 0, 0, 0, 0, months, 0); }
     static Time fromYears(int years) { return Time(0, 0, 0, 0, 0, 0, years); }
 
-    int64_t ticks() const { return value; }
-    int64_t toSeconds() const { return value * Duration::GAME_SECONDS_IN_REALTIME_SECOND / Duration::TICKS_PER_REALTIME_SECOND; }
+    int64_t ticks() const { return _ticks; }
+    int64_t toSeconds() const { return _ticks * Duration::GAME_SECONDS_IN_REALTIME_SECOND / Duration::TICKS_PER_REALTIME_SECOND; }
     int64_t toMinutes() const { return toSeconds() / 60; }
     int64_t toHours() const { return toMinutes() / 60; }
     int toDays() const { return toHours() / 24; }
@@ -60,21 +60,21 @@ class Time {
         return result;
     }
 
-    // TODO(captainurist): doesn't belong to GameTime.
-    void SetExpired() { value = -1;  }
-    bool Expired() const { return value < 0; }
+    // TODO(captainurist): #time doesn't belong to GameTime.
+    void SetExpired() { _ticks = -1;  }
+    bool Expired() const { return _ticks < 0; }
 
-    // TODO(captainurist): This is something to look at, we have comparisons with GameTime() in the code, they are not
+    // TODO(captainurist): #time This is something to look at, we have comparisons with GameTime() in the code, they are not
     //                     the same as Valid().
-    bool isValid() const { return value > 0; }
+    bool isValid() const { return _ticks > 0; }
 
     Time &operator+=(const Duration &rhs) {
-        value += rhs.ticks();
+        _ticks += rhs.ticks();
         return *this;
     }
 
     Time &operator-=(const Duration &rhs) {
-        value -= rhs.ticks();
+        _ticks -= rhs.ticks();
         return *this;
     }
 
@@ -86,7 +86,7 @@ class Time {
     }
 
  private:
-    int64_t value = 0;
+    int64_t _ticks = 0;
 };
 
 inline Time operator+(const Time &l, const Duration &r) {

--- a/src/Engine/Time/Time.h
+++ b/src/Engine/Time/Time.h
@@ -76,18 +76,18 @@ class Time {
     //                     the same as Valid().
     bool isValid() const { return _ticks > 0; }
 
-    Time &operator+=(const Duration &rhs) {
+    Time &operator+=(Duration rhs) {
         _ticks += rhs.ticks();
         return *this;
     }
 
-    Time &operator-=(const Duration &rhs) {
+    Time &operator-=(Duration rhs) {
         _ticks -= rhs.ticks();
         return *this;
     }
 
-    friend bool operator==(const Time &l, const Time &r) = default;
-    friend auto operator<=>(const Time &l, const Time &r) = default;
+    friend bool operator==(Time l, Time r) = default;
+    friend auto operator<=>(Time l, Time r) = default;
 
     explicit operator bool() const {
         return isValid();
@@ -97,16 +97,16 @@ class Time {
     int64_t _ticks = 0;
 };
 
-inline Time operator+(const Time &l, const Duration &r) {
+inline Time operator+(Time l, Duration r) {
     return Time::fromTicks(l.ticks() + r.ticks());
 }
 
 // We don't provide operator+(Duration, Time)
 
-inline Time operator-(const Time &l, const Duration &r) {
+inline Time operator-(Time l, Duration r) {
     return Time::fromTicks(l.ticks() - r.ticks());
 }
 
-inline Duration operator-(const Time &l, const Time &r) {
+inline Duration operator-(Time l, Time r) {
     return Duration::fromTicks(l.ticks() - r.ticks());
 }

--- a/src/Engine/Time/Time.h
+++ b/src/Engine/Time/Time.h
@@ -25,6 +25,14 @@ class Time {
         _ticks = _ticks * Duration::TICKS_PER_REALTIME_SECOND / Duration::GAME_SECONDS_IN_REALTIME_SECOND;
     }
 
+    Duration toDurationSinceSilence() const {
+        return Duration::fromYears(game_starting_year) + Duration::fromTicks(_ticks);
+    }
+
+    static Time fromDurationSinceSilence(Duration duration) {
+        return Time::fromTicks((duration - Duration::fromYears(game_starting_year)).ticks());
+    }
+
     static Time fromTicks(int64_t ticks) {
         Time result;
         result._ticks = ticks;

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -215,6 +215,7 @@ enum UIMessageType : uint32_t {
 
     UIMSG_DebugSpecialItem = 971,
     UIMSG_DebugGenItem = 972,
+    UIMSG_DebugLich = 973,
     UIMSG_DebugSeasonsChange = 974,
     UIMSG_DebugShowFPS = 975,
     UIMSG_DebugPickedFace = 976,

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -88,23 +88,25 @@ void GUIWindow_CalendarBook::Update() {
     calendar_window.uFrameW = game_viewport_w;
     calendar_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_calendar_title_color, localization->GetString(LSTR_TIME_IN_ERATHIA), 3);
 
+    CivilTime time = pParty->GetPlayingTime().toCivilTime();
+
     std::string str = fmt::format("{}\t100:\t110{}:{:02} {} - {}", localization->GetString(LSTR_TIME), hour,
-                                  pParty->uCurrentMinute, localization->GetAmPm(am), getDayPart());
+                                  time.minute, localization->GetAmPm(am), getDayPart());
     calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 55}, ui_book_calendar_time_color, str);
 
-    str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_DAY_CAPITALIZED), pParty->uCurrentDayOfMonth + 1,
-                      localization->GetDayName(pParty->uCurrentDayOfMonth % 7));
+    str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_DAY_CAPITALIZED), time.day,
+                      localization->GetDayName(time.dayOfWeek - 1));
     calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 2 * assets->pFontBookCalendar->GetHeight() + 49}, ui_book_calendar_day_color, str);
 
-    str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_MONTH), pParty->uCurrentMonth + 1,
-                      localization->GetMonthName(pParty->uCurrentMonth));
+    str = fmt::format("{}\t100:\t110{} - {}", localization->GetString(LSTR_MONTH), time.month,
+                      localization->GetMonthName(time.month - 1));
     calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 4 * assets->pFontBookCalendar->GetHeight() + 43}, ui_book_calendar_month_color, str);
 
-    str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_YEAR), pParty->uCurrentYear);
+    str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_YEAR), time.year);
     calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 6 * assets->pFontBookCalendar->GetHeight() + 37}, ui_book_calendar_year_color, str);
 
-    str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_MOON), localization->GetMoonPhaseName(pDayMoonPhase[pParty->uCurrentDayOfMonth]));
-    calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 8 * (unsigned char)assets->pFontBookCalendar->GetHeight() + 31}, ui_book_calendar_moon_color, str);
+    str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_MOON), localization->GetMoonPhaseName(pDayMoonPhase[time.day - 1]));
+    calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 8 * assets->pFontBookCalendar->GetHeight() + 31}, ui_book_calendar_moon_color, str);
 
     MapId pMapID = pMapStats->GetMapInfo(pCurrentMapName);
     std::string pMapName;

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -115,17 +115,16 @@ void GUIWindow_LloydsBook::Update() {
             pWindow.uFrameY -= 6 + pTextHeight;
             pWindow.DrawTitleText(assets->pFontBookLloyds.get(), 0, 0, colorTable.Black, Str, 3);
 
-            // TODO(captainurist): #time honestly these d.days + 1 below make no sense.
             pWindow.uFrameY = lloydsBeaconsPreviewYs[beaconId];
             Duration remainingTime = beacon.uBeaconTime - pParty->GetPlayingTime();
             CivilDuration d = remainingTime.toCivilDuration();
             std::string str;
-            if (d.days > 1) {
-                str = fmt::format("{} {}", d.days + 1, localization->GetString(LSTR_DAYS));
-            } else if (d.hours + 1 <= 23) {
-                str = fmt::format("{} {}", d.hours + 1, localization->GetString((d.hours < 1) ? LSTR_HOUR : LSTR_HOURS));
+            if (d.days > 0) {
+                str = fmt::format("{} {}", d.days, localization->GetString(d.days == 1 ? LSTR_DAY_CAPITALIZED : LSTR_DAYS));
+            } else if (d.hours > 0) {
+                str = fmt::format("{} {}", d.hours, localization->GetString(d.hours == 1 ? LSTR_HOUR : LSTR_HOURS));
             } else {
-                str = fmt::format("{} {}", d.days + 1, localization->GetString(LSTR_DAY_CAPITALIZED));
+                str = fmt::format("{} {}", d.minutes, localization->GetString(d.minutes == 1 ? LSTR_MINUTE : LSTR_MINUTES));
             }
             pWindow.uFrameY = pWindow.uFrameY + pWindow.uFrameHeight + 4;
             pWindow.DrawTitleText(assets->pFontBookLloyds.get(), 0, 0, colorTable.Black, str, 3);
@@ -185,7 +184,6 @@ void GUIWindow_LloydsBook::installOrRecallBeacon(int beaconId) {
     assert(pSpellDatas[SPELL_WATER_LLOYDS_BEACON].recovery_per_skill[CHARACTER_SKILL_MASTERY_NOVICE] == pSpellDatas[SPELL_WATER_LLOYDS_BEACON].recovery_per_skill[CHARACTER_SKILL_MASTERY_MASTER]);
     assert(pSpellDatas[SPELL_WATER_LLOYDS_BEACON].recovery_per_skill[CHARACTER_SKILL_MASTERY_NOVICE] == pSpellDatas[SPELL_WATER_LLOYDS_BEACON].recovery_per_skill[CHARACTER_SKILL_MASTERY_GRANDMASTER]);
 
-    // TODO(captainurist): #time drop .ticks()
     Duration sRecoveryTime = pSpellDatas[SPELL_WATER_LLOYDS_BEACON].recovery_per_skill[CHARACTER_SKILL_MASTERY_NOVICE];
     if (pParty->bTurnBasedModeOn) {
         pParty->pTurnBasedCharacterRecoveryTimes[_casterId] = sRecoveryTime;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1695,39 +1695,26 @@ void GameUI_DrawTorchlightAndWizardEye() {
 
 //----- (00491F87) --------------------------------------------------------
 void GameUI_DrawHiredNPCs() {
-    unsigned int v13;               // eax@23
     signed int uFrameID;            // [sp+24h] [bp-18h]@19
-    int v22;                        // [sp+34h] [bp-8h]@2
-    uint8_t pNPC_limit_ID;  // [sp+3Bh] [bp-1h]@2
 
     if (bNoNPCHiring != 1) {
         FlatHirelings buf;
         buf.Prepare();
 
-        pNPC_limit_ID = 0;
-
-        for (int i = pParty->hirelingScrollPosition; i < buf.Size() && pNPC_limit_ID < 2; i++) {
+        for (int i = pParty->hirelingScrollPosition, count = 0; i < buf.Size() && count < 2; i++, count++) {
             std::string pContainer = fmt::format("NPC{:03}", buf.Get(i)->uPortraitID);
             render->DrawTextureNew(
-                    pHiredNPCsIconsOffsetsX[pNPC_limit_ID] / 640.0f,
-                    pHiredNPCsIconsOffsetsY[pNPC_limit_ID] / 480.0f,
+                    pHiredNPCsIconsOffsetsX[count] / 640.0f,
+                    pHiredNPCsIconsOffsetsY[count] / 480.0f,
                     assets->getImage_ColorKey(pContainer));
 
-            if (!buf.IsFollower(i) && buf.Get(i)->dialogue_1_evt_id == 1) {
-                uFrameID = buf.Get(i)->dialogue_2_evt_id;
-                v13 = 0;
-                if (!pIconsFrameTable->pIcons.empty()) {
-                    for (v13 = 0; v13 < pIconsFrameTable->pIcons.size(); ++v13) {
-                        if (iequals("spell96", pIconsFrameTable->pIcons[v13].GetAnimationName()))
-                            break;
-                    }
-                }
+            // Dark sacrifice animation.
+            if (!buf.IsFollower(i) && buf.GetSacrificeStatus(i)->inProgress) {
                 render->DrawTextureNew(
-                    pHiredNPCsIconsOffsetsX[pNPC_limit_ID] / 640.0f,
-                    pHiredNPCsIconsOffsetsY[pNPC_limit_ID] / 480.0f,
-                    pIconsFrameTable->GetFrame(v13, Duration::fromTicks(uFrameID))->GetTexture());
+                    pHiredNPCsIconsOffsetsX[count] / 640.0f,
+                    pHiredNPCsIconsOffsetsY[count] / 480.0f,
+                    pIconsFrameTable->GetFrame(pIconsFrameTable->FindIcon("spell96"), buf.GetSacrificeStatus(i)->elapsedTime)->GetTexture());
             }
-            ++pNPC_limit_ID;
         }
     }
 }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1823,7 +1823,7 @@ GUIWindow_DebugMenu::GUIWindow_DebugMenu()
     GUIButton *pBtn_DebugShowFPS = CreateButton({354, 248}, {width, height}, 1, 0, UIMSG_DebugShowFPS, 0, Io::InputAction::Invalid, "DEBUG TOGGLE SHOW FPS");
 
     GUIButton *pBtn_DebugSeasonsChange = CreateButton({13, 275}, {width, height}, 1, 0, UIMSG_DebugSeasonsChange, 0, Io::InputAction::Invalid, "DEBUG TOGGLE SEASONS CHANGE");
-    GUIButton *pBtn_DebugVerboseLogging = CreateButton({127, 275}, {width, height}, 1, 0, UIMSG_DebugUnused, 0, Io::InputAction::Invalid, "DEBUG unused0");
+    GUIButton *pBtn_DebugVerboseLogging = CreateButton({127, 275}, {width, height}, 1, 0, UIMSG_DebugLich, 0, Io::InputAction::Invalid, "DEBUG LICH");
     GUIButton *pBtn_DebugGenItem = CreateButton({241, 275}, {width, height}, 1, 0, UIMSG_DebugGenItem, 0, Io::InputAction::Invalid, "DEBUG GENERATE RANDOM ITEM");
     GUIButton *pBtn_DebugSpecialItem = CreateButton({354, 275}, {width, height}, 1, 0, UIMSG_DebugSpecialItem, 0, Io::InputAction::Invalid, "DEBUG GENERATE RANDOM SPECIAL ITEM");
 
@@ -1882,7 +1882,7 @@ void GUIWindow_DebugMenu::Update() {
     buttonbox(354, 248, "Show FPS", engine->config->debug.ShowFPS.value());
 
     buttonbox(13, 275, "Seasons", engine->config->graphics.SeasonsChange.value());
-    buttonbox(127, 275, "Unused0", 2);
+    buttonbox(127, 275, "Lich", 2);
     buttonbox(241, 275, "Gen Item", 2);
     buttonbox(354, 275, "Special Item", 2);
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -655,7 +655,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
         pMonsterInfoUI_Doll = pActors[uActorID];
         pMonsterInfoUI_Doll.currentActionAnimation = ANIM_Bored;
         pMonsterInfoUI_Doll.currentActionTime = 0_ticks;
-        actionLen = Duration::fromTicks(vrng->random(256) + 128);
+        actionLen = Duration::randomRealtimeSeconds(vrng, 1, 3);
         pMonsterInfoUI_Doll.currentActionLength = actionLen;
     }
 

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 16590b309b684814d27fb7b7d275d3caca4fc5f0
+            GIT_TAG 9fe52763ed22011e2cf0d8faad168ececed098f2
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 9fe52763ed22011e2cf0d8faad168ececed098f2
+            GIT_TAG 1192cf153516a355ed3d4516e7159bda01e50efb
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG e8765bcf8a3692ddd120e96e931dfff2a1accf00
+            GIT_TAG 16590b309b684814d27fb7b7d275d3caca4fc5f0
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 4aef9144e6aa853690201e17a490ab504c6af218
+            GIT_TAG e8765bcf8a3692ddd120e96e931dfff2a1accf00
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -337,8 +337,8 @@ GAME_TEST(Issues, Issue661) {
     test.playTraceFromTestData("issue_661.mm7", "issue_661.json");
     // two hour wait period is 24 blocks of 5 mins
     // one item that heals hp, three items heal mana
-    EXPECT_EQ(healthTape.delta(), +24);
-    EXPECT_EQ(manaTape.delta(), +3 * 24);
+    EXPECT_EQ(healthTape.delta(), +12);
+    EXPECT_EQ(manaTape.delta(), +3 * 12);
 }
 
 GAME_TEST(Issues, Issue662) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -332,11 +332,18 @@ GAME_TEST(Issues, Issue651) {
 
 GAME_TEST(Issues, Issue661) {
     // HP/SP regen from items is too high.
+    auto timeTape = tapes.time();
     auto healthTape = charTapes.hp(0);
     auto manaTape = charTapes.mp(0);
     test.playTraceFromTestData("issue_661.mm7", "issue_661.json");
-    // two hour wait period is 24 blocks of 5 mins
-    // one item that heals hp, three items heal mana
+
+    // Actual # of 5-min ticks hit is 12.
+    Duration interval = Duration::fromMinutes(5);
+    Duration firstTick = timeTape.front().toDurationSinceSilence().roundedUp(interval);
+    Duration lastTick = timeTape.back().toDurationSinceSilence().roundedDown(interval);
+    EXPECT_EQ((lastTick - firstTick) / interval + 1, 12);
+
+    // One item that heals hp, three items heal mana.
     EXPECT_EQ(healthTape.delta(), +12);
     EXPECT_EQ(manaTape.delta(), +3 * 12);
 }

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -89,7 +89,7 @@ GAME_TEST(Issues, Issue1093) {
     auto statusTape = tapes.statusBar();
     test.playTraceFromTestData("issue_1093.mm7", "issue_1093.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_SPELL_BOOK, SCREEN_GAME));
-    EXPECT_EQ(manaTape, tape(355)); // Character's mana didn't change.
+    EXPECT_EQ(manaTape, tape(355, 356)); // +1 mana from mana regen, no mana spent on spells.
     EXPECT_TRUE(statusTape.contains("Cast Town Portal"));
     EXPECT_TRUE(statusTape.contains("Spell failed"));
 }

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -7,6 +7,7 @@
 
 #include "Engine/Graphics/TextureFrameTable.h"
 #include "Engine/Objects/Actor.h"
+#include "Engine/Objects/NPC.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Party.h"
@@ -603,4 +604,20 @@ GAME_TEST(Issues, Issue1467) {
     test.playTraceFromTestData("issue_1467.mm7", "issue_1467.json");
     EXPECT_EQ(hirelingsTape, tape(1, 0)); // We did sacrifice the last one.
     EXPECT_EQ(statusTape, tape("", "Select Target", "", "Select Target", "")); // Sacrifice was cast twice. Also, no "Spell Failed".
+}
+
+GAME_TEST(Issues, Issue1475) {
+    // Warlock mana regen from Baby Dragon regens mana for dead characters.
+    auto timeTape = tapes.time();
+    auto conditionTape = charTapes.condition(3);
+    auto hpTape = charTapes.hp(3);
+    auto mpTape = charTapes.mp(3);
+    test.playTraceFromTestData("issue_1475.mm7", "issue_1475.json", [] {
+        EXPECT_EQ(pParty->pCharacters[3].classType, CLASS_WARLOCK);
+        EXPECT_TRUE(PartyHasDragon()); // Dragon provides mana regen.
+    });
+    EXPECT_GT(timeTape.delta(), Duration::fromHours(1));
+    EXPECT_EQ(conditionTape, tape(CONDITION_DEAD));
+    EXPECT_EQ(hpTape, tape(-44)); // Very dead.
+    EXPECT_EQ(mpTape, tape(0)); // No mana regen.
 }

--- a/test/Testing/Game/CharacterTapeRecorder.cpp
+++ b/test/Testing/Game/CharacterTapeRecorder.cpp
@@ -67,6 +67,10 @@ TestMultiTape<int> CharacterTapeRecorder::skillLevels(CharacterSkillType skill) 
     return custom(std::bind(&Character::actualSkillLevel, _1, skill));
 }
 
+TestTape<Condition> CharacterTapeRecorder::condition(int characterIndex) {
+    return custom(characterIndex, std::bind(&Character::GetMajorConditionIdx, _1));
+}
+
 TestMultiTape<Condition> CharacterTapeRecorder::conditions() {
     return custom(std::bind(&Character::GetMajorConditionIdx, _1));
 }

--- a/test/Testing/Game/CharacterTapeRecorder.h
+++ b/test/Testing/Game/CharacterTapeRecorder.h
@@ -49,6 +49,7 @@ class CharacterTapeRecorder {
 
     TestMultiTape<int> skillLevels(CharacterSkillType skill);
 
+    TestTape<Condition> condition(int characterIndex);
     TestMultiTape<Condition> conditions();
 
     TestMultiTape<int> resistances(CharacterAttributeType resistance);


### PR DESCRIPTION
* Fix #908.
* Fix #1429.
* Fix #1475.
* Some cleanup in `Time` and `Duration` implementation.
* Resolved a couple time-related TODOs.
* Using `std::array` and `IndexedArray` in `Localization`.
* Don't save `quick_saves_count` to traces.
* Rewritten `RegeneratePartyHealthMana`.
* Added a debug action to turn a character into a Lich (also gives the lich jar).
* Moved out npc sacrifice status into a separate struct, `NPCSacrificeStatus`.
* Time left for a beacon as displayed in the Lloyd's beacon book was broken, fixed it.