### PR TITLE
More Utility/String work

### DIFF
--- a/src/Bin/OpenEnroth/OpenEnroth.cpp
+++ b/src/Bin/OpenEnroth/OpenEnroth.cpp
@@ -49,8 +49,8 @@ static void printTraceDiff(std::string_view current, std::string_view canonical)
     size_t pos = *std::ranges::find_if(std::views::iota(0), [&] (size_t i) { return canonical[i] != current[i]; });
     size_t line = std::ranges::count(std::string_view(canonical.data(), pos), '\n'); // 0-indexed.
 
-    std::vector<std::string_view> canonicalLines = splitString(canonical, '\n');
-    std::vector<std::string_view> currentLines = splitString(current, '\n');
+    std::vector<std::string_view> canonicalLines = split(canonical, '\n');
+    std::vector<std::string_view> currentLines = split(current, '\n');
 
     fmt::println(stderr, "Canonical:");
     printLines(canonicalLines, line, 2);

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -422,7 +422,7 @@ void Localization::InitializeAttributeNames() {
     strtok(this->attribute_desc_raw.data(), "\r");
     for (int i = 0; i < 26; ++i) {
         char *test_string = strtok(NULL, "\r") + 1;
-        auto tokens = splitString(test_string, '\t');
+        auto tokens = split(test_string, '\t');
         assert(tokens.size() == 2 && "Invalid number of tokens");
         switch (i) {
             case 0:

--- a/src/Utility/String/Tests/Transformations_ut.cpp
+++ b/src/Utility/String/Tests/Transformations_ut.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <set>
 
 #include "Testing/Unit/UnitTest.h"
 
@@ -41,6 +42,19 @@ UNIT_TEST(StringTransformations, join) {
     EXPECT_EQ(join("", '/', std::string_view("123"), std::string("321")), "/123321");
 }
 
+UNIT_TEST(StringTransformations, joinSeparator) {
+    std::vector<std::string> v1 = {"1", "2"};
+    EXPECT_EQ(join(v1, '/'), "1/2");
+
+    std::vector<std::string> v2;
+    EXPECT_EQ(join(v2, '/'), "");
+
+    std::vector<std::string_view> v3 = {"1", "2"};
+    EXPECT_EQ(join(v3, '/'), "1/2");
+
+    std::set<std::string_view> v4 = {"4", "1", "99"};
+    EXPECT_EQ(join(v4, '/'), "1/4/99");
+}
 
 
 

--- a/src/Utility/String/Tests/Transformations_ut.cpp
+++ b/src/Utility/String/Tests/Transformations_ut.cpp
@@ -20,20 +20,21 @@ UNIT_TEST(StringTransformations, replaceAll) {
 UNIT_TEST(StringTransformations, split) {
     std::vector<std::string_view> v;
 
-    splitString("aa;bb;cc", ';', &v);
+    split("aa;bb;cc", ';', &v);
     std::vector<std::string_view> r0 = {"aa", "bb", "cc"};
     EXPECT_EQ(v, r0);
 
-    splitString("ABC", ';', &v);
+    split("ABC", ';', &v);
     std::vector<std::string_view> r1 = {"ABC"};
     EXPECT_EQ(v, r1);
 
-    splitString("AB", 'B', &v);
+    split("AB", 'B', &v);
     std::vector<std::string_view> r2 = {"A", ""};
     EXPECT_EQ(v, r2);
 
-    splitString("", ';', &v);
-    EXPECT_TRUE(v.empty());
+    split("", ';', &v);
+    std::vector<std::string_view> r3 = {""};
+    EXPECT_EQ(v, r3);
 }
 
 UNIT_TEST(StringTransformations, join) {

--- a/src/Utility/String/Transformations.cpp
+++ b/src/Utility/String/Transformations.cpp
@@ -59,12 +59,10 @@ std::string replaceAll(std::string_view text, char what, char replacement) {
     return result;
 }
 
-void splitString(std::string_view s, char sep, std::vector<std::string_view> *result) {
+void split(std::string_view s, char sep, std::vector<std::string_view> *result) {
     result->clear();
-    if(s.empty())
-        return;
-
     result->reserve(16);
+
     const char *pos = s.data();
     const char *end = s.data() + s.size();
     while (pos != end + 1) {

--- a/src/Utility/String/Transformations.h
+++ b/src/Utility/String/Transformations.h
@@ -95,3 +95,21 @@ std::string join(Joinables &&... joinables) {
     return result;
 }
 
+template<class Strings>
+    requires JoinableToString<typename Strings::value_type> && // We can use std::ranges::range_value_t, but I'd rather not bring in <ranges>
+             (!JoinableToString<Strings>)
+std::string join(const Strings &strings, char sep) {
+    std::string result;
+
+    auto pos = strings.begin();
+    if (pos == strings.end())
+        return result;
+    result += *pos++;
+
+    while (pos != strings.end()) {
+        result += sep;
+        result += *pos++;
+    }
+
+    return result;
+}

--- a/src/Utility/String/Transformations.h
+++ b/src/Utility/String/Transformations.h
@@ -54,19 +54,19 @@ std::string replaceAll(std::string_view text, std::string_view what, std::string
 
 std::string replaceAll(std::string_view text, char what, char replacement);
 
-void splitString(std::string_view s, char sep, std::vector<std::string_view> *result);
+void split(std::string_view s, char sep, std::vector<std::string_view> *result);
 
-inline std::vector<std::string_view> splitString(std::string_view s, char sep) {
+inline std::vector<std::string_view> split(std::string_view s, char sep) {
     std::vector<std::string_view> result;
-    splitString(s, sep, &result);
+    split(s, sep, &result);
     return result;
 }
 
-inline std::vector<std::string_view> splitString(const char *s, char sep) {
-    return splitString(std::string_view(s), sep);
+inline std::vector<std::string_view> split(const char *s, char sep) {
+    return split(std::string_view(s), sep);
 }
 
-std::vector<std::string_view> splitString(std::string &&s, char sep) = delete; // Don't dangle!
+std::vector<std::string_view> split(std::string &&s, char sep) = delete; // Don't dangle!
 
 namespace detail {
 


### PR DESCRIPTION
* Renamed `splitString` to `split`.
* Added `join` operating on a container, so now we have a function that's symmetric to `split`.