### PR TITLE
Join the control routine first in GameStarter dtor

### DIFF
--- a/src/Application/GameStarter.cpp
+++ b/src/Application/GameStarter.cpp
@@ -170,10 +170,10 @@ GameStarter::GameStarter(GameStarterOptions options): _options(std::move(options
 }
 
 GameStarter::~GameStarter() {
+    _application->removeComponent<EngineControlComponent>(); // Join the control thread first.
+
     ::engine = nullptr;
-
     ::render = nullptr;
-
     ::application = nullptr;
     ::platform = nullptr;
     ::eventLoop = nullptr;


### PR DESCRIPTION
This is needed for the rare case when:
1. We run game tests.
2. Game thread decides it's had enough and exits via exception.

In this case test (control) thread needs to terminate & clean up properly before all other cleanup is performed.