### PR TITLE
Fix requred food for different outdoor tiles

### DIFF
--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -452,14 +452,13 @@ int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3i &pos) {
         case Tileset_Grass:
             return 1;
         case Tileset_Snow:
+        case Tileset_Swamp:
             return 3;
+        case Tileset_CooledLava:
+        case Tileset_Badlands:
+            return 4;
         case Tileset_Desert:
             return 5;
-        case Tileset_CooledLava:
-        case Tileset_Dirt:
-            return 4;
-        case Tileset_Water:
-            return 3;
         default:
             return 2;
     }


### PR DESCRIPTION
Fix 2nd item from #1226.
Not only dirt was wrong but others as well.
Most of the values I rechecked against vanilla but I don't remember where can I find "Swamp", "Lava" or "Tropical" tiles.
Swamp I looked up here: https://gamefaqs.gamespot.com/pc/143119-might-and-magic-vii-for-blood-and-honor/faqs/27528