### PR TITLE
Propagating FFmpegBlobInputStream usage

### DIFF
--- a/src/Media/AudioBufferDataSource.cpp
+++ b/src/Media/AudioBufferDataSource.cpp
@@ -10,13 +10,7 @@ extern "C" {
 
 #include "Library/Logger/Logger.h"
 
-AudioBufferDataSource::AudioBufferDataSource(Blob buffer) : buffer(std::move(buffer)) {
-    buf_pos = nullptr;
-    buf_end = nullptr;
-    avio_ctx_buffer = nullptr;
-    avio_ctx_buffer_size = 4096;
-    avio_ctx = nullptr;
-}
+AudioBufferDataSource::AudioBufferDataSource(Blob buffer) : stream(std::move(buffer)) {}
 
 bool AudioBufferDataSource::Open() {
     if (bOpened) {
@@ -28,26 +22,10 @@ bool AudioBufferDataSource::Open() {
         return false;
     }
 
-    avio_ctx_buffer = (uint8_t *)av_malloc(avio_ctx_buffer_size);
-    if (avio_ctx_buffer == nullptr) {
-        Close();
-        return false;
-    }
-
-    avio_ctx = avio_alloc_context(avio_ctx_buffer, avio_ctx_buffer_size, 0,
-                                  this, &read_packet, nullptr, &seek);
-    if (!avio_ctx) {
-        Close();
-        return false;
-    }
-
-    pFormatContext->pb = avio_ctx;
-
-    buf_pos = static_cast<const uint8_t *>(buffer.data());
-    buf_end = buf_pos + buffer.size();
+    pFormatContext->pb = stream.ioContext();
 
     // Open audio file
-    if (avformat_open_input(&pFormatContext, nullptr, nullptr, nullptr) < 0) {
+    if (avformat_open_input(&pFormatContext, stream.displayPath().c_str(), nullptr, nullptr) < 0) {
         logger->warning("ffmpeg: Unable to open input buffer");
         return false;
     }
@@ -56,49 +34,6 @@ bool AudioBufferDataSource::Open() {
     av_dump_format(pFormatContext, 0, nullptr, 0);
 
     return AudioBaseDataSource::Open();
-}
-
-int AudioBufferDataSource::read_packet(void *opaque, uint8_t *buf,
-                                       int buf_size) {
-    AudioBufferDataSource *pThis = (AudioBufferDataSource *)opaque;
-    return pThis->ReadPacket(buf, buf_size);
-}
-
-int AudioBufferDataSource::ReadPacket(uint8_t *buf, int buf_size) {
-    int size = buf_end - buf_pos;
-    if (size <= 0) {
-        return AVERROR_EOF;
-    }
-    size = std::min(buf_size, size);
-    memcpy(buf, buf_pos, size);
-    buf_pos += size;
-    return size;
-}
-
-int64_t AudioBufferDataSource::seek(void *opaque, int64_t offset, int whence) {
-    AudioBufferDataSource *pThis = (AudioBufferDataSource *)opaque;
-    return pThis->Seek(opaque, offset, whence);
-}
-
-int64_t AudioBufferDataSource::Seek(void *opaque, int64_t offset, int whence) {
-    if ((whence & AVSEEK_SIZE) == AVSEEK_SIZE) {
-        return buffer.size();
-    }
-    int force = whence & AVSEEK_FORCE;
-    whence &= ~AVSEEK_FORCE;
-    whence &= ~AVSEEK_SIZE;
-    const uint8_t *buf_start = static_cast<const uint8_t *>(buffer.data());
-    if (whence == SEEK_SET) {
-        buf_pos = std::clamp(buf_start + offset, buf_start, buf_end);
-        return buf_pos - buf_start;
-    } else if (whence == SEEK_CUR) {
-        buf_pos = std::clamp(buf_pos + offset, buf_start, buf_end);
-        return buf_pos - buf_start;
-    } else if (whence == SEEK_END) {
-        buf_pos = std::clamp(buf_end + offset, buf_start, buf_end);
-        return buf_pos - buf_start;
-    }
-    return AVERROR(EIO);
 }
 
 PAudioDataSource CreateAudioBufferDataSource(Blob buffer) {

--- a/src/Media/AudioBufferDataSource.h
+++ b/src/Media/AudioBufferDataSource.h
@@ -3,29 +3,19 @@
 #include <memory>
 
 #include "AudioBaseDataSource.h"
+#include "FFmpegBlobInputStream.h"
 
 struct AVIOContext;
 
 class AudioBufferDataSource : public AudioBaseDataSource {
  public:
     explicit AudioBufferDataSource(Blob buffer);
-    virtual ~AudioBufferDataSource() {}
+    virtual ~AudioBufferDataSource() = default;
 
     virtual bool Open() override;
 
  protected:
-    Blob buffer;
-    const uint8_t *buf_pos;
-    const uint8_t *buf_end;
-    uint8_t *avio_ctx_buffer;
-    size_t avio_ctx_buffer_size;
-    AVIOContext *avio_ctx;
-
-    static int read_packet(void *opaque, uint8_t *buf, int buf_size);
-    int ReadPacket(uint8_t *buf, int buf_size);
-
-    static int64_t seek(void *opaque, int64_t offset, int whence);
-    int64_t Seek(void *opaque, int64_t offset, int whence);
+    FFmpegBlobInputStream stream;
 };
 
 PAudioDataSource CreateAudioBufferDataSource(Blob buffer);

--- a/src/Media/FFmpegBlobInputStream.cpp
+++ b/src/Media/FFmpegBlobInputStream.cpp
@@ -29,7 +29,7 @@ static int64_t ffSeek(void *opaque, int64_t offset, int whence) {
         stream->seek(stream->position() + offset);
         break;
     case SEEK_END:
-        stream->seek(stream->size() - std::min(offset, static_cast<int64_t>(stream->size()))); // std::min to handle the overflow correctly.
+        stream->seek(stream->size() + offset);
         break;
     default:
         assert(false);

--- a/src/Media/FFmpegBlobInputStream.cpp
+++ b/src/Media/FFmpegBlobInputStream.cpp
@@ -11,7 +11,8 @@ extern "C" {
 
 static int ffRead(void *opaque, uint8_t *buf, int size) {
     FFmpegBlobInputStream *stream = static_cast<FFmpegBlobInputStream *>(opaque);
-    return stream->read(buf, size);
+    int result = stream->read(buf, size);
+    return result == 0 ? AVERROR_EOF : result;
 }
 
 static int64_t ffSeek(void *opaque, int64_t offset, int whence) {
@@ -33,7 +34,7 @@ static int64_t ffSeek(void *opaque, int64_t offset, int whence) {
         break;
     default:
         assert(false);
-        break;
+        return AVERROR(EIO);
     }
 
     return stream->position();

--- a/src/Utility/Streams/BlobInputStream.cpp
+++ b/src/Utility/Streams/BlobInputStream.cpp
@@ -55,19 +55,19 @@ std::string BlobInputStream::displayPath() const {
     return _blob.displayPath();
 }
 
-void BlobInputStream::seek(size_t pos) {
+void BlobInputStream::seek(ssize_t pos) {
     assert(_pos);
 
-    _pos = static_cast<const char *>(_blob.data()) + std::min(pos, _blob.size());
+    _pos = static_cast<const char *>(_blob.data()) + std::clamp<ssize_t>(pos, 0, size());
 }
 
-size_t BlobInputStream::position() const {
+ssize_t BlobInputStream::position() const {
     assert(_pos);
 
     return _pos - static_cast<const char *>(_blob.data());
 }
 
-size_t BlobInputStream::size() const {
+ssize_t BlobInputStream::size() const {
     assert(_pos);
 
     return _blob.size();

--- a/src/Utility/Streams/BlobInputStream.h
+++ b/src/Utility/Streams/BlobInputStream.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Utility/Memory/Blob.h"
+#include "Utility/Types.h"
 
 #include "InputStream.h"
 
@@ -26,9 +27,9 @@ class BlobInputStream : public InputStream {
     virtual void close() override;
     [[nodiscard]] virtual std::string displayPath() const override;
 
-    void seek(size_t pos);
-    [[nodiscard]] size_t position() const;
-    [[nodiscard]] size_t size() const;
+    void seek(ssize_t pos);
+    [[nodiscard]] ssize_t position() const;
+    [[nodiscard]] ssize_t size() const;
 
     /**
      * @return                          Remaining stream data, as a blob that's shared with the blob that this

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -77,7 +77,7 @@ std::string FileInputStream::displayPath() const {
     return _path;
 }
 
-void FileInputStream::seek(size_t pos) {
+void FileInputStream::seek(ssize_t pos) {
     assert(isOpen());
 
     if (fseeko(_file, 0, SEEK_END) != 0)
@@ -87,8 +87,7 @@ void FileInputStream::seek(size_t pos) {
     if (end == -1)
         Exception::throwFromErrno(_path);
 
-    if (pos > end)
-        pos = end; // Seek beyond EOF just seeks to EOF.
+    pos = std::clamp<ssize_t>(pos, 0, end); // Seek beyond EOF just seeks to EOF.
 
     if (fseeko(_file, pos, SEEK_SET) != 0)
         Exception::throwFromErrno(_path);

--- a/src/Utility/Streams/FileInputStream.h
+++ b/src/Utility/Streams/FileInputStream.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <string_view>
 
+#include "Utility/Types.h"
+
 #include "InputStream.h"
 
 class FileInputStream : public InputStream {
@@ -23,7 +25,7 @@ class FileInputStream : public InputStream {
     virtual void close() override;
     [[nodiscard]] virtual std::string displayPath() const override;
 
-    void seek(size_t pos);
+    void seek(ssize_t pos);
 
     [[nodiscard]] FILE *handle() {
         return _file;

--- a/src/Utility/Streams/MemoryInputStream.cpp
+++ b/src/Utility/Streams/MemoryInputStream.cpp
@@ -48,19 +48,19 @@ std::string MemoryInputStream::displayPath() const {
     return _displayPath;
 }
 
-void MemoryInputStream::seek(size_t pos) {
+void MemoryInputStream::seek(ssize_t pos) {
     assert(_pos);
 
     _pos = _begin + std::min(pos, size());
 }
 
-size_t MemoryInputStream::position() const {
+ssize_t MemoryInputStream::position() const {
     assert(_pos);
 
     return _pos - _begin;
 }
 
-size_t MemoryInputStream::size() const {
+ssize_t MemoryInputStream::size() const {
     assert(_pos);
 
     return _end - _begin;

--- a/src/Utility/Streams/MemoryInputStream.h
+++ b/src/Utility/Streams/MemoryInputStream.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "Utility/Types.h"
+
 #include "InputStream.h"
 
 class MemoryInputStream: public InputStream {
@@ -17,9 +19,9 @@ class MemoryInputStream: public InputStream {
     virtual void close() override;
     [[nodiscard]] std::string displayPath() const override;
 
-    void seek(size_t pos);
-    [[nodiscard]] size_t position() const;
-    [[nodiscard]] size_t size() const;
+    void seek(ssize_t pos);
+    [[nodiscard]] ssize_t position() const;
+    [[nodiscard]] ssize_t size() const;
 
  private:
     const char *_begin = nullptr;


### PR DESCRIPTION
* Seekable streams API now uses ssize_t for offsets & sizes, makes things easier in other places.
* Using FFmpegBlobInputStream in AudioBufferDataSource.