### PR TITLE
Work on stairs

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -945,6 +945,14 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
                 if (collision_state.pid.id() == 398) // Secret tunnel under prison bed
                     bFaceSlopeTooSteep = false;
             }
+            if (engine->_currentLoadedMapId == MapId::MAP_HALL_OF_THE_PIT) {
+                if (collision_state.pid.id() == 787 || collision_state.pid.id() == 832 || collision_state.pid.id() == 790)
+                    bFaceSlopeTooSteep = false;
+            }
+            if (engine->_currentLoadedMapId == MAP_CASTLE_GLOAMING) {
+                if (collision_state.pid.id() == 2439 || collision_state.pid.id() == 2438 || collision_state.pid.id() == 2437 || collision_state.pid.id() == 2436) // gloaming
+                    bFaceSlopeTooSteep = false;
+            }
 
             // new sliding plane
             Vec3f slidePlaneOrigin = collision_state.collisionPos;
@@ -972,6 +980,8 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
 
             if (pFace->uPolygonType == POLYGON_Floor) {
                 float new_party_z_tmp = pIndoor->pVertices[*pFace->pVertexIDs].z;
+                if (pParty->velocity.z > 0.0f)
+                    pParty->pos.z = new_party_z_tmp;
                 if (pParty->uFallStartZ - new_party_z_tmp < 512)
                     pParty->uFallStartZ = new_party_z_tmp;
             }

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -954,6 +954,10 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
                     bFaceSlopeTooSteep = false;
             }
 
+            // TODO(pskelton): This 'catch all' is probably unsafe - would be better as above
+            if (bFaceSlopeTooSteep && pFace->Invisible() && pFace->uPolygonType == PolygonType::POLYGON_InBetweenFloorAndWall)
+                bFaceSlopeTooSteep = false;
+
             // new sliding plane
             Vec3f slidePlaneOrigin = collision_state.collisionPos;
             Vec3f slidePlaneNormal = adjusted_pos + Vec3f(0, 0, collision_state.radius_lo) - slidePlaneOrigin;

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -1159,6 +1159,11 @@ void ProcessPartyCollisionsODM(Vec3f *partyNewPos, Vec3f *partyInputSpeed, bool 
                 pParty->uFlags &= ~(PARTY_FLAG_LANDING | PARTY_FLAG_JUMPING);
             }
 
+            if (pODMFace->uPolygonType == POLYGON_Floor) {
+                if (pParty->velocity.z > 0.0f)
+                    pParty->pos.z = pOutdoor->pBModels[collision_state.pid.id() >> 6].pVertices[pODMFace->pVertexIDs[0]].z;
+            }
+
             continue;
         }
 

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -984,6 +984,8 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
 
             if (pFace->uPolygonType == POLYGON_Floor) {
                 float new_party_z_tmp = pIndoor->pVertices[*pFace->pVertexIDs].z;
+                // We dont collide with the rear of faces so hitting a floor poly with upwards direction means that
+                // weve collided with its edge and we should step up onto its level.
                 if (pParty->velocity.z > 0.0f)
                     pParty->pos.z = new_party_z_tmp;
                 if (pParty->uFallStartZ - new_party_z_tmp < 512)
@@ -1160,6 +1162,8 @@ void ProcessPartyCollisionsODM(Vec3f *partyNewPos, Vec3f *partyInputSpeed, bool 
             }
 
             if (pODMFace->uPolygonType == POLYGON_Floor) {
+                // We dont collide with the rear of faces so hitting a floor poly with upwards direction means that
+                // weve collided with its edge and we should step up onto its level.
                 if (pParty->velocity.z > 0.0f)
                     pParty->pos.z = pOutdoor->pBModels[collision_state.pid.id() >> 6].pVertices[pODMFace->pVertexIDs[0]].z;
             }

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG d46c7d443a8560f2fd17a15b60eae3de84ae6e13
+        GIT_TAG 48b04580afb19cf48c696285d06295b82185d925
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 0a8c307a40c7fe2ffdc43ccc585c231c2391b232
+        GIT_TAG d46c7d443a8560f2fd17a15b60eae3de84ae6e13
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -430,6 +430,8 @@ GAME_TEST(Issues, Issue1786) {
     EXPECT_MISSES(sprites.back(), SPRITE_SPELL_FIRE_FIRE_BOLT);
 }
 
+// 1800
+
 GAME_TEST(Issues, Issue1807) {
     // Opening arcomage menu in a tavern while not carrying a deck asserts.
     auto deckTape = tapes.hasItem(ITEM_QUEST_ARCOMAGE_DECK);
@@ -440,4 +442,24 @@ GAME_TEST(Issues, Issue1807) {
     EXPECT_CONTAINS(houseTape, HOUSE_TAVERN_HARMONDALE); // We've visited the Harmondale tavern.
     EXPECT_CONTAINS(textTape.flattened(), "Victory Conditions"); // We've seen the Arcomage dialog.
     EXPECT_MISSES(textTape.flattened(), "Play"); // But there was no "Play" option.
+}
+
+GAME_TEST(Issues, Issue1851a) {
+    // Collisions: stair climbing - hall of the pit - using catch all
+    auto zPos = tapes.custom([]() { return static_cast<int>(pParty->pos.z); });
+    auto jumpTape = tapes.custom([]() { return !!(pParty->uFlags & PARTY_FLAG_JUMPING); });
+    test.playTraceFromTestData("issue_1851a.mm7", "issue_1851a.json");
+    EXPECT_LT(zPos.front(), -190);
+    EXPECT_GE(zPos.back(), 0);
+    EXPECT_MISSES(jumpTape, true);
+}
+
+GAME_TEST(Issues, Issue1851b) {
+    // Collisions: stair climbing - castle gloaming - using face exclusion
+    auto zPos = tapes.custom([]() { return static_cast<int>(pParty->pos.z); });
+    auto jumpTape = tapes.custom([]() { return !!(pParty->uFlags & PARTY_FLAG_JUMPING); });
+    test.playTraceFromTestData("issue_1851b.mm7", "issue_1851b.json");
+    EXPECT_LT(zPos.front(), -90);
+    EXPECT_GT(zPos.back(), 525);
+    EXPECT_MISSES(jumpTape, true);
 }


### PR DESCRIPTION
Fixes #1851

Adding a kludge to allow all the invisible stair "assist" geometry to be climbable. This helps the party traverse without issue for most cases. However this may cause unintended consequences. A preferred future solution will be to mark all those faces with a special attribute.