### PR TITLE
Add missing #include <string>

### DIFF
--- a/src/Library/Environment/Win/WinEnvironment.cpp
+++ b/src/Library/Environment/Win/WinEnvironment.cpp
@@ -4,6 +4,7 @@
 #include <Windows.h>
 
 #include <cstdlib>
+#include <string>
 #include <array>
 #include <memory>
 

--- a/src/Utility/Win/Unicode.cpp
+++ b/src/Utility/Win/Unicode.cpp
@@ -3,6 +3,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+#include <string>
+
 std::string win::toUtf8(std::wstring_view wstr) {
     std::string result;
 


### PR DESCRIPTION
When I try to compile on windows I get come check_style errors:

`3>Win/Unicode.cpp:7:  Add #include <string> for string  [build/include_what_you_use] [4]`
`39>WinEnvironment.cpp:99:  Add #include <string> for string  [build/include_what_you_use] [4]`

I added the missing includes.