### PR TITLE
Consistent use of int64_t in TextureFrameTable

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -246,12 +246,12 @@ GraphicsImage *BLVFace::GetTexture() {
 
 void BLVFace::SetTexture(const std::string &filename) {
     if (this->IsTextureFrameTable()) {
-        this->resource =
-            (void *)pTextureFrameTable->FindTextureByName(filename);
+        this->resource = (void *)pTextureFrameTable->FindTextureByName(filename);
         if (this->resource != (void *)-1) {
             return;
         }
 
+        // Failed to find animated texture so disable
         this->ToggleIsTextureFrameTable();
     }
 

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -130,7 +130,7 @@ struct BLVFace {  // 60h
     int16_t *pVertexUIDs = nullptr;
     int16_t *pVertexVIDs = nullptr;
     uint16_t uFaceExtraID = 0;
-    void *resource = nullptr;  // uint16_t  uBitmapID;
+    void *resource = nullptr;  // int64_t or GraphicsImage
     int texunit = -1;
     int texlayer = -1;
 

--- a/src/Engine/Graphics/TextureFrameTable.cpp
+++ b/src/Engine/Graphics/TextureFrameTable.cpp
@@ -23,9 +23,9 @@ int64_t TextureFrameTable::FindTextureByName(const std::string &Str2) {
     return -1;
 }
 
-GraphicsImage *TextureFrameTable::GetFrameTexture(int frameId, Duration offset) {
+GraphicsImage *TextureFrameTable::GetFrameTexture(int64_t frameId, Duration offset) {
     if (frameId < 0 || frameId >= textures.size()) {
-        logger->warning("Failed to retreive OOB frameID '{}' from TextureFrameTable::GetFrameTexture", frameId);
+        logger->error("Failed to retreive OOB frameID '{}' from TextureFrameTable::GetFrameTexture", frameId);
         return nullptr;
     }
 
@@ -42,13 +42,21 @@ GraphicsImage *TextureFrameTable::GetFrameTexture(int frameId, Duration offset) 
     return textures[frameId].GetTexture();
 }
 
-Duration TextureFrameTable::textureFrameAnimLength(int frameID) {
+Duration TextureFrameTable::textureFrameAnimLength(int64_t frameID) {
+    if (frameID < 0 || frameID >= textures.size()) {
+        logger->error("Failed to retreive OOB frameID '{}' from TextureFrameTable::textureFrameAnimLength", frameID);
+        return 1_ticks;
+    }
     Duration result = textures[frameID].animationDuration;
     if ((textures[frameID].flags & TEXTURE_FRAME_TABLE_MORE_FRAMES) && result)
         return result;
     return 1_ticks;
 }
 
-Duration TextureFrameTable::textureFrameAnimTime(int frameID) {
+Duration TextureFrameTable::textureFrameAnimTime(int64_t frameID) {
+    if (frameID < 0 || frameID >= textures.size()) {
+        logger->error("Failed to retreive OOB frameID '{}' from TextureFrameTable::textureFrameAnimTime", frameID);
+        return 1_ticks;
+    }
     return textures[frameID].frameDuration;
 }

--- a/src/Engine/Graphics/TextureFrameTable.h
+++ b/src/Engine/Graphics/TextureFrameTable.h
@@ -33,20 +33,20 @@ class TextureFrame {
 };
 
 struct TextureFrameTable {
-    GraphicsImage *GetFrameTexture(int frameId, Duration offset);
+    GraphicsImage *GetFrameTexture(int64_t frameId, Duration offset);
 
     /**
      * @param frameID                   Texture index in this table.
      * @return                          Total duration of the corresponding animation. Passed frame must be the first
      *                                  one in a sequence.
      */
-    Duration textureFrameAnimLength(int frameID);
+    Duration textureFrameAnimLength(int64_t frameID);
 
     /**
      * @param frameID                   Texture index in this table.
      * @return                          Dwell time of this texture.
      */
-    Duration textureFrameAnimTime(int frameID);
+    Duration textureFrameAnimTime(int64_t frameID);
 
     int64_t FindTextureByName(const std::string &Str2);
 


### PR DESCRIPTION
Upgrade warning logs to error, and added the bounds checking on other functions too