### PR TITLE
Tapes for arbitrary data pushed from the engine

### DIFF
--- a/src/Application/GameKeyboardController.cpp
+++ b/src/Application/GameKeyboardController.cpp
@@ -8,6 +8,7 @@ bool GameKeyboardController::ConsumeKeyPress(PlatformKey key) {
     if (key == PlatformKey::KEY_NONE)
         return false;
 
+    // TODO(captainurist): this is false if we have received press & release events inside a single frame.
     if (!isKeyDown_[key])
         return false;
 

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -76,5 +76,8 @@ OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {
         }
     }
 
+    if (result.subcommand == SUBCOMMAND_PLAY)
+        result.useConfig = false; // Don't use external config if playing a trace.
+
     return result;
 }

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -31,6 +31,7 @@ set(ENGINE_HEADERS
         AttackList.h
         Conditions.h
         Engine.h
+        EngineCallObserver.h
         EngineGlobals.h
         EngineIocContainer.h
         LOD.h

--- a/src/Engine/Components/Trace/EngineTracePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTracePlayer.cpp
@@ -29,8 +29,7 @@ EngineTracePlayer::~EngineTracePlayer() {
 }
 
 void EngineTracePlayer::playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath,
-                                  EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback,
-                                  std::function<void()> tickCallback) {
+                                  EngineTracePlaybackFlags flags, std::function<void()> postLoadCallback) {
     assert(!isPlaying());
 
     _tracePath = tracePath;
@@ -66,7 +65,7 @@ void EngineTracePlayer::playTrace(EngineController *game, const std::string &sav
         postLoadCallback();
 
     checkState(_trace->header.startState, true);
-    component<EngineTraceSimplePlayer>()->playTrace(game, std::move(_trace->events), _tracePath, _flags, std::move(tickCallback));
+    component<EngineTraceSimplePlayer>()->playTrace(game, std::move(_trace->events), _tracePath, _flags);
     checkState(_trace->header.endState, false);
 }
 

--- a/src/Engine/Components/Trace/EngineTracePlayer.h
+++ b/src/Engine/Components/Trace/EngineTracePlayer.h
@@ -33,11 +33,9 @@ class EngineTracePlayer : private PlatformApplicationAware {
      * @param tracePath                 Path to trace file.
      * @param flags                     Playback flags.
      * @param postLoadCallback          Callback to call once the saved game is loaded.
-     * @param tickCallback              Callback to call every frame and also before & after running the trace.
      */
     void playTrace(EngineController *game, const std::string &savePath, const std::string &tracePath,
-                   EngineTracePlaybackFlags flags = 0, std::function<void()> postLoadCallback = {},
-                   std::function<void()> tickCallback = {});
+                   EngineTracePlaybackFlags flags = 0, std::function<void()> postLoadCallback = {});
 
     [[nodiscard]] bool isPlaying() const {
         return _trace != nullptr;

--- a/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
+++ b/src/Engine/Components/Trace/EngineTraceSimplePlayer.cpp
@@ -16,7 +16,7 @@ EngineTraceSimplePlayer::EngineTraceSimplePlayer() = default;
 EngineTraceSimplePlayer::~EngineTraceSimplePlayer() = default;
 
 void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std::unique_ptr<PlatformEvent>> events,
-                                        const std::string &tracePath, EngineTracePlaybackFlags flags, std::function<void()> tickCallback) {
+                                        const std::string &tracePath, EngineTracePlaybackFlags flags) {
     assert(!isPlaying());
 
     _playing = true;
@@ -25,15 +25,9 @@ void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std:
     _tracePath = tracePath;
     _flags = flags;
 
-    if (tickCallback)
-        tickCallback();
-
     for (std::unique_ptr<PlatformEvent> &event : events) {
         if (event->type == EVENT_PAINT) {
             game->tick(1);
-
-            if (tickCallback)
-                tickCallback();
 
             const PaintEvent *paintEvent = static_cast<const PaintEvent *>(event.get());
             checkTime(paintEvent);
@@ -42,9 +36,6 @@ void EngineTraceSimplePlayer::playTrace(EngineController *game, std::vector<std:
             game->postEvent(std::move(event));
         }
     }
-
-    if (tickCallback)
-        tickCallback();
 }
 
 void EngineTraceSimplePlayer::checkTime(const PaintEvent *paintEvent) {

--- a/src/Engine/Components/Trace/EngineTraceSimplePlayer.h
+++ b/src/Engine/Components/Trace/EngineTraceSimplePlayer.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include <functional>
 
 #include "Library/Platform/Application/PlatformApplicationAware.h"
 
@@ -32,11 +31,9 @@ class EngineTraceSimplePlayer : private PlatformApplicationAware {
      * @param tracePath                 Path to trace file that the events were loaded from. Used only for error
      *                                  reporting.
      * @param flags                     Playback flags.
-     * @param tickCallback              Callback to run at the end of every frame & also once at the start and at the
-     *                                  end of the trace.
      */
     void playTrace(EngineController *game, std::vector<std::unique_ptr<PlatformEvent>> events,
-                   const std::string &tracePath, EngineTracePlaybackFlags flags, std::function<void()> tickCallback = {});
+                   const std::string &tracePath, EngineTracePlaybackFlags flags);
 
     bool isPlaying() const {
         return _playing;

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -37,6 +37,7 @@ struct stru10;
 class GUIMessageQueue;
 class GameResourceManager;
 class StatusBar;
+class EngineCallObserver;
 struct IndoorLocation;
 struct OutdoorLocation;
 struct LightsStack_StationaryLight_;
@@ -115,6 +116,7 @@ class Engine {
     BloodsplatContainer *bloodsplat_container = nullptr;
     DecalBuilder *decal_builder = nullptr;
     SpellFxRenderer *spell_fx_renedrer = nullptr;
+    EngineCallObserver *callObserver = nullptr;
     std::shared_ptr<Io::Mouse> mouse;
     std::shared_ptr<Nuklear> nuklear;
     std::shared_ptr<ParticleEngine> particle_engine;

--- a/src/Engine/EngineCallObserver.h
+++ b/src/Engine/EngineCallObserver.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <typeinfo>
+
+enum class EngineCall {
+    CALL_PLAY_SOUND,
+    CALL_DRAW_2D_TEXTURE,
+
+    CALL_FIRST = CALL_PLAY_SOUND,
+    CALL_LAST = CALL_DRAW_2D_TEXTURE
+};
+using enum EngineCall;
+
+class EngineCallObserver {
+ public:
+    virtual ~EngineCallObserver() = default;
+
+    template<class T>
+    void notify(EngineCall call, const T &data) {
+        notify(call, typeid(T), &data);
+    }
+
+ protected:
+    virtual void notify(EngineCall call, const std::type_info &type, const void *data) = 0;
+};

--- a/src/Engine/EngineCallObserver.h
+++ b/src/Engine/EngineCallObserver.h
@@ -5,9 +5,10 @@
 enum class EngineCall {
     CALL_PLAY_SOUND,
     CALL_DRAW_2D_TEXTURE,
+    CALL_DRAW_MESSAGE_BOX,
 
     CALL_FIRST = CALL_PLAY_SOUND,
-    CALL_LAST = CALL_DRAW_2D_TEXTURE
+    CALL_LAST = CALL_DRAW_MESSAGE_BOX
 };
 using enum EngineCall;
 

--- a/src/Engine/Graphics/Image.cpp
+++ b/src/Engine/Graphics/Image.cpp
@@ -7,6 +7,8 @@
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/AssetsManager.h"
 
+static std::string globalEmptyString;
+
 GraphicsImage::GraphicsImage(bool lazy_initialization): _lazyInitialization(lazy_initialization) {}
 
 GraphicsImage::~GraphicsImage() = default;
@@ -57,10 +59,8 @@ const GrayscaleImage &GraphicsImage::indexed() {
     return _indexedImage;
 }
 
-std::string *GraphicsImage::GetName() {
-    assert(_loader);
-
-    return _loader->GetResourceNamePtr();
+const std::string &GraphicsImage::GetName() {
+    return _loader ? _loader->GetResourceName() : globalEmptyString;
 }
 
 void GraphicsImage::Release() {

--- a/src/Engine/Graphics/Image.h
+++ b/src/Engine/Graphics/Image.h
@@ -31,7 +31,7 @@ class GraphicsImage {
 
     const GrayscaleImage &indexed();
 
-    std::string *GetName();
+    const std::string &GetName();
 
     void Release();
 

--- a/src/Engine/Graphics/ImageLoader.h
+++ b/src/Engine/Graphics/ImageLoader.h
@@ -14,7 +14,7 @@ class LodReader;
 class ImageLoader {
  public:
     virtual ~ImageLoader() = default;
-    virtual std::string GetResourceName() const { return this->resource_name; }
+    virtual const std::string &GetResourceName() const { return this->resource_name; }
     virtual std::string *GetResourceNamePtr() { return &this->resource_name; }
 
     virtual bool Load(RgbaImage *rgbaImage, GrayscaleImage *indexedImage, Palette *palette) = 0;

--- a/src/Engine/Graphics/Renderer/NullRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/NullRenderer.cpp
@@ -3,6 +3,9 @@
 #include <nuklear_config.h> // NOLINT: not a C system header.
 
 #include "Engine/EngineGlobals.h"
+#include "Engine/Engine.h"
+#include "Engine/EngineCallObserver.h"
+#include "Engine/Graphics/Image.h"
 
 #include "Library/Platform/Application/PlatformApplication.h"
 
@@ -97,10 +100,16 @@ void NullRenderer::SetUIClipRect(unsigned int uX, unsigned int uY,
                                  unsigned int uZ, unsigned int uW) {}
 void NullRenderer::ResetUIClipRect() {}
 
-void NullRenderer::DrawTextureNew(float u, float v, class GraphicsImage *, Color colourmask) {}
+void NullRenderer::DrawTextureNew(float u, float v, GraphicsImage *tex, Color colourmask) {
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_DRAW_2D_TEXTURE, tex->GetName());
+}
 
-void NullRenderer::DrawTextureCustomHeight(float u, float v, class GraphicsImage *,
-                                           int height) {}
+void NullRenderer::DrawTextureCustomHeight(float u, float v, GraphicsImage *tex, int height) {
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_DRAW_2D_TEXTURE, tex->GetName());
+}
+
 void NullRenderer::DrawTextureOffset(int x, int y, int offset_x, int offset_y,
                                      GraphicsImage *) {}
 void NullRenderer::DrawImage(GraphicsImage *, const Recti &rect, unsigned int paletteid, Color colourmask) {}

--- a/src/Engine/Graphics/Renderer/NullRenderer.h
+++ b/src/Engine/Graphics/Renderer/NullRenderer.h
@@ -62,9 +62,9 @@ class NullRenderer : public BaseRenderer {
                                unsigned int uZ, unsigned int uW) override;
     virtual void ResetUIClipRect() override;
 
-    virtual void DrawTextureNew(float u, float v, class GraphicsImage *, Color colourmask = colorTable.White) override;
+    virtual void DrawTextureNew(float u, float v, GraphicsImage *, Color colourmask = colorTable.White) override;
 
-    virtual void DrawTextureCustomHeight(float u, float v, class GraphicsImage *,
+    virtual void DrawTextureCustomHeight(float u, float v, GraphicsImage *,
                                          int height) override;
     virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y,
                                    GraphicsImage *) override;

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -40,6 +40,7 @@
 #include "Engine/SpellFxRenderer.h"
 #include "Arcomage/Arcomage.h"
 #include "Engine/AssetsManager.h"
+#include "Engine/EngineCallObserver.h"
 
 #include "Library/Platform/Application/PlatformApplication.h"
 #include "Library/Serialization/EnumSerialization.h"
@@ -2749,10 +2750,10 @@ void OpenGLRenderer::BeginScene2D() {
 
 // TODO(pskelton): use alpha from mask too
 void OpenGLRenderer::DrawTextureNew(float u, float v, GraphicsImage *tex, Color colourmask) {
-    if (!tex) {
-        logger->trace("Null texture passed to DrawTextureNew");
-        return;
-    }
+    assert(tex);
+
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_DRAW_2D_TEXTURE, tex->GetName());
 
     Colorf cf = colourmask.toColorf();
 
@@ -2855,11 +2856,11 @@ void OpenGLRenderer::DrawTextureNew(float u, float v, GraphicsImage *tex, Color 
 }
 
 // TODO(pskelton): add optional colour32
-void OpenGLRenderer::DrawTextureCustomHeight(float u, float v, class GraphicsImage *img, int custom_height) {
-    if (!img) {
-        logger->trace("Null texture passed to DrawTextureCustomHeight");
-        return;
-    }
+void OpenGLRenderer::DrawTextureCustomHeight(float u, float v, GraphicsImage *img, int custom_height) {
+    assert(img);
+
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_DRAW_2D_TEXTURE, img->GetName());
 
     Colorf cf(1.0f, 1.0f, 1.0f);
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -817,7 +817,7 @@ void OpenGLRenderer::TexturePixelRotateDraw(float u, float v, GraphicsImage *img
     static std::array<int, 14> cachetime { -1 };
 
     if (img) {
-        std::string_view tempstr{ *img->GetName() };
+        std::string_view tempstr{ img->GetName() };
         int number = tempstr[4] - 48;
         int number2 = tempstr[5] - 48;
 
@@ -3291,7 +3291,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                         // TODO(pskelton): Same as indoors. When ODM and BLV face is combined - seperate out function
 
                         GraphicsImage *tex = face.GetTexture();
-                        std::string *texname = tex->GetName();
+                        std::string texname = tex->GetName();
 
                         Duration animLength;
                         Duration frame;
@@ -3324,19 +3324,19 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                         // loop while running down animlength with frame animtimes
                         do {
                             // check if tile->name is already in list
-                            auto mapiter = outbuildtexmap.find(*texname);
+                            auto mapiter = outbuildtexmap.find(texname);
                             if (mapiter != outbuildtexmap.end()) {
                                 // if so, extract unit and layer
                                 int unitlayer = mapiter->second;
                                 texlayer = unitlayer & 0xFF;
                                 texunit = (unitlayer & 0xFF00) >> 8;
-                            } else if (*texname == "wtrtyl") {
+                            } else if (texname == "wtrtyl") {
                                 // water tile
                                 texunit = 0;
                                 texlayer = 0;
                             } else {
                                 // else need to add it
-                                auto thistexture = assets->getBitmap(*texname);
+                                auto thistexture = assets->getBitmap(texname);
                                 int width = thistexture->width();
                                 int height = thistexture->height();
                                 // check size to see what unit it needs
@@ -3363,7 +3363,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
 
                                     if (numoutbuildtexloaded[i] < 256) {
                                         // intsert into tex map
-                                        outbuildtexmap.insert(std::make_pair(*texname, encode));
+                                        outbuildtexmap.insert(std::make_pair(texname, encode));
                                         numoutbuildtexloaded[i]++;
                                     } else {
                                         logger->warning("Texture layer full - draw building!");
@@ -3505,8 +3505,8 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
 
                                 if (texlayer == -1) { // texture has been reset - see if its in the map
                                     GraphicsImage *tex = face.GetTexture();
-                                    std::string *texname = tex->GetName();
-                                    auto mapiter = bsptexmap.find(*texname);
+                                    std::string texname = tex->GetName();
+                                    auto mapiter = bsptexmap.find(texname);
                                     if (mapiter != bsptexmap.end()) {
                                         // if so, extract unit and layer
                                         int unitlayer = mapiter->second;
@@ -3909,7 +3909,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
 
                 // TODO(pskelton): Same as outdoors. When ODM and BLV face is combined - seperate out function
                 GraphicsImage *tex = face->GetTexture();
-                std::string *texname = tex->GetName();
+                std::string texname = tex->GetName();
 
                 Duration animLength;
                 Duration frame;
@@ -3942,20 +3942,20 @@ void OpenGLRenderer::DrawIndoorFaces() {
                 // loop while running down animlength with frame animtimes
                 do {
                     // check if tile->name is already in list
-                    auto mapiter = bsptexmap.find(*texname);
+                    auto mapiter = bsptexmap.find(texname);
                     if (mapiter != bsptexmap.end()) {
                         // if so, extract unit and layer
                         int unitlayer = mapiter->second;
                         // TODO(pskelton): make this a pair/struct rather than encoding
                         texlayer = unitlayer & 0xFF;
                         texunit = (unitlayer & 0xFF00) >> 8;
-                    } else if (*texname == "wtrtyl") {
+                    } else if (texname == "wtrtyl") {
                         // water tile
                         texunit = 0;
                         texlayer = 0;
                     } else {
                         // else need to add it
-                        auto thistexture = assets->getBitmap(*texname);
+                        auto thistexture = assets->getBitmap(texname);
                         int width = thistexture->width();
                         int height = thistexture->height();
                         // check size to see what unit it needs
@@ -3982,7 +3982,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
 
                             if (bsptexloaded[i] < 256) {
                                 // intsert into tex map
-                                bsptexmap.insert(std::make_pair(*texname, encode));
+                                bsptexmap.insert(std::make_pair(texname, encode));
                                 bsptexloaded[i]++;
                             } else {
                                 logger->warning("Texture layer full - draw indoor faces!");
@@ -4188,8 +4188,8 @@ void OpenGLRenderer::DrawIndoorFaces() {
 
                             if (texlayer == -1) { // texture has been reset - see if its in the map
                                 GraphicsImage *tex = face->GetTexture();
-                                std::string *texname = tex->GetName();
-                                auto mapiter = bsptexmap.find(*texname);
+                                std::string texname = tex->GetName();
+                                auto mapiter = bsptexmap.find(texname);
                                 if (mapiter != bsptexmap.end()) {
                                     // if so, extract unit and layer
                                     int unitlayer = mapiter->second;

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.h
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.h
@@ -84,7 +84,7 @@ class OpenGLRenderer : public BaseRenderer {
 
     virtual void DrawTextureNew(float u, float v, class GraphicsImage *, Color colourmask = colorTable.White) override;
 
-        virtual void DrawTextureCustomHeight(float u, float v, class GraphicsImage *,
+    virtual void DrawTextureCustomHeight(float u, float v, class GraphicsImage *,
                                          int height) override;
     virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y,
                                    GraphicsImage *) override;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -7,6 +7,7 @@
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
 #include "Engine/AssetsManager.h"
+#include "Engine/EngineCallObserver.h"
 #include "Engine/Graphics/Level/Decoration.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/Viewport.h"
@@ -21,7 +22,6 @@
 #include "Engine/Party.h"
 #include "Engine/PriceCalculator.h"
 #include "Engine/EngineIocContainer.h"
-#include "Engine/Tables/ItemTable.h"
 #include "Engine/Tables/IconFrameTable.h"
 #include "Engine/Tables/AwardTable.h"
 #include "Engine/Time/Timer.h"
@@ -34,7 +34,6 @@
 #include "GUI/UI/UIGame.h"
 #include "GUI/UI/UIHouses.h"
 #include "GUI/UI/UIPopup.h"
-#include "GUI/UI/UIStatusBar.h"
 
 #include "Io/InputAction.h"
 #include "Io/KeyboardInputHandler.h"
@@ -205,6 +204,9 @@ GUIButton *GUIWindow::GetControl(unsigned int uID) {
 }
 
 void GUIWindow::DrawMessageBox(bool inside_game_viewport) {
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_DRAW_MESSAGE_BOX, sHint);
+
     int x = 0;
     int y = 0;
     int z, w;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Random/Random.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Tables/IconFrameTable.h"
+#include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Spells/SpellEnumFunctions.h"
 #include "Engine/Time/Timer.h"
 
@@ -248,6 +249,10 @@ void CreateParty_EventLoop() {
 bool PartyCreationUI_Loop() {
     pAudioPlayer->MusicStop();
     pEventTimer->setPaused(true);
+
+    // This call is here b/c otherwise Character::timeToRecovery will be overwritten in the main loop from the
+    // turn-based queue if we're currently in turn-based combat.
+    pTurnEngine->End(false);
 
     pParty->Reset();
     pParty->createDefaultParty();

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -30,6 +30,7 @@
 #include "OpenALSample16.h"
 #include "OpenALAudioDataSource.h"
 #include "OpenALSoundProvider.h"
+#include "Engine/EngineCallObserver.h"
 
 std::unique_ptr<AudioPlayer> pAudioPlayer;
 
@@ -187,6 +188,9 @@ void AudioPlayer::resumeSounds() {
 }
 
 void AudioPlayer::playSound(SoundId eSoundID, SoundPlaybackMode mode, Pid pid) {
+    if (engine->callObserver)
+        engine->callObserver->notify(CALL_PLAY_SOUND, eSoundID);
+
     if (!bPlayerReady)
         return;
 

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 1e9e081bd7d19f2e55e3ba4154a5e97a2fe7fac2
+            GIT_TAG 9ee096523cabd460111483c6adf51654cef7c087
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -520,6 +520,7 @@ GAME_TEST(Issues, Issue408_939_970_996) {
     auto screenTape = tapes.screen();
     auto mapTape = tapes.map();
     auto certTape = tapes.custom([] { return assets->winnerCert; });
+    auto messageBoxesTape = tapes.messageBoxes();
     test.playTraceFromTestData("issue_408.mm7", "issue_408.json");
     // we should return to game screen
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_HOUSE, SCREEN_GAMEOVER_WINDOW, SCREEN_GAME));
@@ -529,6 +530,10 @@ GAME_TEST(Issues, Issue408_939_970_996) {
     EXPECT_GT(certTape.size(), 1);
     // we should be teleported to harmondale
     EXPECT_EQ(mapTape, tape("d30.blv", "out02.odm"));
+    // ending message box was displayed.
+    auto flatMessageBoxes = messageBoxesTape.flattened();
+    EXPECT_EQ(flatMessageBoxes.size(), 1);
+    EXPECT_TRUE(flatMessageBoxes.front().starts_with("Congratulations Adventurer"));
 
     // #970: Armor Class is wrong.
     // #939: Quick reference doesnt match vanilla.

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -848,11 +848,12 @@ GAME_TEST(Issues, Issue833b) {
     auto manaTape = charTapes.mp(0);
     auto quickSpellTape = charTapes.quickSpell(0);
     auto actorsHpTape = actorTapes.totalHp();
+    auto soundsTape = tapes.sounds();
     test.playTraceFromTestData("issue_833b.mm7", "issue_833b.json");
     EXPECT_EQ(manaTape.delta(), 0);
     EXPECT_EQ(quickSpellTape, tape(SPELL_NONE));
     EXPECT_EQ(actorsHpTape.size(), 1); // No one was hurt.
-    // TODO(captainurist): test that error sound was played?
+    EXPECT_TRUE(soundsTape.flattened().contains(SOUND_error));
 }
 
 GAME_TEST(Issues, Issue840) {

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -680,9 +680,9 @@ GAME_TEST(Issues, Issue1478) {
     EXPECT_EQ(pParty->alignment, PartyAlignment_Evil);
     // Check buttons have correct texture set.
     const auto quickRefButton = std::ranges::find_if(pPrimaryWindow->vButtons, [](const GUIButton* but) { return but->msg == UIMSG_QuickReference; });
-    EXPECT_EQ(*(*quickRefButton)->vTextures[0]->GetName(), "ib-m3d-c");
+    EXPECT_EQ((*quickRefButton)->vTextures[0]->GetName(), "ib-m3d-c");
     const auto npcLeftButton = std::ranges::find_if(pPrimaryWindow->vButtons, [](const GUIButton* but) { return but->msg == UIMSG_ScrollNPCPanel && but->msg_param == 0; });
-    EXPECT_EQ(*(*npcLeftButton)->vTextures[0]->GetName(), "ib-npcld-c");
+    EXPECT_EQ((*npcLeftButton)->vTextures[0]->GetName(), "ib-npcld-c");
 }
 
 GAME_TEST(Issues, Issue1479) {

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -251,6 +251,16 @@ GAME_TEST(Issues, Issue1273) {
     EXPECT_EQ(dialogueTape, tape(DIALOGUE_NULL, DIALOGUE_MAIN));
 }
 
+GAME_TEST(Issues, Issue1274) {
+    // Right clicking in guild when not member brings up skill tooltips
+    auto screenTape = tapes.screen();
+    auto messageBoxesTape = tapes.messageBoxes();
+    test.playTraceFromTestData("issue_1274.mm7", "issue_1274.json");
+    EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_HOUSE)); // Entered a house.
+    EXPECT_EQ(messageBoxesTape.size(), 1);
+    EXPECT_TRUE(messageBoxesTape.front().empty()); // No message boxes.
+}
+
 GAME_TEST(Issues, Issue1277) {
     // Crash when press enter on character skills tab
     test.playTraceFromTestData("issue_1277.mm7", "issue_1277.json");

--- a/test/Testing/Game/CMakeLists.txt
+++ b/test/Testing/Game/CMakeLists.txt
@@ -14,6 +14,7 @@ if(OE_BUILD_TESTS)
             CommonTapeRecorder.h
             GameTest.h
             TestTape.h
+            TestCallObserver.h
             TestController.h
             AccessibleVector.h)
 

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -140,3 +140,11 @@ TestMultiTape<SpriteId> CommonTapeRecorder::sprites() {
 TestTape<int> CommonTapeRecorder::activeCharacterIndex() {
     return custom([] { return pParty->hasActiveCharacter() ? pParty->activeCharacterIndex() : 0; });
 }
+
+TestMultiTape<SoundId> CommonTapeRecorder::sounds() {
+    return _controller->recordFunctionTape<SoundId>(CALL_PLAY_SOUND);
+}
+
+TestMultiTape<std::string> CommonTapeRecorder::hudTextures() {
+    return _controller->recordFunctionTape<std::string>(CALL_DRAW_2D_TEXTURE);
+}

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -148,3 +148,7 @@ TestMultiTape<SoundId> CommonTapeRecorder::sounds() {
 TestMultiTape<std::string> CommonTapeRecorder::hudTextures() {
     return _controller->recordFunctionTape<std::string>(CALL_DRAW_2D_TEXTURE);
 }
+
+TestMultiTape<std::string> CommonTapeRecorder::messageBoxes() {
+    return _controller->recordFunctionTape<std::string>(CALL_DRAW_MESSAGE_BOX);
+}

--- a/test/Testing/Game/CommonTapeRecorder.h
+++ b/test/Testing/Game/CommonTapeRecorder.h
@@ -9,6 +9,7 @@
 #include "Engine/Objects/ActorEnums.h"
 #include "Engine/Objects/SpriteEnums.h"
 #include "Engine/Time/Time.h"
+#include "Media/Audio/SoundEnums.h"
 #include "GUI/GUIEnums.h"
 #include "GUI/GUIDialogues.h"
 #include "GUI/UI/UIHouseEnums.h"
@@ -82,6 +83,10 @@ class CommonTapeRecorder {
     TestMultiTape<SpriteId> sprites();
 
     TestTape<int> activeCharacterIndex(); // Remember that 0 means none!
+
+    TestMultiTape<SoundId> sounds();
+
+    TestMultiTape<std::string> hudTextures();
 
  private:
     TestController *_controller = nullptr;

--- a/test/Testing/Game/CommonTapeRecorder.h
+++ b/test/Testing/Game/CommonTapeRecorder.h
@@ -88,6 +88,8 @@ class CommonTapeRecorder {
 
     TestMultiTape<std::string> hudTextures();
 
+    TestMultiTape<std::string> messageBoxes();
+
  private:
     TestController *_controller = nullptr;
 };

--- a/test/Testing/Game/GameTest.cpp
+++ b/test/Testing/Game/GameTest.cpp
@@ -3,8 +3,11 @@
 #include <cassert>
 #include <string>
 
+#include "Engine/EngineGlobals.h"
 #include "Engine/Components/Control/EngineController.h"
 #include "Engine/Components/Control/EngineControlState.h"
+
+#include "Library/Platform/Application/PlatformApplication.h"
 
 #include "Utility/Format.h"
 
@@ -51,6 +54,11 @@ void GameTest::runTestBody(TestBodyFunction testBody) {
     };
 
     try {
+        game->runGameRoutine([] {
+            const testing::TestInfo *info = testing::UnitTest::GetInstance()->current_test_info();
+            ::application->window()->setTitle(fmt::format("{}.{}", info->test_suite_name(), info->name()));
+        });
+
         CommonTapeRecorder tapes(test);
         CharacterTapeRecorder charTapes(test);
         ActorTapeRecorder actorTapes(test);

--- a/test/Testing/Game/TestCallObserver.h
+++ b/test/Testing/Game/TestCallObserver.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <functional>
+#include <typeinfo>
+#include <memory>
+
+#include "Engine/EngineCallObserver.h"
+
+#include "Utility/IndexedArray.h"
+
+#include "AccessibleVector.h"
+
+class TestCallObserver : public EngineCallObserver {
+ public:
+    void reset() {
+        _enabled = false;
+        _handlers.fill({});
+    }
+
+    bool isEnabled() const {
+        return _enabled;
+    }
+
+    void setEnabled(bool enabled) {
+        _enabled = enabled;
+    }
+
+    template<class T>
+    std::function<AccessibleVector<T>()> record(EngineCall call) {
+        assert(!_handlers[call]); // Are you creating the same tape twice?
+
+        std::shared_ptr<AccessibleVector<T>> sharedState = std::make_shared<AccessibleVector<T>>();
+
+        // That's the push side - engine will be adding new values into the shared state using this callback.
+        _handlers[call] = [sharedState] (const std::type_info &type, const void *data) {
+            assert(type == typeid(T));
+            sharedState->push_back(*static_cast<const T *>(data));
+        };
+
+        // And that's the pull side - this function will be called between frames to return what was accumulated in the
+        // shared state.
+        return [sharedState] {
+            AccessibleVector<T> result;
+            sharedState->swap(result);
+            return result;
+        };
+    }
+
+ protected:
+    virtual void notify(EngineCall call, const std::type_info &type, const void *data) override {
+        if (_enabled && _handlers[call])
+            _handlers[call](type, data);
+    }
+
+ private:
+    bool _enabled = false;
+    IndexedArray<std::function<void(const std::type_info &, const void *)>, CALL_FIRST, CALL_LAST> _handlers;
+};

--- a/test/Testing/Game/TestTape.h
+++ b/test/Testing/Game/TestTape.h
@@ -10,8 +10,6 @@
 
 #include "AccessibleVector.h"
 
-namespace testing {} // Forward-declare gtest namespace.
-
 namespace detail {
 template<class T>
 class TestTapeState {

--- a/test/Testing/Game/TestTape.h
+++ b/test/Testing/Game/TestTape.h
@@ -50,11 +50,6 @@ class TestTapeBase {
         return _state->values().end();
     }
 
-    friend void PrintTo(const TestTapeBase &tape, std::ostream* stream) { // gtest printers support.
-        using namespace testing; // NOLINT
-        *stream << PrintToString(tape.values());
-    }
-
  private:
     std::shared_ptr<detail::TestTapeState<T>> _state;
 };


### PR DESCRIPTION
Added a push-mode for test tapes. Can now record data that doesn't have associated global state.

Also reworked the way tape callbacks are called, so now they are also called for hand-written test cases (before tapes worked only when playing back pre-recorded traces).

All of this used together to test #1449 and #1274.