### PR TITLE
Resolve globals: uIconID_TurnHour and uIconID_CharacterFrame

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -954,8 +954,6 @@ void Engine::_461103_load_level_sub() {
 
 //----- (0042F3D6) --------------------------------------------------------
 void InitializeTurnBasedAnimations(void *_this) {
-    uIconID_TurnHour = pIconsFrameTable->FindIcon("turnhour");
-    uIconID_CharacterFrame = pIconsFrameTable->FindIcon("aframe1");
     uSpriteID_Spell11 = pSpriteFrameTable->FastFindSprite("spell11");
 
     turnBasedOverlay.loadIcons();

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2410,8 +2410,6 @@ SpellId dword_507B00_spell_info_to_draw_in_popup;
 int dword_507CC0_activ_ch;
 bool OpenedTelekinesis;
 int enchantingActiveCharacter;
-unsigned int uIconID_TurnHour;
-int uIconID_CharacterFrame;  // idb
 int uSpriteID_Spell11;  // idb
 bool IsEnchantingInProgress;
 Duration ItemEnchantmentTimer;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -73,8 +73,6 @@ extern SpellId dword_507B00_spell_info_to_draw_in_popup;
 extern int dword_507CC0_activ_ch;
 extern bool OpenedTelekinesis;
 extern int enchantingActiveCharacter;
-extern unsigned int uIconID_TurnHour;
-extern int uIconID_CharacterFrame;  // idb
 extern int uSpriteID_Spell11;  // idb
 extern bool IsEnchantingInProgress; // 50C9A0 Indicates that inventory window is opened for enchant-like spell
 extern Duration ItemEnchantmentTimer; // 50C9A8 Timer for enchanting animation for item in inventory

--- a/src/GUI/GUIProgressBar.cpp
+++ b/src/GUI/GUIProgressBar.cpp
@@ -35,6 +35,8 @@ bool GUIProgressBar::Initialize(Type type) {
     assert(type == TYPE_Box || type == TYPE_Fullscreen);
     uType = type;
 
+    turnHourIconId = pIconsFrameTable->FindIcon("turnhour");
+
     if (uType == TYPE_Fullscreen) {
         loading_bg = assets->getImage_PCXFromIconsLOD(fmt::format("loading{}.pcx", vrng->random(5) + 1));
 
@@ -98,7 +100,7 @@ void GUIProgressBar::Draw() {
         pParty->updateCharactersAndHirelingsEmotions();
 
         render->DrawTextureNew(80 / 640.0f, 122 / 480.0f, progressbar_dungeon);
-        render->DrawTextureNew(100 / 640.0f, 146 / 480.0f, pIconsFrameTable->GetFrame(uIconID_TurnHour, 0_ticks)->GetTexture());
+        render->DrawTextureNew(100 / 640.0f, 146 / 480.0f, pIconsFrameTable->GetFrame(turnHourIconId, 0_ticks)->GetTexture());
         render->FillRectFast(174, 164, floorf(((double)(113 * uProgressCurrent) / (double)uProgressMax) + 0.5f), 16, colorTable.Red);
     } else {
         if (loading_bg) {

--- a/src/GUI/GUIProgressBar.h
+++ b/src/GUI/GUIProgressBar.h
@@ -34,6 +34,7 @@ class GUIProgressBar {
     GraphicsImage *progressbar_dungeon = nullptr;  // struct Texture_MM7 pBardata;
     GraphicsImage *progressbar_loading = nullptr;  // struct Texture_MM7 pLoadingProgress;
     GraphicsImage *loading_bg = nullptr;
+    int turnHourIconId = 0;
 };
 
 extern GUIProgressBar *pGameLoadingUI_ProgressBar;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -41,6 +41,8 @@ GraphicsImage *ui_partycreation_plus = nullptr;
 GraphicsImage *ui_partycreation_buttmake2 = nullptr;
 GraphicsImage *ui_partycreation_buttmake = nullptr;
 
+GraphicsImage *ui_partycreation_character_frame = nullptr;
+
 std::array<GraphicsImage *, 9> ui_partycreation_class_icons;
 std::array<GraphicsImage *, 22> ui_partycreation_portraits;
 
@@ -329,8 +331,7 @@ void GUIWindow_PartyCreation::Update() {
     render->DrawTextureNew(494 / oldDims.w, 35 / oldDims.h, ui_partycreation_portraits[pParty->pCharacters[3].uCurrentFace]);
 
     // arrows
-    pFrame = pIconsFrameTable->GetFrame(uIconID_CharacterFrame, pEventTimer->time());
-    render->DrawTextureNew(pX / oldDims.w, 29 / oldDims.h, pFrame->GetTexture());
+    render->DrawTextureNew(pX / oldDims.w, 29 / oldDims.h, ui_partycreation_character_frame);
     uPosActiveItem = pGUIWindow_CurrentMenu->GetControl(pGUIWindow_CurrentMenu->pCurrentPosActiveItem);
     // cycle arrows backwards
     int arrowAnimTextureNum = ui_partycreation_arrow_l.size() - 1 - (pMiscTimer->time().realtimeMilliseconds() % ARROW_SPIN_PERIOD_MS) / (ARROW_SPIN_PERIOD_MS / ui_partycreation_arrow_l.size());
@@ -606,6 +607,8 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
 
     ui_partycreation_top = assets->getImage_Alpha("MAKETOP");
     ui_partycreation_sky_scroller = assets->getImage_Solid("MAKESKY");
+
+    ui_partycreation_character_frame = assets->getImage_Solid("aframe1");
 
     for (int uX = 0; uX < 22; ++uX) {
         ui_partycreation_portraits[uX] = assets->getImage_ColorKey(fmt::format("{}01", pPlayerPortraitsNames[uX]));


### PR DESCRIPTION
- Move `uIconID_CharacterFrame` into party creation menu and change it's usage for one texture only. Character frame there is not dynamic.
- Move `uIconID_TurnHour` to progress bar UI class. Same icon for turn based mode is being initialized elsewhere.