### PR TITLE
"fix" #1523

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,6 +38,7 @@ env:
 
 jobs:
   build_android:
+    timeout-minutes: 60
     name: Build Android Client
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,7 @@ on:
 
 jobs:
   build_linux:
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   build_macos:
+    timeout-minutes: 60
     runs-on: macos-13
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   build_windows:
+    timeout-minutes: 60
     runs-on: windows-2022
     strategy:
       fail-fast: false


### PR DESCRIPTION
github actions vm's can sometimes be a bit buggy, sometimes the vm just hangs... this is especially bad on osx

This will limit the time to 1 hour rather than 6 at least...

fixes https://github.com/OpenEnroth/OpenEnroth/issues/1523