### PR TITLE
Dont update FACE_TEXTURE_FRAME from delta attribs

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -252,6 +252,7 @@ void BLVFace::SetTexture(const std::string &filename) {
         }
 
         // Failed to find animated texture so disable
+        this->resource = nullptr;
         this->ToggleIsTextureFrameTable();
     }
 

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -204,7 +204,8 @@ void reconstruct(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
         BLVFace *pFace = &dst->pFaces[i];
         BLVFaceExtra *pFaceExtra = &dst->pFaceExtras[pFace->uFaceExtraID];
 
-        pFace->uAttributes = FaceAttributes(src.faceAttributes[i]);
+        // Do not re toggle TextureFrameTable when restoring attribute flags
+        pFace->uAttributes = (pFace->uAttributes & FACE_TEXTURE_FRAME) | FaceAttributes((src.faceAttributes[i] & ~std::to_underlying(FACE_TEXTURE_FRAME)));
 
         if (pFaceExtra->uEventID) {
             if (pFaceExtra->HasEventHint())


### PR DESCRIPTION
Further work on #1560 - this will at least stop trying to index into bad texture ids.

The crux of the issue is an incorrect/incompatible data table being supplied with some language versions.