### PR TITLE
Fix character name possessive in lich jar item name

### DIFF
--- a/src/Engine/Objects/Items.cpp
+++ b/src/Engine/Objects/Items.cpp
@@ -192,9 +192,9 @@ std::string ItemGen::GetIdentifiedName() {
         if (uHolderPlayer >= 0 && uHolderPlayer < pParty->pCharacters.size()) {
             const std::string &player_name = pParty->pCharacters[uHolderPlayer].name;
             if (player_name.back() == 's')
-                return localization->FormatString(LSTR_FMT_JAR, player_name);
-            else
                 return localization->FormatString(LSTR_FMT_JAR_2, player_name);
+            else
+                return localization->FormatString(LSTR_FMT_JAR, player_name);
         }
     }
 


### PR DESCRIPTION
This fixes https://github.com/OpenEnroth/OpenEnroth/issues/1685.

The code was already checking whether the character name ended in "s", but it was picking the wrong localization string, so I just inverted the logic.

Testing done:
- Reloaded a save file where the lich was "Alexis". The lich jar item name was "Alexis' jar" as expected.
- Made a new game where I promoted a character "Kathleen" to a lich with the debug tools. The lich jar item name was "Kathleen's jar" as expected.