### PR TITLE
Scripting: Better way to import Bindings Tables in lua

### DIFF
--- a/resources/scripts/core/config.lua
+++ b/resources/scripts/core/config.lua
@@ -1,4 +1,5 @@
-local configBindings = requireConfigBindings()
+--- @type ConfigBindings
+local ConfigBindings = require "bindings.config"
 return {
-    bindings = configBindings
+    bindings = ConfigBindings
 }

--- a/resources/scripts/core/game.lua
+++ b/resources/scripts/core/game.lua
@@ -1,4 +1,5 @@
-local gameBindings = requireGameBindings()
+---@type GameBindings
+local GameBindings = require "bindings.game"
 return {
-    bindings = gameBindings
+    bindings = GameBindings
 }

--- a/resources/scripts/core/input.lua
+++ b/resources/scripts/core/input.lua
@@ -1,3 +1,5 @@
+---@type InputBindings
+local InputBindings = require "bindings.input"
 local inputListener = {}
 
 ---@type table<PlatformKey, table<integer, fun()>>
@@ -65,8 +67,7 @@ _globalOnKeyPress = function (keyPressed)
     return false
 end
 
-local inputBindings = requireInputBindings()
 return {
-    bindings = inputBindings,
+    bindings = InputBindings,
     listener = inputListener
 }

--- a/resources/scripts/core/logger.lua
+++ b/resources/scripts/core/logger.lua
@@ -1,4 +1,5 @@
-local logBindings = requireLogBindings()
+--- @type LogBindings
+local LogBindings = require "bindings.log"
 
 ---@type function[]
 local callbacks = {}
@@ -32,6 +33,6 @@ local logListener = {
 }
 
 return {
-    bindings = logBindings,
+    bindings = LogBindings,
     listener = logListener
 }

--- a/resources/scripts/core/nuklear.lua
+++ b/resources/scripts/core/nuklear.lua
@@ -1,2 +1,3 @@
-local NuklearBindings = requireNuklearBindings()
+--- @type NuklearBindings
+local NuklearBindings = require "bindings.nuklear"
 return NuklearBindings

--- a/src/Application/GameStarter.cpp
+++ b/src/Application/GameStarter.cpp
@@ -160,11 +160,11 @@ GameStarter::GameStarter(GameStarterOptions options): _options(std::move(options
     _game = std::make_unique<Game>(_application.get(), _config);
 
     _scriptingSystem = std::make_unique<ScriptingSystem>("scripts", "init.lua", *_application, *_defaultLogSink);
-    _scriptingSystem->addBindings<LoggerBindings>("Log");
-    _scriptingSystem->addBindings<GameLuaBindings>("Game");
-    _scriptingSystem->addBindings<ConfigBindings>("Config");
-    _scriptingSystem->addBindings<InputBindings>("Input", *_application->component<InputScriptEventHandler>());
-    _scriptingSystem->addBindings<NuklearBindings>("Nuklear", _engine->nuklear.get());
+    _scriptingSystem->addBindings<LoggerBindings>("log");
+    _scriptingSystem->addBindings<GameLuaBindings>("game");
+    _scriptingSystem->addBindings<ConfigBindings>("config");
+    _scriptingSystem->addBindings<InputBindings>("input", *_application->component<InputScriptEventHandler>());
+    _scriptingSystem->addBindings<NuklearBindings>("nuklear", _engine->nuklear.get());
     _scriptingSystem->executeEntryPoint();
 }
 

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -70,7 +70,7 @@ int _loadBindingTableThroughRequire(lua_State *luaState) {
     if (path.starts_with(prefix)) {
         // When requesting a module, Lua expects us to place a code chunk on the stack.
         // We utilize loadbuffer to load this chunk, after which the Lua VM promptly executes it.
-        std::string script = std::format("return _createBindingTable('{}')", path);
+        std::string script = fmt::format("return _createBindingTable('{}')", path);
         luaL_loadbuffer(luaState, script.data(), script.size(), path.c_str());
         return 1;
     }

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -56,14 +56,19 @@ void ScriptingSystem::_initBaseLibraries() {
     );
 }
 
-/* Internal lua function used as package loader for the Bindings table.
-* 
-* Usage in lua: 
-*   local gameBindings = require "bindings.game" -- If the module starts with 'bindings.' we try to load/create the binding table
-*   gameBindings.doSomething()
-* 
-* TODO(Gerark) I'm asking in the sol2 repo if there's a way to avoid a lua_CFunction and use the sol2 approach instead.
-* Here's the question: https://github.com/ThePhD/sol2/issues/1601 */
+/**
+ * @brief Internal Lua function used as package loader for the Bindings table.
+ *
+ * Usage in Lua:
+ *   local gameBindings = require "bindings.game" -- If the module starts with 'bindings.' we try to load/create the binding table
+ *   gameBindings.doSomething()
+ *
+ * @param luaState The Lua state.
+ * @return int Returns 1 if the binding table is loaded, otherwise returns 0.
+ *
+ * @todo(Gerark) I'm asking in the sol2 repo if there's a way to avoid a lua_CFunction and use the sol2 approach instead.
+ * Here's the question: [link to the question](https://github.com/ThePhD/sol2/issues/1601)
+ */
 int _loadBindingTableThroughRequire(lua_State *luaState) {
     std::string path = sol::stack::get<std::string>(luaState, 1);
     std::string_view prefix = "bindings.";

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <memory>
 #include <utility>
+#include <unordered_map>
 
 #include "IBindings.h"
 #include "InputScriptEventHandler.h"
@@ -25,6 +26,7 @@ ScriptingSystem::ScriptingSystem(std::string_view scriptFolder, std::string_view
 
     _initBaseLibraries();
     _initPackageTable(scriptFolder);
+    _initBindingFunction();
 }
 
 ScriptingSystem::~ScriptingSystem() {
@@ -54,16 +56,40 @@ void ScriptingSystem::_initBaseLibraries() {
     );
 }
 
+/* Internal lua function used as package loader for the Bindings table.
+* 
+* Usage in lua: 
+*   local gameBindings = require "bindings.game" -- If the module starts with 'bindings.' we try to load/create the binding table
+*   gameBindings.doSomething()
+* 
+* TODO(Gerark) I'm asking in the sol2 repo if there's a way to avoid a lua_CFunction and use the sol2 approach instead.
+* Here's the question: https://github.com/ThePhD/sol2/issues/1601 */
+int _loadBindingTableThroughRequire(lua_State *luaState) {
+    std::string path = sol::stack::get<std::string>(luaState, 1);
+    std::string_view prefix = "bindings.";
+    if (path.starts_with(prefix)) {
+        // When requesting a module, Lua expects us to place a code chunk on the stack.
+        // We utilize loadbuffer to load this chunk, after which the Lua VM promptly executes it.
+        std::string script = std::format("return _createBindingTable('{}')", path);
+        luaL_loadbuffer(luaState, script.data(), script.size(), path.c_str());
+        return 1;
+    }
+    return 0;
+}
+
 void ScriptingSystem::_initPackageTable(std::string_view scriptFolder) {
     sol::table packageTable = (*_solState)["package"];
     packageTable["path"] = makeDataPath(scriptFolder, "?.lua");
     packageTable["cpath"] = ""; //Reset the path for any c loaders
+    _solState->add_package_loader(_loadBindingTableThroughRequire);
 }
 
-void ScriptingSystem::_addBindings(std::string_view bindingTableName, std::unique_ptr<IBindings> bindings) {
-    (*_solState)[bindingTableName] = bindings->createBindingTable(*_solState);
-    (*_solState)["require" + std::string(bindingTableName) + "Bindings"] = [this, bindingTableName]() -> sol::table {
-        return (*_solState)[bindingTableName];
+void ScriptingSystem::_initBindingFunction() {
+    (*_solState)["_createBindingTable"] = [this](std::string tableName) {
+        if (auto itr = _bindings.find(tableName); itr != _bindings.end()) {
+            return itr->second->createBindingTable(*_solState);
+        }
+        logger->warning(ScriptingLogCategory, "Can't find a binding table with name: {}", tableName);
+        return _solState->create_table();
     };
-    _bindings.insert({ bindingTableName.data(), std::move(bindings) });
 }

--- a/src/Scripting/ScriptingSystem.h
+++ b/src/Scripting/ScriptingSystem.h
@@ -25,7 +25,7 @@ class ScriptingSystem {
     template<typename TBindings, typename ...TArgs>
     void addBindings(std::string_view bindingTableName, TArgs &&... args) {
         auto bindings = std::make_unique<TBindings>(std::forward<TArgs>(args) ...);
-        _addBindings(bindingTableName, std::move(bindings));
+        _bindings.insert({ "bindings." + std::string(bindingTableName), std::move(bindings)});
     }
 
     static LogCategory ScriptingLogCategory;
@@ -33,7 +33,7 @@ class ScriptingSystem {
  private:
     void _initBaseLibraries();
     void _initPackageTable(std::string_view scriptFolder);
-    void _addBindings(std::string_view name, std::unique_ptr<IBindings> bindings);
+    void _initBindingFunction();
 
     std::shared_ptr<sol::state> _solState;
     std::unordered_map<std::string, std::unique_ptr<IBindings>> _bindings;


### PR DESCRIPTION
I changed the way how bindings tables can be loaded in lua
```lua
-- Before
local gameBindings = requireGameBindings()
-- Now
local GameBindings = require "bindings.game"
-- Why G is in uppercase here? We have a lua style rule. Modules starts with capital letter ( pascal case ) 
```
Having the same approach to load modules/files keeps things simple. By doing so we don't have to cache on c++ a global table or function for each binding.
```lua
-- With the previous approach you can access a binding table like this.
-- Variable 'Game' and 'Input' are globals that can be overridden too and that's not ideal.
local gameBindings = Game
local inputBindings = Input

-- With the new approach we only have a "under the hood" global function named _createBindingTable
-- If the user wants to mess with it, it's way harder and we also can log a better 
-- error message if the module name is not valid.
local gameBindings = _createBindingTable("bindings.game")
```

I went back to a lazy-initialization approach to avoid having global tables or functions instantiated in lua. And it's not that bad after all. 
When the script run this code:
```lua
local gameBindings = require "bindings.game"
```
The `_createBindingTable("bindings.game")` is called internally. Any other subsequent request for the same module returns the same table. This is how the `require` command works in lua by default. If you load a module:
- And it's the first time, it runs the code in the file
- From that moment on, any other next requests returns the cached result

I thought it was way better to keep the caching functionality in lua and instantiate the table from c++ only on-demand.

To be clear, scripters can still force the creation of the same table over and over if they are crazy enough or they think there's a reason for it. To do so they have to use directly the `_createBindingTable("bindings.game")`. Since I don't see a good reason to use the `_createBindingTable` directly, I didn't expose it in the lua definition. By doing so, the lua check will raise a warning if we're trying to use an undefined function.