### PR TITLE
Fix #1666

### DIFF
--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1953,8 +1953,6 @@ void ODM_ProcessPartyActions() {
         pParty->uFallStartZ = partyNewPos.z;
     } else if (partyNewPos.z < currentGroundLevel) {
         partyNewPos.z = currentGroundLevel;
-        if (partyIsOnWater && !fuzzyIsNull(partyInputSpeed.z))
-            SpriteObject::createSplashObject(partyNewPos);
         partyInputSpeed.z = 0;
         pParty->uFallStartZ = currentGroundLevel;
         partyOldFlightZ = partyNewPos.z;
@@ -2121,6 +2119,13 @@ void ODM_ProcessPartyActions() {
         pParty->pos.y == partyNewPos.y && pParty->pos.z == partyNewPos.z) {
         if (((pParty->pos.z <= newGroundLevel || partyHasHitModel) && savedZ < 0)) {
             pParty->velocity.z = 0;
+
+            if (partyIsOnWater && savedZ < -400.0f) {
+                // SpriteObject::createSplashObject(partyNewPos);
+                // Party can never see its own splashes so just play the sound - only one splash at a time for party
+                pAudioPlayer->playSound(SOUND_splash, SOUND_MODE_EXCLUSIVE, Pid::character(0));
+            }
+
             if (!partyHasHitModel)
                 pParty->pos.z = newGroundLevel;
             if (pParty->uFallStartZ - partyNewPos.z > 512 && !partyHasFeatherFall &&

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2120,7 +2120,8 @@ void ODM_ProcessPartyActions() {
         if (((pParty->pos.z <= newGroundLevel || partyHasHitModel) && savedZ < 0)) {
             pParty->velocity.z = 0;
 
-            if (partyIsOnWater && savedZ < -400.0f) {
+            if (partyIsOnWater && savedZ < -400.0f) { // Require that we have a bit of impact into water surface to cause a splash
+                // -400 chosen so that it is just under z impact speed from standing jump
                 // SpriteObject::createSplashObject(partyNewPos);
                 // Party can never see its own splashes so just play the sound - only one splash at a time for party
                 pAudioPlayer->playSound(SOUND_splash, SOUND_MODE_EXCLUSIVE, Pid::character(0));

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -2005,13 +2005,13 @@ void ODM_ProcessPartyActions() {
     // has the party collided with a outdoor model
     bool partyHasHitModel{ false };
 
-    float savedZ = partyInputSpeed.z;
+    float savedZSpeed = partyInputSpeed.z;
     // horizontal
     partyInputSpeed.z = 0;
     ProcessPartyCollisionsODM(&partyNewPos, &partyInputSpeed, &partyIsOnWater, &floorFaceId, &partyNotOnModel, &partyHasHitModel, &triggerID);
     // vertical - only when horizonal motion hasnt caused height gain
     if (partyNewPos.z <= pParty->pos.z) {
-        partyInputSpeed = Vec3f(0, 0, savedZ);
+        partyInputSpeed = Vec3f(0, 0, savedZSpeed);
         ProcessPartyCollisionsODM(&partyNewPos, &partyInputSpeed, &partyIsOnWater, &floorFaceId, &partyNotOnModel, &partyHasHitModel, &triggerID);
     }
 
@@ -2117,10 +2117,10 @@ void ODM_ProcessPartyActions() {
     if (!triggerID ||
         (eventProcessor(triggerID, Pid(), 1), pParty->pos.x == partyNewPos.x) &&
         pParty->pos.y == partyNewPos.y && pParty->pos.z == partyNewPos.z) {
-        if (((pParty->pos.z <= newGroundLevel || partyHasHitModel) && savedZ < 0)) {
+        if (((pParty->pos.z <= newGroundLevel || partyHasHitModel) && savedZSpeed < 0)) {
             pParty->velocity.z = 0;
 
-            if (partyIsOnWater && savedZ < -400.0f) { // Require that we have a bit of impact into water surface to cause a splash
+            if (partyIsOnWater && savedZSpeed < -400.0f) { // Require that we have a bit of impact into water surface to cause a splash
                 // -400 chosen so that it is just under z impact speed from standing jump
                 // SpriteObject::createSplashObject(partyNewPos);
                 // Party can never see its own splashes so just play the sound - only one splash at a time for party

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 7a1dd1b9ee61e6b99f8297589688ad8007183257
+            GIT_TAG 2500f9dff02947dab8a7e74bfc6734edff110cc8
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 2500f9dff02947dab8a7e74bfc6734edff110cc8
+            GIT_TAG 7a1dd1b9ee61e6b99f8297589688ad8007183257
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -186,6 +186,16 @@ GAME_TEST(Issues, Issue1665) {
     EXPECT_GT(zpos.back(), -1550); // And made it back out
 }
 
+GAME_TEST(Issues, Issue1666) {
+    // Sound 220 'splash' getting spammed
+    auto mapTape = tapes.map();
+    auto soundsTape = tapes.sounds();
+    test.playTraceFromTestData("issue_1666.mm7", "issue_1666.json");
+    EXPECT_EQ(mapTape.size(), 2);
+    int count = soundsTape.flattened().filtered([](const auto& sound) { return sound == SOUND_splash; }).size();
+    EXPECT_EQ(count, 1); // jump splash at start
+}
+
 GAME_TEST(Issues, Issue1671) {
     // Falling from height outdoors onto models doesnt cause damage
     auto health = tapes.totalHp();


### PR DESCRIPTION
Moves where the splash is triggered in collisions.
Dont bother creating the sprite - the party can never see it.
Make the splash sound exclusive.

Testing may be annoying - will need to trace and playback at high fps to capture all the sound calls. Thoughts?