### PR TITLE
Refactor globals of curretly loaded location ID and name

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1244,7 +1244,7 @@ void Game::processQueuedMessages() {
                     for (Character &character : pParty->pCharacters) {
                         character.conditions.Set(CONDITION_SLEEP, pParty->GetPlayingTime());
                     }
-                    MapId mapIdx = pMapStats->GetMapInfo(pCurrentMapName);
+                    MapId mapIdx = engine->_currentLoadedMapId;
                     assert(mapIdx != MAP_INVALID);
                     // Was this, which made exactly zero sense:
                     // if (mapIdx == MAP_INVALID)

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -196,7 +196,10 @@ bool Game::loop() {
 
             pParty->pPickedItem.uItemID = ITEM_NULL;
 
-            pCurrentMapName = _config->gameplay.StartingMap.value();
+            engine->_transitionMapId = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
+
+            assert(engine->_transitionMapId != MAP_INVALID);
+
             bFlashQuestBook = true;
             pMediaPlayer->PlayFullscreenMovie("Intro Post");
             SaveNewGame();
@@ -814,7 +817,6 @@ void Game::processQueuedMessages() {
 
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 // encounter_index = (NPCData *)getTravelTime();
-                pOutdoor->level_filename = pCurrentMapName;
                 if (!engine->IsUnderwater() && pParty->bFlying ||
                     pOutdoor->GetTravelDestination(pParty->pos.x, pParty->pos.y, &pOut) != 1) {
                     PlayButtonClickSound();
@@ -851,25 +853,26 @@ void Game::processQueuedMessages() {
                         ++pParty->days_played_without_rest;
                     }
                     pSpriteFrameTable->ResetLoadedFlags();
-                    pCurrentMapName = pOut;
-                    Level_LoadEvtAndStr(pCurrentMapName.substr(0, pCurrentMapName.rfind('.')));
+                    engine->_currentLoadedMapId = pMapStats->GetMapInfo(pOut);
+                    Level_LoadEvtAndStr(pOut.substr(0, pOut.rfind('.')));
                     _decalBuilder->Reset(0);
 
                     bNoNPCHiring = 0;
 
-                    engine->SetUnderwater(Is_out15odm_underwater());
+                    engine->SetUnderwater(engine->_currentLoadedMapId == MAP_SHOALS);
 
-                    if (Is_out15odm_underwater() || (pCurrentMapName == "d47.blv"))
+                    // Previously was checking maps 'out15.odm' and 'd47.blv', but d47 is not present in MM7.
+                    // Logically here must check Shoals and Lincoln.
+                    if (engine->_currentLoadedMapId == MAP_SHOALS || engine->_currentLoadedMapId == MAP_LINCOLN)
                         bNoNPCHiring = 1;
 
-                    PrepareToLoadODM(pCurrentMapName, 1u, (ODMRenderParams *)1);
+                    PrepareToLoadODM(pOut, 1u, (ODMRenderParams *)1);
                     bDialogueUI_InitializeActor_NPC_ID = 0;
                     onMapLoad();
                     pOutdoor->SetFog();
                     TeleportToStartingPoint(uLevel_StartingPointType);
                     bool bOnWater = false;
-                    pParty->pos.z = GetTerrainHeightsAroundParty2(
-                        pParty->pos.x, pParty->pos.y, &bOnWater, 0);
+                    pParty->pos.z = GetTerrainHeightsAroundParty2(pParty->pos.x, pParty->pos.y, &bOnWater, 0);
                     pParty->uFallStartZ = pParty->pos.z;
                     engine->_461103_load_level_sub();
                     pEventTimer->setPaused(false);
@@ -950,7 +953,7 @@ void Game::processQueuedMessages() {
                 playButtonSoundOnEscape = false;
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 AutoSave();
-                pCurrentMapName = pMapStats->pInfos[houseNpcs[currentHouseNpc].targetMapID].fileName;
+                engine->_transitionMapId = houseNpcs[currentHouseNpc].targetMapID;
                 dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
                 uGameState = GAME_STATE_CHANGE_LOCATION;
                 // v53 = buildingTable_minus1_::30[26 * (unsigned
@@ -1011,7 +1014,7 @@ void Game::processQueuedMessages() {
                 pParty->_viewPitch = 0;
 
                 // change map to Harmondale
-                pCurrentMapName = "out02.odm";
+                engine->_transitionMapId = MAP_HARMONDALE;
                 engine->_teleportPoint.setTeleportTarget(pParty->pos, pParty->_viewYaw, pParty->_viewPitch, 0);
                 PrepareWorld(1);
                 Actor::InitializeActors();
@@ -1035,9 +1038,9 @@ void Game::processQueuedMessages() {
                 std::string status_string;
                 if (frameTableTxtLine.uPropCount == 1) {
                     MapId map_index = static_cast<MapId>(atoi(frameTableTxtLine.pProperties[0]));
-                    if (map_index < MAP_FIRST || map_index > MAP_LAST) continue;
-                    std::string map_name = pMapStats->pInfos[map_index].fileName;
-                    pCurrentMapName = map_name;
+                    if (map_index < MAP_FIRST || map_index > MAP_LAST)
+                        continue;
+                    engine->_transitionMapId = map_index;
                     dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
                     uGameState = GAME_STATE_CHANGE_LOCATION;
                     onMapLeave();
@@ -1692,9 +1695,8 @@ void Game::onPressSpace() {
 }
 
 void Game::gameLoop() {
-    std::string pLocationName;  // [sp-4h] [bp-68h]@74
-    bool bLoading;              // [sp+10h] [bp-54h]@1
-    std::string Source;            // [sp+44h] [bp-20h]@76
+    bool bLoading;
+    MapId mapid;
 
     bLoading = sCurrentMenuID == MENU_LoadingProcInMainMenu;
     SetCurrentMenuID(MENU_NONE);
@@ -1718,8 +1720,7 @@ void Game::gameLoop() {
 
         DoPrepareWorld(bLoading, 1);
         pEventTimer->setPaused(false);
-        dword_6BE364_game_settings_1 |=
-            GAME_SETTINGS_0080_SKIP_USER_INPUT_THIS_FRAME;
+        dword_6BE364_game_settings_1 |= GAME_SETTINGS_0080_SKIP_USER_INPUT_THIS_FRAME;
         // uGame_if_0_else_ui_id__11_save__else_load__8_drawSpellInfoPopup__22_final_window__26_keymapOptions__2_options__28_videoOptions
         // = 0;
         current_screen_type = SCREEN_GAME;
@@ -1850,19 +1851,19 @@ void Game::gameLoop() {
                 if (pParty->_questBits[QBIT_ESCAPED_EMERALD_ISLE]) {
                     pParty->pos = Vec3f(-17331, 12547, 465); // respawn in harmondale
                     pParty->_viewYaw = 0;
-                    pLocationName = "out02.odm";
+                    mapid = MAP_HARMONDALE;
                 } else {
                     pParty->pos = Vec3f(12552, 1816, 193); // respawn on emerald isle
                     pParty->_viewYaw = 512;
-                    pLocationName = _config->gameplay.StartingMap.value();
+                    mapid = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
+                    assert(mapid != MAP_INVALID);
                 }
-                Source = pLocationName;
                 pParty->uFallStartZ = pParty->pos.z;
                 pParty->_viewPitch = 0;
                 pParty->velocity = Vec3f();
                 // change map
-                if (pCurrentMapName != Source) {
-                    pCurrentMapName = Source;
+                if (engine->_currentLoadedMapId != mapid) {
+                    engine->_transitionMapId = mapid;
                     engine->_teleportPoint.setTeleportTarget(pParty->pos, pParty->_viewYaw, pParty->_viewPitch, 0);
                     PrepareWorld(1);
                 }

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -854,7 +854,6 @@ void Game::processQueuedMessages() {
                     pCurrentMapName = pOut;
                     Level_LoadEvtAndStr(pCurrentMapName.substr(0, pCurrentMapName.rfind('.')));
                     _decalBuilder->Reset(0);
-                    uLevelMapStatsID = pMapStats->GetMapInfo(pCurrentMapName);
 
                     bNoNPCHiring = 0;
 

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -777,7 +777,7 @@ void Game::processQueuedMessages() {
                 if (engine->_teleportPoint.isValid()) {
                     if (!engine->_teleportPoint.getTeleportMap().starts_with('0')) {
                         //pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_Box);
-                        bool leavingArena = ascii::noCaseEquals(pCurrentMapName, "d05.blv");
+                        bool leavingArena = engine->_currentLoadedMapId == MAP_ARENA;
                         onMapLeave();
                         Transition_StopSound_Autosave(engine->_teleportPoint.getTeleportMap(), MAP_START_POINT_PARTY);
                         if (leavingArena)
@@ -1652,7 +1652,7 @@ void Game::processQueuedMessages() {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 continue;
             case UIMSG_QuickSave:
-                if (pCurrentMapName == "d05.blv") {
+                if (engine->_currentLoadedMapId == MAP_ARENA) {
                     engine->_statusBar->setEvent(LSTR_NO_SAVING_IN_ARENA);
                     pAudioPlayer->playUISound(SOUND_error);
                 } else {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -861,7 +861,8 @@ void Game::processQueuedMessages() {
 
                     if (Is_out15odm_underwater() || (pCurrentMapName == "d47.blv"))
                         bNoNPCHiring = 1;
-                    PrepareToLoadODM(1u, (ODMRenderParams *)1);
+
+                    PrepareToLoadODM(pCurrentMapName, 1u, (ODMRenderParams *)1);
                     bDialogueUI_InitializeActor_NPC_ID = 0;
                     onMapLoad();
                     pOutdoor->SetFog();

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -198,6 +198,7 @@ bool Game::loop() {
 
             engine->_transitionMapId = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
 
+            // TODO(Nik-RE-dev): should not be an assert but an exception or error message.
             assert(engine->_transitionMapId != MAP_INVALID);
 
             bFlashQuestBook = true;
@@ -817,6 +818,7 @@ void Game::processQueuedMessages() {
 
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 // encounter_index = (NPCData *)getTravelTime();
+                // TODO(Nik-RE-dev): pOut should be an enum
                 if (!engine->IsUnderwater() && pParty->bFlying ||
                     pOutdoor->GetTravelDestination(pParty->pos.x, pParty->pos.y, &pOut) != 1) {
                     PlayButtonClickSound();
@@ -1856,6 +1858,7 @@ void Game::gameLoop() {
                     pParty->pos = Vec3f(12552, 1816, 193); // respawn on emerald isle
                     pParty->_viewYaw = 512;
                     mapid = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
+                    // TODO(Nik-RE-dev): should not be an assert but an exception or error message.
                     assert(mapid != MAP_INVALID);
                 }
                 pParty->uFallStartZ = pParty->pos.z;

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -172,7 +172,7 @@ void Menu::EventLoop() {
                 DoSavegame(pSavegameList->selectedSlot);
                 continue;
             case UIMSG_Game_OpenSaveGameDialog: {
-                if (pCurrentMapName == "d05.blv") {
+                if (engine->_currentLoadedMapId == MAP_ARENA) {
                     engine->_statusBar->setEvent(LSTR_NO_SAVING_IN_ARENA);
                     pAudioPlayer->playUISound(SOUND_error);
                 } else {

--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -5,6 +5,8 @@
 #include "Application/GameConfig.h"
 
 #include "Engine/Party.h"
+#include "Engine/Engine.h"
+#include "Engine/MapInfo.h"
 #include "Engine/mm7_data.h"
 
 #include "Media/Audio/AudioPlayer.h"
@@ -66,7 +68,7 @@ void EngineTraceStateAccessor::prepareForPlayback(GameConfig *config, const Conf
 
 EventTraceGameState EngineTraceStateAccessor::makeGameState() {
     EventTraceGameState result;
-    result.locationName = ascii::toLower(pCurrentMapName);
+    result.locationName = ascii::toLower(pMapStats->pInfos[engine->_currentLoadedMapId].fileName);
     result.partyPosition = pParty->pos.toInt();
     for (const Character &character : pParty->pCharacters) {
         EventTraceCharacterState &traceCharacter = result.characters.emplace_back();

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -573,8 +573,7 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     pNPCStats->setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
-    if ((pCurrentMapName == "d11.blv") ||
-        (pCurrentMapName == "d10.blv")) {
+    if (engine->_currentLoadedMapId == MAP_BREEDING_ZONE || engine->_currentLoadedMapId == MAP_WALLS_OF_MIST) {
         // spawning grounds & walls of mist - no loot & exp from monsters
 
         for (unsigned i = 0; i < pActors.size(); ++i) {
@@ -1519,7 +1518,7 @@ void Transition_StopSound_Autosave(std::string_view pMapName,
 //----- (0044C28F) --------------------------------------------------------
 void TeleportToNWCDungeon() {
     // return if we are already in the NWC dungeon
-    if ("nwc.blv" == pCurrentMapName) {
+    if (engine->_currentLoadedMapId == MAP_STRANGE_TEMPLE) {
         return;
     }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -567,9 +567,9 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     pParty->floor_face_id = 0; // TODO(captainurist): drop?
     if (ascii::noCaseEquals(mapExt, "blv"))
-        PrepareToLoadBLV(bLoading);
+        PrepareToLoadBLV(pCurrentMapName, bLoading);
     else
-        PrepareToLoadODM(bLoading, 0);
+        PrepareToLoadODM(pCurrentMapName, bLoading, 0);
 
     pNPCStats->setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
@@ -1091,7 +1091,8 @@ void _494035_timed_effects__water_walking_damage__etc(Duration dt) {
                 }
             }
         }
-        if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) pOutdoor->SetFog();
+        if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR)
+            pOutdoor->SetFog();
 
         for (Character &character : pParty->pCharacters) {
             character.uNumDivineInterventionCastsThisDay = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -122,7 +122,7 @@ Engine *engine;
 GameState uGameState;
 
 void Engine::drawWorld() {
-    engine->SetSaturateFaces(pParty->_497FC5_check_party_perception_against_level());
+    engine->SetSaturateFaces(pParty->checkPartyPerceptionAgainstCurrentMap());
 
     pCamera3D->_viewPitch = pParty->_viewPitch;
     pCamera3D->_viewYaw = pParty->_viewYaw;
@@ -559,8 +559,6 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
                                                       // maxExt == pCurrentMapName.
 
     Level_LoadEvtAndStr(mapName);
-
-    uLevelMapStatsID = pMapStats->GetMapInfo(pCurrentMapName);
 
     // TODO(captainurist): need to zero this one out when loading a save, but is this a proper place to do that?
     attackList.clear();

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -547,7 +547,6 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
 //----- (00464866) --------------------------------------------------------
 void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     // char *v3;         // eax@1
-    MapId v5;  // eax@3
 
     // v9 = bLoading;
     engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
@@ -561,9 +560,7 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     Level_LoadEvtAndStr(mapName);
 
-    v5 = pMapStats->GetMapInfo(pCurrentMapName);
-
-    uLevelMapStatsID = v5;
+    uLevelMapStatsID = pMapStats->GetMapInfo(pCurrentMapName);
 
     // TODO(captainurist): need to zero this one out when loading a save, but is this a proper place to do that?
     attackList.clear();
@@ -845,26 +842,6 @@ void MM7Initialization() {
     pViewport->SetScreen(viewparams->uScreen_topL_X, viewparams->uScreen_topL_Y,
                          viewparams->uScreen_BttmR_X,
                          viewparams->uScreen_BttmR_Y);
-}
-
-// TODO(pskelton): move to outdoor?
-//----- (004610AA) --------------------------------------------------------
-void PrepareToLoadODM(bool bLoading, ODMRenderParams *a2) {
-    pGameLoadingUI_ProgressBar->Reset(27);
-    uCurrentlyLoadedLevelType = LEVEL_OUTDOOR;
-
-    ODM_LoadAndInitialize(pCurrentMapName, a2);
-    if (!bLoading)
-        TeleportToStartingPoint(uLevel_StartingPointType);
-
-    viewparams->_443365();
-    PlayLevelMusic();
-
-    //  level decoration sound
-    for (int decorIdx : decorationsWithSound) {
-        const DecorationDesc *decoration = pDecorationList->GetDecoration(pLevelDecorations[decorIdx].uDecorationDescID);
-        pAudioPlayer->playSound(decoration->uSoundID, SOUND_MODE_PID, Pid(OBJECT_Decoration, decorIdx));
-    }
 }
 
 //----- (00464479) --------------------------------------------------------

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -130,6 +130,7 @@ class Engine {
     std::vector<std::string> _levelStrings;
     PersistentVariables _persistentVariables;
     MapId _currentLoadedMapId = MAP_INVALID;
+    MapId _transitionMapId = MAP_INVALID;
     TeleportPoint _teleportPoint;
     OverlaySystem &_overlaySystem;
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -22,7 +22,6 @@ class KeyboardActionMapping;
 } // namespace Io
 
 struct BLVFace;
-struct ODMRenderParams;
 struct Vis_PIDAndDepth;
 struct Vis_SelectionFilter;
 struct Polygon;
@@ -130,6 +129,7 @@ class Engine {
     EventMap _localEventMap;
     std::vector<std::string> _levelStrings;
     PersistentVariables _persistentVariables;
+    MapId _currentLoadedMapId = MAP_INVALID;
     TeleportPoint _teleportPoint;
     OverlaySystem &_overlaySystem;
 
@@ -159,7 +159,6 @@ void FinalInitialization();
 void MM6_Initialize();
 void MM7Initialization();
 
-void PrepareToLoadODM(bool bLoading, ODMRenderParams *a2);
 void InitializeTurnBasedAnimations(void *);
 unsigned int GetGravityStrength();
 

--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -70,7 +70,6 @@ static bool checkSeason(Season season) {
  */
 static void spawnMonsters(int16_t typeindex, int16_t level, int count,
                           Vec3f pos, int group, unsigned int uUniqueName) {
-    MapId mapId = pMapStats->GetMapInfo(pCurrentMapName);
     SpawnPoint pSpawnPoint;
 
     pSpawnPoint.vPosition = pos;
@@ -79,10 +78,10 @@ static void spawnMonsters(int16_t typeindex, int16_t level, int count,
     pSpawnPoint.uKind = OBJECT_Actor;
     pSpawnPoint.uMonsterIndex = typeindex + 2 * level + level;
 
-    if (mapId != MAP_INVALID) {
+    if (engine->_currentLoadedMapId != MAP_INVALID) {
         AIDirection direction;
         int oldNumActors = pActors.size();
-        SpawnEncounter(&pMapStats->pInfos[mapId], &pSpawnPoint, 0, count, 0);
+        SpawnEncounter(&pMapStats->pInfos[engine->_currentLoadedMapId], &pSpawnPoint, 0, count, 0);
         Actor::GetDirectionInfo(Pid(OBJECT_Actor, oldNumActors), Pid::character(0), &direction, 1);
         for (int i = oldNumActors; i < pActors.size(); ++i) {
             pActors[i].PrepareSprites(0);

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -924,7 +924,7 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
 
             // TODO(pskelton): Better way to do this?
             // Special case for steep staircase in tidewater
-            if (pCurrentMapName == "D17.blv") {
+            if (engine->_currentLoadedMapId == MAP_TIDEWATER_CAVERNS) {
                 if (collision_state.pid.id() == 650)
                     bFaceSlopeTooSteep = false;
             }

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -890,7 +890,7 @@ void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
     pBLVRenderParams->uPartyEyeSectorID = 0;
     engine->_currentLoadedMapId = map_id;
 
-    engine->SetUnderwater(Is_out15odm_underwater());
+    engine->SetUnderwater(map_id == MAP_SHOALS);
 
     if ((map_id == MAP_SHOALS) || (map_id == MAP_LINCOLN)) {
         bNoNPCHiring = true;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -873,14 +873,14 @@ void UpdateActors_BLV() {
 }
 
 //----- (00460A78) --------------------------------------------------------
-void PrepareToLoadBLV(bool bLoading) {
+void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
     unsigned int respawn_interval;  // ebx@1
     MapInfo *map_info;              // edi@9
     bool v28;                       // zf@81
     bool alertStatus;                        // [sp+404h] [bp-10h]@1
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
 
-    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
+    MapId map_id = pMapStats->GetMapInfo(filename);
 
     respawn_interval = 0;
     pGameLoadingUI_ProgressBar->Reset(0x20u);
@@ -909,7 +909,7 @@ void PrepareToLoadBLV(bool bLoading) {
     }
 
     pStationaryLightsStack->uNumLightsActive = 0;
-    pIndoor->Load(pCurrentMapName, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);
+    pIndoor->Load(filename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);
     if (!(dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)) {
         Actor::InitializeActors();
         SpriteObject::InitializeSpriteObjects();

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -342,7 +342,7 @@ void IndoorLocation::Load(std::string_view filename, int num_days_played, int re
             if (dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)
                 respawn_interval_days = 0x1BAF800;
 
-            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && pCurrentMapName != "d29.dlv")
+            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && pMapStats->GetMapInfo(filename) != MAP_CASTLE_HARMONDALE)
                 respawnTimed = true;
         } catch (const Exception &e) {
             logger->error("Failed to load '{}', respawning location: {}", dlv_filename, e.what());
@@ -880,16 +880,19 @@ void PrepareToLoadBLV(bool bLoading) {
     bool alertStatus;                        // [sp+404h] [bp-10h]@1
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
 
+    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
+
     respawn_interval = 0;
     pGameLoadingUI_ProgressBar->Reset(0x20u);
     bNoNPCHiring = false;
     uCurrentlyLoadedLevelType = LEVEL_INDOOR;
     pBLVRenderParams->uPartySectorID = 0;
     pBLVRenderParams->uPartyEyeSectorID = 0;
+    engine->_currentLoadedMapId = map_id;
 
     engine->SetUnderwater(Is_out15odm_underwater());
 
-    if ((pCurrentMapName == "out15.odm") || (pCurrentMapName == "d23.blv")) {
+    if ((map_id == MAP_SHOALS) || (map_id == MAP_LINCOLN)) {
         bNoNPCHiring = true;
     }
     //pPaletteManager->pPalette_tintColor[0] = 0;
@@ -897,7 +900,6 @@ void PrepareToLoadBLV(bool bLoading) {
     //pPaletteManager->pPalette_tintColor[2] = 0;
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
-    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
     if (map_id != MAP_INVALID) {
         map_info = &pMapStats->pInfos[map_id];
         respawn_interval = pMapStats->pInfos[map_id].respawnIntervalDays;
@@ -905,7 +907,6 @@ void PrepareToLoadBLV(bool bLoading) {
     } else {
         map_info = nullptr;
     }
-    engine->_currentLoadedMapId = map_id;
 
     pStationaryLightsStack->uNumLightsActive = 0;
     pIndoor->Load(pCurrentMapName, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -673,8 +673,8 @@ bool BLVFaceExtra::HasEventHint() {
 //----- (0046F228) --------------------------------------------------------
 void BLV_UpdateDoors() {
     SoundId eDoorSoundID = SOUND_wood_door0101;
-    if (dword_6BE13C_uCurrentlyLoadedLocationID != MAP_INVALID)
-        eDoorSoundID = pDoorSoundIDsByLocationID[dword_6BE13C_uCurrentlyLoadedLocationID];
+    if (engine->_currentLoadedMapId != MAP_INVALID)
+        eDoorSoundID = pDoorSoundIDsByLocationID[engine->_currentLoadedMapId];
 
     // loop over all doors
     for (unsigned i = 0; i < pIndoor->pDoors.size(); ++i) {
@@ -905,7 +905,7 @@ void PrepareToLoadBLV(bool bLoading) {
     } else {
         map_info = nullptr;
     }
-    dword_6BE13C_uCurrentlyLoadedLocationID = map_id;
+    engine->_currentLoadedMapId = map_id;
 
     pStationaryLightsStack->uNumLightsActive = 0;
     pIndoor->Load(pCurrentMapName, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -304,7 +304,7 @@ void BLV_ProcessPartyActions();
 void switchDoorAnimation(unsigned int uDoorID, DoorAction a2);
 int CalcDistPointToLine(int a1, int a2, int a3, int a4, int a5, int a6);
 void PrepareDrawLists_BLV();
-void PrepareToLoadBLV(bool bLoading);
+void PrepareToLoadBLV(std::string_view filename, bool bLoading);
 int SpawnEncounterMonsters(MapInfo *a1, int a2);
 int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f pos, uint16_t facing);
 void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2);

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -250,7 +250,7 @@ bool OutdoorLocation::Initialize(std::string_view filename, int days_played,
         ::day_attrib = this->loc_time.day_attrib;
         ::day_fogrange_1 = this->loc_time.day_fogrange_1;
         ::day_fogrange_2 = this->loc_time.day_fogrange_2;
-        if (Is_out15odm_underwater())
+        if (engine->_currentLoadedMapId == MAP_SHOALS)
             SetUnderwaterFog();
 
         return true;
@@ -495,7 +495,8 @@ void OutdoorLocation::SetFog() {
         ::day_attrib &= ~MAP_WEATHER_FOGGY;
     }
 
-    if (Is_out15odm_underwater()) SetUnderwaterFog();
+    if (map_id == MAP_SHOALS)
+        SetUnderwaterFog();
     pOutdoor->loc_time.day_fogrange_1 = ::day_fogrange_1;
     pOutdoor->loc_time.day_fogrange_2 = ::day_fogrange_2;
     pOutdoor->loc_time.day_attrib = ::day_attrib;
@@ -2270,11 +2271,6 @@ int GetCeilingHeight(int Party_X, signed int Party_Y, int Party_ZHeight, int *pF
         *pFaceID = 0;
         return ceiling_height_level[result_idx];
     }
-}
-
-//----- (00464839) --------------------------------------------------------
-char Is_out15odm_underwater() {
-    return (pCurrentMapName == "out15.odm");
 }
 
 //----- (00464851) --------------------------------------------------------

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2464,10 +2464,28 @@ void UpdateActors_ODM() {
     }
 }
 
+//----- (004610AA) --------------------------------------------------------
+void PrepareToLoadODM(bool bLoading, ODMRenderParams *a2) {
+    pGameLoadingUI_ProgressBar->Reset(27);
+    uCurrentlyLoadedLevelType = LEVEL_OUTDOOR;
+
+    ODM_LoadAndInitialize(pCurrentMapName, a2);
+    if (!bLoading)
+        TeleportToStartingPoint(uLevel_StartingPointType);
+
+    viewparams->_443365();
+    PlayLevelMusic();
+
+    //  level decoration sound
+    for (int decorIdx : decorationsWithSound) {
+        const DecorationDesc *decoration = pDecorationList->GetDecoration(pLevelDecorations[decorIdx].uDecorationDescID);
+        pAudioPlayer->playSound(decoration->uSoundID, SOUND_MODE_PID, Pid(OBJECT_Decoration, decorIdx));
+    }
+}
+
 //----- (0047A384) --------------------------------------------------------
 void ODM_LoadAndInitialize(std::string_view pFilename, ODMRenderParams *thisa) {
     MapInfo *map_info;            // edi@4
-    // size_t v7;              // eax@19
 
     // thisa->AllocSoftwareDrawBuffers();
     pWeather->bRenderSnow = false;
@@ -2475,14 +2493,14 @@ void ODM_LoadAndInitialize(std::string_view pFilename, ODMRenderParams *thisa) {
     // thisa = (ODMRenderParams *)1;
     GetAlertStatus(); // Result unused.
     pParty->_delayedReactionTimer = 0_ticks;
-    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
+    MapId map_id = pMapStats->GetMapInfo(pFilename);
     unsigned int respawn_interval = 0;
     if (map_id != MAP_INVALID) {
         map_info = &pMapStats->pInfos[map_id];
         respawn_interval = map_info->respawnIntervalDays;
     }
     day_attrib &= ~MAP_WEATHER_FOGGY;
-    dword_6BE13C_uCurrentlyLoadedLocationID = map_id;
+    engine->_currentLoadedMapId = map_id;
     bool outdoor_was_respawned;
     pOutdoor->Initialize(pFilename, pParty->GetPlayingTime().toDays() + 1,
         respawn_interval, &outdoor_was_respawned);
@@ -2523,6 +2541,7 @@ void ODM_LoadAndInitialize(std::string_view pFilename, ODMRenderParams *thisa) {
 
     MM7Initialization();
 }
+
 // returns 0xXXYYZZ fog color
 Color GetLevelFogColor() {
     if (engine->IsUnderwater()) {

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -214,6 +214,7 @@ void ODM_ProcessPartyActions();
 char Is_out15odm_underwater();
 void SetUnderwaterFog();
 void sub_487DA9();
+void PrepareToLoadODM(bool bLoading, ODMRenderParams *a2);
 void ODM_LoadAndInitialize(std::string_view pLevelFilename,
                            ODMRenderParams *thisa);
 Color GetLevelFogColor();

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -214,9 +214,8 @@ void ODM_ProcessPartyActions();
 char Is_out15odm_underwater();
 void SetUnderwaterFog();
 void sub_487DA9();
-void PrepareToLoadODM(bool bLoading, ODMRenderParams *a2);
-void ODM_LoadAndInitialize(std::string_view pLevelFilename,
-                           ODMRenderParams *thisa);
+void PrepareToLoadODM(std::string_view filename, bool bLoading, ODMRenderParams *a2);
+void ODM_LoadAndInitialize(std::string_view pLevelFilename, ODMRenderParams *thisa);
 Color GetLevelFogColor();
 int sub_47C3D7_get_fog_specular(int unused, int a2, float a3);
 unsigned int WorldPosToGridCellX(int);

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -211,7 +211,6 @@ int GetCeilingHeight(int Party_X, signed int Party_Y, int Party_ZHeight,
 void ODM_GetTerrainNormalAt(float pos_x, float pos_y, Vec3f *out);
 void UpdateActors_ODM();
 void ODM_ProcessPartyActions();
-char Is_out15odm_underwater();
 void SetUnderwaterFog();
 void sub_487DA9();
 void PrepareToLoadODM(std::string_view filename, bool bLoading, ODMRenderParams *a2);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2954,14 +2954,16 @@ void Actor::InitializeActors() {
     bool bPit = false;
     bool good = false;
     bool evil = false;
-    if (pCurrentMapName == "d25.blv") {  // the Celestia
+    if (engine->_currentLoadedMapId == MAP_CELESTE) {
         bCelestia = true;
     }
-    if (pCurrentMapName == "d26.blv") {  // the Pit
+    if (engine->_currentLoadedMapId == MAP_PIT) {
         bPit = true;
     }
-    if (pParty->isPartyGood()) good = true;
-    if (pParty->isPartyEvil()) evil = true;
+    if (pParty->isPartyGood())
+        good = true;
+    if (pParty->isPartyEvil())
+        evil = true;
 
     ai_near_actors_targets_pid.fill(Pid());
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1271,17 +1271,15 @@ bool Actor::IsPeasant() {
 //----- (0042EBEE) --------------------------------------------------------
 void Actor::StealFrom(unsigned int uActorID) {
     Character *pPlayer;     // edi@1
-    int v4;              // ebx@2
-    MapId v5;     // eax@2
+    int v4 = 0;              // ebx@2
     LocationInfo *v6;  // esi@4
     Duration v8;              // [sp+8h] [bp-4h]@6
 
     pPlayer = &pParty->pCharacters[pParty->activeCharacterIndex() - 1];
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
-        v4 = 0;
-        v5 = pMapStats->GetMapInfo(pCurrentMapName);
-        if (v5 != MAP_INVALID) v4 = pMapStats->pInfos[v5].baseStealingFine;
+        if (engine->_currentLoadedMapId != MAP_INVALID)
+            v4 = pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine;
         v6 = &currentLocationInfo();
         pPlayer->StealFromActor(uActorID, v4, v6->reputation++);
         v8 = pPlayer->GetAttackRecoveryTime(false);

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1126,19 +1126,22 @@ void Actor::AI_MeleeAttack(unsigned int uActorID, Pid sTargetPid,
 
 //----- (00438CF3) --------------------------------------------------------
 void Actor::ApplyFineForKillingPeasant(unsigned int uActorID) {
-    if (uLevelMapStatsID == MAP_INVALID || !pActors[uActorID].IsPeasant()) return;
-
-    if ((uLevelMapStatsID == MAP_BRACADA_DESERT || uLevelMapStatsID == MAP_CELESTE) && pParty->isPartyEvil())
+    if (engine->_currentLoadedMapId == MAP_INVALID || !pActors[uActorID].IsPeasant())
         return;
 
-    if ((uLevelMapStatsID == MAP_DEYJA || uLevelMapStatsID == MAP_PIT) && pParty->isPartyGood())
+    if ((engine->_currentLoadedMapId == MAP_BRACADA_DESERT || engine->_currentLoadedMapId == MAP_CELESTE) && pParty->isPartyEvil())
         return;
 
-    pParty->uFine += 100 * (pMapStats->pInfos[uLevelMapStatsID].baseStealingFine +
+    if ((engine->_currentLoadedMapId == MAP_DEYJA || engine->_currentLoadedMapId == MAP_PIT) && pParty->isPartyGood())
+        return;
+
+    pParty->uFine += 100 * (pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine +
                             pActors[uActorID].monsterInfo.level +
                             pParty->GetPartyReputation());
-    if (pParty->uFine < 0) pParty->uFine = 0;
-    if (pParty->uFine > 4000000) pParty->uFine = 4000000;
+    if (pParty->uFine < 0)
+        pParty->uFine = 0;
+    if (pParty->uFine > 4000000)
+        pParty->uFine = 4000000;
 
     if (currentLocationInfo().reputation < 10000)
         currentLocationInfo().reputation++;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -7309,8 +7309,7 @@ void Character::cleanupBeacons() {
 }
 
 bool Character::setBeacon(int index, Duration duration) {
-    MapId file_index = pMapStats->GetMapInfo(pCurrentMapName);
-    if (file_index == MAP_INVALID) {
+    if (engine->_currentLoadedMapId == MAP_INVALID) {
         return false;
     }
 
@@ -7321,7 +7320,7 @@ bool Character::setBeacon(int index, Duration duration) {
     beacon._partyPos = pParty->pos;
     beacon._partyViewYaw = pParty->_viewYaw;
     beacon._partyViewPitch = pParty->_viewPitch;
-    beacon.mapId = file_index;
+    beacon.mapId = engine->_currentLoadedMapId;
 
     if (index < vBeacons.size()) {
         // overwrite so clear image

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -61,9 +61,8 @@ bool Chest::open(int uChestID, Pid objectPid) {
     if (!pParty->hasActiveCharacter())
         return false;
     flag_shout = false;
-    MapId pMapID = pMapStats->GetMapInfo(pCurrentMapName);
-    if (chest->Trapped() && pMapID != MAP_INVALID) {
-        if (pParty->activeCharacter().GetDisarmTrap() < 2 * pMapStats->pInfos[pMapID].disarmDifficulty) {
+    if (chest->Trapped() && engine->_currentLoadedMapId != MAP_INVALID) {
+        if (pParty->activeCharacter().GetDisarmTrap() < 2 * pMapStats->pInfos[engine->_currentLoadedMapId].disarmDifficulty) {
             pSpriteID[0] = SPRITE_TRAP_FIRE;
             pSpriteID[1] = SPRITE_TRAP_LIGHTNING;
             pSpriteID[2] = SPRITE_TRAP_COLD;
@@ -543,8 +542,7 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
 }
 
 void GenerateItemsInChest() {
-    MapId mapType = pMapStats->GetMapInfo(pCurrentMapName);
-    MapInfo *currMapInfo = &pMapStats->pInfos[mapType];
+    MapInfo *currMapInfo = &pMapStats->pInfos[engine->_currentLoadedMapId];
     for (int i = 0; i < 20; ++i) {
         for (int j = 0; j < 140; ++j) {
             ItemGen *currItem = &vChests[i].igChestItems[j];

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -513,7 +513,7 @@ LABEL_25:
 }
 
 void SpriteObject::explosionTraps() {
-    MapInfo *pMapInfo = &pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)];
+    MapInfo *pMapInfo = &pMapStats->pInfos[engine->_currentLoadedMapId];
     int dir_x = std::abs(pParty->pos.x - this->vPosition.x);
     int dir_y = std::abs(pParty->pos.y - this->vPosition.y);
     int dir_z = std::abs(pParty->pos.z + pParty->eyeLevel - this->vPosition.z);

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -183,23 +183,19 @@ void ActionQueue::Add(PartyAction action) {
     if (uNumActions < 30) pActions[uNumActions++] = action;
 }
 
-//----- (00497FC5) --------------------------------------------------------
-bool Party::_497FC5_check_party_perception_against_level() {
-    int uMaxPerception;  // edi@1
-    signed int v5;       // eax@3
-    bool result;         // eax@7
+bool Party::checkPartyPerceptionAgainstCurrentMap() {
+    int maxPerception = 0;
+    bool result = 0;
 
-    uMaxPerception = 0;
     for (Character &player : this->pCharacters) {
         if (player.CanAct()) {
-            v5 = player.GetPerception();
-            if (v5 > uMaxPerception) uMaxPerception = v5;
+            int playerPerception = player.GetPerception();
+            if (playerPerception > maxPerception)
+                maxPerception = playerPerception;
         }
     }
-    if (uLevelMapStatsID >= MAP_FIRST && uLevelMapStatsID <= MAP_LAST)
-        result = uMaxPerception >= 2 * pMapStats->pInfos[uLevelMapStatsID].perceptionDifficulty;
-    else
-        result = 0;
+    if (engine->_currentLoadedMapId >= MAP_FIRST && engine->_currentLoadedMapId <= MAP_LAST)
+        result = maxPerception >= 2 * pMapStats->pInfos[engine->_currentLoadedMapId].perceptionDifficulty;
     return result;
 }
 

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -91,7 +91,11 @@ struct Party {
     * Sets _activeCharacter to the first active (recoverd) character
     */
     void switchToNextActiveCharacter();
-    bool _497FC5_check_party_perception_against_level();
+
+    /**
+     * @offset 0x497FC5
+     */
+    bool checkPartyPerceptionAgainstCurrentMap();
 
     /**
      * @return                          Total number of characters who can act.

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -10,6 +10,7 @@
 #include "Engine/LOD.h"
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
+#include "Engine/MapInfo.h"
 #include "Engine/Time/Timer.h"
 
 #include "Engine/Graphics/ImageLoader.h"
@@ -121,7 +122,7 @@ void LoadGame(int uSlot) {
         logger->error("Unable to find: {}!", header.locationName);
     }
 
-    pCurrentMapName = header.locationName;
+    engine->_transitionMapId = pMapStats->GetMapInfo(header.locationName);
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
 
@@ -150,6 +151,8 @@ SaveGameHeader SaveGame(bool isAutoSave, bool resetWorld, std::string_view path,
     if (engine->_currentLoadedMapId == MAP_ARENA) {
         return {};
     }
+
+    std::string currentMapName = pMapStats->pInfos[engine->_currentLoadedMapId].fileName;
 
     // TODO(captainurist): why do we need to save & restore party position in this function?
     int pPositionX = pParty->pos.x;
@@ -204,7 +207,7 @@ SaveGameHeader SaveGame(bool isAutoSave, bool resetWorld, std::string_view path,
             serialize(*pOutdoor, &uncompressed, tags::via<OutdoorDelta_MM7>);
         }
 
-        std::string file_name = pCurrentMapName;
+        std::string file_name = currentMapName;
         size_t pos = file_name.find_last_of(".");
         file_name[pos + 1] = 'd';
         lodWriter.write(file_name, lod::encodeCompressed(uncompressed));
@@ -214,7 +217,7 @@ SaveGameHeader SaveGame(bool isAutoSave, bool resetWorld, std::string_view path,
 
     SaveGameHeader save_header;
     save_header.name = title;
-    save_header.locationName = pCurrentMapName;
+    save_header.locationName = currentMapName;
     save_header.playingTime = pParty->GetPlayingTime();
     serialize(save_header, &lodWriter, tags::via<SaveGame_MM7>);
 
@@ -324,7 +327,7 @@ void SavegameList::Reset() {
 }
 
 void SaveNewGame() {
-    pCurrentMapName = "out01.odm";
+    engine->_currentLoadedMapId = MAP_EMERALD_ISLAND;
     pParty->lastPos.x = 12552;
     pParty->lastPos.y = 800;
     pParty->lastPos.z = 193;

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -145,9 +145,9 @@ void LoadGame(int uSlot) {
 
 SaveGameHeader SaveGame(bool isAutoSave, bool resetWorld, std::string_view path, std::string_view title) {
     assert(isAutoSave || !title.empty());
-    assert(pCurrentMapName != "d05.blv" || isAutoSave); // No manual saves in Arena.
+    assert(engine->_currentLoadedMapId != MAP_ARENA || isAutoSave); // No manual saves in Arena.
 
-    if (pCurrentMapName == "d05.blv") { // arena
+    if (engine->_currentLoadedMapId == MAP_ARENA) {
         return {};
     }
 
@@ -262,7 +262,7 @@ void AutoSave() {
 }
 
 void DoSavegame(int uSlot) {
-    assert(pCurrentMapName != "d05.blv"); // Not Arena.
+    assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
     pSavegameList->pSavegameHeader[uSlot] = SaveGame(false, false, makeDataPath("saves", fmt::format("save{:03}.mm7", uSlot)),
                                                      pSavegameList->pSavegameHeader[uSlot].name);
@@ -345,7 +345,7 @@ void SaveNewGame() {
 }
 
 void QuickSaveGame() {
-    assert(pCurrentMapName != "d05.blv"); // Not Arena.
+    assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
     pSavegameList->Initialize();
 
     engine->config->gameplay.QuickSavesCount.cycleIncrement();

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -314,7 +314,7 @@ void CastSpellInfoHelpers::castSpell() {
                 pAudioPlayer->playSpellSound(pCastSpell->uSpellID, false, SOUND_MODE_EXCLUSIVE);
             }
         } else if (pCastSpell->uSpellID == SPELL_WATER_LLOYDS_BEACON) {
-            if (pCurrentMapName == "d05.blv") {  // Arena
+            if (engine->_currentLoadedMapId == MAP_ARENA) {
                 spellFailed(pCastSpell, LSTR_SPELL_FAILED);
             } else {
                 engine->_messageQueue->addMessageCurrentFrame(UIMSG_OnCastLloydsBeacon, pCastSpell->casterCharacterIndex, spell_level);

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2447,7 +2447,6 @@ int day_fogrange_2; // fog end dist
 float fWalkSpeedMultiplier = 1.0f;
 float fBackwardWalkSpeedMultiplier = 1.0f;
 float fTurnSpeedMultiplier = 1.0f;
-std::string pCurrentMapName;
 int dword_6BE364_game_settings_1 = 0;
 
 char bNoNPCHiring = false;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2444,7 +2444,6 @@ int uDefaultTravelTime_ByFoot;
 MapWeatherFlags day_attrib;
 int day_fogrange_1; // fog start dist
 int day_fogrange_2; // fog end dist
-MapId dword_6BE13C_uCurrentlyLoadedLocationID;
 float fWalkSpeedMultiplier = 1.0f;
 float fBackwardWalkSpeedMultiplier = 1.0f;
 float fTurnSpeedMultiplier = 1.0f;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2448,7 +2448,6 @@ float fWalkSpeedMultiplier = 1.0f;
 float fBackwardWalkSpeedMultiplier = 1.0f;
 float fTurnSpeedMultiplier = 1.0f;
 std::string pCurrentMapName;
-MapId uLevelMapStatsID;
 int dword_6BE364_game_settings_1 = 0;
 
 char bNoNPCHiring = false;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -105,7 +105,6 @@ extern float fWalkSpeedMultiplier;
 extern float fBackwardWalkSpeedMultiplier;
 extern float fTurnSpeedMultiplier;
 extern std::string pCurrentMapName; // TODO(captainurist): replace with MAP_TYPE & drop!
-extern MapId uLevelMapStatsID;
 
 // TODO(captainurist): #enum
 #define GAME_SETTINGS_SKIP_WORLD_UPDATE 0x0001  // Skip updating world next frame due to changing levels etc.

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -105,7 +105,6 @@ extern float fWalkSpeedMultiplier;
 extern float fBackwardWalkSpeedMultiplier;
 extern float fTurnSpeedMultiplier;
 extern std::string pCurrentMapName; // TODO(captainurist): replace with MAP_TYPE & drop!
-extern MapId dword_6BE13C_uCurrentlyLoadedLocationID;
 extern MapId uLevelMapStatsID;
 
 // TODO(captainurist): #enum

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -104,7 +104,6 @@ extern int day_fogrange_2;
 extern float fWalkSpeedMultiplier;
 extern float fBackwardWalkSpeedMultiplier;
 extern float fTurnSpeedMultiplier;
-extern std::string pCurrentMapName; // TODO(captainurist): replace with MAP_TYPE & drop!
 
 // TODO(captainurist): #enum
 #define GAME_SETTINGS_SKIP_WORLD_UPDATE 0x0001  // Skip updating world next frame due to changing levels etc.

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -883,8 +883,8 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, NPCData *np
                 result += v1;
                 break;
             case 23:
-                if (pMapStats->GetMapInfo(pCurrentMapName) != MAP_INVALID)
-                    result += pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].name;
+                if (engine->_currentLoadedMapId != MAP_INVALID)
+                    result += pMapStats->pInfos[engine->_currentLoadedMapId].name;
                 else
                     result += localization->GetString(LSTR_UNKNOWN);
                 break;

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -6,6 +6,7 @@
 #include "Engine/Party.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/MapInfo.h"
+#include "Engine/Engine.h"
 #include "Engine/mm7_data.h"
 
 #include "Engine/Graphics/Renderer/Renderer.h"
@@ -108,12 +109,9 @@ void GUIWindow_CalendarBook::Update() {
     str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_MOON), localization->GetMoonPhaseName(pDayMoonPhase[time.day - 1]));
     calendar_window.DrawText(assets->pFontBookCalendar.get(), {70, 8 * assets->pFontBookCalendar->GetHeight() + 31}, ui_book_calendar_moon_color, str);
 
-    MapId pMapID = pMapStats->GetMapInfo(pCurrentMapName);
-    std::string pMapName;
-    if (pMapID != MAP_INVALID) {
-        pMapName = pMapStats->pInfos[pMapID].name;
-    } else {
-        pMapName = "Unknown";
+    std::string pMapName = "Unknown";
+    if (engine->_currentLoadedMapId != MAP_INVALID) {
+        pMapName = pMapStats->pInfos[engine->_currentLoadedMapId].name;
     }
 
     str = fmt::format("{}\t100:\t110{}", localization->GetString(LSTR_LOCATION), pMapName);

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -200,7 +200,7 @@ void GUIWindow_LloydsBook::installOrRecallBeacon(int beaconId) {
             // TODO(Nik-RE-dev): need separate function for teleportation to other maps
             AutoSave();
             onMapLeave();
-            pCurrentMapName = pMapStats->pInfos[character.vBeacons[beaconId].mapId].fileName;
+            engine->_transitionMapId = character.vBeacons[beaconId].mapId;
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
             uGameState = GAME_STATE_CHANGE_LOCATION;
             engine->_teleportPoint.setTeleportTarget(character.vBeacons[beaconId]._partyPos, character.vBeacons[beaconId]._partyViewYaw, character.vBeacons[beaconId]._partyViewPitch, 0);

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -196,7 +196,7 @@ void GUIWindow_LloydsBook::installOrRecallBeacon(int beaconId) {
     }
     pAudioPlayer->playSpellSound(SPELL_WATER_LLOYDS_BEACON, false, SOUND_MODE_UI);
     if (_recallingBeacon) {
-        if (ascii::toLower(pCurrentMapName) != ascii::toLower(pMapStats->pInfos[character.vBeacons[beaconId].mapId].fileName)) {
+        if (engine->_currentLoadedMapId != character.vBeacons[beaconId].mapId) {
             // TODO(Nik-RE-dev): need separate function for teleportation to other maps
             AutoSave();
             onMapLeave();

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -157,10 +157,9 @@ void GUIWindow_LloydsBook::hintBeaconSlot(int beaconId) {
             engine->_statusBar->setPermanent(LSTR_FMT_RECALL_TO_S, mapName);
         }
     } else {
-        MapId mapId = pMapStats->GetMapInfo(pCurrentMapName);
         std::string mapName = "Not in Map Stats";
-        if (mapId != MAP_INVALID) {
-            mapName = pMapStats->pInfos[mapId].name;
+        if (engine->_currentLoadedMapId != MAP_INVALID) {
+            mapName = pMapStats->pInfos[engine->_currentLoadedMapId].name;
         }
 
         if (beacon.uBeaconTime) {

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -14,6 +14,7 @@
 #include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/MapInfo.h"
+#include "Engine/Engine.h"
 
 #include "GUI/GUIButton.h"
 #include "GUI/UI/UIGame.h"
@@ -131,9 +132,8 @@ void GUIWindow_MapBook::Update() {
     map_window.uFrameZ = game_viewport_z;
     map_window.uFrameW = game_viewport_w;
 
-    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
-    if (map_id != MAP_INVALID) {
-        map_window.DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapStats->pInfos[map_id].name, 3);
+    if (engine->_currentLoadedMapId != MAP_INVALID) {
+        map_window.DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapStats->pInfos[engine->_currentLoadedMapId].name, 3);
     }
 
     auto party_coordinates = localization->FormatString(LSTR_FMT_X_D_Y_D, static_cast<int>(pParty->pos.x), static_cast<int>(pParty->pos.y));

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -128,7 +128,7 @@ void GUIWindow_TownPortalBook::clickTown(int townId) {
         onMapLeave();
         dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
         uGameState = GAME_STATE_CHANGE_LOCATION;
-        pCurrentMapName = pMapStats->pInfos[townPortalList[townId].mapInfoID].fileName;
+        engine->_transitionMapId = townPortalList[townId].mapInfoID;
         engine->_teleportPoint.setTeleportTarget(townPortalList[townId].pos, townPortalList[townId].viewYaw, townPortalList[townId].viewPitch, 0);
         Actor::InitializeActors();
     }

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -119,7 +119,7 @@ void GUIWindow_TownPortalBook::clickTown(int townId) {
     AutoSave();
     // if in current map
     // TODO(Nik-RE-dev): need separate function for teleportation to other maps
-    if (pMapStats->GetMapInfo(pCurrentMapName) == townPortalList[townId].mapInfoID) {
+    if (engine->_currentLoadedMapId == townPortalList[townId].mapInfoID) {
         pParty->pos = townPortalList[townId].pos;
         pParty->uFallStartZ = pParty->pos.z;
         pParty->_viewYaw = townPortalList[townId].viewYaw;

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -1101,8 +1101,8 @@ void GUIWindow_Shop::houseScreenClick() {
             int stealResult = 0;
             int stealDifficulty = 0;
             int fine;
-            if (pMapStats->GetMapInfo(pCurrentMapName) != MAP_INVALID) {
-                stealDifficulty = pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].baseStealingFine;
+            if (engine->_currentLoadedMapId != MAP_INVALID) {
+                stealDifficulty = pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine;
             }
             int partyReputation = pParty->GetPartyReputation();
             if (isStealingModeActive()) {

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -159,7 +159,7 @@ void GUIWindow_Transport::transportDialogue() {
     if (pTravel->pSchedule[pParty->uCurrentDayOfMonth % 7]) {
         if (engine->_currentLoadedMapId != pTravel->uMapInfoID) {
             AutoSave();
-            pCurrentMapName = pMapStats->pInfos[pTravel->uMapInfoID].fileName;
+            engine->_transitionMapId = pTravel->uMapInfoID;
 
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
             uGameState = GAME_STATE_CHANGE_LOCATION;

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -157,7 +157,7 @@ void GUIWindow_Transport::transportDialogue() {
     const TransportInfo *pTravel = &transportSchedule[transportRoutes[houseId()][choice_id]];
 
     if (pTravel->pSchedule[pParty->uCurrentDayOfMonth % 7]) {
-        if (pCurrentMapName != pMapStats->pInfos[pTravel->uMapInfoID].fileName) {
+        if (engine->_currentLoadedMapId != pTravel->uMapInfoID) {
             AutoSave();
             pCurrentMapName = pMapStats->pInfos[pTravel->uMapInfoID].fileName;
 

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -695,7 +695,6 @@ void GameUI_OnPlayerPortraitLeftClick(int uPlayerID) {
 std::string GameUI_GetMinimapHintText() {
     double v3;            // st7@1
     int v7;               // eax@4
-    MapId pMapID;  // eax@14
     int global_coord_X;   // [sp+10h] [bp-1Ch]@1
     int global_coord_Y;   // [sp+14h] [bp-18h]@1
     int pY;      // [sp+1Ch] [bp-10h]@1
@@ -710,11 +709,10 @@ std::string GameUI_GetMinimapHintText() {
         (int64_t)((double)pParty->pos.y - (double)(pY - 74) * v3);
     if (uCurrentlyLoadedLevelType != LEVEL_OUTDOOR ||
         pOutdoor->pBModels.empty()) {
-        pMapID = pMapStats->GetMapInfo(pCurrentMapName);
-        if (pMapID == MAP_INVALID)
+        if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = pMapStats->pInfos[pMapID].name;
+            result = pMapStats->pInfos[engine->_currentLoadedMapId].name;
     } else {
         for (BSPModel &model : pOutdoor->pBModels) {
             v7 = int_get_vector_length(
@@ -730,14 +728,14 @@ std::string GameUI_GetMinimapHintText() {
                         }
                     }
                 }
-                if (!result.empty()) return result;
+                if (!result.empty())
+                    return result;
             }
         }
-        pMapID = pMapStats->GetMapInfo(pCurrentMapName);
-        if (pMapID == MAP_INVALID)
+        if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = pMapStats->pInfos[pMapID].name;
+            result = pMapStats->pInfos[engine->_currentLoadedMapId].name;
         return result;
     }
     return result;

--- a/src/GUI/UI/UIRest.cpp
+++ b/src/GUI/UI/UIRest.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Objects/NPC.h"
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
+#include "Engine/Engine.h"
 #include "Engine/Time/Timer.h"
 
 #include "GUI/GUIButton.h"
@@ -65,7 +66,7 @@ static void calculateRequiredFood() {
     if (foodRequiredToRest < 1) {
         foodRequiredToRest = 1;
     }
-    if (pCurrentMapName == "d29.blv" && pParty->_questBits[QBIT_HARMONDALE_REBUILT]) {
+    if (engine->_currentLoadedMapId == MAP_CASTLE_HARMONDALE && pParty->_questBits[QBIT_HARMONDALE_REBUILT]) {
         foodRequiredToRest = 0;
     }
 }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -92,18 +92,18 @@ GUIWindow_Transition::GUIWindow_Transition(HouseId transitionHouse, unsigned exi
         if (!IndoorLocation::GetLocationIndex(locationName))
             pMediaPlayer->OpenHouseMovie(pAnimatedRooms[buildingTable[transitionHouse].uAnimationID].video_name, 1);
 
-        std::string v15 = std::string(locationName);
+        std::string destMap = std::string(locationName);
         if (locationName[0] == '0') {
-            v15 = pCurrentMapName;
+            destMap = pMapStats->pInfos[engine->_currentLoadedMapId].fileName;
         }
-        if (pMapStats->GetMapInfo(v15) != MAP_INVALID) {
-            transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].name);
+        if (pMapStats->GetMapInfo(destMap) != MAP_INVALID) {
+            transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(destMap)].name);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
                 pParty->activeCharacter().playReaction(SPEECH_LEAVE_DUNGEON);
             if (IndoorLocation::GetLocationIndex(locationName))
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(locationName);
         } else {
-            transition_button_label = localization->FormatString(LSTR_FMT_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(v15)].name);
+            transition_button_label = localization->GetString(LSTR_DIALOGUE_EXIT);
             if (transitionHouse != HOUSE_INVALID && pAnimatedRooms[buildingTable[transitionHouse].uAnimationID].uRoomSoundId)
                 playHouseSound(transitionHouse, HOUSE_SOUND_GENERAL_GREETING);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -81,7 +81,6 @@ GUIWindow_Transition::GUIWindow_Transition(HouseId transitionHouse, unsigned exi
     pEventTimer->setPaused(true);
     current_screen_type = SCREEN_CHANGE_LOCATION;
 
-    mapid = pMapStats->GetMapInfo(pCurrentMapName);
     _mapName = locationName;
 
     game_ui_dialogue_background = assets->getImage_Solid(dialogueBackgroundResourceByAlignment[pParty->alignment]);
@@ -113,8 +112,8 @@ GUIWindow_Transition::GUIWindow_Transition(HouseId transitionHouse, unsigned exi
                 uCurrentHouse_Animation = IndoorLocation::GetLocationIndex(locationName);
         }
     } else if (!IndoorLocation::GetLocationIndex(locationName)) { // transfer to outdoors - no special message
-        if (pMapStats->GetMapInfo(pCurrentMapName) != MAP_INVALID) {
-            transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].name);
+        if (engine->_currentLoadedMapId != MAP_INVALID) {
+            transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);
             if (transitionHouse != HOUSE_INVALID && pAnimatedRooms[buildingTable[transitionHouse].uAnimationID].uRoomSoundId)
                 playHouseSound(transitionHouse, HOUSE_SOUND_GENERAL_GREETING);
             if (uCurrentlyLoadedLevelType == LEVEL_INDOOR && pParty->hasActiveCharacter() && pParty->GetRedOrYellowAlert())
@@ -149,8 +148,8 @@ GUIWindow_Travel::GUIWindow_Travel() : GUIWindow(WINDOW_ChangeLocation, {0, 0}, 
     game_ui_dialogue_background = assets->getImage_Solid(dialogueBackgroundResourceByAlignment[pParty->alignment]);
 
     transition_ui_icon = assets->getImage_Solid("outside");
-    if (pMapStats->GetMapInfo(pCurrentMapName) != MAP_INVALID) {
-        transition_button_label = localization->FormatString( LSTR_FMT_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].name);
+    if (engine->_currentLoadedMapId != MAP_INVALID) {
+        transition_button_label = localization->FormatString(LSTR_FMT_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);
     } else {
         transition_button_label = localization->GetString(LSTR_DIALOGUE_EXIT);
     }
@@ -192,7 +191,7 @@ void GUIWindow_Travel::Update() {
             str = localization->FormatString(LSTR_FMT_IT_TAKES_D_DAYS_TO_S, getTravelTime(), pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].name);
         }
         str += "\n \n";
-        str += localization->FormatString(LSTR_FMT_DO_YOU_WISH_TO_LEAVE_S, pMapStats->pInfos[pMapStats->GetMapInfo(pCurrentMapName)].name);
+        str += localization->FormatString(LSTR_FMT_DO_YOU_WISH_TO_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);
 
         travel_window.DrawTitleText(assets->pFontCreate.get(), 0, (212 - assets->pFontCreate->CalcTextHeight(str, travel_window.uFrameWidth, 0)) / 2 + 101, colorTable.White, str, 3);
     }
@@ -206,7 +205,7 @@ void GUIWindow_Transition::Update() {
     render->DrawTextureNew(556 / 640.0f, 451 / 480.0f, dialogue_ui_x_x_u);
     render->DrawTextureNew(476 / 640.0f, 451 / 480.0f, dialogue_ui_x_ok_u);
 
-    MapId map_id = mapid;
+    MapId map_id = engine->_currentLoadedMapId;
     // TODO(captainurist): mm7 map names never starts with ' ', what is this check?
     if ((pMovie_Track || IndoorLocation::GetLocationIndex(_mapName)) && !engine->_teleportPoint.getTeleportMap().starts_with(' ')) {
         map_id = pMapStats->GetMapInfo(_mapName);

--- a/src/GUI/UI/UITransition.h
+++ b/src/GUI/UI/UITransition.h
@@ -24,7 +24,6 @@ class GUIWindow_Transition : public GUIWindow {
     virtual void Update() override;
     virtual void Release() override;
 
-    MapId mapid = MAP_INVALID;
     std::string _mapName{};
 };
 

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -464,9 +464,8 @@ void AudioPlayer::UpdateVolumeFromConfig() {
 }
 
 void PlayLevelMusic() {
-    MapId map_id = pMapStats->GetMapInfo(pCurrentMapName);
-    if (map_id != MAP_INVALID) {
-        pAudioPlayer->MusicPlayTrack(pMapStats->pInfos[map_id].musicId);
+    if (engine->_currentLoadedMapId != MAP_INVALID) {
+        pAudioPlayer->MusicPlayTrack(pMapStats->pInfos[engine->_currentLoadedMapId].musicId);
     }
 }
 

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -11,6 +11,7 @@
 #include "Engine/mm7_data.h"
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
+#include "Engine/MapInfo.h"
 
 #include "GUI/UI/UIHouses.h"
 #include "GUI/UI/UIDialogue.h"
@@ -76,7 +77,7 @@ TestTape<int> CommonTapeRecorder::deaths() {
 }
 
 TestTape<std::string> CommonTapeRecorder::map() {
-    return custom([] { return ascii::toLower(pCurrentMapName); });
+    return custom([] { return ascii::toLower(pMapStats->pInfos[engine->_currentLoadedMapId].fileName); });
 }
 
 TestTape<ScreenType> CommonTapeRecorder::screen() {


### PR DESCRIPTION
Refactor code around 3 globals:
- `dword_6BE13C_uCurrentlyLoadedLocationID` which held ID of current location.
- `uLevelMapStatsID` which was a copy of previous ID but used in different places.
- `pCurrentMapName` string name of the file of current map

Remove said globals and create 2 fields in Engine class:
- `_currentLoadedMapId` ID of current loaded location
- `_transitionMapId` ID of location that should be loaded and initialized because of gameplay map transition events, load game, new game or gameover events

While one field could be used for everything I think that separating these 2 is more straightforward.

Replace all functionality to use new fields which allowed to replace direct checking of map filenames and use enum entries instead.

As a result this change fixes 3-rd issue in #1226.