### PR TITLE
Display paths should be absolute

### DIFF
--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -40,14 +40,16 @@ Blob Blob::fromMalloc(std::unique_ptr<void, FreeDeleter> data, size_t size) {
 }
 
 Blob Blob::fromFile(std::string_view path) {
+    std::filesystem::path absolutePath = absolute(std::filesystem::path(path));
+    std::string pathString = absolutePath.generic_string();
+
     // On Mac mapping an empty file throws, so we need to provide a workaround.
     std::error_code error;
-    uintmax_t size = std::filesystem::file_size(path, error);
+    uintmax_t size = std::filesystem::file_size(absolutePath, error);
     if (!error && size == 0)
-        return Blob().withDisplayPath(path);
+        return Blob().withDisplayPath(pathString);
 
     // On Windows mio::mmap_source expects UTF8-encoded paths. If the file doesn't exist, std::system_error is thrown.
-    std::string pathString(path);
     std::shared_ptr<mio::mmap_source> mmap = std::make_shared<mio::mmap_source>(pathString);
 
     Blob result;

--- a/src/Utility/Memory/Tests/Blob_ut.cpp
+++ b/src/Utility/Memory/Tests/Blob_ut.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <filesystem>
 
 #include "Testing/Unit/UnitTest.h"
 
@@ -60,12 +61,24 @@ UNIT_TEST(Blob, DisplayPathCopyShare) {
 UNIT_TEST(Blob, DisplayPathFromFile) {
     TestExistingFile tmp("1.bin", "123");
 
-    EXPECT_EQ(Blob::fromFile("1.bin").displayPath(), "1.bin");
+    std::string displayPath = Blob::fromFile("1.bin").displayPath();
+    EXPECT_TRUE(displayPath.ends_with("1.bin"));
+    EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
+}
+
+UNIT_TEST(Blob, DisplayPathFromEmptyFile) {
+    TestExistingFile tmp("1.txt", "");
+
+    std::string displayPath = Blob::fromFile("1.txt").displayPath();
+    EXPECT_TRUE(displayPath.ends_with("1.txt"));
+    EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
 }
 
 UNIT_TEST(Blob, DisplayPathFromStream) {
     TestExistingFile tmp("1.bin", "123");
 
     FileInputStream in("1.bin");
-    EXPECT_EQ(Blob::read(&in, 2).displayPath(), "1.bin");
+    std::string displayPath = Blob::read(&in, 2).displayPath();
+    EXPECT_TRUE(displayPath.ends_with("1.bin"));
+    EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
 }

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <algorithm> // For std::min.
 #include <string>
+#include <filesystem>
 
 #include "Utility/Exception.h"
 #include "Utility/UnicodeCrt.h"
@@ -24,7 +25,7 @@ FileInputStream::~FileInputStream() {
 void FileInputStream::open(std::string_view path) {
     assert(UnicodeCrt::isInitialized()); // Otherwise fopen on Windows will choke on UTF-8 paths.
 
-    _path = std::string(path);
+    _path = absolute(std::filesystem::path(path)).generic_string();
     _file = fopen(_path.c_str(), "rb");
     if (!_file)
         Exception::throwFromErrno(_path);

--- a/src/Utility/Streams/FileOutputStream.cpp
+++ b/src/Utility/Streams/FileOutputStream.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstdio>
 #include <string>
+#include <filesystem>
 
 #include "Utility/Exception.h"
 #include "Utility/UnicodeCrt.h"
@@ -20,7 +21,7 @@ void FileOutputStream::open(std::string_view path) {
 
     close();
 
-    _path = std::string(path);
+    _path = absolute(std::filesystem::path(path)).generic_string();
     _file = fopen(_path.c_str(), "wb");
     if (!_file)
         Exception::throwFromErrno(_path);


### PR DESCRIPTION
This is mainly to make debugging easier, with a full path you know where the file is.