### PR TITLE
Slightly refactor transition UI

### DIFF
--- a/src/Engine/Events/EventInterpreter.cpp
+++ b/src/Engine/Events/EventInterpreter.cpp
@@ -190,9 +190,9 @@ int EventInterpreter::executeOneEvent(int step, bool isNpc) {
         case EVENT_MoveToMap:
         {
             if (ir.data.move_map_descr.house_id != HOUSE_INVALID || ir.data.move_map_descr.exit_pic_id) {
-                pDialogueWindow = new GUIWindow_Transition(ir.data.move_map_descr.house_id, ir.data.move_map_descr.exit_pic_id,
-                                                           Vec3f(ir.data.move_map_descr.x, ir.data.move_map_descr.y, ir.data.move_map_descr.z),
-                                                           ir.data.move_map_descr.yaw, ir.data.move_map_descr.pitch, ir.data.move_map_descr.zspeed, ir.str);
+                pDialogueWindow = new GUIWindow_IndoorEntryExit(ir.data.move_map_descr.house_id, ir.data.move_map_descr.exit_pic_id,
+                                                                Vec3f(ir.data.move_map_descr.x, ir.data.move_map_descr.y, ir.data.move_map_descr.z),
+                                                                ir.data.move_map_descr.yaw, ir.data.move_map_descr.pitch, ir.data.move_map_descr.zspeed, ir.str);
                 savedEventID = _eventId;
                 savedEventStep = step + 1;
                 return -1;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -136,15 +136,6 @@ static constexpr IndexedArray<SoundId, MAP_FIRST, MAP_LAST> pDoorSoundIDsByLocat
     {MAP_ARENA,                     SOUND_wood_door0101}
 };
 
-// all locations which should have special tranfer message
-// dragon caves, markham, bandit cave, haunted mansion
-// barrow 7, barrow 9, barrow 10, setag tower
-// wromthrax cave, toberti, hidden tomb
-std::array<const char *, 11> _4E6BDC_loc_names = {
-    "mdt12.blv", "d18.blv",   "mdt14.blv", "d37.blv",
-    "mdk01.blv", "mdt01.blv", "mdr01.blv", "mdt10.blv",
-    "mdt09.blv", "mdt15.blv", "mdt11.blv"};
-
 //----- (0043F39E) --------------------------------------------------------
 void PrepareDrawLists_BLV() {
     // unsigned int v7;  // ebx@8
@@ -281,15 +272,6 @@ void IndoorLocation::Release() {
     render->ReleaseBSP();
 
     this->bLoaded = 0;
-}
-
-//----- (00444810) --------------------------------------------------------
-// index of special transfer message, 0 otherwise
-unsigned int IndoorLocation::GetLocationIndex(std::string_view locationName) {
-    for (unsigned i = 0; i < _4E6BDC_loc_names.size(); ++i)
-        if (ascii::noCaseEquals(locationName, _4E6BDC_loc_names[i]))
-            return i + 1;
-    return 0;
 }
 
 void IndoorLocation::toggleLight(signed int sLightID, unsigned int bToggle) {

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -219,7 +219,6 @@ struct IndoorLocation {
      */
     void toggleLight(signed int uLightID, unsigned int bToggle);
 
-    static unsigned int GetLocationIndex(std::string_view locationName);
     void DrawIndoorFaces(bool bD3D);
     void PrepareActorRenderList_BLV();
     void PrepareDecorationsRenderList_BLV(unsigned int uDecorationID, int uSectorID);

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -34,7 +34,7 @@ class GUIButton {
     GUIWindow *pParent = nullptr;
     std::vector<GraphicsImage*> vTextures;
     Io::InputAction action = Io::InputAction::Invalid;
-    std::string sLabel = "";
+    std::string sLabel = ""; // TODO(Nik-RE-dev): rename properly. In most cases it is a hover hint for status bar.
     std::string field_75 = "";
 };
 

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -294,7 +294,7 @@ enum WindowType {
     WINDOW_QuickReference = 12,
     WINDOW_F = 15,
     WINDOW_Rest = 16,
-    WINDOW_ChangeLocation = 17,
+    WINDOW_Travel = 17,
     WINDOW_SpellBook = 18,
     WINDOW_GreetingNPC = 19,
     WINDOW_Chest = 20,
@@ -302,7 +302,7 @@ enum WindowType {
     WINDOW_SaveLoadButtons = 23,
     WINDOW_MainMenu_Load = 0x18,
     WINDOW_HouseInterior = 0x19,
-    WINDOW_Transition = 26,
+    WINDOW_IndoorEntryExit = 26,
     WINDOW_CastSpell = 27,  // OnCastTargetedSpell
     WINDOW_Scroll = 0x1E,
     WINDOW_CastSpell_InInventory = 31,

--- a/src/GUI/GUIEnums.h
+++ b/src/GUI/GUIEnums.h
@@ -69,7 +69,7 @@ enum UIMessageType : uint32_t {
     UIMSG_ClickInstallRemoveQuickSpellBtn = 88,
 
     UIMSG_OnTravelByFoot = 90,
-    UIMSG_CHANGE_LOCATION_ClickCancelBtn = 91,
+    UIMSG_CancelTravelByFoot = 91,
     UIMSG_ShowStatus_DateTime = 92,
     UIMSG_ShowStatus_ManaHP = 93,
     UIMSG_ShowStatus_Player = 94,
@@ -191,8 +191,8 @@ enum UIMessageType : uint32_t {
 
     UIMSG_RentRoom = 409,
     UIMSG_ClickHouseNPCPortrait = 410,
-    UIMSG_TransitionUI_Confirm = 411,
-    UIMSG_TransitionWindowCloseBtn = 412,
+    UIMSG_OnIndoorEntryExit = 411,
+    UIMSG_CancelIndoorEntryExit = 412,
 
     UIMSG_OpenKeyMappingOptions = 415,
     UIMSG_SelectKeyPage1 = 416,

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -526,13 +526,13 @@ void updateHouseNPCTopics(int npc) {
     currentHouseNpc = npc;
     if (houseNpcs[npc].type == HOUSE_TRANSITION) {
         pDialogueWindow->Release();
+        // TODO(Nik-RE-dev): can use GUIWindow_Transition
         pDialogueWindow = new GUIWindow(WINDOW_Dialogue, {0, 0}, render->GetRenderDimensions());
-        transition_button_label = houseNpcs[npc].label;
         pBtn_ExitCancel = pDialogueWindow->CreateButton({566, 445}, {75, 33}, 1, 0, UIMSG_Escape, 0, Io::InputAction::No, localization->GetString(LSTR_CANCEL), {ui_buttdesc2});
-        pBtn_YES = pDialogueWindow->CreateButton({486, 445}, {75, 33}, 1, 0, UIMSG_HouseTransitionConfirmation, 1, Io::InputAction::Yes, transition_button_label, {ui_buttyes2});
+        pBtn_YES = pDialogueWindow->CreateButton({486, 445}, {75, 33}, 1, 0, UIMSG_HouseTransitionConfirmation, 1, Io::InputAction::Yes, houseNpcs[npc].label, {ui_buttyes2});
         pDialogueWindow->CreateButton({pNPCPortraits_x[0][0], pNPCPortraits_y[0][0]}, {63, 73}, 1, 0, UIMSG_HouseTransitionConfirmation, 1,
-                                      Io::InputAction::EventTrigger, transition_button_label);
-        pDialogueWindow->CreateButton({8, 8}, {460, 344}, 1, 0, UIMSG_HouseTransitionConfirmation, 1, Io::InputAction::Yes, transition_button_label);
+                                      Io::InputAction::EventTrigger, houseNpcs[npc].label);
+        pDialogueWindow->CreateButton({8, 8}, {460, 344}, 1, 0, UIMSG_HouseTransitionConfirmation, 1, Io::InputAction::Yes, houseNpcs[npc].label);
     } else {
         if (window_SpeakInHouse->getCurrentDialogue() != DIALOGUE_OTHER) {
             for (int i = 0; i < houseNpcs.size(); ++i) {

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -102,7 +102,7 @@ GUIWindow_Travel::GUIWindow_Travel() : GUIWindow_Transition(WINDOW_Travel, SCREE
         hint = localization->GetString(LSTR_DIALOGUE_EXIT);
     }
 
-    createButtons(hint, localization->GetString(LSTR_STAY_IN_THIS_AREA), UIMSG_OnTravelByFoot, UIMSG_CHANGE_LOCATION_ClickCancelBtn);
+    createButtons(hint, localization->GetString(LSTR_STAY_IN_THIS_AREA), UIMSG_OnTravelByFoot, UIMSG_CancelTravelByFoot);
 }
 
 void GUIWindow_Travel::Update() {
@@ -183,7 +183,7 @@ GUIWindow_IndoorEntryExit::GUIWindow_IndoorEntryExit(HouseId transitionHouse, un
             pParty->activeCharacter().playReaction(SPEECH_LEAVE_DUNGEON);
     }
 
-    createButtons(hint, localization->GetString(LSTR_CANCEL), UIMSG_TransitionUI_Confirm, UIMSG_TransitionWindowCloseBtn);
+    createButtons(hint, localization->GetString(LSTR_CANCEL), UIMSG_OnIndoorEntryExit, UIMSG_CancelIndoorEntryExit);
 }
 
 void GUIWindow_IndoorEntryExit::Update() {

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -37,6 +37,7 @@ GraphicsImage *transition_ui_icon = nullptr;
  * dragon caves, markham, bandit cave, haunted mansion,
  * barrow 7, barrow 9, barrow 10, setag tower,
  * wromthrax cave, toberti, hidden tomb
+ * TODO(Nik-RE-dev): Use location enums here.
  */
 std::array<std::string, 11> specialTransferMessageLocationNames = {
     "mdt12.blv", "d18.blv",   "mdt14.blv", "d37.blv",
@@ -63,13 +64,13 @@ GUIWindow_Transition::GUIWindow_Transition(WindowType windowType, ScreenType scr
     current_screen_type = screenType;
 }
 
-void GUIWindow_Transition::createButtons(const std::string &hint, const std::string &cancelLabel, UIMessageType confirmMsg, UIMessageType cancelMsg) {
-    this->sHint = hint;
+void GUIWindow_Transition::createButtons(const std::string &okHint, const std::string &cancelHint, UIMessageType confirmMsg, UIMessageType cancelMsg) {
+    this->sHint = okHint;
 
-    pBtn_ExitCancel = CreateButton({556, 445}, {75, 33}, 1, 0, cancelMsg, 0, Io::InputAction::No, cancelLabel, {ui_buttdesc2});
-    pBtn_YES = CreateButton({476, 445}, {75, 33}, 1, 0, confirmMsg, 0, Io::InputAction::Yes, hint, {ui_buttyes2});
-    CreateButton({pNPCPortraits_x[0][0], pNPCPortraits_y[0][0]}, {63, 73}, 1, 0, confirmMsg, 1, Io::InputAction::EventTrigger, hint);
-    CreateButton({8, 8}, {460, 344}, 1, 0, confirmMsg, 1, Io::InputAction::Invalid, hint);
+    pBtn_ExitCancel = CreateButton({556, 445}, {75, 33}, 1, 0, cancelMsg, 0, Io::InputAction::No, cancelHint, {ui_buttdesc2});
+    pBtn_YES = CreateButton({476, 445}, {75, 33}, 1, 0, confirmMsg, 0, Io::InputAction::Yes, okHint, {ui_buttyes2});
+    CreateButton({pNPCPortraits_x[0][0], pNPCPortraits_y[0][0]}, {63, 73}, 1, 0, confirmMsg, 1, Io::InputAction::EventTrigger, okHint);
+    CreateButton({8, 8}, {460, 344}, 1, 0, confirmMsg, 1, Io::InputAction::Invalid, okHint);
 }
 
 void GUIWindow_Transition::Release() {

--- a/src/GUI/UI/UITransition.h
+++ b/src/GUI/UI/UITransition.h
@@ -7,24 +7,31 @@
 #include "GUI/GUIWindow.h"
 #include "GUI/UI/UIHouseEnums.h"
 
-class GUIWindow_Travel : public GUIWindow {
+class GUIWindow_Transition : public GUIWindow {
+ public:
+    GUIWindow_Transition(WindowType windowType, ScreenType screenType);
+    virtual ~GUIWindow_Transition() {}
+
+    virtual void Release() override;
+
+ protected:
+    void createButtons(const std::string &hint, const std::string &cancelLabel, UIMessageType confirmMsg, UIMessageType cancelMsg);
+};
+
+class GUIWindow_Travel : public GUIWindow_Transition {
  public:
     GUIWindow_Travel();
     virtual ~GUIWindow_Travel() {}
 
     virtual void Update() override;
-    virtual void Release() override;
 };
 
-class GUIWindow_Transition : public GUIWindow {
+class GUIWindow_IndoorEntryExit : public GUIWindow_Transition {
  public:
-    GUIWindow_Transition(HouseId transitionHouse, uint32_t exit_pic_id, Vec3f pos, int yaw, int pitch, int zspeed, std::string_view locationName);
-    virtual ~GUIWindow_Transition() {}
+    GUIWindow_IndoorEntryExit(HouseId transitionHouse, uint32_t exit_pic_id, Vec3f pos, int yaw, int pitch, int zspeed, std::string_view locationName);
+    virtual ~GUIWindow_IndoorEntryExit() {}
 
     virtual void Update() override;
-    virtual void Release() override;
 
     std::string _mapName{};
 };
-
-extern std::string transition_button_label;

--- a/src/GUI/UI/UITransition.h
+++ b/src/GUI/UI/UITransition.h
@@ -33,5 +33,6 @@ class GUIWindow_IndoorEntryExit : public GUIWindow_Transition {
 
     virtual void Update() override;
 
-    std::string _mapName{};
+    std::string _mapName = "";
+    int _transitionStringId = 0;
 };

--- a/src/GUI/UI/UITransition.h
+++ b/src/GUI/UI/UITransition.h
@@ -15,7 +15,7 @@ class GUIWindow_Transition : public GUIWindow {
     virtual void Release() override;
 
  protected:
-    void createButtons(const std::string &hint, const std::string &cancelLabel, UIMessageType confirmMsg, UIMessageType cancelMsg);
+    void createButtons(const std::string &okHint, const std::string &cancelHint, UIMessageType confirmMsg, UIMessageType cancelMsg);
 };
 
 class GUIWindow_Travel : public GUIWindow_Transition {


### PR DESCRIPTION
Create base class for transition GUI windows: "travel by foot" (ODM<->ODM transfers) and "dungeon entry/exit" (ODM<->BLV transfers).
Do some renames around these classes, do slight cleanup of the code and detach it from several globals.
Remove manual processing of foot travel procedure - instead of loading new map in processing code just do it the same way all other map transfer are done.