### PR TITLE
Map id/name cleanup

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -358,7 +358,6 @@ void Game::processQueuedMessages() {
     UIMessageType uMessage;  // [sp+2Ch] [bp-5D0h]@7
     int uMessageParam2;            // [sp+30h] [bp-5CCh]@7
     MapId travelMapId;
-    std::string pOut;
     std::array<MagicSchool, 9> spellbookPages = {};                  // [sp+158h] [bp-4A4h]@652
     int currHour;
     bool playButtonSoundOnEscape = true;
@@ -820,7 +819,6 @@ void Game::processQueuedMessages() {
 
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 // encounter_index = (NPCData *)getTravelTime();
-                // TODO(Nik-RE-dev): pOut should be an enum
                 travelMapId = pOutdoor->getTravelDestination(pParty->pos.x, pParty->pos.y);
                 if (!engine->IsUnderwater() && pParty->bFlying || travelMapId == MAP_INVALID) {
                     PlayButtonClickSound();
@@ -858,8 +856,7 @@ void Game::processQueuedMessages() {
                     }
                     pSpriteFrameTable->ResetLoadedFlags();
                     engine->_currentLoadedMapId = travelMapId;
-                    pOut = pMapStats->pInfos[travelMapId].fileName;
-                    Level_LoadEvtAndStr(pOut.substr(0, pOut.rfind('.')));
+                    loadMapEventsAndStrings(travelMapId);
                     _decalBuilder->Reset(0);
 
                     engine->SetUnderwater(isMapUnderwater(engine->_currentLoadedMapId));
@@ -869,7 +866,7 @@ void Game::processQueuedMessages() {
                     //if (engine->_currentLoadedMapId == MAP_SHOALS || engine->_currentLoadedMapId == MAP_LINCOLN)
                     //    bNoNPCHiring = 1;
 
-                    PrepareToLoadODM(pOut, 1u, (ODMRenderParams *)1);
+                    loadAndPrepareODM(travelMapId, 1u, (ODMRenderParams *)1);
                     bDialogueUI_InitializeActor_NPC_ID = 0;
                     onMapLoad();
                     pOutdoor->SetFog();

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -357,7 +357,8 @@ void Game::processQueuedMessages() {
     int uNumSeconds;     // [sp+24h] [bp-5D8h]@18
     UIMessageType uMessage;  // [sp+2Ch] [bp-5D0h]@7
     int uMessageParam2;            // [sp+30h] [bp-5CCh]@7
-    std::string pOut;                // [sp+BCh] [bp-540h]@370
+    MapId travelMapId;
+    std::string pOut;
     std::array<MagicSchool, 9> spellbookPages = {};                  // [sp+158h] [bp-4A4h]@652
     int currHour;
     bool playButtonSoundOnEscape = true;
@@ -820,8 +821,8 @@ void Game::processQueuedMessages() {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 // encounter_index = (NPCData *)getTravelTime();
                 // TODO(Nik-RE-dev): pOut should be an enum
-                if (!engine->IsUnderwater() && pParty->bFlying ||
-                    pOutdoor->GetTravelDestination(pParty->pos.x, pParty->pos.y, &pOut) != 1) {
+                travelMapId = pOutdoor->getTravelDestination(pParty->pos.x, pParty->pos.y);
+                if (!engine->IsUnderwater() && pParty->bFlying || travelMapId == MAP_INVALID) {
                     PlayButtonClickSound();
                     if (pParty->pos.x < -22528)
                         pParty->pos.x = -22528;
@@ -856,7 +857,8 @@ void Game::processQueuedMessages() {
                         ++pParty->days_played_without_rest;
                     }
                     pSpriteFrameTable->ResetLoadedFlags();
-                    engine->_currentLoadedMapId = pMapStats->GetMapInfo(pOut);
+                    engine->_currentLoadedMapId = travelMapId;
+                    pOut = pMapStats->pInfos[travelMapId].fileName;
                     Level_LoadEvtAndStr(pOut.substr(0, pOut.rfind('.')));
                     _decalBuilder->Reset(0);
 

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -280,7 +280,8 @@ void Game_StartDialogue(int actor_id) {
 void Game_StartHirelingDialogue(int hireling_id) {
     assert(hireling_id == 0 || hireling_id == 1);
 
-    if (bNoNPCHiring || current_screen_type != SCREEN_GAME) return;
+    if (isHirelingsBlockedOnMap(engine->_currentLoadedMapId) || current_screen_type != SCREEN_GAME)
+        return;
 
     engine->_messageQueue->clear();
 
@@ -859,14 +860,12 @@ void Game::processQueuedMessages() {
                     Level_LoadEvtAndStr(pOut.substr(0, pOut.rfind('.')));
                     _decalBuilder->Reset(0);
 
-                    bNoNPCHiring = 0;
-
-                    engine->SetUnderwater(engine->_currentLoadedMapId == MAP_SHOALS);
+                    engine->SetUnderwater(isMapUnderwater(engine->_currentLoadedMapId));
 
                     // Previously was checking maps 'out15.odm' and 'd47.blv', but d47 is not present in MM7.
                     // Logically here must check Shoals and Lincoln.
-                    if (engine->_currentLoadedMapId == MAP_SHOALS || engine->_currentLoadedMapId == MAP_LINCOLN)
-                        bNoNPCHiring = 1;
+                    //if (engine->_currentLoadedMapId == MAP_SHOALS || engine->_currentLoadedMapId == MAP_LINCOLN)
+                    //    bNoNPCHiring = 1;
 
                     PrepareToLoadODM(pOut, 1u, (ODMRenderParams *)1);
                     bDialogueUI_InitializeActor_NPC_ID = 0;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -538,7 +538,6 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
     pEventTimer->setPaused(true);
     pMiscTimer->setPaused(true);
     CastSpellInfoHelpers::cancelSpellCastInProgress();
-    engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
     DoPrepareWorld(false, (_0_box_loading_1_fullscreen == 0) + 1);
     pMiscTimer->setPaused(false);
     pEventTimer->setPaused(false);
@@ -546,20 +545,10 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
 
 //----- (00464866) --------------------------------------------------------
 void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
-    // char *v3;         // eax@1
-
-    // v9 = bLoading;
     engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
-    pGameLoadingUI_ProgressBar->Initialize(_1_fullscreen_loading_2_box == 1
-                                               ? GUIProgressBar::TYPE_Fullscreen
-                                               : GUIProgressBar::TYPE_Box);
-    std::string mapToLoad = pMapStats->pInfos[engine->_transitionMapId].fileName;
-    size_t pos = mapToLoad.rfind('.');
-    std::string mapName = mapToLoad.substr(0, pos);
-    std::string mapExt = mapToLoad.substr(pos + 1);  // This magically works even when pos == std::string::npos, in this case
-                                                      // maxExt == mapToLoad.
+    pGameLoadingUI_ProgressBar->Initialize(_1_fullscreen_loading_2_box == 1 ? GUIProgressBar::TYPE_Fullscreen : GUIProgressBar::TYPE_Box);
 
-    Level_LoadEvtAndStr(mapName);
+    loadMapEventsAndStrings(engine->_transitionMapId);
 
     // TODO(captainurist): need to zero this one out when loading a save, but is this a proper place to do that?
     attackList.clear();
@@ -567,10 +556,13 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     engine->SetUnderwater(isMapUnderwater(engine->_transitionMapId));
 
     pParty->floor_face_id = 0; // TODO(captainurist): drop?
-    if (ascii::noCaseEquals(mapExt, "blv"))
-        PrepareToLoadBLV(mapToLoad, bLoading);
+
+    engine->_currentLoadedMapId = engine->_transitionMapId;
+
+    if (isMapIndoor(engine->_transitionMapId))
+        loadAndPrepareBLV(engine->_transitionMapId, bLoading);
     else
-        PrepareToLoadODM(mapToLoad, bLoading, 0);
+        loadAndPrepareODM(engine->_transitionMapId, bLoading, 0);
 
     pNPCStats->setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
@@ -1483,10 +1475,13 @@ void initLevelStrings(const Blob &blob) {
     }
 }
 
-void Level_LoadEvtAndStr(std::string_view pLevelName) {
-    initLevelStrings(engine->_gameResourceManager->getEventsFile(fmt::format("{}.str", pLevelName)));
+void loadMapEventsAndStrings(MapId mapid) {
+    std::string mapName = pMapStats->pInfos[mapid].fileName;
+    std::string mapNameWithoutExt = mapName.substr(0, mapName.rfind('.'));
 
-    engine->_localEventMap = EventMap::load(engine->_gameResourceManager->getEventsFile(fmt::format("{}.evt", pLevelName)));
+    initLevelStrings(engine->_gameResourceManager->getEventsFile(fmt::format("{}.str", mapNameWithoutExt)));
+
+    engine->_localEventMap = EventMap::load(engine->_gameResourceManager->getEventsFile(fmt::format("{}.evt", mapNameWithoutExt)));
 }
 
 bool _44100D_should_alter_right_panel() {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -564,7 +564,7 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     // TODO(captainurist): need to zero this one out when loading a save, but is this a proper place to do that?
     attackList.clear();
 
-    engine->SetUnderwater(engine->_transitionMapId == MAP_SHOALS);
+    engine->SetUnderwater(isMapUnderwater(engine->_transitionMapId));
 
     pParty->floor_face_id = 0; // TODO(captainurist): drop?
     if (ascii::noCaseEquals(mapExt, "blv"))

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -198,7 +198,7 @@ Duration timeUntilDawn();
  * @offset 0x443E31
  */
 void initLevelStrings(const Blob &blob);
-void Level_LoadEvtAndStr(std::string_view pLevelName);
+void loadMapEventsAndStrings(MapId mapid);
 bool _44100D_should_alter_right_panel();
 void Transition_StopSound_Autosave(std::string_view pMapName, MapStartPoint point);  // sub_44987B idb
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -872,26 +872,23 @@ void UpdateActors_BLV() {
     }
 }
 
-//----- (00460A78) --------------------------------------------------------
-void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
+void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     unsigned int respawn_interval;  // ebx@1
     MapInfo *map_info;              // edi@9
     bool v28;                       // zf@81
     bool alertStatus;                        // [sp+404h] [bp-10h]@1
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
-
-    MapId map_id = pMapStats->GetMapInfo(filename);
+    std::string mapFilename;
 
     respawn_interval = 0;
     pGameLoadingUI_ProgressBar->Reset(0x20u);
     uCurrentlyLoadedLevelType = LEVEL_INDOOR;
     pBLVRenderParams->uPartySectorID = 0;
     pBLVRenderParams->uPartyEyeSectorID = 0;
-    engine->_currentLoadedMapId = map_id;
 
-    engine->SetUnderwater(isMapUnderwater(map_id));
+    engine->SetUnderwater(isMapUnderwater(mapid));
 
-    //if ((map_id == MAP_SHOALS) || (map_id == MAP_LINCOLN)) {
+    //if ((mapid == MAP_SHOALS) || (mapid == MAP_LINCOLN)) {
     //    bNoNPCHiring = true;
     //}
     //pPaletteManager->pPalette_tintColor[0] = 0;
@@ -899,22 +896,28 @@ void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
     //pPaletteManager->pPalette_tintColor[2] = 0;
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
-    if (map_id != MAP_INVALID) {
-        map_info = &pMapStats->pInfos[map_id];
-        respawn_interval = pMapStats->pInfos[map_id].respawnIntervalDays;
+
+    if (mapid != MAP_INVALID) {
+        mapFilename = pMapStats->pInfos[mapid].fileName;
+        map_info = &pMapStats->pInfos[mapid];
+        respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
         alertStatus = GetAlertStatus();
+
+        assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"));
     } else {
+        // TODO(Nik-RE-dev): why there's logic for loading maps that are not listed in info?
+        mapFilename = "";
         map_info = nullptr;
     }
 
     pStationaryLightsStack->uNumLightsActive = 0;
-    pIndoor->Load(filename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);
+    pIndoor->Load(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);
     if (!(dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)) {
         Actor::InitializeActors();
         SpriteObject::InitializeSpriteObjects();
     }
     dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN;
-    if (map_id == MAP_INVALID)
+    if (mapid == MAP_INVALID)
         indoor_was_respawned = false;
 
     if (indoor_was_respawned) {
@@ -1010,7 +1013,7 @@ void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
 
     for (unsigned i = 0; i < pActors.size(); ++i) {
         if (pActors[i].attributes & ACTOR_UNKNOW7) {
-            if (map_id == MAP_INVALID) {
+            if (mapid == MAP_INVALID) {
                 pActors[i].monsterInfo.field_3E = 19;
                 pActors[i].attributes |= ACTOR_UNKNOW11;
                 continue;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -888,9 +888,6 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
 
     engine->SetUnderwater(isMapUnderwater(mapid));
 
-    //if ((mapid == MAP_SHOALS) || (mapid == MAP_LINCOLN)) {
-    //    bNoNPCHiring = true;
-    //}
     //pPaletteManager->pPalette_tintColor[0] = 0;
     //pPaletteManager->pPalette_tintColor[1] = 0;
     //pPaletteManager->pPalette_tintColor[2] = 0;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -884,17 +884,16 @@ void PrepareToLoadBLV(std::string_view filename, bool bLoading) {
 
     respawn_interval = 0;
     pGameLoadingUI_ProgressBar->Reset(0x20u);
-    bNoNPCHiring = false;
     uCurrentlyLoadedLevelType = LEVEL_INDOOR;
     pBLVRenderParams->uPartySectorID = 0;
     pBLVRenderParams->uPartyEyeSectorID = 0;
     engine->_currentLoadedMapId = map_id;
 
-    engine->SetUnderwater(map_id == MAP_SHOALS);
+    engine->SetUnderwater(isMapUnderwater(map_id));
 
-    if ((map_id == MAP_SHOALS) || (map_id == MAP_LINCOLN)) {
-        bNoNPCHiring = true;
-    }
+    //if ((map_id == MAP_SHOALS) || (map_id == MAP_LINCOLN)) {
+    //    bNoNPCHiring = true;
+    //}
     //pPaletteManager->pPalette_tintColor[0] = 0;
     //pPaletteManager->pPalette_tintColor[1] = 0;
     //pPaletteManager->pPalette_tintColor[2] = 0;

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -304,7 +304,11 @@ void BLV_ProcessPartyActions();
 void switchDoorAnimation(unsigned int uDoorID, DoorAction a2);
 int CalcDistPointToLine(int a1, int a2, int a3, int a4, int a5, int a6);
 void PrepareDrawLists_BLV();
-void PrepareToLoadBLV(std::string_view filename, bool bLoading);
+
+/**
+ * @offset 0x460A78
+ */
+void loadAndPrepareBLV(MapId mapid, bool bLoading);
 int SpawnEncounterMonsters(MapInfo *a1, int a2);
 int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f pos, uint16_t facing);
 void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2);

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -63,6 +63,63 @@ ODMRenderParams *pODMRenderParams = nullptr;
 SkyBillboardStruct SkyBillboard;  // skybox planes
 std::array<struct Polygon, 2000 + 18000> array_77EC08;
 
+static constexpr IndexedArray<std::array<MapId, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> footTravelDestinations = {
+    // from                      north                south                east                 west
+    {MAP_EMERALD_ISLAND,        {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_HARMONDALE,            {MAP_TULAREAN_FOREST, MAP_BARROW_DOWNS,    MAP_TULAREAN_FOREST, MAP_ERATHIA}},
+    {MAP_ERATHIA,               {MAP_DEYJA,           MAP_BRACADA_DESERT,  MAP_HARMONDALE,      MAP_TATALIA}},
+    {MAP_TULAREAN_FOREST,       {MAP_AVLEE,           MAP_HARMONDALE,      MAP_INVALID,         MAP_DEYJA}},
+    {MAP_DEYJA,                 {MAP_TULAREAN_FOREST, MAP_ERATHIA,         MAP_TULAREAN_FOREST, MAP_ERATHIA}},
+    {MAP_BRACADA_DESERT,        {MAP_ERATHIA,         MAP_INVALID,         MAP_BARROW_DOWNS,    MAP_INVALID}},
+    {MAP_CELESTE,               {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_PIT,                   {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_EVENMORN_ISLAND,       {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_MOUNT_NIGHON,          {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_BARROW_DOWNS,          {MAP_HARMONDALE,      MAP_BRACADA_DESERT,  MAP_HARMONDALE,      MAP_BRACADA_DESERT}},
+    {MAP_LAND_OF_THE_GIANTS,    {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
+    {MAP_TATALIA,               {MAP_INVALID,         MAP_INVALID,         MAP_ERATHIA,         MAP_INVALID}},
+    {MAP_AVLEE,                 {MAP_INVALID,         MAP_TULAREAN_FOREST, MAP_TULAREAN_FOREST, MAP_INVALID}},
+    {MAP_SHOALS,                {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}}
+};
+
+static constexpr IndexedArray<std::array<int, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> footTravelTimes = {
+    // from                  north south east west
+    {MAP_EMERALD_ISLAND,        {0, 0, 0, 0}},
+    {MAP_HARMONDALE,            {5, 5, 7, 5}},
+    {MAP_ERATHIA,               {5, 5, 5, 5}},
+    {MAP_TULAREAN_FOREST,       {5, 5, 0, 5}},
+    {MAP_DEYJA,                 {7, 5, 5, 4}},
+    {MAP_BRACADA_DESERT,        {5, 0, 5, 0}},
+    {MAP_CELESTE,               {0, 0, 0, 0}},
+    {MAP_PIT,                   {0, 0, 0, 0}},
+    {MAP_EVENMORN_ISLAND,       {0, 0, 0, 0}},
+    {MAP_MOUNT_NIGHON,          {0, 0, 0, 0}},
+    {MAP_BARROW_DOWNS,          {5, 7, 7, 5}},
+    {MAP_LAND_OF_THE_GIANTS,    {0, 0, 0, 0}},
+    {MAP_TATALIA,               {0, 0, 5, 0}},
+    {MAP_AVLEE,                 {0, 7, 5, 0}},
+    {MAP_SHOALS,                {0, 0, 0, 0}},
+};
+
+static constexpr IndexedArray<std::array<MapStartPoint, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> footTravelArrivalPoints = {
+    // from                      north                south                east                 west
+    {MAP_EMERALD_ISLAND,        {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_HARMONDALE,            {MAP_START_POINT_SOUTH, MAP_START_POINT_NORTH, MAP_START_POINT_SOUTH, MAP_START_POINT_EAST}},
+    {MAP_ERATHIA,               {MAP_START_POINT_SOUTH, MAP_START_POINT_NORTH, MAP_START_POINT_WEST,  MAP_START_POINT_EAST}},
+    {MAP_TULAREAN_FOREST,       {MAP_START_POINT_EAST,  MAP_START_POINT_NORTH, MAP_START_POINT_PARTY, MAP_START_POINT_EAST}},
+    {MAP_DEYJA,                 {MAP_START_POINT_WEST,  MAP_START_POINT_NORTH, MAP_START_POINT_WEST,  MAP_START_POINT_NORTH}},
+    {MAP_BRACADA_DESERT,        {MAP_START_POINT_SOUTH, MAP_START_POINT_PARTY, MAP_START_POINT_WEST,  MAP_START_POINT_PARTY}},
+    {MAP_CELESTE,               {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_PIT,                   {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_EVENMORN_ISLAND,       {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_MOUNT_NIGHON,          {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_BARROW_DOWNS,          {MAP_START_POINT_SOUTH, MAP_START_POINT_EAST,  MAP_START_POINT_SOUTH, MAP_START_POINT_EAST}},
+    {MAP_LAND_OF_THE_GIANTS,    {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+    {MAP_TATALIA,               {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_WEST,  MAP_START_POINT_PARTY}},
+    {MAP_AVLEE,                 {MAP_START_POINT_PARTY, MAP_START_POINT_NORTH, MAP_START_POINT_NORTH, MAP_START_POINT_PARTY}},
+    {MAP_SHOALS,                {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
+};
+
 struct FogProbabilityTableEntry {
     unsigned char small_fog_chance;
     unsigned char average_fog_chance;
@@ -259,88 +316,27 @@ bool OutdoorLocation::Initialize(std::string_view filename, int days_played,
     return false;
 }
 
-static constexpr IndexedArray<std::array<MapId, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> foot_travel_destinations = {
-    // from                      north                south                east                 west
-    {MAP_EMERALD_ISLAND,        {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_HARMONDALE,            {MAP_TULAREAN_FOREST, MAP_BARROW_DOWNS,    MAP_TULAREAN_FOREST, MAP_ERATHIA}},
-    {MAP_ERATHIA,               {MAP_DEYJA,           MAP_BRACADA_DESERT,  MAP_HARMONDALE,      MAP_TATALIA}},
-    {MAP_TULAREAN_FOREST,       {MAP_AVLEE,           MAP_HARMONDALE,      MAP_INVALID,         MAP_DEYJA}},
-    {MAP_DEYJA,                 {MAP_TULAREAN_FOREST, MAP_ERATHIA,         MAP_TULAREAN_FOREST, MAP_ERATHIA}},
-    {MAP_BRACADA_DESERT,        {MAP_ERATHIA,         MAP_INVALID,         MAP_BARROW_DOWNS,    MAP_INVALID}},
-    {MAP_CELESTE,               {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_PIT,                   {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_EVENMORN_ISLAND,       {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_MOUNT_NIGHON,          {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_BARROW_DOWNS,          {MAP_HARMONDALE,      MAP_BRACADA_DESERT,  MAP_HARMONDALE,      MAP_BRACADA_DESERT}},
-    {MAP_LAND_OF_THE_GIANTS,    {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}},
-    {MAP_TATALIA,               {MAP_INVALID,         MAP_INVALID,         MAP_ERATHIA,         MAP_INVALID}},
-    {MAP_AVLEE,                 {MAP_INVALID,         MAP_TULAREAN_FOREST, MAP_TULAREAN_FOREST, MAP_INVALID}},
-    {MAP_SHOALS,                {MAP_INVALID,         MAP_INVALID,         MAP_INVALID,         MAP_INVALID}}
-};
+MapId OutdoorLocation::getTravelDestination(int partyX, int partyY) {
+    int direction;
+    MapId currentMap = engine->_currentLoadedMapId;
+    MapId destinationMap;
 
-static constexpr IndexedArray<std::array<int, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> foot_travel_times = {
-    // from                  north south east west
-    {MAP_EMERALD_ISLAND,        {0, 0, 0, 0}},
-    {MAP_HARMONDALE,            {5, 5, 7, 5}},
-    {MAP_ERATHIA,               {5, 5, 5, 5}},
-    {MAP_TULAREAN_FOREST,       {5, 5, 0, 5}},
-    {MAP_DEYJA,                 {7, 5, 5, 4}},
-    {MAP_BRACADA_DESERT,        {5, 0, 5, 0}},
-    {MAP_CELESTE,               {0, 0, 0, 0}},
-    {MAP_PIT,                   {0, 0, 0, 0}},
-    {MAP_EVENMORN_ISLAND,       {0, 0, 0, 0}},
-    {MAP_MOUNT_NIGHON,          {0, 0, 0, 0}},
-    {MAP_BARROW_DOWNS,          {5, 7, 7, 5}},
-    {MAP_LAND_OF_THE_GIANTS,    {0, 0, 0, 0}},
-    {MAP_TATALIA,               {0, 0, 5, 0}},
-    {MAP_AVLEE,                 {0, 7, 5, 0}},
-    {MAP_SHOALS,                {0, 0, 0, 0}},
-};
+    if (!isMapOutdoor(currentMap))
+        return MAP_INVALID;
 
-static constexpr IndexedArray<std::array<MapStartPoint, 4>, MAP_EMERALD_ISLAND, MAP_SHOALS> foot_travel_arrival_points = {
-    // from                      north                south                east                 west
-    {MAP_EMERALD_ISLAND,        {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_HARMONDALE,            {MAP_START_POINT_SOUTH, MAP_START_POINT_NORTH, MAP_START_POINT_SOUTH, MAP_START_POINT_EAST}},
-    {MAP_ERATHIA,               {MAP_START_POINT_SOUTH, MAP_START_POINT_NORTH, MAP_START_POINT_WEST,  MAP_START_POINT_EAST}},
-    {MAP_TULAREAN_FOREST,       {MAP_START_POINT_EAST,  MAP_START_POINT_NORTH, MAP_START_POINT_PARTY, MAP_START_POINT_EAST}},
-    {MAP_DEYJA,                 {MAP_START_POINT_WEST,  MAP_START_POINT_NORTH, MAP_START_POINT_WEST,  MAP_START_POINT_NORTH}},
-    {MAP_BRACADA_DESERT,        {MAP_START_POINT_SOUTH, MAP_START_POINT_PARTY, MAP_START_POINT_WEST,  MAP_START_POINT_PARTY}},
-    {MAP_CELESTE,               {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_PIT,                   {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_EVENMORN_ISLAND,       {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_MOUNT_NIGHON,          {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_BARROW_DOWNS,          {MAP_START_POINT_SOUTH, MAP_START_POINT_EAST,  MAP_START_POINT_SOUTH, MAP_START_POINT_EAST}},
-    {MAP_LAND_OF_THE_GIANTS,    {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-    {MAP_TATALIA,               {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_WEST,  MAP_START_POINT_PARTY}},
-    {MAP_AVLEE,                 {MAP_START_POINT_PARTY, MAP_START_POINT_NORTH, MAP_START_POINT_NORTH, MAP_START_POINT_PARTY}},
-    {MAP_SHOALS,                {MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY, MAP_START_POINT_PARTY}},
-};
-
-//----- (0048902E) --------------------------------------------------------
-bool OutdoorLocation::GetTravelDestination(int sPartyX, int sPartyZ, std::string *pOut) {
-    signed int direction;       // esi@7
-    MapId destinationMap;  // eax@23
-
-    std::string str = this->level_filename;
-    str = str.substr(str.find_first_of("0123456789"));
-    MapId mapNumberAsInt = static_cast<MapId>(atoi(str.c_str()));
-
-    // TODO(captainurist): pit & celeste fall into the range below. Also, the logic here is retarded.
-    if (this->level_filename.length() != 9 || mapNumberAsInt < MAP_EMERALD_ISLAND || mapNumberAsInt > MAP_SHOALS)
-        return false;
-
-    if (sPartyX < -22528)  // граница карты
-        direction = 4;
-    else if (sPartyX > 22528)
-        direction = 3;
-    else if (sPartyZ < -22528)
-        direction = 2;
-    else if (sPartyZ > 22528)
-        direction = 1;
+    // Check which side of the map
+    if (partyX < -22528)
+        direction = 3; // west
+    else if (partyX > 22528)
+        direction = 2; // east
+    else if (partyY < -22528)
+        direction = 1; // south
+    else if (partyY > 22528)
+        direction = 0; // north
     else
-        return false;
+        return MAP_INVALID;
 
-    if (mapNumberAsInt == MAP_AVLEE && direction == 4) {  // to Shoals
+    if (currentMap == MAP_AVLEE && direction == 3) {  // to Shoals
         bool wholePartyUnderwaterSuitEquipped = true;
         for (Character &player : pParty->pCharacters) {
             if (!player.hasUnderwaterSuitEquipped()) {
@@ -351,28 +347,25 @@ bool OutdoorLocation::GetTravelDestination(int sPartyX, int sPartyZ, std::string
 
         if (wholePartyUnderwaterSuitEquipped) {
             uDefaultTravelTime_ByFoot = 1;
-            *pOut = "out15.odm";  // Shoals
             uLevel_StartingPointType = MAP_START_POINT_EAST;
             pParty->uFlags &= ~(PARTY_FLAG_BURNING | PARTY_FLAG_STANDING_ON_WATER | PARTY_FLAG_WATER_DAMAGE);
-            return true;
+            return MAP_SHOALS;
         }
-    } else if (mapNumberAsInt == MAP_SHOALS && direction == 3) {  // from Shoals
+    } else if (currentMap == MAP_SHOALS && direction == 2) {  // from Shoals
         uDefaultTravelTime_ByFoot = 1;
-        *pOut = "out14.odm";  // Avlee
         uLevel_StartingPointType = MAP_START_POINT_WEST;
         pParty->uFlags &= ~(PARTY_FLAG_BURNING | PARTY_FLAG_STANDING_ON_WATER | PARTY_FLAG_WATER_DAMAGE);
-        return true;
+        return MAP_AVLEE;
     }
-    destinationMap = foot_travel_destinations[mapNumberAsInt][direction - 1];
+    destinationMap = footTravelDestinations[currentMap][direction];
     if (destinationMap == MAP_INVALID)
-        return false;
+        return MAP_INVALID;
 
     assert(destinationMap <= MAP_SHOALS);
 
-    uDefaultTravelTime_ByFoot = foot_travel_times[mapNumberAsInt][direction - 1];
-    uLevel_StartingPointType = foot_travel_arrival_points[mapNumberAsInt][direction - 1];
-    *pOut = pMapStats->pInfos[destinationMap].fileName;
-    return true;
+    uDefaultTravelTime_ByFoot = footTravelTimes[currentMap][direction];
+    uLevel_StartingPointType = footTravelArrivalPoints[currentMap][direction];
+    return destinationMap;
 }
 
 //----- (0048917E) --------------------------------------------------------
@@ -1566,15 +1559,13 @@ void ODM_GetTerrainNormalAt(float pos_x, float pos_y, Vec3f *out) {
 }
 //----- (0046BE0A) --------------------------------------------------------
 void ODM_UpdateUserInputAndOther() {
-    bool v0;        // eax@5
-    std::string pOut;  // [sp+8h] [bp-20h]@5
-
     ODM_ProcessPartyActions();
+
     if (pParty->pos.x < -22528 || pParty->pos.x > 22528 ||
         pParty->pos.y < -22528 || pParty->pos.y > 22528) {
-        v0 = pOutdoor->GetTravelDestination(pParty->pos.x, pParty->pos.y, &pOut);
+        MapId mapid = pOutdoor->getTravelDestination(pParty->pos.x, pParty->pos.y);
         if (!engine->IsUnderwater() && (pParty->isAirborne() || (pParty->uFlags & (PARTY_FLAG_STANDING_ON_WATER | PARTY_FLAG_WATER_DAMAGE)) ||
-                             pParty->uFlags & PARTY_FLAG_BURNING || pParty->bFlying) || !v0) {
+                             pParty->uFlags & PARTY_FLAG_BURNING || pParty->bFlying) || mapid == MAP_INVALID) {
             if (pParty->pos.x < -22528) pParty->pos.x = -22528;
             if (pParty->pos.x > 22528) pParty->pos.x = 22528;
             if (pParty->pos.y < -22528) pParty->pos.y = -22528;
@@ -1583,6 +1574,7 @@ void ODM_UpdateUserInputAndOther() {
             pDialogueWindow = new GUIWindow_Travel();  // TravelUI_Load();
         }
     }
+
     UpdateActors_ODM();
 }
 //----- (0041F54A) --------------------------------------------------------

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -250,7 +250,7 @@ bool OutdoorLocation::Initialize(std::string_view filename, int days_played,
         ::day_attrib = this->loc_time.day_attrib;
         ::day_fogrange_1 = this->loc_time.day_fogrange_1;
         ::day_fogrange_2 = this->loc_time.day_fogrange_2;
-        if (engine->_currentLoadedMapId == MAP_SHOALS)
+        if (isMapUnderwater(engine->_currentLoadedMapId))
             SetUnderwaterFog();
 
         return true;
@@ -495,7 +495,7 @@ void OutdoorLocation::SetFog() {
         ::day_attrib &= ~MAP_WEATHER_FOGGY;
     }
 
-    if (map_id == MAP_SHOALS)
+    if (isMapUnderwater(map_id))
         SetUnderwaterFog();
     pOutdoor->loc_time.day_fogrange_1 = ::day_fogrange_1;
     pOutdoor->loc_time.day_fogrange_2 = ::day_fogrange_2;

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -217,8 +217,11 @@ void UpdateActors_ODM();
 void ODM_ProcessPartyActions();
 void SetUnderwaterFog();
 void sub_487DA9();
-void PrepareToLoadODM(std::string_view filename, bool bLoading, ODMRenderParams *a2);
-void ODM_LoadAndInitialize(std::string_view pLevelFilename, ODMRenderParams *thisa);
+
+/**
+ * @offset 0x4610AA
+ */
+void loadAndPrepareODM(MapId mapid, bool bLoading, ODMRenderParams *a2);
 Color GetLevelFogColor();
 int sub_47C3D7_get_fog_specular(int unused, int a2, float a3);
 unsigned int WorldPosToGridCellX(int);

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -113,7 +113,11 @@ struct OutdoorLocation {
                     int respawn_interval_days,
                     bool * outdoors_was_respawned);
     // bool Release2();
-    bool GetTravelDestination(int sPartyX, int sPartyZ, std::string *pOut);
+
+    /**
+     * @offset 0x48902E
+     */
+    MapId getTravelDestination(int partyX, int partyY);
     void MessWithLUN();
     void UpdateSunlightVectors();
     void UpdateFog();

--- a/src/Engine/MapEnumFunctions.h
+++ b/src/Engine/MapEnumFunctions.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "MapEnums.h"
+
+/**
+ * Is map an outdoor map?
+ */
+inline bool isMapOutdoor(MapId mapid) {
+    return mapid >= MAP_EMERALD_ISLAND && mapid <= MAP_SHOALS && mapid != MAP_PIT && mapid != MAP_CELESTE;
+}
+
+/**
+ * Is map an indoor map?
+ */
+inline bool isMapIndoor(MapId mapid) {
+    return (mapid >= MAP_DRAGON_CAVES && mapid <= MAP_ARENA) || mapid == MAP_PIT || mapid == MAP_CELESTE;
+}
+
+/**
+ * Is map an outdoor underwater map (requires wetsuit etc.)?
+ */
+inline bool isMapUnderwater(MapId mapid) {
+    return mapid == MAP_SHOALS;
+}
+
+/**
+ * Is hirelings interactions are forbidden on this map?
+ */
+inline bool isHirelingsBlockedOnMap(MapId mapid) {
+    return (mapid == MAP_SHOALS) || (mapid == MAP_LINCOLN);
+}

--- a/src/Engine/MapEnums.h
+++ b/src/Engine/MapEnums.h
@@ -147,3 +147,11 @@ enum class MapStartPoint : uint32_t {
 };
 using enum MapStartPoint;
 MM_DECLARE_SERIALIZATION_FUNCTIONS(MapStartPoint)
+
+inline bool isMapUnderwater(MapId mapid) {
+    return mapid == MAP_SHOALS;
+}
+
+inline bool isHirelingsBlockedOnMap(MapId mapid) {
+    return (mapid == MAP_SHOALS) || (mapid == MAP_LINCOLN);
+}

--- a/src/Engine/MapEnums.h
+++ b/src/Engine/MapEnums.h
@@ -148,6 +148,14 @@ enum class MapStartPoint : uint32_t {
 using enum MapStartPoint;
 MM_DECLARE_SERIALIZATION_FUNCTIONS(MapStartPoint)
 
+inline bool isMapOutdoor(MapId mapid) {
+    return mapid >= MAP_EMERALD_ISLAND && mapid <= MAP_SHOALS && mapid != MAP_PIT && mapid != MAP_CELESTE;
+}
+
+inline bool isMapIndoor(MapId mapid) {
+    return (mapid >= MAP_DRAGON_CAVES && mapid <= MAP_ARENA) || mapid == MAP_PIT || mapid == MAP_CELESTE;
+}
+
 inline bool isMapUnderwater(MapId mapid) {
     return mapid == MAP_SHOALS;
 }

--- a/src/Engine/MapEnums.h
+++ b/src/Engine/MapEnums.h
@@ -147,19 +147,3 @@ enum class MapStartPoint : uint32_t {
 };
 using enum MapStartPoint;
 MM_DECLARE_SERIALIZATION_FUNCTIONS(MapStartPoint)
-
-inline bool isMapOutdoor(MapId mapid) {
-    return mapid >= MAP_EMERALD_ISLAND && mapid <= MAP_SHOALS && mapid != MAP_PIT && mapid != MAP_CELESTE;
-}
-
-inline bool isMapIndoor(MapId mapid) {
-    return (mapid >= MAP_DRAGON_CAVES && mapid <= MAP_ARENA) || mapid == MAP_PIT || mapid == MAP_CELESTE;
-}
-
-inline bool isMapUnderwater(MapId mapid) {
-    return mapid == MAP_SHOALS;
-}
-
-inline bool isHirelingsBlockedOnMap(MapId mapid) {
-    return (mapid == MAP_SHOALS) || (mapid == MAP_LINCOLN);
-}

--- a/src/Engine/MapInfo.h
+++ b/src/Engine/MapInfo.h
@@ -8,6 +8,7 @@
 
 #include "Utility/IndexedArray.h"
 
+#include "MapEnumFunctions.h"
 #include "MapEnums.h"
 
 class Blob;

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -51,7 +51,8 @@ bool PartyHasDragon() { return pNPCStats->pNPCData[57].Hired(); }
 //----- (00476395) --------------------------------------------------------
 // 0x26 Wizard eye at skill level 2
 bool CheckHiredNPCSpeciality(NpcProfession prof) {
-    if (bNoNPCHiring == 1) return false;
+    if (isHirelingsBlockedOnMap(engine->_currentLoadedMapId))
+        return false;
 
     for (unsigned i = 0; i < pNPCStats->uNumNewNPCs; ++i) {
         if (pNPCStats->pNPCData[i].profession == prof &&

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Localization.h"
 #include "Engine/Objects/Actor.h"
 #include "Engine/Party.h"
+#include "Engine/MapEnumFunctions.h"
 #include "Engine/Spells/CastSpellInfo.h"
 #include "Engine/Tables/NPCTable.h"
 

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -20,6 +20,7 @@
 #include "Engine/Objects/MonsterEnumFunctions.h"
 #include "Engine/OurMath.h"
 #include "Engine/Party.h"
+#include "Engine/MapEnumFunctions.h"
 #include "Engine/SpellFxRenderer.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Tables/IconFrameTable.h"

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2779,7 +2779,7 @@ void CastSpellInfoHelpers::castSpell() {
 
                 case SPELL_DARK_SACRIFICE:
                 {
-                    if (bNoNPCHiring) {
+                    if (isHirelingsBlockedOnMap(engine->_currentLoadedMapId)) {
                         spellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         pPlayer->SpendMana(uRequiredMana); // decrease mana on failure
                         setSpellRecovery(pCastSpell, recoveryTime);

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2447,7 +2447,6 @@ float fBackwardWalkSpeedMultiplier = 1.0f;
 float fTurnSpeedMultiplier = 1.0f;
 int dword_6BE364_game_settings_1 = 0;
 
-char bNoNPCHiring = false;
 std::vector<Vec3f> pTerrainNormals;
 std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -136,8 +136,6 @@ constexpr float flt_debugrecmod3 = 2.133333333333333f;
 
 constexpr float meleeRange = 307.2f;
 
-extern char bNoNPCHiring;
-
 extern std::vector<Vec3f> pTerrainNormals;
 extern std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 extern std::array<unsigned int, 128 * 128 * 2> pTerrainSomeOtherData;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1693,7 +1693,7 @@ void GameUI_DrawTorchlightAndWizardEye() {
 void GameUI_DrawHiredNPCs() {
     signed int uFrameID;            // [sp+24h] [bp-18h]@19
 
-    if (bNoNPCHiring != 1) {
+    if (!isHirelingsBlockedOnMap(engine->_currentLoadedMapId)) {
         FlatHirelings buf;
         buf.Prepare();
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -23,6 +23,7 @@
 #include "Engine/Tables/CharacterFrameTable.h"
 #include "Engine/Spells/Spells.h"
 #include "Engine/Party.h"
+#include "Engine/MapEnumFunctions.h"
 #include "Engine/Time/Timer.h"
 #include "Engine/Conditions.h"
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1712,7 +1712,7 @@ void GameUI_CharacterQuickRecord_Draw(GUIWindow *window, int characterIndex) {
 }
 
 void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
-    if (bNoNPCHiring != 1) {
+    if (!isHirelingsBlockedOnMap(engine->_currentLoadedMapId)) {
         FlatHirelings buf;
         buf.Prepare();
 

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -166,29 +166,28 @@ GUIWindow_Travel::GUIWindow_Travel() : GUIWindow(WINDOW_ChangeLocation, {0, 0}, 
 }
 
 void GUIWindow_Travel::Update() {
-    std::string pDestinationMapName;
+    MapId destinationMap = pOutdoor->getTravelDestination(pParty->pos.x, pParty->pos.y);
 
-    pOutdoor->GetTravelDestination(pParty->pos.x, pParty->pos.y, &pDestinationMapName);
     render->DrawTextureNew(477 / 640.0f, 0, game_ui_dialogue_background);
     render->DrawTextureNew(468 / 640.0f, 0, game_ui_right_panel_frame);
     render->DrawTextureNew(pNPCPortraits_x[0][0] / 640.0f, pNPCPortraits_y[0][0] / 480.0f, transition_ui_icon);
     render->DrawTextureNew(556 / 640.0f, 451 / 480.0f, dialogue_ui_x_x_u);
     render->DrawTextureNew(476 / 640.0f, 451 / 480.0f, dialogue_ui_x_ok_u);
-    if (pMapStats->GetMapInfo(pDestinationMapName) != MAP_INVALID) {
+    if (destinationMap != MAP_INVALID) {
         GUIWindow travel_window = *pPrimaryWindow;
         travel_window.uFrameX = 493;
         travel_window.uFrameWidth = 126;
         travel_window.uFrameZ = 366;
-        travel_window.DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].name, 3);
+        travel_window.DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, pMapStats->pInfos[destinationMap].name, 3);
         travel_window.uFrameX = SIDE_TEXT_BOX_POS_X;
         travel_window.uFrameWidth = SIDE_TEXT_BOX_WIDTH;
         travel_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
         std::string str;
         if (getTravelTime() == 1) {
-            str = localization->FormatString(LSTR_FMT_IT_TAKES_D_DAY_TO_S, 1, pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].name);
+            str = localization->FormatString(LSTR_FMT_IT_TAKES_D_DAY_TO_S, 1, pMapStats->pInfos[destinationMap].name);
         } else {
-            str = localization->FormatString(LSTR_FMT_IT_TAKES_D_DAYS_TO_S, getTravelTime(), pMapStats->pInfos[pMapStats->GetMapInfo(pDestinationMapName)].name);
+            str = localization->FormatString(LSTR_FMT_IT_TAKES_D_DAYS_TO_S, getTravelTime(), pMapStats->pInfos[destinationMap].name);
         }
         str += "\n \n";
         str += localization->FormatString(LSTR_FMT_DO_YOU_WISH_TO_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -43,7 +43,7 @@ GAME_TEST(Issues, Issue159) {
     // Exception when entering Tidewater Caverns
     auto mapTape = tapes.map();
     test.playTraceFromTestData("issue_159.mm7", "issue_159.json");
-    EXPECT_EQ(mapTape, tape("out13.odm", "d17.blv", "out13.odm"));
+    EXPECT_EQ(mapTape, tape(MAP_TATALIA, MAP_TIDEWATER_CAVERNS, MAP_TATALIA));
 }
 
 GAME_TEST(Issues, Issue163) {
@@ -122,7 +122,7 @@ GAME_TEST(Issues, Issue201) {
     auto daysTape = tapes.custom([] { return pParty->GetPlayingTime().toDays(); });
     test.playTraceFromTestData("issue_201.mm7", "issue_201.json");
     EXPECT_GT(healthTape.delta(), 0); // Party should heal.
-    EXPECT_EQ(mapTape, tape("out01.odm", "out02.odm")); // Emerald isle to Harmondale.
+    EXPECT_EQ(mapTape, tape(MAP_EMERALD_ISLAND, MAP_HARMONDALE)); // Emerald isle to Harmondale.
     EXPECT_EQ(daysTape.delta(), 7); // Time should advance by a week.
 }
 
@@ -401,7 +401,7 @@ GAME_TEST(Issues, Issue331_679) {
     auto goldTape = tapes.gold();
     auto mapTape = tapes.map();
     test.playTraceFromTestData("issue_331.mm7", "issue_331.json");
-    EXPECT_EQ(mapTape, tape("out04.odm", "out02.odm", "out04.odm")); // We did travel.
+    EXPECT_EQ(mapTape, tape(MAP_TULAREAN_FOREST, MAP_HARMONDALE, MAP_TULAREAN_FOREST)); // We did travel.
 
     // #679: Loading autosave after travelling by stables / boat results in gold loss.
     EXPECT_EQ(goldTape.delta(), 0);
@@ -472,7 +472,7 @@ GAME_TEST(Issues, Issue403_970) {
     // Entering Lincoln shouldn't crash.
     auto mapTape = tapes.map();
     test.playTraceFromTestData("issue_403.mm7", "issue_403.json");
-    EXPECT_EQ(mapTape, tape("out15.odm", "d23.blv")); // Shoals -> Lincoln.
+    EXPECT_EQ(mapTape, tape(MAP_SHOALS, MAP_LINCOLN)); // Shoals -> Lincoln.
 
     // #970: Armor Class is wrong.
     EXPECT_EQ(pParty->pCharacters[0].GetActualAC(), 10);
@@ -532,7 +532,7 @@ GAME_TEST(Issues, Issue408_939_970_996) {
     // should have saved a winner cert tex
     EXPECT_GT(certTape.size(), 1);
     // we should be teleported to harmondale
-    EXPECT_EQ(mapTape, tape("d30.blv", "out02.odm"));
+    EXPECT_EQ(mapTape, tape(MAP_CASTLE_LAMBENT, MAP_HARMONDALE));
     // ending message box was displayed.
     auto flatMessageBoxes = messageBoxesTape.flattened();
     EXPECT_EQ(flatMessageBoxes.size(), 1);

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -67,7 +67,7 @@ GAME_TEST(Issues, Issue503) {
     EXPECT_EQ(hpTape, tape({1147, 699, 350, 242})); // Game was paused, the party wasn't shot at, no HP change.
     EXPECT_EQ(noDamageTape, tape(false)); // HP change was actually possible.
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_BOOKS, SCREEN_GAME)); // TP book was opened.
-    EXPECT_EQ(mapTape, tape("mdt12.blv", "d29.blv")); // And party was teleported to Harmondale.
+    EXPECT_EQ(mapTape, tape(MAP_DRAGON_CAVES, MAP_CASTLE_HARMONDALE)); // And party was teleported to Harmondale.
 }
 
 GAME_TEST(Issues, Issue504) {
@@ -575,7 +575,7 @@ GAME_TEST(Issues, Issue735c) {
     // Checking location names explicitly so that we'll notice if party misses cave entrance after retracing.
     auto mapTape = tapes.map();
     test.playTraceFromTestData("issue_735c.mm7", "issue_735c.json");
-    EXPECT_EQ(mapTape, tape("out01.odm", "d28.blv")); // Emerald Isle -> Dragon's cave.
+    EXPECT_EQ(mapTape, tape(MAP_EMERALD_ISLAND, MAP_DRAGONS_LAIR)); // Emerald Isle -> Dragon's cave.
 }
 
 GAME_TEST(Issues, Issue735d) {

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -114,7 +114,7 @@ GAME_TEST(Issues, Issue1115) {
     auto dialogueTape = tapes.dialogueType();
     auto levelTape = charTapes.levels();
     test.playTraceFromTestData("issue_1115.mm7", "issue_1115.json");
-    EXPECT_EQ(mapTape, tape("out02.odm", "d05.blv")); // Harmondale -> Arena.
+    EXPECT_EQ(mapTape, tape(MAP_HARMONDALE, MAP_ARENA)); // Harmondale -> Arena.
     EXPECT_TRUE(dialogueTape.contains(DIALOGUE_ARENA_SELECT_LORD));
     EXPECT_EQ(levelTape, tape({21, 21, 21, 21}));
 }
@@ -206,7 +206,7 @@ GAME_TEST(Issues, Issue1197) {
     auto loc = tapes.map();
     auto deaths = tapes.deaths();
     test.playTraceFromTestData("issue_1197.mm7", "issue_1197.json");
-    EXPECT_TRUE(loc.contains("out01.odm")); // make it back to emerald
+    EXPECT_TRUE(loc.contains(MAP_EMERALD_ISLAND)); // make it back to emerald
     EXPECT_EQ(deaths.delta(), 1);
 }
 
@@ -345,7 +345,7 @@ GAME_TEST(Issues, Issue1315) {
     auto stateTape = tapes.custom([] { return std::tuple(pParty->bTurnBasedModeOn, uGameState); });
     test.playTraceFromTestData("issue_1315.mm7", "issue_1315.json");
     EXPECT_EQ(deathsTape.delta(), +1);
-    EXPECT_EQ(mapTape, tape("out12.odm", "out02.odm")); // Land of the Giants -> Harmondale.
+    EXPECT_EQ(mapTape, tape(MAP_LAND_OF_THE_GIANTS, MAP_HARMONDALE)); // Land of the Giants -> Harmondale.
     EXPECT_EQ(stateTape, tape(std::tuple(false, GAME_STATE_PLAYING),
                               std::tuple(true, GAME_STATE_PLAYING),
                               std::tuple(false, GAME_STATE_PARTY_DIED), // Instant switch from turn-based & alive into realtime & dead,
@@ -412,7 +412,7 @@ GAME_TEST(Issues, Issue1340) {
         Blob origHarmondale = pGames_LOD->read("d29.dlv");
         EXPECT_EQ(saveHarmondale.string_view(), origHarmondale.string_view());
     });
-    EXPECT_EQ(mapTape, tape("out01.odm", "d29.blv")); // Emerald Isle -> Castle Harmondale. Map change is important because
+    EXPECT_EQ(mapTape, tape(MAP_EMERALD_ISLAND, MAP_CASTLE_HARMONDALE)); // Emerald Isle -> Castle Harmondale. Map change is important because
                                                       // we want to trigger map respawn on first visit.
     EXPECT_TRUE(screenTape.contains(SCREEN_CHEST));
     EXPECT_GT(goldTape.delta(), 0); // Party should have picked some gold from the chest.
@@ -442,7 +442,7 @@ GAME_TEST(Issues, Issue1342) {
     test.playTraceFromTestData("issue_1342.mm7", "issue_1342.json");
 
     // Emerald Isle -> Dragon Cave. Map change is important here because we need to trigger map respawn on first visit.
-    EXPECT_EQ(mapTape, tape("out01.odm", "d28.blv"));
+    EXPECT_EQ(mapTape, tape(MAP_EMERALD_ISLAND, MAP_DRAGONS_LAIR));
 
     EXPECT_GT(goldTape.delta(), 0); // We picked up some gold.
     EXPECT_EQ(pilesTape.max() - pilesTape.back(), 3); // Minus three small gold piles.
@@ -477,7 +477,7 @@ GAME_TEST(Issues, Issue1364) {
     auto statusTape = tapes.statusBar();
     auto screenTape = tapes.screen();
     test.playTraceFromTestData("issue_1364.mm7", "issue_1364.json");
-    EXPECT_EQ(mapTape, tape("out02.odm", "d05.blv")); // Harmondale -> Arena.
+    EXPECT_EQ(mapTape, tape(MAP_HARMONDALE, MAP_ARENA)); // Harmondale -> Arena.
     EXPECT_TRUE(statusTape.contains("No saving in the Arena")); // Clicking the save button didn't work.
     EXPECT_TRUE(screenTape.contains(SCREEN_HOUSE)); // We have visited the stables.
     EXPECT_TRUE(screenTape.contains(SCREEN_MENU)); // Opened the game menu while in the Arena.

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -11,7 +11,6 @@
 #include "Engine/mm7_data.h"
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
-#include "Engine/MapInfo.h"
 
 #include "GUI/UI/UIHouses.h"
 #include "GUI/UI/UIDialogue.h"
@@ -76,8 +75,8 @@ TestTape<int> CommonTapeRecorder::deaths() {
     return custom([] { return pParty->uNumDeaths; });
 }
 
-TestTape<std::string> CommonTapeRecorder::map() {
-    return custom([] { return ascii::toLower(pMapStats->pInfos[engine->_currentLoadedMapId].fileName); });
+TestTape<MapId> CommonTapeRecorder::map() {
+    return custom([] { return engine->_currentLoadedMapId; });
 }
 
 TestTape<ScreenType> CommonTapeRecorder::screen() {

--- a/test/Testing/Game/CommonTapeRecorder.h
+++ b/test/Testing/Game/CommonTapeRecorder.h
@@ -8,6 +8,7 @@
 #include "Engine/Objects/ItemEnums.h"
 #include "Engine/Objects/SpriteEnums.h"
 #include "Engine/Time/Time.h"
+#include "Engine/MapEnums.h"
 #include "Media/Audio/SoundEnums.h"
 #include "GUI/GUIEnums.h"
 #include "GUI/GUIDialogues.h"
@@ -56,7 +57,7 @@ class CommonTapeRecorder {
 
     TestTape<int> deaths();
 
-    TestTape<std::string> map();
+    TestTape<MapId> map();
 
     TestTape<ScreenType> screen();
 


### PR DESCRIPTION
Minimize usage of string map name - use MapId instead.
- Refactor `getTravelDestination` function and get rid of string map name there.
- Use MapId in interface of function `loadMapEventsAndStrings`. 
- Change propagation of string map name to MapId in ODM/BLV map loading functions.
- Set current map name before calling these functions in more common place.

Also: get rid of `bNoNPCHiring` global - just check MapId for maps where hirelings are blocked.