### PR TITLE
Random tweaks

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -86,7 +86,7 @@ class GameConfig : public Config {
         Int TraceFrameTimeMs = {this, "trace_frame_time_ms", 50, &ValidateFrameTime,
                                 "Number of milliseconds per frame when recording game traces."};
 
-        ConfigEntry<RandomEngineType> TraceRandomEngine = {this, "trace_random_engine", RANDOM_ENGINE_SEQUENTIAL,
+        ConfigEntry<RandomEngineType> TraceRandomEngine = {this, "trace_random_engine", RANDOM_ENGINE_MERSENNE_TWISTER,
                                                            "Random engine to use for trace recording, 'sequential' or 'mersenne_twister'."};
 
         Bool TraceNoVideo = {this, "trace_no_video", true, "Don't play movies when recording traces."};

--- a/src/Engine/Components/Trace/EngineTracePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTracePlayer.cpp
@@ -82,7 +82,7 @@ void EngineTracePlayer::checkAfterLoadRng(int expectedRandomState) {
     if (_flags & TRACE_PLAYBACK_SKIP_RANDOM_CHECKS)
         return;
 
-    int randomState = grng->peek(1024);
+    int randomState = grng->peek(1024 * 1024);
     if (randomState != expectedRandomState) {
         throw Exception("Random state desynchronized after loading a save for trace '{}': expected {}, got {}",
                         _tracePath, expectedRandomState, randomState);

--- a/src/Engine/Components/Trace/EngineTraceRecorder.cpp
+++ b/src/Engine/Components/Trace/EngineTraceRecorder.cpp
@@ -53,7 +53,7 @@ void EngineTraceRecorder::startRecording(EngineController *game, const std::stri
     game->goToMainMenu(); // This might call into a random engine.
     component<EngineDeterministicComponent>()->restart(frameTimeMs, rngType);
     game->loadGame(savePath);
-    _trace->header.afterLoadRandomState = grng->peek(1024);
+    _trace->header.afterLoadRandomState = grng->peek(1024 * 1024);
     component<EngineDeterministicComponent>()->restart(frameTimeMs, rngType);
 
     _trace->header.startState = EngineTraceStateAccessor::makeGameState();

--- a/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
@@ -62,7 +62,7 @@ void EngineTraceSimplePlayer::checkRng(const PaintEvent *paintEvent) {
     if (_flags & TRACE_PLAYBACK_SKIP_RANDOM_CHECKS)
         return;
 
-    int randomState = grng->peek(1024);
+    int randomState = grng->peek(1024 * 1024);
     int64_t tickCount = application()->platform()->tickCount();
     if (randomState != paintEvent->randomState) {
         throw Exception("Random state desynchronized when playing back trace '{}' at {}ms: expected {}, got {}",

--- a/src/Engine/Components/Trace/EngineTraceSimpleRecorder.cpp
+++ b/src/Engine/Components/Trace/EngineTraceSimpleRecorder.cpp
@@ -32,7 +32,7 @@ void EngineTraceSimpleRecorder::swapBuffers() {
         std::unique_ptr<PaintEvent> e = std::make_unique<PaintEvent>();
         e->type = EVENT_PAINT;
         e->tickCount = application()->platform()->tickCount();
-        e->randomState = grng->peek(1024);
+        e->randomState = grng->peek(1024 * 1024);
         _events.push_back(std::move(e));
     }
 

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG b763724180ab44800a9fe863efaab22fa8bc0dfd
+            GIT_TAG 3395f997e8b27d7719e11743800284df543a41a7
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""


### PR DESCRIPTION
* Using Mersenne Twister in traces by default - honestly, Sequential RNG was a bad idea.
* `randomState` in traces is stored mod 2^20 instead of 2^10.