### PR TITLE
Fixed crash caused by null pointer exception #1504

### DIFF
--- a/src/Application/GamePathResolver.cpp
+++ b/src/Application/GamePathResolver.cpp
@@ -5,10 +5,13 @@
 
 struct PathResolutionConfig {
     const char *overrideEnvKey = nullptr;
-    std::initializer_list<const char *> registryKeys;
+    const std::vector<const char *> registryKeys;
+
+    constexpr PathResolutionConfig(const char* overrideEnvKey, std::initializer_list<const char*> registryKeys)
+        : overrideEnvKey(overrideEnvKey), registryKeys(registryKeys) {}
 };
 
-static constexpr PathResolutionConfig mm6Config = {
+static PathResolutionConfig mm6Config = {
     mm6PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207661253/PATH",
@@ -20,7 +23,7 @@ static constexpr PathResolutionConfig mm6Config = {
     }
 };
 
-static constexpr PathResolutionConfig mm7Config = {
+static PathResolutionConfig mm7Config = {
     mm7PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207658916/Path",
@@ -32,7 +35,7 @@ static constexpr PathResolutionConfig mm7Config = {
     }
 };
 
-static constexpr PathResolutionConfig mm8Config = {
+static PathResolutionConfig mm8Config = {
     mm8PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM8/PATH",
@@ -57,9 +60,11 @@ static std::vector<std::string> resolvePaths(Environment *environment, const Pat
 
     // Then we check paths from registry on Windows,...
     for (const char *registryKey : config.registryKeys) {
-        std::string registryPath = environment->queryRegistry(registryKey);
-        if (!registryPath.empty())
-            result.push_back(registryPath);
+        if (registryKey) {
+            std::string registryPath = environment->queryRegistry(registryKey);
+            if (!registryPath.empty())
+                result.push_back(registryPath);
+        }
     }
 
     // ...Android storage paths on Android,...

--- a/src/Application/GamePathResolver.cpp
+++ b/src/Application/GamePathResolver.cpp
@@ -11,7 +11,7 @@ struct PathResolutionConfig {
         : overrideEnvKey(overrideEnvKey), registryKeys(registryKeys) {}
 };
 
-static PathResolutionConfig mm6Config = {
+static const PathResolutionConfig mm6Config = {
     mm6PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207661253/PATH",
@@ -23,7 +23,7 @@ static PathResolutionConfig mm6Config = {
     }
 };
 
-static PathResolutionConfig mm7Config = {
+static const PathResolutionConfig mm7Config = {
     mm7PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/Games/1207658916/Path",
@@ -35,7 +35,7 @@ static PathResolutionConfig mm7Config = {
     }
 };
 
-static PathResolutionConfig mm8Config = {
+static const PathResolutionConfig mm8Config = {
     mm8PathOverrideKey,
     {
         "HKEY_LOCAL_MACHINE/SOFTWARE/GOG.com/GOGMM8/PATH",


### PR DESCRIPTION
Fixes #1504

Main issue here is that the paths being stored for MM7 were all null. The issue stemmed from the way `std::initializer_list` stores it's data. The list does use an underlying array but the array is not copied at any point and the actually array itself is treated as a temporary object so it is disposed of after the current scope leaves.

Also, I can't really think of a way to preserve the `constexpr` qualifier in this case. The issue is the use of `const char *` as it is impossible for the compiler to compute the correct size needed to do so. And for a situation like this `constexpr` does not really help in this situation as there isn't a huge amount of computation complexity reduced by providing the objects at compile time.

Resources:
[std::initializer_list](https://en.cppreference.com/w/cpp/utility/initializer_list)
[List initialization](https://en.cppreference.com/w/cpp/language/list_initialization)

![image](https://github.com/OpenEnroth/OpenEnroth/assets/3174205/7cc88ed6-0461-4c8f-9a5e-769c384afe82)