### PR TITLE
Bug: Don't show overlay if enabled flag is false

### DIFF
--- a/src/GUI/Overlay/OverlaySystem.cpp
+++ b/src/GUI/Overlay/OverlaySystem.cpp
@@ -48,7 +48,7 @@ void OverlaySystem::drawOverlays() {
 }
 
 void OverlaySystem::_update() {
-    if (_isEnabled) {
+    if (!_isEnabled) {
         return;
     }
 


### PR DESCRIPTION
Well... whoops!! 😅 🤦 
The only downside right now is that overlays are visible as soon as you enter the game. This is fixing that behaviour and, of course, using the boolean flag correctly.