### PR TITLE
Set lich jar holder player index correctly during save/load

### DIFF
--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -457,7 +457,7 @@ void snapshot(const ItemGen &src, ItemGen_MM7 *dst) {
     dst->attributes = std::to_underlying(src.uAttributes);
     dst->bodyAnchor = std::to_underlying(src.uBodyAnchor);
     dst->maxCharges = src.uMaxCharges;
-    dst->holderPlayer = src.uHolderPlayer;
+    dst->holderPlayer = src.uHolderPlayer + 1;
     dst->placedInChest = src.placedInChest;
     snapshot(src.uExpireTime, &dst->expireTime);
 }
@@ -486,7 +486,7 @@ void reconstruct(const ItemGen_MM7 &src, ItemGen *dst) {
     dst->uAttributes = ItemFlags(src.attributes);
     dst->uBodyAnchor = static_cast<ItemSlot>(src.bodyAnchor);
     dst->uMaxCharges = src.maxCharges;
-    dst->uHolderPlayer = src.holderPlayer;
+    dst->uHolderPlayer = src.holderPlayer - 1;
     dst->placedInChest = src.placedInChest;
     reconstruct(src.expireTime, &dst->uExpireTime);
 }

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -238,7 +238,7 @@ struct ItemGen_MM7 {
     /* 14 */ uint32_t attributes;
     /* 18 */ uint8_t bodyAnchor;
     /* 19 */ uint8_t maxCharges;
-    /* 1A */ uint8_t holderPlayer;
+    /* 1A */ uint8_t holderPlayer; // Only for full lich jars. 1-based index of the character whose essence it stored in it.
     /* 1B */ uint8_t placedInChest; // unknown unused 8-bit field, was repurposed
     /* 1C */ int64_t expireTime;
 };

--- a/test/Bin/GameTest/CMakeLists.txt
+++ b/test/Bin/GameTest/CMakeLists.txt
@@ -21,7 +21,7 @@ if(OE_BUILD_TESTS)
     ExternalProject_Add(OpenEnroth_TestData
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
             GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-            GIT_TAG 2500f9dff02947dab8a7e74bfc6734edff110cc8
+            GIT_TAG 24eface3f58d9fcf47c78e9adf66ec7995fcebc7
             SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""


### PR DESCRIPTION
This fixes https://github.com/OpenEnroth/OpenEnroth/issues/1658.

The issue was caused by the fact that `ItemGen.uHolderPlayer` is 0-based but `ItemGen_MM7.holderPlayer` is 1-based. To fix it, I introduced an offset in `snapshot` for saving and `reconstruct` for loading.

Unfortunately, any save files with a lich character made prior to this fix are already invalid, but any save file made after the fix should be valid and compatible with Vanilla.

I tested the following scenarios:
- Took a save file made in OE before the fix and loaded it in OE after the fix. The lich jar is bound to character `i-1` instead of `i`, which is consistent with the Vanilla behaviour for the same save file.
- Made a save file with OE after the fix and loaded it in Vanilla MM7. The lich jar is bound to the correct player.
- Made a save file with OE after the fix and loaded it in OE after the fix. The lich jar is bound to the correct player.