### PR TITLE
Fix nuklear errors

### DIFF
--- a/src/Engine/Graphics/Renderer/NuklearOverlayRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/NuklearOverlayRenderer.cpp
@@ -157,8 +157,10 @@ struct nk_tex_font *NuklearOverlayRenderer::_loadFont(const char *font_path, siz
 
 void NuklearOverlayRenderer::_cleanup() {
     if (_state) {
-        glDeleteTextures(1, &_defaultFont->texid);
-        delete _defaultFont;
+        if (_defaultFont) {
+            glDeleteTextures(1, &_defaultFont->texid);
+            delete _defaultFont;
+        }
 
         nk_font_atlas_clear(&_state->dev.atlas);
 

--- a/src/Engine/Graphics/Renderer/NuklearOverlayRenderer.h
+++ b/src/Engine/Graphics/Renderer/NuklearOverlayRenderer.h
@@ -29,7 +29,7 @@ class NuklearOverlayRenderer {
     void _cleanup();
 
     std::unique_ptr<nk_state> _state;
-    bool _useOGLES;
+    bool _useOGLES = false;
     OpenGLShader _shader;
-    nk_tex_font *_defaultFont;
+    nk_tex_font *_defaultFont = nullptr;
 };


### PR DESCRIPTION
Was defaulting to ES on my system causing shader errors. Then referencing invalid pointer during cleanup.
