### PR TITLE
Fix #1704

### DIFF
--- a/src/Engine/Graphics/BspRenderer.cpp
+++ b/src/Engine/Graphics/BspRenderer.cpp
@@ -84,19 +84,20 @@ void BspRenderer::AddFaceToRenderList_d3d(int node_id, int uFaceID) {
         nodes[num_nodes].uSectorID = pTransitionSector;
         nodes[num_nodes].uFaceID = uFaceID;
 
-        // avoid circular loops in portals
-        for (int test = 0; test < num_nodes; test++) {
-            if (nodes[test].uSectorID == nodes[num_nodes].uSectorID &&
-                nodes[test].uFaceID == nodes[num_nodes].uFaceID) {
-                return;
-            }
-        }
-
         // calculates the portal bounding and frustum
         bool bFrustumbuilt = engine->pStru10Instance->CalcPortalShapePoly(
                 pFace, static_subAddFaceToRenderList_d3d_stru_F79E08,
                 &pNewNumVertices, nodes[num_nodes].ViewportNodeFrustum.data(),
                 nodes[num_nodes].pPortalBounding.data());
+
+        // avoid circular loops in portals
+        for (int test = 0; test < num_nodes; test++) {
+            if (nodes[test].uSectorID == nodes[num_nodes].uSectorID &&
+                nodes[test].uFaceID == nodes[num_nodes].uFaceID &&
+                nodes[test].pPortalBounding == nodes[num_nodes].pPortalBounding) {
+                return;
+            }
+        }
 
         if (bFrustumbuilt) {
             // add portal sector to drawing list
@@ -129,6 +130,7 @@ void BspRenderer::MakeVisibleSectorList() {
 
         // drop all sectors beyond config limit
         if (uNumVisibleNotEmptySectors >= engine->config->graphics.MaxVisibleSectors.value()) {
+            logger->warning("Hit visible sector limit!");
             break;
         }
     }

--- a/src/Engine/Graphics/BspRenderer.cpp
+++ b/src/Engine/Graphics/BspRenderer.cpp
@@ -90,11 +90,19 @@ void BspRenderer::AddFaceToRenderList_d3d(int node_id, int uFaceID) {
                 &pNewNumVertices, nodes[num_nodes].ViewportNodeFrustum.data(),
                 nodes[num_nodes].pPortalBounding.data());
 
+        auto boundingMatches = [](const std::array<RenderVertexSoft, 4> &l, const std::array<RenderVertexSoft, 4> &r) {
+            for (int i = 0; i < l.size(); i++) {
+                if (l[i].vWorldPosition != r[i].vWorldPosition)
+                    return false;
+            }
+            return true;
+        };
+
         // avoid circular loops in portals
         for (int test = 0; test < num_nodes; test++) {
             if (nodes[test].uSectorID == nodes[num_nodes].uSectorID &&
                 nodes[test].uFaceID == nodes[num_nodes].uFaceID &&
-                nodes[test].pPortalBounding == nodes[num_nodes].pPortalBounding) {
+                boundingMatches(nodes[test].pPortalBounding, nodes[num_nodes].pPortalBounding)) {
                 return;
             }
         }

--- a/src/Engine/Graphics/RenderEntities.h
+++ b/src/Engine/Graphics/RenderEntities.h
@@ -78,6 +78,10 @@ struct RenderVertexSoft {
     float u = 0;
     float v = 0;
     float flt_2C = 0;
+
+    bool operator==(const RenderVertexSoft& other) const {
+        return vWorldPosition == other.vWorldPosition;
+    }
 };
 
 struct RenderVertexD3D3 {

--- a/src/Engine/Graphics/RenderEntities.h
+++ b/src/Engine/Graphics/RenderEntities.h
@@ -78,10 +78,6 @@ struct RenderVertexSoft {
     float u = 0;
     float v = 0;
     float flt_2C = 0;
-
-    bool operator==(const RenderVertexSoft& other) const {
-        return vWorldPosition == other.vWorldPosition;
-    }
 };
 
 struct RenderVertexD3D3 {


### PR DESCRIPTION
Added more checks when dealing with looping portals. In this instance the portal is split over two frustum so we need to check that the bounding doesn't match before excluding it.

We already test for circular portal looping in 417 so Ive not added any more tests.