### PR TITLE
Add test for #1226

### DIFF
--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG dd421940f43fade4c3bc2a6f2be28f008d918005
+            GIT_TAG fdd5108dcd2bf6ba2a4d7130e36006b8bb8a7ac4
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG bd542b7e6b8df5b8e51b0a4f303c6a72b4c2cc5b
+            GIT_TAG dd421940f43fade4c3bc2a6f2be28f008d918005
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -187,9 +187,8 @@ GAME_TEST(Issues, Issue1191) {
     EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_DARK).level(), 0);
     EXPECT_EQ(pParty->pCharacters[2].getActualSkillValue(CHARACTER_SKILL_LIGHT).level(), 0);
 
-    // TODO(captainurist): Uncomment when food issues (1226) resolved
-    // EXPECT_EQ(foodTape.delta(), -3);
-    // EXPECT_EQ(pParty->GetFood(), 7);
+    EXPECT_EQ(foodTape.delta(), -3);
+    EXPECT_EQ(pParty->GetFood(), 7);
 }
 
 GAME_TEST(Issues, Issue1196) {
@@ -211,6 +210,16 @@ GAME_TEST(Issues, Issue1197) {
 }
 
 // 1200
+
+GAME_TEST(Issues, Issue1226) {
+    // Check that food consumed while resting on different tiles is correct
+    // Also check that baby dragon consumes only one additional food
+    auto loc = tapes.map();
+    auto foodTape = tapes.food();
+    test.playTraceFromTestData("issue_1226.mm7", "issue_1226.json");
+    EXPECT_EQ(loc, tape(MAP_LAND_OF_THE_GIANTS, MAP_CASTLE_HARMONDALE, MAP_HARMONDALE, MAP_CASTLE_HARMONDALE));
+    EXPECT_EQ(foodTape, tape(30, 25, 21, 17, 14, 11));
+}
 
 GAME_TEST(Issues, Issue1251a) {
     // Part A - test that wand damage matches vanilla damage should be in range (d6 per skill) 8-48 for novice 8 fireball wand


### PR DESCRIPTION
Test for #1226
Probes rest food on several tiles types and in castle harmondale.
Also checks that only one more food consumed for baby dragon.