### PR TITLE
LodTool extract added

### DIFF
--- a/src/Bin/LodTool/CMakeLists.txt
+++ b/src/Bin/LodTool/CMakeLists.txt
@@ -9,6 +9,6 @@ set(BIN_LODTOOL_HEADERS
 
 if(NOT OE_BUILD_PLATFORM STREQUAL "android")
     add_executable(LodTool ${BIN_LODTOOL_SOURCES} ${BIN_LODTOOL_HEADERS})
-    target_link_libraries(LodTool PUBLIC library_lod library_lod_formats library_cli)
+    target_link_libraries(LodTool PUBLIC library_lod library_lod_formats library_image library_filesystem_directory library_cli)
     target_check_style(LodTool)
 endif()

--- a/src/Bin/LodTool/LodTool.cpp
+++ b/src/Bin/LodTool/LodTool.cpp
@@ -3,14 +3,39 @@
 #include <cstdio>
 #include <string>
 
+#include "Library/Image/ImageFunctions.h"
+#include "Library/Image/Pcx.h"
+#include "Library/Image/Png.h"
 #include "Library/Lod/LodReader.h"
 #include "Library/LodFormats/LodFormats.h"
+#include "Library/FileSystem/Directory/DirectoryFileSystem.h"
 #include "Library/Serialization/Serialization.h"
 
 #include "Utility/String/Format.h"
 #include "Utility/String/Ascii.h"
 #include "Utility/String/Transformations.h"
 #include "Utility/UnicodeCrt.h"
+
+bool isPcx(const Blob &blob) {
+    if (blob.size() < 4)
+        return false;
+
+    // Check for PCX signature:
+    // - s[0] should be 0x0A (PCX identifier).
+    // - s[1] should be one of the valid version numbers (0x00, 0x02, 0x03, 0x04, 0x05)
+    // - s[2] should be 0x01 (indicating RLE encoding)
+    // - s[3] should be one of the common bits per pixel values (0x01, 0x02, 0x04, 0x08)
+    std::string_view s = blob.string_view();
+    if (s[0] != '\x0A')
+        return false;
+    if (s[1] != '\x00' && s[1] != '\x02' && s[1] != '\x03' && s[1] != '\x04' && s[1] != '\x05')
+        return false;
+    if (s[2] != '\x01')
+        return false;
+    if (s[3] != '\x01' && s[3] != '\x02' && s[3] != '\x04' && s[3] != '\x08')
+        return false;
+    return true;
+}
 
 int runLs(const LodToolOptions &options) {
     LodReader reader(options.lodPath, LOD_ALLOW_DUPLICATES);
@@ -53,12 +78,61 @@ int runDump(const LodToolOptions &options) {
 int runCat(const LodToolOptions &options) {
     LodReader reader(options.lodPath, LOD_ALLOW_DUPLICATES);
     Blob data = reader.read(options.cat.entry);
+    // TODO(captainurist): cat should work the same way as extract & spit out pngs?
     if (!options.cat.raw) {
         LodFileFormat format = lod::magic(data, options.cat.entry);
         if (format == LOD_FILE_COMPRESSED || format == LOD_FILE_PSEUDO_IMAGE)
             data = lod::decodeCompressed(data);
     }
-    return fwrite(data.data(), data.size(), 1, stdout) != 1;
+    return fwrite(data.data(), data.size(), 1, stdout) != 1 ? 1 : 0;
+}
+
+int runExtract(const LodToolOptions &options) {
+    LodReader reader(options.lodPath, LOD_ALLOW_DUPLICATES);
+    DirectoryFileSystem output(options.extract.output);
+
+    for (const std::string &entryName : reader.ls()) {
+        Blob data = reader.read(entryName);
+        Blob result;
+        std::string resultName;
+
+        if (options.extract.raw) {
+            result = Blob::share(data);
+            resultName = entryName;
+        } else if (isPcx(data)) {
+            result = png::encode(pcx::decode(data));
+            resultName = (entryName.ends_with(".pcx") ? entryName.substr(0, entryName.size() - 4) : entryName) + ".png";
+        } else {
+            LodFileFormat format = lod::magic(data, entryName);
+
+            if (format == LOD_FILE_IMAGE) {
+                LodImage lodImage = lod::decodeImage(data);
+                result = png::encode(makeRgbaImage(lodImage.image, lodImage.palette));
+                resultName = entryName + ".png";
+            } else if (format == LOD_FILE_PALETTE) {
+                LodImage lodImage = lod::decodeImage(data);
+                RgbaImage palImage = RgbaImage::uninitialized(256, 1);
+                for (size_t i = 0; i < 256; i++)
+                    palImage[0][i] = lodImage.palette.colors[i];
+                result = png::encode(palImage);
+                resultName = entryName + ".png";
+            } else if (format == LOD_FILE_SPRITE) {
+                LodSprite sprite = lod::decodeSprite(data);
+                result = png::encode(sprite.image);
+                resultName = entryName + ".png";
+            } else if (format == LOD_FILE_COMPRESSED || format == LOD_FILE_PSEUDO_IMAGE) {
+                result = lod::decodeCompressed(data);
+                resultName = entryName;
+            } else {
+                result = Blob::share(data);
+                resultName = entryName;
+            }
+        }
+
+        output.write(resultName, result);
+    }
+
+    return 0;
 }
 
 int main(int argc, char **argv) {
@@ -73,6 +147,7 @@ int main(int argc, char **argv) {
         case LodToolOptions::SUBCOMMAND_LS: return runLs(options);
         case LodToolOptions::SUBCOMMAND_DUMP: return runDump(options);
         case LodToolOptions::SUBCOMMAND_CAT: return runCat(options);
+        case LodToolOptions::SUBCOMMAND_EXTRACT: return runExtract(options);
         }
     } catch (const std::exception &e) {
         fmt::print(stderr, "{}\n", e.what());

--- a/src/Bin/LodTool/LodToolOptions.cpp
+++ b/src/Bin/LodTool/LodToolOptions.cpp
@@ -22,6 +22,11 @@ LodToolOptions LodToolOptions::parse(int argc, char **argv) {
     cat->add_option("LOD", result.lodPath, "Path to lod file.")->check(CLI::ExistingFile)->required()->option_text(" ");
     cat->add_option("ENTRY", result.cat.entry, "Name of the entry to print.")->required()->option_text(" ");
 
+    CLI::App *extract = app->add_subcommand("extract", "Extract everything from a lod file.", result.subcommand, SUBCOMMAND_EXTRACT)->fallthrough();
+    extract->add_flag("--raw", result.cat.raw, "Don't decompress compressed entries & don't convert images to png.");
+    extract->add_option("LOD", result.lodPath, "Path to lod file.")->check(CLI::ExistingFile)->required()->option_text(" ");
+    extract->add_option("OUTPUT", result.extract.output, "Directory to extract the entries to.")->required()->option_text(" ");
+
     app->parse(argc, argv, result.helpPrinted);
     return result;
 }

--- a/src/Bin/LodTool/LodToolOptions.h
+++ b/src/Bin/LodTool/LodToolOptions.h
@@ -7,6 +7,7 @@ struct LodToolOptions {
         SUBCOMMAND_LS,
         SUBCOMMAND_DUMP,
         SUBCOMMAND_CAT,
+        SUBCOMMAND_EXTRACT,
     };
     using enum Subcommand;
 
@@ -15,10 +16,16 @@ struct LodToolOptions {
         bool raw = false;
     };
 
+    struct ExtractOptions {
+        std::string output;
+        bool raw = false;
+    };
+
     Subcommand subcommand = SUBCOMMAND_DUMP;
     std::string lodPath;
     bool helpPrinted = false; // True means that help message was already printed.
     CatOptions cat;
+    ExtractOptions extract;
 
     static LodToolOptions parse(int argc, char **argv);
 };

--- a/src/Library/Image/Pcx.cpp
+++ b/src/Library/Image/Pcx.cpp
@@ -105,7 +105,6 @@ RgbaImage pcx::decode(const Blob &data) {
     if (header->manufacturer != 0x0a)
         throw Exception("Invalid PCX starting byte, expected {:02x}, got {:02x}", 0x0a, header->manufacturer);
 
-
     if (header->version < PCX_VERSION_2_5 || header->version == PCX_VERSION_NOT_VALID || header->version > PCX_VERSION_3_0)
         throw Exception("Invalid PCX version: {}", header->version);
 

--- a/src/Library/Image/Png.cpp
+++ b/src/Library/Image/Png.cpp
@@ -28,12 +28,13 @@ RgbaImage png::decode(const Blob &data) {
     return result;
 }
 
-Blob png::encode(RgbaImageView image) {
+template<class Color>
+static Blob encodeWithFormat(ImageView<Color> image, int format) {
     png_image pngImage = {};
     pngImage.version = PNG_IMAGE_VERSION;
     pngImage.width = image.width();
     pngImage.height = image.height();
-    pngImage.format = PNG_FORMAT_RGBA;
+    pngImage.format = format;
 
     size_t size = PNG_IMAGE_PNG_SIZE_MAX(pngImage);
     std::unique_ptr<void, FreeDeleter> data(malloc(size));
@@ -41,4 +42,12 @@ Blob png::encode(RgbaImageView image) {
         throw Exception("Failed to encode PNG image ({})", pngImage.message);
 
     return Blob::fromMalloc(std::move(data), size);
+}
+
+Blob png::encode(RgbaImageView image) {
+    return encodeWithFormat(image, PNG_FORMAT_RGBA);
+}
+
+Blob png::encode(GrayscaleImageView image) {
+    return encodeWithFormat(image, PNG_FORMAT_GRAY);
 }

--- a/src/Library/Image/Png.h
+++ b/src/Library/Image/Png.h
@@ -6,4 +6,5 @@
 namespace png {
 RgbaImage decode(const Blob &data);
 Blob encode(RgbaImageView image);
+Blob encode(GrayscaleImageView image);
 } // namespace png

--- a/src/Library/LodFormats/LodFormats.cpp
+++ b/src/Library/LodFormats/LodFormats.cpp
@@ -128,7 +128,7 @@ Blob lod::decodeCompressed(const Blob &blob) {
         return result;
     }
 
-    if (format == LodFileFormat::LOD_FILE_PSEUDO_IMAGE) {
+    if (format == LOD_FILE_PSEUDO_IMAGE) {
         BlobInputStream stream(blob);
         LodImageHeader_MM6 header;
         deserialize(stream, &header);


### PR DESCRIPTION
Depends on #1835 – it has to be merged first.

`LodTool extract` can be used to extract everything from a Lod file, uncompressing whatever's compressed, and converting images to pngs. Palettes are exported as 256x1 pngs, sprites are exported in grayscale (b/c they use different palettes).