### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,6 @@ elseif(OE_BUILD_COMPILER STREQUAL "msvc")
     add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE) # POSIX deprecation warnings are also just noise
     add_compile_definitions(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS) # These are also useless
     add_compile_definitions(_USE_MATH_DEFINES) # Pull in M_PI and other <cmath> defines
-    add_compile_definitions(FMT_CONSTEVAL=) # MSVC chokes on fmt consteval formatting, so we define FMT_CONSTEVAL=<empty>
     add_compile_options(/MP) # Multi-threaded build
     add_compile_options(/Zc:preprocessor) # Use standard compliant preprocessor
     add_link_options(/OPT:REF) # Eliminate unreferenced data & functions.

--- a/src/GUI/Overlay/OverlayEventHandler.cpp
+++ b/src/GUI/Overlay/OverlayEventHandler.cpp
@@ -3,6 +3,8 @@
 #include <imgui/backends/imgui_impl_sdl2.h>
 #include <imgui/imgui.h>
 
+#include "Engine/Engine.h"
+
 OverlayEventHandler::OverlayEventHandler() : PlatformEventFilter(EVENTS_ALL) {
 }
 
@@ -15,6 +17,9 @@ bool OverlayEventHandler::keyReleaseEvent(const PlatformKeyEvent *event) {
 }
 
 bool OverlayEventHandler::keyEvent(PlatformKey key, PlatformModifiers mods, bool keyPressed) {
+    if (key == engine->config->keybindings.Console.value() || key == engine->config->gamepad.Console.value())
+        return false; // Pass close console keys to the game to handle.
+
     return ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard;
 }
 

--- a/src/Library/Logger/LogSink.cpp
+++ b/src/Library/Logger/LogSink.cpp
@@ -7,11 +7,6 @@
 #include <unordered_map>
 #include <memory>
 
-#ifdef _WINDOWS
-#   define WIN32_LEAN_AND_MEAN
-#   include <Windows.h>
-#endif
-
 #include <spdlog/sinks/android_sink.h> // NOLINT
 #include <spdlog/sinks/dist_sink.h> // NOLINT
 #include <spdlog/sinks/msvc_sink.h> // NOLINT
@@ -59,35 +54,12 @@ class AndroidSinkSt : public LogSink {
 };
 #endif
 
-#ifdef _WINDOWS
-/**
- * Need a custom sink here b/c `spdlog::sinks::msvc_sink_st` throws an exception on invalid UTF8, and this is totally
- * NOT OK.
- */
-class MsvcSinkSt : public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
- public:
-    MsvcSinkSt() = default;
-
- protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override {
-        if (!IsDebuggerPresent())
-            return;
-
-        spdlog::memory_buf_t formatted;
-        formatter_->format(msg, formatted);
-        OutputDebugStringW(win::toUtf16(std::string_view(formatted.data(), formatted.size())).data());
-    }
-
-    void flush_() override {}
-};
-#endif
-
 std::unique_ptr<LogSink> LogSink::createDefaultSink() {
 #if defined(__ANDROID__)
     return std::make_unique<AndroidSinkSt>();
 #elif defined(_WINDOWS)
     std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks = {
-        std::make_shared<MsvcSinkSt>(),
+        std::make_shared<spdlog::sinks::msvc_sink_st>(),
         std::make_shared<spdlog::sinks::stderr_color_sink_st>()
     };
     return std::make_unique<SpdlogSink<spdlog::sinks::dist_sink_st>>(std::move(sinks));

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -38,11 +38,8 @@ ScriptingSystem::~ScriptingSystem() {
 }
 
 void ScriptingSystem::executeEntryPoint() {
-    try {
-        _solState->script(dfs->read(fmt::format("{}/{}", _scriptFolder, _entryPointFile)).string_view());
-    } catch (const sol::error &e) {
-        logger->warning(ScriptingLogCategory, "An unexpected error has occurred: {}", e.what());
-    }
+    // This will throw if we have script errors.
+    _solState->script(dfs->read(fmt::format("{}/{}", _scriptFolder, _entryPointFile)).string_view());
 }
 
 void ScriptingSystem::_initBaseLibraries() {

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -45,7 +45,9 @@ add_subdirectory(small_vector EXCLUDE_FROM_ALL)
 # spdlog
 set(SPDLOG_FMT_EXTERNAL ON)
 set(SPDLOG_DISABLE_DEFAULT_LOGGER ON)
-set(SPDLOG_WCHAR_SUPPORT ON) # Use unicode APIs on Windows.
+if(OE_BUILD_PLATFORM STREQUAL "windows")
+    set(SPDLOG_WCHAR_SUPPORT ON) # Use unicode APIs on Windows.
+endif()
 add_subdirectory(spdlog EXCLUDE_FROM_ALL)
 
 # googletest


### PR DESCRIPTION
* Double-tapping ` now closes and opens console.
* Lazy-lazy test for #1853. OE & OE tests will just exit with an error if lua entrypoint fails.
* `MsvcSinkSt` changes pushed upstream, so dropped our workaround.