### PR TITLE
Cleanup around NPC dialogue globals

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -252,7 +252,7 @@ void Game_StartDialogue(int actor_id) {
     if (pParty->hasActiveCharacter()) {
         engine->_messageQueue->clear();
 
-        initializeNPCDialogue(&pActors[actor_id], true);
+        initializeNPCDialogue(pActors[actor_id].npcId, true, &pActors[actor_id]);
     }
 }
 
@@ -271,9 +271,7 @@ void Game_StartHirelingDialogue(int hireling_id) {
         if (buf.GetSacrificeStatus(index) && buf.GetSacrificeStatus(index)->inProgress)
             return; // Hireling is being dark sacrificed.
 
-        Actor actor;
-        actor.npcId += -1 - pParty->hirelingScrollPosition - hireling_id;
-        initializeNPCDialogue(&actor, true);
+        initializeNPCDialogue(-1 - pParty->hirelingScrollPosition - hireling_id, true);
     }
 }
 
@@ -343,10 +341,7 @@ void Game::processQueuedMessages() {
     bool playButtonSoundOnEscape = true;
 
     if (bDialogueUI_InitializeActor_NPC_ID) {
-        // Actor::Actor(&actor);
-        Actor actor = Actor();
-        actor.npcId = bDialogueUI_InitializeActor_NPC_ID;
-        initializeNPCDialogue(&actor, false);
+        initializeNPCDialogue(bDialogueUI_InitializeActor_NPC_ID, false);
         bDialogueUI_InitializeActor_NPC_ID = 0;
     }
 

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -328,9 +328,7 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
             break;
         case EVENT_SpeakNPC:
             if (_canShowMessages) {
-                Actor actor = Actor();
-                actor.npcId = ir.data.npc_descr.npc_id;
-                initializeNPCDialogue(&actor, false);
+                initializeNPCDialogue(ir.data.npc_descr.npc_id, false);
             } else {
                 bDialogueUI_InitializeActor_NPC_ID = ir.data.npc_descr.npc_id;
             }

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6135,7 +6135,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             return;
         case VAR_NPCs2:
             npcIndex = 0;
-            GetNPCData(sDialogue_SpeakingActorNPC_ID, &npcIndex);
+            getNPCData(sDialogue_SpeakingActorNPC_ID, &npcIndex);
             if (npcIndex == pValue) {
                 npcIdToDismissAfterDialogue = pValue;
             } else {

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -5669,7 +5669,6 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
     LocationInfo *locationHeader;  // eax@90
     int randGold;
     int randFood;
-    int npcIndex;
 
     if (VarNum >= VAR_MapPersistentVariable_0 && VarNum <= VAR_MapPersistentVariable_74) {
         engine->_persistentVariables.mapVars[std::to_underlying(VarNum) - std::to_underlying(VAR_MapPersistentVariable_0)] -= pValue;
@@ -6135,9 +6134,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             _characterEventBits.reset(pValue);
             return;
         case VAR_NPCs2:
-            npcIndex = 0;
-            getNPCData(speakingNpcId, &npcIndex);
-            if (npcIndex == pValue) {
+            if (getNPCType(speakingNpcId) == NPC_TYPE_QUEST && speakingNpcId == pValue) {
                 npcIdToDismissAfterDialogue = pValue;
             } else {
                 npcIdToDismissAfterDialogue = 0;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -45,6 +45,7 @@
 #include "GUI/UI/UIStatusBar.h"
 #include "GUI/UI/UIMessageScroll.h"
 #include "GUI/UI/UISpell.h"
+#include "GUI/UI/UIDialogue.h"
 #include "GUI/UI/Books/AutonotesBook.h"
 
 #include "Library/Logger/Logger.h"
@@ -6135,7 +6136,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             return;
         case VAR_NPCs2:
             npcIndex = 0;
-            getNPCData(sDialogue_SpeakingActorNPC_ID, &npcIndex);
+            getNPCData(speakingNpcId, &npcIndex);
             if (npcIndex == pValue) {
                 npcIdToDismissAfterDialogue = pValue;
             } else {

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6135,7 +6135,7 @@ void Character::SubtractVariable(VariableType VarNum, signed int pValue) {
             return;
         case VAR_NPCs2:
             npcIndex = 0;
-            GetNewNPCData(sDialogue_SpeakingActorNPC_ID, &npcIndex);
+            GetNPCData(sDialogue_SpeakingActorNPC_ID, &npcIndex);
             if (npcIndex == pValue) {
                 npcIdToDismissAfterDialogue = pValue;
             } else {

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -27,31 +27,22 @@ static const Segment<Condition> standardConditionsExcludeDead = {CONDITION_CURSE
 // All conditions including dead character ones, but still excluding zombie
 static const Segment<Condition> standardConditionsIncludeDead = {CONDITION_CURSED, CONDITION_ERADICATED};
 
-NPCData *getNPCData(signed int npcid, int *npc_indx) {
-    NPCData *result;
-    int outIdx = -1;
-
-    if (npcid >= 0) {
-        if (npcid < 5000) {
-            if (npcid >= 501) {
+NPCData *getNPCData(int npcId) {
+    if (npcId >= 0) {
+        if (npcId < 5000) {
+            if (npcId >= 501) {
                 logger->warning("NPC id exceeds MAX_DATA!");
             }
-            outIdx = npcid;
-            result = &pNPCStats->pNPCData[npcid];
+            return &pNPCStats->pNPCData[npcId];
         } else {
-            outIdx = npcid - 5000;
-            result = &pNPCStats->pAdditionalNPC[npcid - 5000];
+            return &pNPCStats->pAdditionalNPC[npcId - 5000];
         }
     } else {
         FlatHirelings buf;
         buf.Prepare();
 
-        result = buf.Get(std::abs(npcid) - 1);
+        return buf.Get(std::abs(npcId) - 1);
     }
-
-    if (npc_indx)
-        *npc_indx = outIdx;
-    return result;
 }
 
 //----- (00476387) --------------------------------------------------------

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -27,8 +27,7 @@ static const Segment<Condition> standardConditionsExcludeDead = {CONDITION_CURSE
 // All conditions including dead character ones, but still excluding zombie
 static const Segment<Condition> standardConditionsIncludeDead = {CONDITION_CURSED, CONDITION_ERADICATED};
 
-//----- (00445B2C) --------------------------------------------------------
-NPCData *GetNPCData(signed int npcid, int *npc_indx) {
+NPCData *getNPCData(signed int npcid, int *npc_indx) {
     NPCData *result;
     int outIdx = -1;
 

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -27,60 +27,31 @@ static const Segment<Condition> standardConditionsExcludeDead = {CONDITION_CURSE
 // All conditions including dead character ones, but still excluding zombie
 static const Segment<Condition> standardConditionsIncludeDead = {CONDITION_CURSED, CONDITION_ERADICATED};
 
-//----- (004459F9) --------------------------------------------------------
-NPCData *GetNPCData(signed int npcid) {
-    NPCData *result;
-
-    if (npcid >= 0) {
-        if (npcid < 5000) {
-            if (npcid >= 501) {
-                logger->warning("NPC id exceeds MAX_DATA!");
-            }
-            return &pNPCStats->pNPCData[npcid];  // - 1];
-        }
-        return &pNPCStats->pAdditionalNPC[npcid - 5000];
-    }
-
-    if (npcid >= 5000) return &pNPCStats->pAdditionalNPC[npcid - 5000];
-    if (sDialogue_SpeakingActorNPC_ID >= 0) {
-        result = 0;
-    } else {
-        FlatHirelings buf;
-        buf.Prepare();
-
-        result = buf.Get(std::abs(sDialogue_SpeakingActorNPC_ID) - 1);
-    }
-    return result;
-}
-
 //----- (00445B2C) --------------------------------------------------------
-NPCData *GetNewNPCData(signed int npcid, int *npc_indx) {
+NPCData *GetNPCData(signed int npcid, int *npc_indx) {
     NPCData *result;
+    int outIdx = -1;
 
     if (npcid >= 0) {
         if (npcid < 5000) {
             if (npcid >= 501) {
                 logger->warning("NPC id exceeds MAX_DATA!");
             }
-            *npc_indx = npcid;
-            return &pNPCStats->pNPCData[npcid];
+            outIdx = npcid;
+            result = &pNPCStats->pNPCData[npcid];
+        } else {
+            outIdx = npcid - 5000;
+            result = &pNPCStats->pAdditionalNPC[npcid - 5000];
         }
-        *npc_indx = npcid - 5000;
-        return &pNPCStats->pAdditionalNPC[npcid - 5000];
-    }
-    if (npcid >= 5000) {
-        *npc_indx = npcid - 5000;
-        return &pNPCStats->pAdditionalNPC[npcid - 5000];
-    }
-    if (sDialogue_SpeakingActorNPC_ID >= 0) {
-        *npc_indx = 0;
-        result = nullptr;
     } else {
         FlatHirelings buf;
         buf.Prepare();
 
-        result = buf.Get(std::abs(sDialogue_SpeakingActorNPC_ID) - 1);
+        result = buf.Get(std::abs(npcid) - 1);
     }
+
+    if (npc_indx)
+        *npc_indx = outIdx;
     return result;
 }
 

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -31,8 +31,10 @@ const std::string &GetProfessionActionText(NpcProfession prof);
 
 /**
  * @offset 0x445B2C
+ * @param npcId                Id of the NPC.
+ * @return                     Pointer to NPC data structure
  */
-NPCData *getNPCData(signed int npcid, int *npc_indx = nullptr);
+NPCData *getNPCData(int npcId);
 
 /**
  * @offset 0x445C8B

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -30,9 +30,9 @@ int UseNPCSkill(NpcProfession profession, int id);
 const std::string &GetProfessionActionText(NpcProfession prof);
 
 /**
- * @offset 0x445B2C
- * @param npcId                Id of the NPC.
- * @return                     Pointer to NPC data structure
+ * @offset 0x4459F9
+ * @param npcId        If positive, means ID of NPC (quest or hireable). If negative, then it's absolute value minus one is index of party hireling.
+ * @return             Pointer to NPC data structure
  */
 NPCData *getNPCData(int npcId);
 

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -28,7 +28,11 @@ bool CheckHiredNPCSpeciality(NpcProfession prof);
 int UseNPCSkill(NpcProfession profession, int id);
 
 const std::string &GetProfessionActionText(NpcProfession prof);
-NPCData *GetNPCData(signed int npcid, int *npc_indx = nullptr);
+
+/**
+ * @offset 0x445B2C
+ */
+NPCData *getNPCData(signed int npcid, int *npc_indx = nullptr);
 
 /**
  * @offset 0x445C8B

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -28,8 +28,7 @@ bool CheckHiredNPCSpeciality(NpcProfession prof);
 int UseNPCSkill(NpcProfession profession, int id);
 
 const std::string &GetProfessionActionText(NpcProfession prof);
-NPCData *GetNPCData(signed int npcid);
-NPCData *GetNewNPCData(signed int npcid, int *npc_indx);
+NPCData *GetNPCData(signed int npcid, int *npc_indx = nullptr);
 
 /**
  * @offset 0x445C8B

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2428,7 +2428,6 @@ std::array<GraphicsImage *, 14> party_buff_icons;
 unsigned int uIconIdx_FlySpell;
 unsigned int uIconIdx_WaterWalk;
 
-int sDialogue_SpeakingActorNPC_ID;
 int uCurrentHouse_Animation;
 std::string branchless_dialogue_str;
 int dword_5B65C4_cancelEventProcessing;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2428,7 +2428,6 @@ std::array<GraphicsImage *, 14> party_buff_icons;
 unsigned int uIconIdx_FlySpell;
 unsigned int uIconIdx_WaterWalk;
 
-Actor *pDialogue_SpeakingActor;
 int sDialogue_SpeakingActorNPC_ID;
 int uCurrentHouse_Animation;
 std::string branchless_dialogue_str;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -89,7 +89,6 @@ extern std::array<GraphicsImage *, 14> party_buff_icons;
 extern unsigned int uIconIdx_FlySpell;
 extern unsigned int uIconIdx_WaterWalk;
 
-extern signed int sDialogue_SpeakingActorNPC_ID;
 extern int uCurrentHouse_Animation;
 
 extern std::string branchless_dialogue_str;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -89,7 +89,6 @@ extern std::array<GraphicsImage *, 14> party_buff_icons;
 extern unsigned int uIconIdx_FlySpell;
 extern unsigned int uIconIdx_WaterWalk;
 
-extern Actor *pDialogue_SpeakingActor;
 extern signed int sDialogue_SpeakingActorNPC_ID;
 extern int uCurrentHouse_Animation;
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -760,29 +760,17 @@ Color GetSkillColor(CharacterClass uPlayerClass, CharacterSkillType uPlayerSkill
     return ui_character_skillinfo_cant_learn;
 }
 
-std::string BuildDialogueString(std::string_view str, int uPlayerID, ItemGen *a3, HouseId houseId, ShopScreen shop_screen, Time *a6) {
+std::string BuildDialogueString(std::string_view str, int uPlayerID, NPCData *npc, ItemGen *item, HouseId houseId, ShopScreen shop_screen, Time *a6) {
     std::string v1;
     Character *pPlayer;       // ebx@3
-    std::string pText;     // esi@7
-    int64_t v18;    // qax@18
     int v29;               // eax@68
     std::vector<int> addressingBits;
     CivilTime time;
+    std::string result;
 
     pPlayer = &pParty->pCharacters[uPlayerID];
 
-    NPCData *npc;
-
-    if (houseNpcs.size()) {
-        npc = houseNpcs[currentHouseNpc].npc;
-    } else {
-        npc = GetNPCData(sDialogue_SpeakingActorNPC_ID);
-    }
-
-    std::string result;
-
-    unsigned len = str.length();
-    for (int i = 0, dst = 0; i < len; ++i) {
+    for (int i = 0, dst = 0; i < str.length(); ++i) {
         char c = str[i];  // skip through string till we find insertion point
         if (c != '%') {
             result += c;  // add char to result string
@@ -805,14 +793,13 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, ItemGen *a3
             case 5:
                 time = pParty->GetPlayingTime().toCivilTime();
                 if (time.hour >= 11 && time.hour < 20) {
-                    pText = localization->GetString(LSTR_DAY);
+                    result += localization->GetString(LSTR_DAY);
                 } else if (time.hour >= 5 && time.hour < 11) {
-                    pText = localization->GetString(LSTR_MORNING);
+                    result += localization->GetString(LSTR_MORNING);
                 } else {
-                    pText = localization->GetString(LSTR_EVENING);
+                    result += localization->GetString(LSTR_EVENING);
                 }
                 // TODO(captainurist): ^ and what about night?
-                result += pText;
                 break;
             case 6:
                 if (pPlayer->uSex == SEX_FEMALE)
@@ -903,24 +890,24 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, ItemGen *a3
                 break;
 
             case 24:  // item name
-                v1 = fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), a3->GetDisplayName());
+                v1 = fmt::format("{::}{}\f00000\n", colorTable.PaleCanary.tag(), item->GetDisplayName());
                 result += v1;
                 break;
 
             case 25:  // base prices
-                v29 = PriceCalculator::baseItemBuyingPrice(a3->GetValue(), buildingTable[houseId].fPriceMultiplier);
+                v29 = PriceCalculator::baseItemBuyingPrice(item->GetValue(), buildingTable[houseId].fPriceMultiplier);
                 switch (shop_screen) {
                 case SHOP_SCREEN_SELL:
-                    v29 = PriceCalculator::baseItemSellingPrice(a3->GetValue(), buildingTable[houseId].fPriceMultiplier);
+                    v29 = PriceCalculator::baseItemSellingPrice(item->GetValue(), buildingTable[houseId].fPriceMultiplier);
                     break;
                 case SHOP_SCREEN_IDENTIFY:
                     v29 = PriceCalculator::baseItemIdentifyPrice(buildingTable[houseId].fPriceMultiplier);
                     break;
                 case SHOP_SCREEN_REPAIR:
-                    v29 = PriceCalculator::baseItemRepairPrice(a3->GetValue(), buildingTable[houseId].fPriceMultiplier);
+                    v29 = PriceCalculator::baseItemRepairPrice(item->GetValue(), buildingTable[houseId].fPriceMultiplier);
                     break;
                 case SHOP_SCREEN_SELL_FOR_CHEAP:
-                    v29 = PriceCalculator::baseItemSellingPrice(a3->GetValue(), buildingTable[houseId].fPriceMultiplier) / 2;
+                    v29 = PriceCalculator::baseItemSellingPrice(item->GetValue(), buildingTable[houseId].fPriceMultiplier) / 2;
                     break;
                 }
                 v1 = fmt::format("{}", v29);
@@ -928,9 +915,9 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, ItemGen *a3
                 break;
 
             case 27:  // actual price
-                v29 = PriceCalculator::itemBuyingPriceForPlayer(pPlayer, a3->GetValue(), buildingTable[houseId].fPriceMultiplier);
+                v29 = PriceCalculator::itemBuyingPriceForPlayer(pPlayer, item->GetValue(), buildingTable[houseId].fPriceMultiplier);
                 if (shop_screen == SHOP_SCREEN_SELL) {
-                    v29 = PriceCalculator::itemSellingPriceForPlayer(pPlayer, *a3, buildingTable[houseId].fPriceMultiplier);
+                    v29 = PriceCalculator::itemSellingPriceForPlayer(pPlayer, *item, buildingTable[houseId].fPriceMultiplier);
                     v1 = fmt::format("{}", v29);
                     result += v1;
                     break;
@@ -938,12 +925,12 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, ItemGen *a3
                 if (shop_screen != SHOP_SCREEN_IDENTIFY) {
                     if (shop_screen == SHOP_SCREEN_REPAIR) {
                     v29 = PriceCalculator::itemRepairPriceForPlayer(
-                        pPlayer, a3->GetValue(),
+                        pPlayer, item->GetValue(),
                         buildingTable[houseId].fPriceMultiplier);
                     } else {
                         if (shop_screen == SHOP_SCREEN_SELL_FOR_CHEAP) {
                             // TODO(captainurist): encapsulate this logic in PriceCalculator
-                            v29 = PriceCalculator::itemSellingPriceForPlayer(pPlayer, *a3, buildingTable[houseId].fPriceMultiplier) / 2;
+                            v29 = PriceCalculator::itemSellingPriceForPlayer(pPlayer, *item, buildingTable[houseId].fPriceMultiplier) / 2;
                             if (!v29)  // cannot be 0
                                 v29 = 1;
                             v1 = fmt::format("{}", v29);

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -38,6 +38,7 @@
 #include "GUI/UI/UIGame.h"
 #include "GUI/UI/UIHouses.h"
 #include "GUI/UI/UIPopup.h"
+#include "GUI/UI/UIDialogue.h"
 
 #include "Io/InputAction.h"
 #include "Io/KeyboardInputHandler.h"
@@ -436,7 +437,7 @@ GUIWindow::GUIWindow(WindowType windowType, Pointi position, Sizei dimensions, s
 }
 
 void DialogueEnding() {
-    sDialogue_SpeakingActorNPC_ID = 0;
+    speakingNpcId = 0;
     if (pDialogueWindow) {
         pDialogueWindow->Release();
     }

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -280,8 +280,8 @@ bool isHoldingMouseRightButton();
 /**
  * @offset 0x495461
  */
-std::string BuildDialogueString(std::string_view str, int uPlayerID,
-                                ItemGen *a3 = nullptr, HouseId houseId = HOUSE_INVALID, ShopScreen shop_screen = SHOP_SCREEN_INVALID,
+std::string BuildDialogueString(std::string_view str, int uPlayerID, NPCData *npc,
+                                ItemGen *item = nullptr, HouseId houseId = HOUSE_INVALID, ShopScreen shop_screen = SHOP_SCREEN_INVALID,
                                 Time *a6 = nullptr);
 
 

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -49,7 +49,8 @@ GUIWindow_JournalBook::GUIWindow_JournalBook() {
     for (int i = 0; i < pParty->PartyTimes.HistoryEventTimes.size(); i++) {
         if (pParty->PartyTimes.HistoryEventTimes[i].isValid()) {
             if (!pStorylineText->StoreLine[i + 1].pText.empty()) {
-                std::string str = BuildDialogueString(pStorylineText->StoreLine[i + 1].pText, 0, 0, HOUSE_INVALID, SHOP_SCREEN_INVALID, &pParty->PartyTimes.HistoryEventTimes[i]);
+                NPCData dummyNpc;
+                std::string str = BuildDialogueString(pStorylineText->StoreLine[i + 1].pText, 0, &dummyNpc, 0, HOUSE_INVALID, SHOP_SCREEN_INVALID, &pParty->PartyTimes.HistoryEventTimes[i]);
                 int pTextHeight = assets->pFontBookOnlyShadow->CalcTextHeight(str, journal_window.uFrameWidth, 1);
                 int pages = ((pTextHeight - (assets->pFontBookOnlyShadow->GetHeight() - 3)) / (signed int)journal_window.uFrameHeight) + 1;
                 for (int j = 0; j < pages; ++j) {
@@ -111,8 +112,9 @@ void GUIWindow_JournalBook::Update() {
     _bookButtonClicked = false;
 
     if (_journalIdx.size()) {
-        std::string str = BuildDialogueString(pStorylineText->StoreLine[_journalIdx[_currentIdx]].pText,
-                                              0, 0, HOUSE_INVALID, SHOP_SCREEN_INVALID, &pParty->PartyTimes.HistoryEventTimes[_journalIdx[_currentIdx] - 1]);
+        NPCData dummyNpc;
+        std::string str = BuildDialogueString(pStorylineText->StoreLine[_journalIdx[_currentIdx]].pText, 0, &dummyNpc, 0, HOUSE_INVALID,
+                                              SHOP_SCREEN_INVALID, &pParty->PartyTimes.HistoryEventTimes[_journalIdx[_currentIdx] - 1]);
         std::string pStringOnPage = assets->pFontBookOnlyShadow->GetPageTop(str, &journal_window, 1, _journalEntryPage[_currentIdx]);
         journal_window.DrawText(assets->pFontBookOnlyShadow.get(), {1, 0}, ui_book_journal_text_color, pStringOnPage,
                                 journal_window.uFrameY + journal_window.uFrameHeight, ui_book_journal_text_shadow);

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -238,7 +238,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
                 if (pt.x >= testpos && pt.x <= testpos + (shop_ui_items_in_store[testx]->width())) {
                     if ((pt.y >= 90 && pt.y <= (90 + (shop_ui_items_in_store[testx]->height()))) || (pt.y >= 250 && pt.y <= (250 + (shop_ui_items_in_store[testx]->height())))) {
                         MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, BUILDING_MAGIC_SHOP, houseId(), SHOP_SCREEN_BUY);
-                        std::string str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                        std::string str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                         int textHeight = assets->pFontArrus->CalcTextHeight(str, working_window.uFrameWidth, 0);
                         working_window.DrawTitleText(assets->pFontArrus.get(), 0, (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - textHeight) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET, colorTable.White, str, 3);
                         return;

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -294,7 +294,7 @@ void GUIWindow_Shop::sellDialogue() {
         if (pItemID) {
             ItemGen *item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
             MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_SELL);
-            std::string str = BuildDialogueString(pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_SELL);
+            std::string str = BuildDialogueString(pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_SELL);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             dialogwin.DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3);
         }
@@ -328,9 +328,9 @@ void GUIWindow_Shop::identifyDialogue() {
             std::string str;
             if (!item->IsIdentified()) {
                 MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_IDENTIFY);
-                str = BuildDialogueString(pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_IDENTIFY);
+                str = BuildDialogueString(pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
             } else {
-                str = BuildDialogueString("%24", pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_IDENTIFY);
+                str = BuildDialogueString("%24", pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
             }
 
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
@@ -365,7 +365,7 @@ void GUIWindow_Shop::repairDialogue() {
         if (pParty->activeCharacter().pInventoryItemList[pItemID - 1].uAttributes & ITEM_BROKEN) {
             ItemGen *item = &pParty->activeCharacter().pInventoryItemList[pItemID - 1];
             MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_REPAIR);
-            std::string str = BuildDialogueString(pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_REPAIR);
+            std::string str = BuildDialogueString(pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_REPAIR);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             dialogwin.DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3);
         }
@@ -423,9 +423,9 @@ void GUIWindow_WeaponShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, BUILDING_WEAPON_SHOP, houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             dialogwin.DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3);
@@ -510,9 +510,9 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             dialogwin.DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3);
@@ -614,9 +614,9 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->GetString(LSTR_STEAL_ITEM_FMT), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.uFrameWidth, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             dialogwin.DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3);

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -43,7 +43,7 @@ void initializeNPCDialogue(Actor *actor, int bPlayerSaysHello) {
     pMiscTimer->setPaused(true);
     sDialogue_SpeakingActorNPC_ID = actor->npcId;
     pDialogue_SpeakingActor = actor;
-    NPCData *pNPCInfo = GetNPCData(actor->npcId);
+    NPCData *pNPCInfo = getNPCData(actor->npcId);
     if (!(pNPCInfo->uFlags & NPC_GREETED_SECOND)) {
         if (pNPCInfo->uFlags & NPC_GREETED_FIRST) {
             pNPCInfo->uFlags &= ~NPC_GREETED_FIRST;
@@ -112,7 +112,7 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(DialogWindowType type) : GUIWindow(WINDOW
                                    localization->GetString(LSTR_DIALOGUE_EXIT), {ui_exit_cancel_button_background});
 
     int text_line_height = assets->pFontArrus->GetHeight() - 3;
-    NPCData *speakingNPC = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *speakingNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
     std::vector<DialogueId> optionList;
 
     if (type == DIALOG_WINDOW_FULL) {
@@ -176,7 +176,7 @@ void GUIWindow_Dialogue::Update() {
 
     // Window title(Заголовок окна)----
     GUIWindow window = *pDialogueWindow;
-    NPCData *pNPC = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *pNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
     NpcType npcType = getNPCType(sDialogue_SpeakingActorNPC_ID);
     window.uFrameWidth -= 10;
     window.uFrameZ -= 10;
@@ -343,7 +343,7 @@ void BuildHireableNpcDialogue() {
 }
 
 void selectNPCDialogueOption(DialogueId option) {
-    NPCData *speakingNPC = GetNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *speakingNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
 
     ((GUIWindow_Dialogue*)pDialogueWindow)->setDisplayedDialogueType(option);
 

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -192,16 +192,16 @@ void GUIWindow_Dialogue::Update() {
     std::string dialogue_string;
     switch (_displayedDialogue) {
         case DIALOGUE_13_hiring_related:
-            dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pJoinText, 0);
+            dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pJoinText, 0, pNPC);
             break;
 
         case DIALOGUE_PROFESSION_DETAILS: {
             if (dialogue_show_profession_details) {
-                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pBenefits, 0);
+                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pBenefits, 0, pNPC);
             } else if (pNPC->Hired()) {
-                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pDismissText, 0);
+                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pDismissText, 0, pNPC);
             } else {
-                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pJoinText, 0);
+                dialogue_string = BuildDialogueString(pNPCStats->pProfessions[pNPC->profession].pJoinText, 0, pNPC);
             }
             break;
         }
@@ -237,9 +237,9 @@ void GUIWindow_Dialogue::Update() {
                 NPCProfession *prof = &pNPCStats->pProfessions[pNPC->profession];
 
                 if (pNPC->Hired()) {
-                    dialogue_string = BuildDialogueString(prof->pDismissText, 0);
+                    dialogue_string = BuildDialogueString(prof->pDismissText, 0, pNPC);
                 } else {
-                    dialogue_string = BuildDialogueString(prof->pJoinText, 0);
+                    dialogue_string = BuildDialogueString(prof->pJoinText, 0, pNPC);
                 }
             }
             break;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -30,6 +30,7 @@
 
 using Io::TextInputType;
 
+int speakingNpcId;
 Actor *currentSpeakingActor = nullptr;
 
 const IndexedArray<std::string, PartyAlignment_Good, PartyAlignment_Evil> dialogueBackgroundResourceByAlignment = {
@@ -43,7 +44,7 @@ void initializeNPCDialogue(int npcId, int bPlayerSaysHello, Actor *actor) {
     pNPCStats->dword_AE336C_LastMispronouncedNameFirstLetter = -1;
     pEventTimer->setPaused(true);
     pMiscTimer->setPaused(true);
-    sDialogue_SpeakingActorNPC_ID = npcId;
+    speakingNpcId = npcId;
     currentSpeakingActor = actor;
     NPCData *pNPCInfo = getNPCData(npcId);
     if (!(pNPCInfo->uFlags & NPC_GREETED_SECOND)) {
@@ -93,7 +94,7 @@ void initializeNPCDialogue(int npcId, int bPlayerSaysHello, Actor *actor) {
             }
         }
     }
-    if (sDialogue_SpeakingActorNPC_ID < 0) v9 = 4;
+    if (speakingNpcId < 0) v9 = 4;
 #endif
 
     pDialogueWindow = new GUIWindow_Dialogue(DIALOG_WINDOW_FULL);
@@ -114,11 +115,11 @@ GUIWindow_Dialogue::GUIWindow_Dialogue(DialogWindowType type) : GUIWindow(WINDOW
                                    localization->GetString(LSTR_DIALOGUE_EXIT), {ui_exit_cancel_button_background});
 
     int text_line_height = assets->pFontArrus->GetHeight() - 3;
-    NPCData *speakingNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *speakingNPC = getNPCData(speakingNpcId);
     std::vector<DialogueId> optionList;
 
     if (type == DIALOG_WINDOW_FULL) {
-        if (getNPCType(sDialogue_SpeakingActorNPC_ID) == NPC_TYPE_QUEST) {
+        if (getNPCType(speakingNpcId) == NPC_TYPE_QUEST) {
             optionList = prepareScriptedNPCDialogueTopics(speakingNPC);
         } else if (speakingNPC->is_joinable) {
             optionList = {DIALOGUE_PROFESSION_DETAILS, DIALOGUE_HIRE_FIRE};
@@ -179,8 +180,8 @@ void GUIWindow_Dialogue::Update() {
 
     // Window title(Заголовок окна)----
     GUIWindow window = *pDialogueWindow;
-    NPCData *pNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
-    NpcType npcType = getNPCType(sDialogue_SpeakingActorNPC_ID);
+    NPCData *pNPC = getNPCData(speakingNpcId);
+    NpcType npcType = getNPCType(speakingNpcId);
     window.uFrameWidth -= 10;
     window.uFrameZ -= 10;
     render->DrawTextureNew(477 / 640.0f, 0, game_ui_dialogue_background);
@@ -346,7 +347,7 @@ void BuildHireableNpcDialogue() {
 }
 
 void selectNPCDialogueOption(DialogueId option) {
-    NPCData *speakingNPC = getNPCData(sDialogue_SpeakingActorNPC_ID);
+    NPCData *speakingNPC = getNPCData(speakingNpcId);
 
     ((GUIWindow_Dialogue*)pDialogueWindow)->setDisplayedDialogueType(option);
 

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -30,20 +30,22 @@
 
 using Io::TextInputType;
 
+Actor *currentSpeakingActor = nullptr;
+
 const IndexedArray<std::string, PartyAlignment_Good, PartyAlignment_Evil> dialogueBackgroundResourceByAlignment = {
     {PartyAlignment_Good, "evt02-b"},
     {PartyAlignment_Neutral, "evt02"},
     {PartyAlignment_Evil, "evt02-c"}
 };
 
-void initializeNPCDialogue(Actor *actor, int bPlayerSaysHello) {
+void initializeNPCDialogue(int npcId, int bPlayerSaysHello, Actor *actor) {
     currentAddressingAwardBit = -1;
     pNPCStats->dword_AE336C_LastMispronouncedNameFirstLetter = -1;
     pEventTimer->setPaused(true);
     pMiscTimer->setPaused(true);
-    sDialogue_SpeakingActorNPC_ID = actor->npcId;
-    pDialogue_SpeakingActor = actor;
-    NPCData *pNPCInfo = getNPCData(actor->npcId);
+    sDialogue_SpeakingActorNPC_ID = npcId;
+    currentSpeakingActor = actor;
+    NPCData *pNPCInfo = getNPCData(npcId);
     if (!(pNPCInfo->uFlags & NPC_GREETED_SECOND)) {
         if (pNPCInfo->uFlags & NPC_GREETED_FIRST) {
             pNPCInfo->uFlags &= ~NPC_GREETED_FIRST;
@@ -165,6 +167,7 @@ void GUIWindow_Dialogue::Release() {
     }
 
     current_screen_type = prev_screen_type;
+    currentSpeakingActor = nullptr;
     pParty->switchToNextActiveCharacter();
     GUIWindow::Release();
 }
@@ -399,8 +402,8 @@ void selectNPCDialogueOption(DialogueId option) {
 
     if (option == DIALOGUE_HIRE_FIRE) {
         if (speakingNPC->Hired()) {
-            if (sDialogue_SpeakingActorNPC_ID >= 0) {
-                pDialogue_SpeakingActor->aiState = Removed;
+            if (currentSpeakingActor && currentSpeakingActor->npcId >= 0) {
+                currentSpeakingActor->aiState = Removed;
             }
         }
     }

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -35,7 +35,7 @@ class GUIWindow_Dialogue : public GUIWindow {
     DialogueId _displayedDialogue = DIALOGUE_MAIN;
 };
 
-void initializeNPCDialogue(Actor *actor, int bPlayerSaysHello);
+void initializeNPCDialogue(int npcId, int bPlayerSaysHello, Actor *actor = nullptr);
 
 void selectNPCDialogueOption(DialogueId option);
 

--- a/src/GUI/UI/UIDialogue.h
+++ b/src/GUI/UI/UIDialogue.h
@@ -39,4 +39,5 @@ void initializeNPCDialogue(int npcId, int bPlayerSaysHello, Actor *actor = nullp
 
 void selectNPCDialogueOption(DialogueId option);
 
+extern int speakingNpcId;
 extern const IndexedArray<std::string, PartyAlignment_Good, PartyAlignment_Evil> dialogueBackgroundResourceByAlignment;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -486,7 +486,7 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
 
     if (topic == DIALOGUE_13_hiring_related) {
         current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                               pParty->activeCharacterIndex() - 1);
+                                               pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
         NPCHireableDialogPrepare();
         dialogue_show_profession_details = false;
         BackToHouseMenu();
@@ -499,10 +499,10 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
         if (topic == DIALOGUE_PROFESSION_DETAILS) {
             if (dialogue_show_profession_details) {
                 current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pBenefits,
-                                                       pParty->activeCharacterIndex() - 1);
+                                                       pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
             } else {
                 current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                                       pParty->activeCharacterIndex() - 1);
+                                                       pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
             }
         }
         BackToHouseMenu();
@@ -511,7 +511,7 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
 
     if (!pCurrentNPCInfo->Hired()) {
         current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                               pParty->activeCharacterIndex() - 1);
+                                               pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
         BackToHouseMenu();
         return;
     }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1754,7 +1754,7 @@ void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
                 popup_window.DrawTitleText(assets->pFontArrus.get(), 0, 12, colorTable.PaleCanary, NameAndTitle(pNPC), 3);
                 popup_window.uFrameWidth -= 24;
                 popup_window.uFrameZ = popup_window.uFrameX + popup_window.uFrameWidth - 1;
-                popup_window.DrawText(assets->pFontArrus.get(), {100, 36}, colorTable.White, BuildDialogueString(pText, 0));
+                popup_window.DrawText(assets->pFontArrus.get(), {100, 36}, colorTable.White, BuildDialogueString(pText, 0, pNPC));
             }
         }
     }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -702,7 +702,7 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     // Draw name and profession
     std::string str;
     if (pActors[uActorID].npcId) {
-        str = NameAndTitle(GetNPCData(pActors[uActorID].npcId));
+        str = NameAndTitle(getNPCData(pActors[uActorID].npcId));
     } else {
         str = GetDisplayName(&pActors[uActorID]);
     }
@@ -1717,7 +1717,7 @@ void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
         buf.Prepare();
 
         if (_this + pParty->hirelingScrollPosition < buf.Size()) {
-            NPCData *pNPC = GetNPCData(-1 - pParty->hirelingScrollPosition - _this);
+            NPCData *pNPC = getNPCData(-1 - pParty->hirelingScrollPosition - _this);
             std::string pText;
 
             if (pNPC) {

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1712,17 +1712,14 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, int characterIndex) {
 }
 
 void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
-    NPCData *pNPC;           // eax@16
-    std::string pText;       // eax@18
-    int a2 = 0;                  // [sp+60h] [bp-Ch]@16
-
     if (bNoNPCHiring != 1) {
         FlatHirelings buf;
         buf.Prepare();
 
         if (_this + pParty->hirelingScrollPosition < buf.Size()) {
-            sDialogue_SpeakingActorNPC_ID = -1 - pParty->hirelingScrollPosition - _this;
-            pNPC = GetNewNPCData(sDialogue_SpeakingActorNPC_ID, &a2);
+            NPCData *pNPC = GetNPCData(-1 - pParty->hirelingScrollPosition - _this);
+            std::string pText;
+
             if (pNPC) {
                 if (pNPC->name == "Baby Dragon")
                     pText = pNPCTopics[512].pText;  // Baby dragon


### PR DESCRIPTION
Was trying to get rid of two NPC dialogue globals.
Was not able to remove them completely because of usage of NPC id global in events but contained pointer to NPC actor in dialogue module.

- Changed initializeNPCDialogue function signature to avoid passing struct created on stack (pointer on which was saved in global).
- Merged GetNPCData function with GetNewNPCData. GetNewNPCData is just a copy of GetNPCData with a little tweak.
- Changed BuildDialogueString function signature and pass NPC data directly to avoid accessing globals.