### PR TITLE
Fix the problem with OE not starting from app bundle on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download
 
 To download the code without having to compile it we have our releases at [https://github.com/OpenEnroth/OpenEnroth/releases](https://github.com/OpenEnroth/OpenEnroth/releases) 
 
-Note: Currently there are only the nightly builds which may have bugs.
+Currently there are only the nightly builds which may have bugs.
 
 Discord
 -------
@@ -35,21 +35,46 @@ Getting Started on Windows
 4. Run `OpenEnroth.exe`.
 
 
-Getting Started on Linux or Mac
+Getting Started on Ubuntu Linux
 -------------------------------
 
 1. You will need a GoG or any other version of Might and Magic VII. If you have an offline GoG installer, then follow these steps:
-   * Install `innoextract`. If you're on Ubuntu, `sudo apt-get install innoextract` should work. If you're on Mac then you'll need homebrew, and `brew install innoextract` should do the job.
+   * Install `innoextract` with `sudo apt-get install innoextract`.
    * Run `innoextract -e -d <target-folder> <mm7-gog-folder>/setup_mm_7.exe`, where `<target-folder>` is the folder where you want to have game data extracted from the mm7 installer.
    * Check the files in `<target-folder>`, it should now contain the `app` subfolder. This is where game assets were extracted into.
 
-2. Build OpenEnroth as described in [HACKING.md](HACKING.md).
+2. Install OpenEnroth dependencies with `sudo apt-get install libsdl2-dev libdwarf-dev libelf-dev`.
 
-3. Set `OPENENROTH_MM7_PATH` env variable to point to the location of the game assets. You might also want to add the following line to your bash profile (e.g. `~/.profile` on Ubuntu or `~/.zshrc` on Mac):
+3. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
 
-    `export OPENENROTH_MM7_PATH="<target-folder>/app"`
+4. From the `dist` folder inside the zip file copy the `OpenEnroth` binary to `<target-folder>/app`.
 
-4. Run the freshly built `OpenEnroth` binary.
+5. Run `OpenEnroth` binary.
+
+
+Getting Started on MacOS
+------------------------
+
+1. You will need a GoG or any other version of Might and Magic VII. If you have an offline GoG installer, then follow these steps:
+   * Install `innoextract` with `brew install innoextract`.
+   * Run `innoextract -e -d <target-folder> <mm7-gog-folder>/setup_mm_7.exe`, where `<target-folder>` is the folder where you want to have game data extracted from the mm7 installer.
+   * Check the files in `<target-folder>`, it should now contain the `app` subfolder. This is where game assets were extracted into.
+
+2. Move extracted game assets to `~/Library/Application Support/OpenEnroth`. This is where `OpenEnroth` will look for game data.
+
+3. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
+   
+4. Run `xattr -rc <extracted-path>/dist/OpenEnroth.app`. This is needed because OpenEnroth binaries are unsigned, without this step the app bundle won't start.
+
+5. Start `OpenEnroth.app`.
+
+
+Game Assets Path Override
+-------------------------
+
+You can set `OPENENROTH_MM7_PATH` env variable to point to the location of the game assets. If this variable is set, OpenEnroth will look for game assets only in the location it's pointing to. You might also want to add the following line to your bash profile (e.g. `~/.profile` on Ubuntu or `~/.zshrc` on Mac):
+
+    `export OPENENROTH_MM7_PATH="<path-to-mm7-game-assets>"`
 
 
 Development

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -24,30 +24,61 @@ DirectoryFileSystem::~DirectoryFileSystem() = default;
 
 bool DirectoryFileSystem::_exists(const FileSystemPath &path) const {
     assert(!path.isEmpty());
-    return std::filesystem::exists(makeBasePath(path));
+
+    std::error_code ec;
+    return std::filesystem::exists(makeBasePath(path), ec); // Returns false on error.
 }
 
 FileStat DirectoryFileSystem::_stat(const FileSystemPath &path) const {
     assert(!path.isEmpty());
 
     std::filesystem::path basePath = makeBasePath(path);
-    std::filesystem::file_status status = std::filesystem::status(basePath);
-    bool isRegular = std::filesystem::is_regular_file(status);
-    bool isDirectory = !isRegular && std::filesystem::is_directory(status);
+
+    std::error_code ec;
+    std::filesystem::directory_entry entry(basePath, ec);
+    bool isRegular = entry.is_regular_file(ec);
+    bool isDirectory = !isRegular && entry.is_directory(ec);
     if (!isRegular && !isDirectory)
-        return {}; // Non-files and non-folders are not visible through this interface.
+        return {}; // Return an empty stat on error or if it's not a file / directory.
+
+    std::int64_t size = 0;
+    if (isRegular) {
+        size = std::filesystem::file_size(basePath, ec);
+        if (ec)
+            return {};
+    }
 
     FileStat result;
     result.type = isRegular ? FILE_REGULAR : FILE_DIRECTORY;
-    result.size = isRegular ? std::filesystem::file_size(basePath) : 0;
-    return result;
-}
+    result.size = size;
+    return result;}
 
 void DirectoryFileSystem::_ls(const FileSystemPath &path, std::vector<DirectoryEntry> *entries) const {
+    std::filesystem::path basePath = makeBasePath(path);
+
+    // Handle the known errors first.
     std::error_code ec;
+    std::filesystem::directory_entry parent(basePath, ec);
+    bool isParentRegular = parent.is_regular_file(ec);
+    bool isParentDirectory = !isParentRegular && parent.is_directory(ec);
+    if (path.isEmpty() && !isParentDirectory)
+        return; // ls("") should always work.
+    if (isParentRegular)
+        FileSystemException::raise(this, FS_LS_FAILED_PATH_IS_FILE, path);
+    if (!isParentDirectory)
+        FileSystemException::raise(this, FS_LS_FAILED_PATH_DOESNT_EXIST, path);
+
+    // Then we do the regular ls and just ignore all errors. The errors we'll get here are most likely
+    // permissions-related, and we're ignoring them in stat() and exists().
     for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(makeBasePath(path), ec)) {
-        bool isRegular = entry.is_regular_file();
-        bool isDirectory = !isRegular && entry.is_directory();
+        // Unfortunately, std::filesystem is retarded. We can get a directory_entry here for a dir that we don't have
+        // permissions for, and which won't be stat-able. Seriously, entry.is_directory() returns true while
+        // std::filesystem::exists(entry.path()) just throws. So we need to check for that.
+        if (!std::filesystem::exists(entry.path(), ec))
+            continue;
+
+        bool isRegular = entry.is_regular_file(ec);
+        bool isDirectory = !isRegular && entry.is_directory(ec);
         if (!isRegular && !isDirectory)
             continue;
 
@@ -58,14 +89,6 @@ void DirectoryFileSystem::_ls(const FileSystemPath &path, std::vector<DirectoryE
         DirectoryEntry &resultEntry = entries->emplace_back();
         resultEntry.name = std::move(name);
         resultEntry.type = isRegular ? FILE_REGULAR : FILE_DIRECTORY;
-    }
-
-    if (ec) {
-        if (path.isEmpty()) {
-            return; // Always pretend the root exists & is accessible.
-        } else {
-            throw std::system_error(ec, path.string());
-        }
     }
 }
 
@@ -101,7 +124,9 @@ void DirectoryFileSystem::_rename(const FileSystemPath &srcPath, const FileSyste
 
     std::filesystem::path srcBasePath = makeBasePath(srcPath);
     std::filesystem::path dstBasePath = makeBasePath(dstPath);
-    if (std::filesystem::is_directory(dstBasePath))
+
+    std::error_code ec;
+    if (std::filesystem::is_directory(dstBasePath, ec))
         FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
 
     // This call will copy the file if POSIX rename() fails, so if it throws then we can't really do anything either.

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.h
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.h
@@ -15,6 +15,10 @@
  *
  * Files outside of the root directory are not observable through this `FileSystem` - the methods will behave as if
  * these files don't exist.
+ *
+ * When it comes to permissions, this filesystem tries its best to provide a simple guarantee that `ls` for an existing
+ * folder never throws, and is in sync with what `stat` / `exists` return. This means that some files or folders that
+ * are observable through `ls` in bash won't be observable through this filesystem.
  */
 class DirectoryFileSystem : public FileSystem {
  public:

--- a/src/Library/FileSystem/Lowercase/LowercaseFileSystem.h
+++ b/src/Library/FileSystem/Lowercase/LowercaseFileSystem.h
@@ -1,33 +1,47 @@
 #pragma once
 
-#include <unordered_map>
 #include <string>
 #include <vector>
 #include <memory>
 #include <tuple>
+#include <utility>
 
 #include "Library/FileSystem/Interface/FileSystem.h"
 #include "Library/FileSystem/Trie/FileSystemTrie.h"
+
+namespace detail {
+struct LowercaseFileData {
+    FileType type = FILE_INVALID; // FILE_INVALID means there was a name conflict in the underlying FS.
+    bool listed = false;
+    std::string baseName;
+
+    LowercaseFileData(FileType type, std::string baseName) : type(type), baseName(std::move(baseName)) {}
+};
+} // namespace detail
 
 /**
  * Provides a lowercase view over another `FileSystem`:
  * - Contains only lowercase-named files.
  * - Effectively gives the user a case-insensitive view over a potentially case-sensitive filesystem.
- * - Caches the contents of the underlying filesystem in constructor. Call `refresh` to update the cache.
- * - Constructor and `refresh` throw on conflicts (e.g. if both "file.txt" and "FILE.txt" exist).
- * - Doesn't preserve empty folders because who needs them?
+ * - Caches the contents of the underlying filesystem. Call `refresh` to clear cache.
+ * - Conflicts are visible as empty files but are not readable / writeable / removeable (conflict is when both
+ *   "file.txt" and "FILE.txt" exist).
+ * - Is not thread-safe. Even const methods update the underlying cache.
  *
- * Some notes on why it is designed the way it is designed. Previous iteration was a writeable FS that was always up
- * to date with the underlying FS (was checking timestamps for all parents in each call). The code was messy, it was
- * `O(N)` on each call, and even after writing an implementation that actually worked, I hated it. Mostly because of the 
- * `O(N)` - which led to a recursive implementation of `FileSystem::rename` becoming `O(N^2)`. It is possible to iron
- * this out, but that would require to redo the `FileSystem` interface & expose the `Directory` abstraction directly. 
- * Which is just not worth it.
- * 
- * If you've been paying attention, you might want to point out that recursive `FileSystem::rename` is `O(N^2)` anyway. 
- * Indeed, we'll be traversing the trie for each file, and that's `O(N)` per file. However, there is no amplification 
- * of the number of calls into the underlying file system, which is the important part. Each of the methods in 
- * `LowercaseFileSystem` calls into the underlying file system at most once.
+ * Some notes on why it is designed the way it is designed.
+ *
+ * Previous iteration was a writeable FS that was always up to date with the underlying FS (was checking timestamps for
+ * all parents in each call). The code was messy, it was `O(N)` on each call, and even after writing an implementation
+ * that actually worked, I hated it. Mostly because of the `O(N)` - which led to a recursive implementation of
+ * `FileSystem::rename` becoming `O(N^2)`. It is possible to iron this out, but that would require to redo the
+ * `FileSystem` interface & expose the `Directory` abstraction directly. Which is just not worth it.
+ *
+ * Next iteration was caching the whole file tree in constructor, but this was blowing up spectacularly when constructed
+ * for `/`. Thus, we're now caching lazily.
+ *
+ * The important point about the implementation is that there is no amplification of the number of calls into the
+ * underlying file system. Each of the methods in `LowercaseFileSystem` calls into the underlying file system at most
+ * once.
  */
 class LowercaseFileSystem : public FileSystem {
  public:
@@ -49,19 +63,17 @@ class LowercaseFileSystem : public FileSystem {
     virtual std::string _displayPath(const FileSystemPath &path) const override;
 
  private:
-    using Node = FileSystemTrieNode<std::string>;
+    using Node = FileSystemTrieNode<detail::LowercaseFileData>;
 
-    void refresh(Node *node, const FileSystemPath &basePath);
-
-    std::tuple<FileSystemPath, Node *, FileSystemPath> walk(const FileSystemPath &path);
-    std::tuple<FileSystemPath, const Node *, FileSystemPath> walk(const FileSystemPath &path) const;
-    Node *blaze(Node *node, const FileSystemPath &tail);
-    void prune(Node *node);
+    std::tuple<FileSystemPath, Node *, FileSystemPath> walk(const FileSystemPath &path) const;
+    void cacheLs(Node *node, const FileSystemPath &basePath) const;
+    void cacheRemove(Node *node) const;
+    void cacheInsert(Node *node, const FileSystemPath &tail, FileType type) const;
 
     FileSystemPath locateForReading(const FileSystemPath &path) const;
     std::tuple<FileSystemPath, Node *, FileSystemPath> locateForWriting(const FileSystemPath &path);
 
  private:
     FileSystem *_base = nullptr;
-    FileSystemTrie<std::string> _trie; // Stores names in the base filesystem, leaf nodes are files.
+    mutable FileSystemTrie<detail::LowercaseFileData> _trie; // Stores names in the base filesystem, leaf nodes are files.
 };

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -191,7 +191,7 @@ void AudioPlayer::playSound(SoundId eSoundID, SoundPlaybackMode mode, Pid pid) {
     //logger->Info("AudioPlayer: trying to load sound id {}", eSoundID);
 
     // TODO(pskelton): do we need to reinstate this optimisation? dropped to allow better sound tracing
-    if (/*engine->config->settings.SoundLevel.value() < 1 ||*/ (eSoundID == SOUND_Invalid)) {
+    if (/*engine->config->settings.SoundLevel.value() < 1 ||*/ eSoundID == SOUND_Invalid) {
         return;
     }
 


### PR DESCRIPTION
Fixes:
* Throwing during initialization keeps log messages.
* DirectoryFS can now recursively LS everything that it sees w/o pissing itself & tripping over.
* LowercaseFS now caches lazily – this is where the problem was, we were trying to cache `/`.
* Readme updated for MacOS.

Fixes #1772 