### PR TITLE
Add lava tiles movement

### DIFF
--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -44,6 +44,7 @@ uniform int waterframe;
 uniform Sunlight sun;
 uniform vec3 CameraPos;
 uniform int flowtimer;
+uniform int flowtimerms;
 uniform int watertiles;
 uniform float gamma;
 
@@ -84,37 +85,15 @@ void main() {
 
     // lava movement
     if ((vsAttrib & 0x4000) > 0) {
-        // flowtimer comes in 1/16th of milliseconds
-        const float accelerationtime = 1000.0 / 16.0;
-        const float consttime = 2000.0 / 16.0;
-        const float acceleration = 0.05;
-        const float constspeed = accelerationtime * acceleration;
-        const float accelerationdist = acceleration * accelerationtime * accelerationtime / 2.0;
-        const float constdist = constspeed * consttime;
-        float curpos;
-        float lavaperiod = mod(float(flowtimer), accelerationtime * 4.0 + consttime * 2.0); // 2 accelerations, 2 deceleraions, 2 periods of constant speed
-        if (lavaperiod < accelerationtime) { // 1s acceleration
-            float modetime = lavaperiod;
-            curpos = acceleration * modetime * modetime / 2.0;
-        } else if (lavaperiod < (accelerationtime + consttime)) { // 2s constant speed
-            float modetime = lavaperiod - accelerationtime;
-            curpos = accelerationdist;
-            curpos = curpos + constspeed * modetime;
-        } else if (lavaperiod < (accelerationtime * 3.0 + consttime)) { // 1s deceleration and 1s acceleration in reverse
-            float modetime = lavaperiod - accelerationtime - consttime;
-            curpos = accelerationdist + constdist;
-            curpos = curpos + constspeed * modetime - acceleration * modetime * modetime / 2.0;
-        } else if (lavaperiod < (accelerationtime * 3.0 + consttime * 2.0)) { // 2s constant speed
-            float modetime = lavaperiod - accelerationtime * 3.0 - consttime;
-            curpos = accelerationdist + constdist;
-            curpos = curpos - constspeed * modetime;
-        } else { // 1s deceleration
-            float modetime = lavaperiod - accelerationtime * 3.0 - consttime * 2.0;
-            curpos = accelerationdist;
-            curpos = curpos - constspeed * modetime + acceleration * modetime * modetime / 2.0;
+        // Texture makes full circle in 8 seconds
+        float lavaperiod = mod(float(flowtimerms), 8000.0);
+        float lavaradians = lavaperiod * radians(360.0) / 8000.0;
+        float curpos = sin(lavaradians);
+        if (curpos < 0.0) {
+            curpos = curpos + 1.0;
         }
         deltas.x = 0.0;
-        deltas.y = mod(curpos, float(texsize.y));
+        deltas.y = float(texsize.y) * curpos;
     } else {
         deltas.x = texuvmod.x * mod(float(flowtimer), float(texsize.x));
         deltas.y = texuvmod.y * mod(float(flowtimer), float(texsize.y));

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -65,7 +65,7 @@ void main() {
     vec2 texcoords = vec2(0.0);
     vec2 texuvmod = vec2(0.0);
     vec2 deltas = vec2(0.0);
-    vec3 texsize = textureSize(textureArray0,0);
+    ivec3 texsize = textureSize(textureArray0,0);
 
     // texture flow mods
     if (abs(vsNorm.z) >= 0.9) {
@@ -114,10 +114,10 @@ void main() {
             curpos = curpos - constspeed * modetime + acceleration * modetime * modetime / 2.0;
         }
         deltas.x = 0.0;
-        deltas.y = mod(curpos, texsize.y);
+        deltas.y = mod(curpos, float(texsize.y));
     } else {
-        deltas.x = texuvmod.x * mod(float(flowtimer), texsize.x);
-        deltas.y = texuvmod.y * mod(float(flowtimer), texsize.y);
+        deltas.x = texuvmod.x * mod(float(flowtimer), float(texsize.x));
+        deltas.y = texuvmod.y * mod(float(flowtimer), float(texsize.y));
     }
 
     texcoords.x = (deltas.x + texuv.x) / float(texsize.x);

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -44,7 +44,7 @@ uniform int waterframe;
 uniform Sunlight sun;
 uniform vec3 CameraPos;
 uniform int flowtimer;
-uniform int flowtimerms;
+uniform int flowtimerms; // TODO(Nik-RE-dev): use a single timer for everything
 uniform int watertiles;
 uniform float gamma;
 
@@ -89,9 +89,6 @@ void main() {
         float lavaperiod = mod(float(flowtimerms), 8000.0);
         float lavaradians = lavaperiod * radians(360.0) / 8000.0;
         float curpos = sin(lavaradians);
-        if (curpos < 0.0) {
-            curpos = curpos + 1.0;
-        }
         deltas.x = 0.0;
         deltas.y = float(texsize.y) * curpos;
     } else {

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -66,7 +66,7 @@ void main() {
     vec2 texcoords = vec2(1.0);
     vec2 texuvmod = vec2(0.0);
     vec2 deltas = vec2(0.0);
-    vec3 texsize = textureSize(textureArray0,0);
+    ivec3 texsize = textureSize(textureArray0,0);
 
     // texture flow mods
     if (abs(vsNorm.z) >= 0.9) {
@@ -93,7 +93,7 @@ void main() {
         const float accelerationdist = acceleration * accelerationtime * accelerationtime / 2.0;
         const float constdist = constspeed * consttime;
         float curpos;
-        float lavaperiod = mod(flowtimer, accelerationtime * 4.0 + consttime * 2.0); // 2 accelerations, 2 deceleraions, 2 periods of constant speed
+        float lavaperiod = mod(float(flowtimer), accelerationtime * 4.0 + consttime * 2.0); // 2 accelerations, 2 deceleraions, 2 periods of constant speed
         if (lavaperiod < accelerationtime) { // 1s acceleration
             float modetime = lavaperiod;
             curpos = acceleration * modetime * modetime / 2.0;
@@ -115,10 +115,10 @@ void main() {
             curpos = curpos - constspeed * modetime + acceleration * modetime * modetime / 2.0;
         }
         deltas.x = 0.0;
-        deltas.y = mod(curpos, texsize.y);
+        deltas.y = mod(curpos, float(texsize.y));
     } else {
-        deltas.x = texuvmod.x * mod(float(flowtimer), texsize.x);
-        deltas.y = texuvmod.y * mod(float(flowtimer), texsize.y);
+        deltas.x = texuvmod.x * mod(float(flowtimer), float(texsize.x));
+        deltas.y = texuvmod.y * mod(float(flowtimer), float(texsize.y));
     }
 
     texcoords.x = (deltas.x + texuv.x) / float(texsize.x);

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -44,6 +44,7 @@ uniform int waterframe;
 uniform Sunlight sun;
 uniform vec3 CameraPos;
 uniform int flowtimer;
+uniform int flowtimerms;
 uniform int watertiles;
 uniform float gamma;
 
@@ -85,37 +86,15 @@ void main() {
 
     // lava movement
     if ((vsAttrib & 0x4000) > 0) {
-        // flowtimer comes in 1/16th of milliseconds
-        const float accelerationtime = 1000.0 / 16.0;
-        const float consttime = 2000.0 / 16.0;
-        const float acceleration = 0.05;
-        const float constspeed = accelerationtime * acceleration;
-        const float accelerationdist = acceleration * accelerationtime * accelerationtime / 2.0;
-        const float constdist = constspeed * consttime;
-        float curpos;
-        float lavaperiod = mod(float(flowtimer), accelerationtime * 4.0 + consttime * 2.0); // 2 accelerations, 2 deceleraions, 2 periods of constant speed
-        if (lavaperiod < accelerationtime) { // 1s acceleration
-            float modetime = lavaperiod;
-            curpos = acceleration * modetime * modetime / 2.0;
-        } else if (lavaperiod < (accelerationtime + consttime)) { // 2s constant speed
-            float modetime = lavaperiod - accelerationtime;
-            curpos = accelerationdist;
-            curpos = curpos + constspeed * modetime;
-        } else if (lavaperiod < (accelerationtime * 3.0 + consttime)) { // 1s deceleration and 1s acceleration in reverse
-            float modetime = lavaperiod - accelerationtime - consttime;
-            curpos = accelerationdist + constdist;
-            curpos = curpos + constspeed * modetime - acceleration * modetime * modetime / 2.0;
-        } else if (lavaperiod < (accelerationtime * 3.0 + consttime * 2.0)) { // 2s constant speed
-            float modetime = lavaperiod - accelerationtime * 3.0 - consttime;
-            curpos = accelerationdist + constdist;
-            curpos = curpos - constspeed * modetime;
-        } else { // 1s deceleration
-            float modetime = lavaperiod - accelerationtime * 3.0 - consttime * 2.0;
-            curpos = accelerationdist;
-            curpos = curpos - constspeed * modetime + acceleration * modetime * modetime / 2.0;
+        // Texture makes full circle in 8 seconds
+        float lavaperiod = mod(float(flowtimerms), 8000.0);
+        float lavaradians = lavaperiod * radians(360.0) / 8000.0;
+        float curpos = sin(lavaradians);
+        if (curpos < 0.0) {
+            curpos = curpos + 1.0;
         }
         deltas.x = 0.0;
-        deltas.y = mod(curpos, float(texsize.y));
+        deltas.y = float(texsize.y) * curpos;
     } else {
         deltas.x = texuvmod.x * mod(float(flowtimer), float(texsize.x));
         deltas.y = texuvmod.y * mod(float(flowtimer), float(texsize.y));

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -44,7 +44,7 @@ uniform int waterframe;
 uniform Sunlight sun;
 uniform vec3 CameraPos;
 uniform int flowtimer;
-uniform int flowtimerms;
+uniform int flowtimerms; // TODO(Nik-RE-dev): use a single timer for everything
 uniform int watertiles;
 uniform float gamma;
 
@@ -90,9 +90,6 @@ void main() {
         float lavaperiod = mod(float(flowtimerms), 8000.0);
         float lavaradians = lavaperiod * radians(360.0) / 8000.0;
         float curpos = sin(lavaradians);
-        if (curpos < 0.0) {
-            curpos = curpos + 1.0;
-        }
         deltas.x = 0.0;
         deltas.y = float(texsize.y) * curpos;
     } else {

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -66,6 +66,7 @@ void main() {
     vec2 texcoords = vec2(1.0);
     vec2 texuvmod = vec2(0.0);
     vec2 deltas = vec2(0.0);
+    vec3 texsize = textureSize(textureArray0,0);
 
     // texture flow mods
     if (abs(vsNorm.z) >= 0.9) {
@@ -82,10 +83,46 @@ void main() {
         texuvmod.x = 1.0;
     }
 
-    deltas.x = texuvmod.x * float(flowtimer & int(textureSize(textureArray0,0).x-1));
-    deltas.y = texuvmod.y * float(flowtimer & int(textureSize(textureArray0,0).y-1));
-    texcoords.x = (deltas.x + texuv.x) / float(textureSize(textureArray0,0).x);
-    texcoords.y = (deltas.y + texuv.y) / float(textureSize(textureArray0,0).y);
+    // lava movement
+    if ((vsAttrib & 0x4000) > 0) {
+        // flowtimer comes in 1/16th of milliseconds
+        const float accelerationtime = 1000.0 / 16.0;
+        const float consttime = 2000.0 / 16.0;
+        const float acceleration = 0.05;
+        const float constspeed = accelerationtime * acceleration;
+        const float accelerationdist = acceleration * accelerationtime * accelerationtime / 2.0;
+        const float constdist = constspeed * consttime;
+        float curpos;
+        float lavaperiod = mod(flowtimer, accelerationtime * 4.0 + consttime * 2.0); // 2 accelerations, 2 deceleraions, 2 periods of constant speed
+        if (lavaperiod < accelerationtime) { // 1s acceleration
+            float modetime = lavaperiod;
+            curpos = acceleration * modetime * modetime / 2.0;
+        } else if (lavaperiod < (accelerationtime + consttime)) { // 2s constant speed
+            float modetime = lavaperiod - accelerationtime;
+            curpos = accelerationdist;
+            curpos = curpos + constspeed * modetime;
+        } else if (lavaperiod < (accelerationtime * 3.0 + consttime)) { // 1s deceleration and 1s acceleration in reverse
+            float modetime = lavaperiod - accelerationtime - consttime;
+            curpos = accelerationdist + constdist;
+            curpos = curpos + constspeed * modetime - acceleration * modetime * modetime / 2.0;
+        } else if (lavaperiod < (accelerationtime * 3.0 + consttime * 2.0)) { // 2s constant speed
+            float modetime = lavaperiod - accelerationtime * 3.0 - consttime;
+            curpos = accelerationdist + constdist;
+            curpos = curpos - constspeed * modetime;
+        } else { // 1s deceleration
+            float modetime = lavaperiod - accelerationtime * 3.0 - consttime * 2.0;
+            curpos = accelerationdist;
+            curpos = curpos - constspeed * modetime + acceleration * modetime * modetime / 2.0;
+        }
+        deltas.x = 0.0;
+        deltas.y = mod(curpos, texsize.y);
+    } else {
+        deltas.x = texuvmod.x * mod(float(flowtimer), texsize.x);
+        deltas.y = texuvmod.y * mod(float(flowtimer), texsize.y);
+    }
+
+    texcoords.x = (deltas.x + texuv.x) / float(texsize.x);
+    texcoords.y = (deltas.y + texuv.y) / float(texsize.y);
     fragcol = texture(textureArray0, vec3(texcoords.x,texcoords.y,olayer.y));
 
     vec4 toplayer = texture(textureArray0, vec3(texcoords.x,texcoords.y,0));

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -3325,6 +3325,9 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                         else if (face.uAttributes & FACE_FlowLeft)
                             attribflags |= 0x1000;
 
+                        if (face.uAttributes & FACE_IsLava)
+                            attribflags |= 0x4000;
+
                         // loop while running down animlength with frame animtimes
                         do {
                             // check if tile->name is already in list
@@ -3540,6 +3543,9 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                                 else if (face.uAttributes & FACE_FlowLeft)
                                     attribflags |= 0x1000;
 
+                                if (face.uAttributes & FACE_IsLava)
+                                    attribflags |= 0x4000;
+
                                 if (face.uAttributes & FACE_OUTLINED || (face.uAttributes & FACE_IsSecret) && engine->is_saturate_faces)
                                     attribflags |= 0x00010000;
 
@@ -3613,8 +3619,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
     glUniformMatrix4fv(glGetUniformLocation(outbuildshader.ID, "view"), 1, GL_FALSE, &viewmat[0][0]);
 
     glUniform1i(glGetUniformLocation(outbuildshader.ID, "waterframe"), GLint(this->hd_water_current_frame));
-    // TODO(pskelton): check tickcount usage here
-    glUniform1i(glGetUniformLocation(outbuildshader.ID, "flowtimer"), GLint(platform->tickCount() >> 4));
+    glUniform1i(glGetUniformLocation(outbuildshader.ID, "flowtimer"), GLint(pMiscTimer->time().realtimeMilliseconds() >> 4));
 
     glUniform1f(glGetUniformLocation(outbuildshader.ID, "gamma"), gamma);
 
@@ -3941,6 +3946,9 @@ void OpenGLRenderer::DrawIndoorFaces() {
                 else if (face->uAttributes & FACE_FlowLeft)
                     attribflags |= 0x1000;
 
+                if (face->uAttributes & FACE_IsLava)
+                    attribflags |= 0x4000;
+
                 if (face->uAttributes & (FACE_OUTLINED | FACE_IsSecret))
                     attribflags |= 0x00010000;
 
@@ -4181,6 +4189,9 @@ void OpenGLRenderer::DrawIndoorFaces() {
                             else if (face->uAttributes & FACE_FlowLeft)
                                 attribflags |= 0x1000;
 
+                            if (face->uAttributes & FACE_IsLava)
+                                attribflags |= 0x4000;
+
                             if (face->uAttributes & FACE_OUTLINED || (face->uAttributes & FACE_IsSecret) && engine->is_saturate_faces)
                                 attribflags |= 0x00010000;
 
@@ -4303,10 +4314,10 @@ void OpenGLRenderer::DrawIndoorFaces() {
         //// set view
         glUniformMatrix4fv(glGetUniformLocation(bspshader.ID, "view"), 1, GL_FALSE, &viewmat[0][0]);
 
-        glUniform1f(glGetUniformLocation(bspshader.ID, "gamma"), gamma);
         glUniform1i(glGetUniformLocation(bspshader.ID, "waterframe"), GLint(this->hd_water_current_frame));
-        // TODO(pskelton): check tickcount usage here
-        glUniform1i(glGetUniformLocation(bspshader.ID, "flowtimer"), GLint(platform->tickCount() >> 4));
+        glUniform1i(glGetUniformLocation(bspshader.ID, "flowtimer"), GLint(pMiscTimer->time().realtimeMilliseconds() >> 4));
+
+        glUniform1f(glGetUniformLocation(bspshader.ID, "gamma"), gamma);
 
         // set texture unit location
         glUniform1i(glGetUniformLocation(bspshader.ID, "textureArray0"), GLint(0));

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -3620,6 +3620,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
 
     glUniform1i(glGetUniformLocation(outbuildshader.ID, "waterframe"), GLint(this->hd_water_current_frame));
     glUniform1i(glGetUniformLocation(outbuildshader.ID, "flowtimer"), GLint(pMiscTimer->time().realtimeMilliseconds() >> 4));
+    glUniform1i(glGetUniformLocation(outbuildshader.ID, "flowtimerms"), GLint(pMiscTimer->time().realtimeMilliseconds()));
 
     glUniform1f(glGetUniformLocation(outbuildshader.ID, "gamma"), gamma);
 
@@ -4316,6 +4317,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
 
         glUniform1i(glGetUniformLocation(bspshader.ID, "waterframe"), GLint(this->hd_water_current_frame));
         glUniform1i(glGetUniformLocation(bspshader.ID, "flowtimer"), GLint(pMiscTimer->time().realtimeMilliseconds() >> 4));
+        glUniform1i(glGetUniformLocation(bspshader.ID, "flowtimerms"), GLint(pMiscTimer->time().realtimeMilliseconds()));
 
         glUniform1f(glGetUniformLocation(bspshader.ID, "gamma"), gamma);
 


### PR DESCRIPTION
Fix #1289.

Implement movement pattern for faces that have IsLava property.
Movement is implemented in shader code using sine wave.

P.S. Changed platfrom timer usage to misc timer for flow tick source. This way textures movement state do not suddenly change on window focus change.

P.S.2. I used 0x4000 in `attribflags` which seems unused yet.

**Result**

[Vanilla](https://github.com/OpenEnroth/OpenEnroth/assets/121443326/1b90b0c0-2c12-4a43-a1b7-7b58f918807a)

[OE](https://github.com/OpenEnroth/OpenEnroth/assets/121443326/1794bbf2-550e-4045-8a7e-0f0cf184f722)
