### PR TITLE
Dropped unnecessary random calls in SaveLoad

### DIFF
--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -61,10 +61,6 @@ void LoadGame(unsigned int uSlot) {
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
 
-    // TODO(captainurist): remained from Party::Reset, retrace & drop.
-    for (int i = 0; i < 8; i++)
-        grng->random(10);
-
     std::string filename = makeDataPath("saves", pSavegameList->pFileList[uSlot]);
     std::string to_file_path = makeDataPath("data", "new.lod");
 

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -20,7 +20,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG c2b8ae0d347474876388dab86500ca6dbf5195e4
+            GIT_TAG 7ad0c67da8405caf408dbd17f3e7f0b27c034a68
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -829,7 +829,7 @@ GAME_TEST(Issues, Issue832) {
     }));
 
     // Peasants were harmed during recording of this trace.
-    EXPECT_EQ(deathsTape.frontBack(), tape(0, 3));
+    EXPECT_EQ(deathsTape.frontBack(), tape(0, 2));
 }
 
 GAME_TEST(Issues, Issue833a) {


### PR DESCRIPTION
These `random` calls remained after I dropped `Party::Reset` from there. Had to retrace all tests b/c this code ran every time.