### PR TITLE
Fix #1524

### DIFF
--- a/src/Media/Audio/AudioSamplePool.cpp
+++ b/src/Media/Audio/AudioSamplePool.cpp
@@ -29,7 +29,9 @@ bool AudioSamplePool::playUniquePid(PAudioSample sample, PAudioDataSource source
     update();
     for (AudioSamplePoolEntry &entry : _samplePool) {
         if (entry.pid == pid) {
-            return true;
+            if (entry.samplePtr == sample) {
+                return true;
+            }
         }
     }
     if (!sample->Open(source)) {


### PR DESCRIPTION
Making it so that each unique PID can fire unique sounds to fix #1524.
When some actors cast spells, it plays their normal spell attack sounds closely followed by the specific spell sound. The second sound got skipped previously.