### PR TITLE
Scripting: Console wrong value-conversion message

### DIFF
--- a/resources/scripts/dev/commands/command_utils.lua
+++ b/resources/scripts/dev/commands/command_utils.lua
@@ -25,7 +25,11 @@ CommandUtilities.changeCharProperty = function (key, op, playAward, conversion)
     ---@return string, boolean
     return function (value, charIndex)
         if conversion then
-            value = conversion(value)
+            local convertedValue = conversion(value)
+            if not convertedValue then
+                return "Value can't be converted properly. Value: " .. value, false
+            end
+            value = convertedValue
         end
 
         charIndex = CommandUtilities.characterOrCurrent(charIndex)
@@ -95,7 +99,11 @@ end
 CommandUtilities.changeProperty = function (get, set, op, propName, conversion, serializer)
     return function (value)
         if conversion then
-            value = conversion(value)
+            local convertedValue = conversion(value)
+            if not convertedValue then
+                return "Value can't be converted properly. Value: " .. value, false
+            end
+            value = convertedValue
         end
 
         local message = ""

--- a/src/Application/GameStarter.cpp
+++ b/src/Application/GameStarter.cpp
@@ -161,19 +161,16 @@ GameStarter::GameStarter(GameStarterOptions options): _options(std::move(options
     _game = std::make_unique<Game>(_application.get(), _config);
 
     // Init scripting system.
-    _scriptingSystem = std::make_unique<ScriptingSystem>("scripts", "init.lua", *_application);
+    _scriptingSystem = std::make_unique<ScriptingSystem>("scripts", "init.lua", *_application, *_rootLogSink);
     _scriptingSystem->addBindings<LoggerBindings>("log");
     _scriptingSystem->addBindings<GameLuaBindings>("game");
     _scriptingSystem->addBindings<ConfigBindings>("config");
     _scriptingSystem->addBindings<InputBindings>("input", *_application->component<InputScriptEventHandler>());
     _scriptingSystem->addBindings<NuklearBindings>("nuklear", _engine->nuklear.get());
     _scriptingSystem->executeEntryPoint();
-    _rootLogSink->addLogSink(_scriptingSystem->scriptingLogSink());
 }
 
 GameStarter::~GameStarter() {
-    _rootLogSink->removeLogSink(_scriptingSystem->scriptingLogSink());
-
     ::engine = nullptr;
 
     ::nuklear = nullptr;

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -17,11 +17,12 @@
 
 LogCategory ScriptingSystem::ScriptingLogCategory("Script");
 
-ScriptingSystem::ScriptingSystem(std::string_view scriptFolder, std::string_view entryPointFile, PlatformApplication &platformApplication)
-    : _scriptFolder(scriptFolder), _entryPointFile(entryPointFile), _platformApplication(platformApplication) {
+ScriptingSystem::ScriptingSystem(std::string_view scriptFolder, std::string_view entryPointFile, PlatformApplication &platformApplication, DistLogSink &distLogSink)
+    : _scriptFolder(scriptFolder), _entryPointFile(entryPointFile), _platformApplication(platformApplication), _distLogSink(distLogSink) {
     _solState = std::make_unique<sol::state>();
     _scriptingLogSink = std::make_unique<ScriptLogSink>(*_solState);
     _platformApplication.installComponent(std::make_unique<InputScriptEventHandler>(*_solState));
+    _distLogSink.addLogSink(_scriptingLogSink.get());
 
     _initBaseLibraries();
     _initPackageTable(scriptFolder);
@@ -30,10 +31,7 @@ ScriptingSystem::ScriptingSystem(std::string_view scriptFolder, std::string_view
 
 ScriptingSystem::~ScriptingSystem() {
     _platformApplication.removeComponent<InputScriptEventHandler>();
-}
-
-LogSink *ScriptingSystem::scriptingLogSink() const {
-    return _scriptingLogSink.get();
+    _distLogSink.removeLogSink(_scriptingLogSink.get());
 }
 
 void ScriptingSystem::executeEntryPoint() {

--- a/src/Scripting/ScriptingSystem.h
+++ b/src/Scripting/ScriptingSystem.h
@@ -15,13 +15,12 @@ class DistLogSink;
 class IBindings;
 class PlatformApplication;
 class ScriptLogSink;
+class DistLogSink;
 
 class ScriptingSystem {
  public:
-    ScriptingSystem(std::string_view scriptFolder, std::string_view entryPointFile, PlatformApplication &platformApplication);
+    ScriptingSystem(std::string_view scriptFolder, std::string_view entryPointFile, PlatformApplication &platformApplication, DistLogSink &distLogSink);
     ~ScriptingSystem();
-
-    LogSink *scriptingLogSink() const;
 
     void executeEntryPoint();
 
@@ -44,4 +43,5 @@ class ScriptingSystem {
     std::string _scriptFolder;
     std::string _entryPointFile;
     PlatformApplication &_platformApplication;
+    DistLogSink &_distLogSink;
 };


### PR DESCRIPTION
When writing console commands if the conversion of a value goes wrong do not raise an exception and check if the value is nil before using it.
```
food set 1000 -> OK
food set asdf -> EXCEPTION RAISED
```
Now we show a proper message telling that something has gone wrong with the conversion of that specific value and no exception is raised:
![image](https://github.com/OpenEnroth/OpenEnroth/assets/7666672/2f2f30ad-145f-4bf3-9387-20acbffe5a09)

I also moved in the `ScriptingSystem` the registration and unregistration of the `ScriptingLogSink`.