### PR TITLE
Terrain cleanup finished

### DIFF
--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -183,6 +183,9 @@ void GameStarter::initWithLogger() {
 GameStarter::~GameStarter() {
     _application->removeComponent<EngineControlComponent>(); // Join the control thread first.
 
+    _game.reset();
+    _engine.reset();
+
     ::engine = nullptr;
     ::render = nullptr;
     ::application = nullptr;

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -24,7 +24,8 @@ set(ENGINE_SOURCES
         TeleportPoint.cpp
         GameResourceManager.cpp
         mm7_data.cpp
-        mm7text_ru.cpp)
+        mm7text_ru.cpp
+        Seasons.cpp)
 
 set(ENGINE_HEADERS
         ArenaEnumFunctions.h
@@ -54,7 +55,7 @@ set(ENGINE_HEADERS
         GameResourceManager.h
         mm7_data.h
         stru314.h
-        Data/AutonoteData.h)
+        Seasons.h)
 
 add_library(engine STATIC ${ENGINE_SOURCES} ${ENGINE_HEADERS})
 target_check_style(engine)

--- a/src/Engine/Data/CMakeLists.txt
+++ b/src/Engine/Data/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
-set(ENGINE_DATA_SOURCES)
+set(ENGINE_DATA_SOURCES
+        TileEnumFunctions.cpp)
 
 set(ENGINE_DATA_HEADERS
         AutonoteEnums.h
@@ -18,6 +19,6 @@ set(ENGINE_DATA_HEADERS
         TileEnums.h
         TileEnumFunctions.h)
 
-add_library(engine_data INTERFACE ${ENGINE_DATA_SOURCES} ${ENGINE_DATA_HEADERS})
-target_link_libraries(engine_data INTERFACE library_serialization utility)
+add_library(engine_data STATIC ${ENGINE_DATA_SOURCES} ${ENGINE_DATA_HEADERS})
+target_link_libraries(engine_data PUBLIC library_serialization utility)
 target_check_style(engine_data)

--- a/src/Engine/Data/CMakeLists.txt
+++ b/src/Engine/Data/CMakeLists.txt
@@ -15,7 +15,8 @@ set(ENGINE_DATA_HEADERS
         IconFrameData.h
         PortraitFrameData.h
         TileData.h
-        TileEnums.h)
+        TileEnums.h
+        TileEnumFunctions.h)
 
 add_library(engine_data INTERFACE ${ENGINE_DATA_SOURCES} ${ENGINE_DATA_HEADERS})
 target_link_libraries(engine_data INTERFACE library_serialization utility)

--- a/src/Engine/Data/TileData.h
+++ b/src/Engine/Data/TileData.h
@@ -8,7 +8,7 @@
 struct TileData {
     std::string name;
     uint16_t uTileID = 0;
-    TileSet tileset = TILE_SET_INVALID;
+    Tileset tileset = TILESET_INVALID;
     TileVariant uSection = TILE_VARIANT_BASE1;
     TileFlags uAttributes;
 };

--- a/src/Engine/Data/TileEnumFunctions.cpp
+++ b/src/Engine/Data/TileEnumFunctions.cpp
@@ -1,0 +1,50 @@
+#include "TileEnumFunctions.h"
+
+#include <cassert>
+
+SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning) {
+    switch (tileSet) {
+    default:
+        assert(false);
+        [[fallthrough]];
+    case TILE_SET_INVALID:
+        return isRunning ? SOUND_RunDirt : SOUND_WalkDirt;
+    case TILE_SET_GRASS:
+        return isRunning ? SOUND_RunGrass : SOUND_WalkGrass;
+    case TILE_SET_SNOW:
+        return isRunning ? SOUND_RunSnow : SOUND_WalkSnow;
+    case TILE_SET_DESERT:
+        return isRunning ? SOUND_RunDesert : SOUND_WalkDesert;
+    case TILE_SET_COOLED_LAVA:
+        return isRunning ? SOUND_RunCooledLava : SOUND_WalkCooledLava;
+    case TILE_SET_DIRT:
+        return isRunning ? SOUND_RunDirt : SOUND_WalkDirt; // Water sounds were used.
+    case TILE_SET_WATER:
+        return isRunning ? SOUND_RunWater : SOUND_WalkWater; // Dirt sounds were used.
+    case TILE_SET_BADLANDS:
+        return isRunning ? SOUND_RunBadlands : SOUND_WalkBadlands;
+    case TILE_SET_SWAMP:
+        return isRunning ? SOUND_RunSwamp : SOUND_WalkSwamp;
+    case TILE_SET_TROPICAL:
+        return isRunning ? SOUND_RunGrass : SOUND_WalkGrass; // TODO(Nik-RE-dev): is that correct?
+    case TILE_SET_CITY:
+        return isRunning ? SOUND_RunGround : SOUND_WalkGround; // TODO(Nik-RE-dev): is that correct?
+    case TILE_SET_ROAD_GRASS_COBBLE:
+    case TILE_SET_ROAD_GRASS_DIRT:
+    case TILE_SET_ROAD_SNOW_COBBLE:
+    case TILE_SET_ROAD_SNOW_DIRT:
+    case TILE_SET_ROAD_SAND_COBBLE:
+    case TILE_SET_ROAD_SAND_DIRT:
+    case TILE_SET_ROAD_VOLCANO_COBBLE:
+    case TILE_SET_ROAD_VOLCANO_DIRT:
+    case TILE_SET_ROAD_CRACKED_COBBLE:
+    case TILE_SET_ROAD_CRACKED_DIRT:
+    case TILE_SET_ROAD_SWAMP_COBBLE:
+    case TILE_SET_ROAD_SWAMP_DIRT:
+    case TILE_SET_ROAD_TROPICAL_COBBLE:
+    case TILE_SET_ROAD_TROPICAL_DIRT:
+        return isRunning ? SOUND_RunRoad : SOUND_WalkRoad;
+    case TILE_SET_ROAD_CITY_STONE:
+        return isRunning ? SOUND_RunGround : SOUND_WalkGround; // TODO(Nik-RE-dev): is that correct?
+    }
+}

--- a/src/Engine/Data/TileEnumFunctions.cpp
+++ b/src/Engine/Data/TileEnumFunctions.cpp
@@ -48,3 +48,20 @@ SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning) {
         return isRunning ? SOUND_RunGround : SOUND_WalkGround; // TODO(Nik-RE-dev): is that correct?
     }
 }
+
+int foodRequiredForTileSet(TileSet tileSet) {
+    switch (tileSet) {
+    case TILE_SET_GRASS:
+        return 1;
+    case TILE_SET_SNOW:
+    case TILE_SET_SWAMP:
+        return 3;
+    case TILE_SET_COOLED_LAVA:
+    case TILE_SET_BADLANDS:
+        return 4;
+    case TILE_SET_DESERT:
+        return 5;
+    default:
+        return 2;
+    }
+}

--- a/src/Engine/Data/TileEnumFunctions.cpp
+++ b/src/Engine/Data/TileEnumFunctions.cpp
@@ -2,64 +2,64 @@
 
 #include <cassert>
 
-SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning) {
-    switch (tileSet) {
+SoundId walkSoundForTileset(Tileset tileset, bool isRunning) {
+    switch (tileset) {
     default:
         assert(false);
         [[fallthrough]];
-    case TILE_SET_INVALID:
+    case TILESET_INVALID:
         return isRunning ? SOUND_RunDirt : SOUND_WalkDirt;
-    case TILE_SET_GRASS:
+    case TILESET_GRASS:
         return isRunning ? SOUND_RunGrass : SOUND_WalkGrass;
-    case TILE_SET_SNOW:
+    case TILESET_SNOW:
         return isRunning ? SOUND_RunSnow : SOUND_WalkSnow;
-    case TILE_SET_DESERT:
+    case TILESET_DESERT:
         return isRunning ? SOUND_RunDesert : SOUND_WalkDesert;
-    case TILE_SET_COOLED_LAVA:
+    case TILESET_COOLED_LAVA:
         return isRunning ? SOUND_RunCooledLava : SOUND_WalkCooledLava;
-    case TILE_SET_DIRT:
+    case TILESET_DIRT:
         return isRunning ? SOUND_RunDirt : SOUND_WalkDirt; // Water sounds were used.
-    case TILE_SET_WATER:
+    case TILESET_WATER:
         return isRunning ? SOUND_RunWater : SOUND_WalkWater; // Dirt sounds were used.
-    case TILE_SET_BADLANDS:
+    case TILESET_BADLANDS:
         return isRunning ? SOUND_RunBadlands : SOUND_WalkBadlands;
-    case TILE_SET_SWAMP:
+    case TILESET_SWAMP:
         return isRunning ? SOUND_RunSwamp : SOUND_WalkSwamp;
-    case TILE_SET_TROPICAL:
+    case TILESET_TROPICAL:
         return isRunning ? SOUND_RunGrass : SOUND_WalkGrass; // TODO(Nik-RE-dev): is that correct?
-    case TILE_SET_CITY:
+    case TILESET_CITY:
         return isRunning ? SOUND_RunGround : SOUND_WalkGround; // TODO(Nik-RE-dev): is that correct?
-    case TILE_SET_ROAD_GRASS_COBBLE:
-    case TILE_SET_ROAD_GRASS_DIRT:
-    case TILE_SET_ROAD_SNOW_COBBLE:
-    case TILE_SET_ROAD_SNOW_DIRT:
-    case TILE_SET_ROAD_SAND_COBBLE:
-    case TILE_SET_ROAD_SAND_DIRT:
-    case TILE_SET_ROAD_VOLCANO_COBBLE:
-    case TILE_SET_ROAD_VOLCANO_DIRT:
-    case TILE_SET_ROAD_CRACKED_COBBLE:
-    case TILE_SET_ROAD_CRACKED_DIRT:
-    case TILE_SET_ROAD_SWAMP_COBBLE:
-    case TILE_SET_ROAD_SWAMP_DIRT:
-    case TILE_SET_ROAD_TROPICAL_COBBLE:
-    case TILE_SET_ROAD_TROPICAL_DIRT:
+    case TILESET_ROAD_GRASS_COBBLE:
+    case TILESET_ROAD_GRASS_DIRT:
+    case TILESET_ROAD_SNOW_COBBLE:
+    case TILESET_ROAD_SNOW_DIRT:
+    case TILESET_ROAD_SAND_COBBLE:
+    case TILESET_ROAD_SAND_DIRT:
+    case TILESET_ROAD_VOLCANO_COBBLE:
+    case TILESET_ROAD_VOLCANO_DIRT:
+    case TILESET_ROAD_CRACKED_COBBLE:
+    case TILESET_ROAD_CRACKED_DIRT:
+    case TILESET_ROAD_SWAMP_COBBLE:
+    case TILESET_ROAD_SWAMP_DIRT:
+    case TILESET_ROAD_TROPICAL_COBBLE:
+    case TILESET_ROAD_TROPICAL_DIRT:
         return isRunning ? SOUND_RunRoad : SOUND_WalkRoad;
-    case TILE_SET_ROAD_CITY_STONE:
+    case TILESET_ROAD_CITY_STONE:
         return isRunning ? SOUND_RunGround : SOUND_WalkGround; // TODO(Nik-RE-dev): is that correct?
     }
 }
 
-int foodRequiredForTileSet(TileSet tileSet) {
-    switch (tileSet) {
-    case TILE_SET_GRASS:
+int foodRequiredForTileset(Tileset tileset) {
+    switch (tileset) {
+    case TILESET_GRASS:
         return 1;
-    case TILE_SET_SNOW:
-    case TILE_SET_SWAMP:
+    case TILESET_SNOW:
+    case TILESET_SWAMP:
         return 3;
-    case TILE_SET_COOLED_LAVA:
-    case TILE_SET_BADLANDS:
+    case TILESET_COOLED_LAVA:
+    case TILESET_BADLANDS:
         return 4;
-    case TILE_SET_DESERT:
+    case TILESET_DESERT:
         return 5;
     default:
         return 2;

--- a/src/Engine/Data/TileEnumFunctions.h
+++ b/src/Engine/Data/TileEnumFunctions.h
@@ -9,7 +9,7 @@ inline Segment<TileVariant> allSpecialTileVariants() {
 }
 
 /**
- * @param tileSet                       Tileset to get walk/run sound for,
+ * @param tileSet                       Tileset to get walk/run sound for.
  * @param isRunning                     Run flag.
  * @return                              Sound id to use.
  * @offset 0x47EE49

--- a/src/Engine/Data/TileEnumFunctions.h
+++ b/src/Engine/Data/TileEnumFunctions.h
@@ -15,3 +15,5 @@ inline Segment<TileVariant> allSpecialTileVariants() {
  * @offset 0x47EE49
  */
 SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning);
+
+int foodRequiredForTileSet(TileSet tileSet);

--- a/src/Engine/Data/TileEnumFunctions.h
+++ b/src/Engine/Data/TileEnumFunctions.h
@@ -9,11 +9,11 @@ inline Segment<TileVariant> allSpecialTileVariants() {
 }
 
 /**
- * @param tileSet                       Tileset to get walk/run sound for.
+ * @param tileset                       Tileset to get walk/run sound for.
  * @param isRunning                     Run flag.
  * @return                              Sound id to use.
  * @offset 0x47EE49
  */
-SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning);
+SoundId walkSoundForTileset(Tileset tileset, bool isRunning);
 
-int foodRequiredForTileSet(TileSet tileSet);
+int foodRequiredForTileset(Tileset tileset);

--- a/src/Engine/Data/TileEnumFunctions.h
+++ b/src/Engine/Data/TileEnumFunctions.h
@@ -1,7 +1,17 @@
 #include "TileEnums.h"
 
+#include "Media/Audio/SoundEnums.h"
+
 #include "Utility/Segment.h"
 
 inline Segment<TileVariant> allSpecialTileVariants() {
     return {TILE_VARIANT_FIRST_SPECIAL, TILE_VARIANT_LAST_SPECIAL};
 }
+
+/**
+ * @param tileSet                       Tileset to get walk/run sound for,
+ * @param isRunning                     Run flag.
+ * @return                              Sound id to use.
+ * @offset 0x47EE49
+ */
+SoundId walkSoundForTileSet(TileSet tileSet, bool isRunning);

--- a/src/Engine/Data/TileEnumFunctions.h
+++ b/src/Engine/Data/TileEnumFunctions.h
@@ -1,0 +1,7 @@
+#include "TileEnums.h"
+
+#include "Utility/Segment.h"
+
+inline Segment<TileVariant> allSpecialTileVariants() {
+    return {TILE_VARIANT_FIRST_SPECIAL, TILE_VARIANT_LAST_SPECIAL};
+}

--- a/src/Engine/Data/TileEnums.h
+++ b/src/Engine/Data/TileEnums.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Utility/Flags.h"
-#include "Utility/Segment.h"
 
 enum class TileFlag {
     TILE_BURN = 0x1,
@@ -61,10 +60,6 @@ enum class TileVariant {
     TILE_VARIANT_LAST_SPECIAL = TILE_VARIANT_SPECIAL8_NCAP,
 };
 using enum TileVariant;
-
-inline Segment<TileVariant> allSpecialTileSects() {
-    return {TILE_VARIANT_FIRST_SPECIAL, TILE_VARIANT_LAST_SPECIAL};
-}
 
 /**
  * Tile set id.

--- a/src/Engine/Data/TileEnums.h
+++ b/src/Engine/Data/TileEnums.h
@@ -66,32 +66,32 @@ using enum TileVariant;
  *
  * Most of these tile sets don't exist in mm7 data, see comments.
  */
-enum class TileSet {
-    TILE_SET_INVALID = 255, // Tile with id 0 has tile set = 255.
-    TILE_SET_GRASS = 0,
-    TILE_SET_SNOW = 1,
-    TILE_SET_DESERT = 2, // Sand.
-    TILE_SET_COOLED_LAVA = 3, // Somehow this tileset is all dirt in the data files.
-    TILE_SET_DIRT = 4, // This one has only 3 tiles.
-    TILE_SET_WATER = 5, // Water tile & shoreline tiles.
-    TILE_SET_BADLANDS = 6, // Looks like Deyja.
-    TILE_SET_SWAMP = 7,
-    TILE_SET_TROPICAL = 8, // This is all dirt.
-    TILE_SET_CITY = 9, // This is sand too, lol.
-    TILE_SET_ROAD_GRASS_COBBLE = 10, // Cobble road on dirt actually.
-    TILE_SET_ROAD_GRASS_DIRT = 11, // This is all dirt.
-    TILE_SET_ROAD_SNOW_COBBLE = 12, // This is all dirt.
-    TILE_SET_ROAD_SNOW_DIRT = 13, // This is all dirt.
-    TILE_SET_ROAD_SAND_COBBLE = 14, // This doesn't exist in mm7 tiles at all.
-    TILE_SET_ROAD_SAND_DIRT = 15, // This doesn't exist in mm7 tiles at all.
-    TILE_SET_ROAD_VOLCANO_COBBLE = 16, // This is all dirt.
-    TILE_SET_ROAD_VOLCANO_DIRT = 17, // This is all dirt.
-    TILE_SET_ROAD_CRACKED_COBBLE = 22, // This is all dirt.
-    TILE_SET_ROAD_CRACKED_DIRT = 23, // This is all dirt.
-    TILE_SET_ROAD_SWAMP_COBBLE = 24, // This is all dirt.
-    TILE_SET_ROAD_SWAMP_DIRT = 25, // This is all dirt.
-    TILE_SET_ROAD_TROPICAL_COBBLE = 26, // This is all dirt.
-    TILE_SET_ROAD_TROPICAL_DIRT = 27, // This is all dirt.
-    TILE_SET_ROAD_CITY_STONE = 28, // This is all dirt.
+enum class Tileset {
+    TILESET_INVALID = 255, // Tile with id 0 has tile set = 255.
+    TILESET_GRASS = 0,
+    TILESET_SNOW = 1,
+    TILESET_DESERT = 2, // Sand.
+    TILESET_COOLED_LAVA = 3, // Somehow this tileset is all dirt in the data files.
+    TILESET_DIRT = 4, // This one has only 3 tiles.
+    TILESET_WATER = 5, // Water tile & shoreline tiles.
+    TILESET_BADLANDS = 6, // Looks like Deyja.
+    TILESET_SWAMP = 7,
+    TILESET_TROPICAL = 8, // This is all dirt.
+    TILESET_CITY = 9, // This is sand too, lol.
+    TILESET_ROAD_GRASS_COBBLE = 10, // Cobble road on dirt actually.
+    TILESET_ROAD_GRASS_DIRT = 11, // This is all dirt.
+    TILESET_ROAD_SNOW_COBBLE = 12, // This is all dirt.
+    TILESET_ROAD_SNOW_DIRT = 13, // This is all dirt.
+    TILESET_ROAD_SAND_COBBLE = 14, // This doesn't exist in mm7 tiles at all.
+    TILESET_ROAD_SAND_DIRT = 15, // This doesn't exist in mm7 tiles at all.
+    TILESET_ROAD_VOLCANO_COBBLE = 16, // This is all dirt.
+    TILESET_ROAD_VOLCANO_DIRT = 17, // This is all dirt.
+    TILESET_ROAD_CRACKED_COBBLE = 22, // This is all dirt.
+    TILESET_ROAD_CRACKED_DIRT = 23, // This is all dirt.
+    TILESET_ROAD_SWAMP_COBBLE = 24, // This is all dirt.
+    TILESET_ROAD_SWAMP_DIRT = 25, // This is all dirt.
+    TILESET_ROAD_TROPICAL_COBBLE = 26, // This is all dirt.
+    TILESET_ROAD_TROPICAL_DIRT = 27, // This is all dirt.
+    TILESET_ROAD_CITY_STONE = 28, // This is all dirt.
 };
-using enum TileSet;
+using enum Tileset;

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -518,27 +518,6 @@ void Camera3D::CalculateRotations(int cameraYaw, int cameraPitch) {
     _pitchRotationCosine = std::cos((pi_double + pi_double) * _viewPitch / 2048.0);
 }
 
-//----- (00436A6D) --------------------------------------------------------
-float Camera3D::GetPolygonMinZ(RenderVertexSoft *pVertices, unsigned int uStripType) {
-    float result = FLT_MAX;
-    for (unsigned i = 0; i < uStripType; i++) {
-        if (pVertices[i].vWorldPosition.z < result) {
-            result = pVertices[i].vWorldPosition.z;
-        }
-    }
-    return result;
-}
-
-//----- (00436A40) --------------------------------------------------------
-float Camera3D::GetPolygonMaxZ(RenderVertexSoft *pVertex, unsigned int uStripType) {
-    float result = FLT_MIN;
-    for (unsigned i = 0; i < uStripType; i++) {
-        if (pVertex[i].vWorldPosition.z > result)
-            result = pVertex[i].vWorldPosition.z;
-    }
-    return result;
-}
-
 void Camera3D::CullByNearClip(RenderVertexSoft *pverts, unsigned *unumverts) {
     float near = GetNearClip();
 

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -27,11 +27,6 @@ struct Camera3D {
         RenderVertexSoft *pVertices,
         signed int NumFrustumPlanes);
 
-    float GetPolygonMaxZ(RenderVertexSoft *pVertex,
-                          unsigned int uStripType);
-    float GetPolygonMinZ(RenderVertexSoft *pVertices,
-                          unsigned int uStripType);
-
     void LightmapNeerClip(RenderVertexSoft *pInVertices,
                           int uNumInVertices,
                           RenderVertexSoft *pOutVertices,

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -744,7 +744,7 @@ void ProcessActorCollisionsODM(Actor &actor, bool isFlying) {
             break;
 
         CollideOutdoorWithModels(true);
-        CollideOutdoorWithDecorations(WorldPosToGrid(actor.pos));
+        CollideOutdoorWithDecorations(worldToGrid(actor.pos));
         CollideWithParty(false);
         _46ED8A_collide_against_sprite_objects(Pid(OBJECT_Actor, actor.id));
 
@@ -1023,7 +1023,7 @@ void ProcessPartyCollisionsODM(Vec3f *partyNewPos, Vec3f *partyInputSpeed, int *
         }
 
         CollideOutdoorWithModels(true);
-        CollideOutdoorWithDecorations(WorldPosToGrid(pParty->pos));
+        CollideOutdoorWithDecorations(worldToGrid(pParty->pos));
         _46ED8A_collide_against_sprite_objects(Pid::character(0));
         if (!engine->config->gameplay.NoPartyActorCollisions.value()) {
             for (size_t actor_id = 0; actor_id < pActors.size(); ++actor_id)

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -230,7 +230,7 @@ bool DecalBuilder::ApplyBloodSplat_OutdoorFace(ODMFace *pFace) {
 
 //----- (0049BE8A) --------------------------------------------------------
 // apply outdoor blodsplats - check to see if bloodsplat hits terrain triangle
-bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, Vec3f *terrnorm, float *tridotdist,
+bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, const Vec3f &terrnorm, float *tridotdist,
                                             RenderVertexSoft *triverts, const int whichsplat) {
     // tracks how many decals are applied to this tri
     this->uNumSplatsThisFace = 0;
@@ -240,8 +240,8 @@ bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, Vec3f *terrnorm, float 
 
     if (NumBloodsplats > 0) {
        // check plane distance
-       *tridotdist = -dot(triverts->vWorldPosition, *terrnorm);
-       float planedist = dot(*terrnorm, bloodsplat_container->pBloodsplats_to_apply[whichsplat].pos) + *tridotdist + 0.5f;
+       *tridotdist = -dot(triverts->vWorldPosition, terrnorm);
+       float planedist = dot(terrnorm, bloodsplat_container->pBloodsplats_to_apply[whichsplat].pos) + *tridotdist + 0.5f;
 
         if (planedist <= bloodsplat_container->pBloodsplats_to_apply[whichsplat].radius) {
             // blood splat hits this terrain tri

--- a/src/Engine/Graphics/DecalBuilder.h
+++ b/src/Engine/Graphics/DecalBuilder.h
@@ -101,7 +101,7 @@ struct DecalBuilder {
      * 
      * @return                              True if bloodsplat_container->uNumBloodsplats > 0, false otherwise.
      */
-    bool ApplyBloodSplatToTerrain(bool fading, Vec3f *terrnorm, float *tridotdist,
+    bool ApplyBloodSplatToTerrain(bool fading, const Vec3f &terrnorm, float *tridotdist,
                                   RenderVertexSoft *triverts, const int whichsplat);
     void DrawDecals(float z_bias);
     void DrawBloodsplats();

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -38,6 +38,7 @@
 #include "Engine/Graphics/BspRenderer.h"
 #include "Engine/MapInfo.h"
 #include "Engine/LOD.h"
+#include "Engine/Seasons.h"
 
 #include "GUI/GUIProgressBar.h"
 #include "GUI/GUIWindow.h"
@@ -569,47 +570,8 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
 TileData *OutdoorLocation::getTileDescByGrid(int sX, int sY) {
     int tileId = pTerrain.tileIdByGrid(Vec2i(sX, sY));
 
-    if (engine->config->graphics.SeasonsChange.value()) {
-        switch (pParty->uCurrentMonth) {
-            case 11:
-            case 0:
-            case 1:            // winter
-                if (tileId >= 90) {  // Tileset_Grass begins at TileID = 90
-                    if (tileId <= 95)  // some grastyl entries
-                        tileId = 348;
-                    else if (tileId <= 113)  // rest of grastyl & all grdrt*
-                        tileId = 348 + (tileId - 96);
-                }
-                /*switch (v3)
-                {
-                case 102: v3 = 354; break;  // grdrtNE -> SNdrtne
-                case 104: v3 = 356; break;  // grdrtNW -> SNdrtnw
-                case 108: v3 = 360; break;  // grdrtN  -> SNdrtn
-                }*/
-                break;
-
-            case 2:
-            case 3:
-            case 4:  // spring
-            case 8:
-            case 9:
-            case 10:  // autumn
-                if (tileId >= 90 &&
-                    tileId <= 113)  // just convert all Tileset_Grass to dirt
-                    tileId = 1;
-                break;
-
-            case 5:
-            case 6:
-            case 7:  // summer
-                // all tiles are green grass by default
-                break;
-
-            default:
-                assert(pParty->uCurrentMonth >= 0 &&
-                       pParty->uCurrentMonth < 12);
-        }
-    }
+    if (engine->config->graphics.SeasonsChange.value())
+        tileId = tileIdForSeason(tileId, pParty->uCurrentMonth);
 
     return &pTileTable->tiles[tileId];
 }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -251,11 +251,6 @@ double OutdoorLocation::GetFogDensityByTime() {
     }
 }
 
-TileData *OutdoorLocation::getTileDescByPos(const Vec3f &pos) {
-    Vec2i gridPos = WorldPosToGrid(pos);
-    return getTileDescByGrid(gridPos.x, gridPos.y);
-}
-
 //----- (00488F5C) --------------------------------------------------------
 bool OutdoorLocation::Initialize(std::string_view filename, int days_played,
                                  int respawn_interval_days,
@@ -369,7 +364,7 @@ int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3f &pos) {
         return 2;
     }
 
-    return foodRequiredForTileSet(getTileDescByPos(pos)->tileset);
+    return foodRequiredForTileSet(pTerrain.tileSetByPos(pos));
 }
 
 //----- (00489487) --------------------------------------------------------

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -190,7 +190,7 @@ void OutdoorLocation::ExecDraw(unsigned int bRedraw) {
     engine->StackPartyTorchLight();
 
     // engine->PrepareBloodsplats(); // not used?
-    UpdateDiscoveredArea(WorldPosToGrid(pParty->pos));
+    UpdateDiscoveredArea(worldToGrid(pParty->pos));
 
     uNumDecorationsDrawnThisFrame = 0;
     uNumSpritesDrawnThisFrame = 0;
@@ -413,7 +413,7 @@ void OutdoorLocation::CreateDebugLocation() {
     this->location_filename = "i6.odm";
     this->location_file_description = "MM6 Outdoor v1.00";
 
-    this->pTerrain.CreateDebugTerrain();
+    this->pTerrain.createDebugTerrain();
     this->pSpawnPoints.clear();
 
     this->pOMAP.fill(0);
@@ -1411,8 +1411,8 @@ void ODM_ProcessPartyActions() {
         pParty->setAirborne(true);
 
     Vec3f partyOldPosition = pParty->pos;
-    Vec2i partyOldGridPos = WorldPosToGrid(pParty->pos);
-    Vec2i partyNewGridPos = WorldPosToGrid(partyNewPos);
+    Vec2i partyOldGridPos = worldToGrid(pParty->pos);
+    Vec2i partyNewGridPos = worldToGrid(partyNewPos);
 
     // this gets if tile is not water
     bool partyCurrentOnLand = !pOutdoor->pTerrain.isWaterByGrid(partyOldGridPos);
@@ -1798,17 +1798,16 @@ void UpdateActors_ODM() {
             if (!uIsFlying && !tile1IsLand && !uIsAboveFloor && Actor_On_Terrain) {
                 // on water and shouldnt be
                 bool tileTestLand = false;  // reset land found
-                Vec2i gridPos = WorldPosToGrid(pActors[Actor_ITR].pos);
+                Vec2i gridPos = worldToGrid(pActors[Actor_ITR].pos);
                 for (int i = gridPos.x - 1; i <= gridPos.x + 1; i++) {
                     // scan surrounding cells for land
                     for (int j = gridPos.y - 1; j <= gridPos.y + 1; j++) {
                         tileTestLand = !pOutdoor->pTerrain.isWaterByGrid({i, j});
                         if (tileTestLand) {  // found land
-                            int target_x = GridCellToWorldPosX(i);
-                            int target_y = GridCellToWorldPosY(j);
+                            Vec2i target = gridToWorld({i, j});
                             if (pActors[Actor_ITR].CanAct()) {  // head to land
-                                pActors[Actor_ITR].yawAngle = TrigLUT.atan2(target_x - pActors[Actor_ITR].pos.x,
-                                                                             target_y - pActors[Actor_ITR].pos.y);
+                                pActors[Actor_ITR].yawAngle = TrigLUT.atan2(target.x - pActors[Actor_ITR].pos.x,
+                                                                             target.y - pActors[Actor_ITR].pos.y);
                                 pActors[Actor_ITR].currentActionTime = 0_ticks;
                                 pActors[Actor_ITR].currentActionLength = 128_ticks;
                                 pActors[Actor_ITR].aiState = Fleeing;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -369,20 +369,7 @@ int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3f &pos) {
         return 2;
     }
 
-    switch (getTileDescByPos(pos)->tileset) {
-        case TILE_SET_GRASS:
-            return 1;
-        case TILE_SET_SNOW:
-        case TILE_SET_SWAMP:
-            return 3;
-        case TILE_SET_COOLED_LAVA:
-        case TILE_SET_BADLANDS:
-            return 4;
-        case TILE_SET_DESERT:
-            return 5;
-        default:
-            return 2;
-    }
+    return foodRequiredForTileSet(getTileDescByPos(pos)->tileset);
 }
 
 //----- (00489487) --------------------------------------------------------

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1997,24 +1997,6 @@ int sub_47C3D7_get_fog_specular(int unused, int isSky, float screen_depth) {
     return (255 - v7) << 24;
 }
 
-//----- (0047F44B) --------------------------------------------------------
-//----- (0047F458) --------------------------------------------------------
-Vec2i WorldPosToGrid(Vec3f worldPos) {
-    int worldX = worldPos.x;
-    int worldY = worldPos.y;
-
-    // sar is in original exe, resulting -880 / 512 = -1 and -880 sar 9 = -2.
-    int gridX = (worldX >> 9) + 64;
-    int gridY = 63 - (worldY >> 9);
-    return Vec2i(gridX, gridY);
-}
-
-//----- (0047F469) --------------------------------------------------------
-int GridCellToWorldPosX(int a1) { return (a1 - 64) << 9; }
-
-//----- (0047F476) --------------------------------------------------------
-int GridCellToWorldPosY(int a1) { return (64 - a1) << 9; }
-
 //----- (00436A6D) --------------------------------------------------------
 double OutdoorLocation::GetPolygonMinZ(RenderVertexSoft *pVertices, unsigned int unumverts) {
     double result = FLT_MAX;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1560,7 +1560,7 @@ void ODM_ProcessPartyActions() {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByGrid(WorldPosToGrid(partyOldPosition)), true);
+                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByPos(partyOldPosition), true);
                             }
                         }
                     } else if (partyIsWalking) {
@@ -1568,7 +1568,7 @@ void ODM_ProcessPartyActions() {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByGrid(WorldPosToGrid(partyOldPosition)), false);
+                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByPos(partyOldPosition), false);
                             }
                         }
                     }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -39,6 +39,7 @@
 #include "Engine/MapInfo.h"
 #include "Engine/LOD.h"
 #include "Engine/Seasons.h"
+#include "Engine/Data/TileEnumFunctions.h"
 
 #include "GUI/GUIProgressBar.h"
 #include "GUI/GUIWindow.h"
@@ -1573,12 +1574,11 @@ void ODM_ProcessPartyActions() {
                     bool isModelWalk = !partyNotOnModel && pOutdoor->pBModels[modelId].pFaces[faceId].Visible();
                     SoundId sound = SOUND_Invalid;
                     if (partyIsRunning) {
-                        if (walkDelta >= 4 ) {
+                        if (walkDelta >= 4) {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                // Old comment: 56 is ground run
-                                sound = pOutdoor->pTerrain.soundIdByGrid(WorldPosToGrid(partyOldPosition), true);
+                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByGrid(WorldPosToGrid(partyOldPosition)), true);
                             }
                         }
                     } else if (partyIsWalking) {
@@ -1586,7 +1586,7 @@ void ODM_ProcessPartyActions() {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                sound = pOutdoor->pTerrain.soundIdByGrid(WorldPosToGrid(partyOldPosition), false);
+                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByGrid(WorldPosToGrid(partyOldPosition)), false);
                             }
                         }
                     }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -986,6 +986,15 @@ OutdoorLocation::OutdoorLocation() {
     this->sky_texture = nullptr;
 
     uLastSunlightUpdateMinute = 0;
+
+    engine->config->graphics.SeasonsChange.addListener(this, [this](bool seasonsChange) {
+        pTerrain.changeSeason(seasonsChange ? pParty->uCurrentMonth : 6);
+        render->ReleaseTerrain();
+    });
+}
+
+OutdoorLocation::~OutdoorLocation() {
+    engine->config->graphics.SeasonsChange.removeListeners(this);
 }
 
 // TODO(pskelton): Magic numbers

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -364,7 +364,7 @@ int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3f &pos) {
         return 2;
     }
 
-    return foodRequiredForTileSet(pTerrain.tileSetByPos(pos));
+    return foodRequiredForTileset(pTerrain.tilesetByPos(pos));
 }
 
 //----- (00489487) --------------------------------------------------------
@@ -1560,7 +1560,7 @@ void ODM_ProcessPartyActions() {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByPos(partyOldPosition), true);
+                                sound = walkSoundForTileset(pOutdoor->pTerrain.tilesetByPos(partyOldPosition), true);
                             }
                         }
                     } else if (partyIsWalking) {
@@ -1568,7 +1568,7 @@ void ODM_ProcessPartyActions() {
                             if (isModelWalk) {
                                 sound = SOUND_RunWood;
                             } else {
-                                sound = walkSoundForTileSet(pOutdoor->pTerrain.tileSetByPos(partyOldPosition), false);
+                                sound = walkSoundForTileset(pOutdoor->pTerrain.tilesetByPos(partyOldPosition), false);
                             }
                         }
                     }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -548,15 +548,9 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
     }
 
     this->sky_texture = assets->getBitmap(loc_time.sky_texture_name);
-}
-
-TileData *OutdoorLocation::getTileDescByGrid(int sX, int sY) {
-    int tileId = pTerrain.tileIdByGrid(Vec2i(sX, sY));
 
     if (engine->config->graphics.SeasonsChange.value())
-        tileId = tileIdForSeason(tileId, pParty->uCurrentMonth);
-
-    return &pTileTable->tiles[tileId];
+        pOutdoor->pTerrain.changeSeason(pParty->uCurrentMonth);
 }
 
 //----- (0047EF60) --------------------------------------------------------

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -29,6 +29,7 @@ struct DMap {
 
 struct OutdoorLocation {
     OutdoorLocation();
+    ~OutdoorLocation();
     // int New_SKY_NIGHT_ID;
     void ExecDraw(unsigned int bRedraw);
     void PrepareActorsDrawList();

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -45,11 +45,6 @@ struct OutdoorLocation {
     double GetFogDensityByTime();
 
     /**
-     * @offset 0x488EEF
-     */
-    TileData *getTileDescByPos(const Vec3f &pos);
-
-    /**
      * @offset 0x47ED08
      */
     TileData *getTileDescByGrid(int uX, int uZ);

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -121,10 +121,7 @@ void SetUnderwaterFog();
 void loadAndPrepareODM(MapId mapid, bool bLoading);
 Color GetLevelFogColor();
 int sub_47C3D7_get_fog_specular(int unused, int a2, float a3);
-Vec2i WorldPosToGrid(Vec3f worldPos);
 
-int GridCellToWorldPosX(int);
-int GridCellToWorldPosY(int);
 void sub_481ED9_MessWithODMRenderParams();
 void TeleportToStartingPoint(MapStartPoint point);  // idb
 

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -44,10 +44,6 @@ struct OutdoorLocation {
     bool InitalizeActors(MapId a1);
     double GetFogDensityByTime();
 
-    /**
-     * @offset 0x47ED08
-     */
-    TileData *getTileDescByGrid(int uX, int uZ);
     bool Initialize(std::string_view filename, int days_played,
                     int respawn_interval_days,
                     bool * outdoors_was_respawned);

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -27,9 +27,9 @@ static int mapToGlobalTileId(const std::array<int, 4> &baseIds, int localTileId)
     if (localTileId >= 234)
         return 0;
 
-    int tileSetIndex = (localTileId - 90) / 36;
-    int tileSetOffset = (localTileId - 90) % 36;
-    return baseIds[tileSetIndex] + tileSetOffset;
+    int tilesetIndex = (localTileId - 90) / 36;
+    int tilesetOffset = (localTileId - 90) % 36;
+    return baseIds[tilesetIndex] + tilesetOffset;
 }
 
 OutdoorTerrain::OutdoorTerrain() {
@@ -39,16 +39,16 @@ OutdoorTerrain::OutdoorTerrain() {
 }
 
 void OutdoorTerrain::CreateDebugTerrain() {
-    int tileId = pTileTable->tileId(TILE_SET_GRASS, TILE_VARIANT_BASE1);
+    int tileId = pTileTable->tileId(TILESET_GRASS, TILE_VARIANT_BASE1);
 
     pHeightmap.fill(0);
     pTilemap.fill(tileId);
     pTerrainNormals.fill({Vec3f(0, 0, 1), Vec3f(0, 0, 1)});
 
-    pTileTypes[0] = TILE_SET_GRASS;
-    pTileTypes[1] = TILE_SET_WATER;
-    pTileTypes[2] = TILE_SET_BADLANDS;
-    pTileTypes[3] = TILE_SET_ROAD_GRASS_COBBLE;
+    pTileTypes[0] = TILESET_GRASS;
+    pTileTypes[1] = TILESET_WATER;
+    pTileTypes[2] = TILESET_BADLANDS;
+    pTileTypes[3] = TILESET_ROAD_GRASS_COBBLE;
 }
 
 int OutdoorTerrain::heightByGrid(Vec2i gridPos) const {
@@ -110,15 +110,15 @@ int OutdoorTerrain::tileIdByGrid(Vec2i gridPos) const {
     return pTilemap[gridPos.y][gridPos.x];
 }
 
-TileSet OutdoorTerrain::tileSetByGrid(Vec2i gridPos) const {
+Tileset OutdoorTerrain::tilesetByGrid(Vec2i gridPos) const {
     if (gridPos.x < 0 || gridPos.x > 127 || gridPos.y < 0 || gridPos.y > 127)
-        return TILE_SET_INVALID;
+        return TILESET_INVALID;
 
     return pTileTable->tiles[pTilemap[gridPos.y][gridPos.x]].tileset;
 }
 
-TileSet OutdoorTerrain::tileSetByPos(const Vec3f &pos) const {
-    return tileSetByGrid(WorldPosToGrid(pos));
+Tileset OutdoorTerrain::tilesetByPos(const Vec3f &pos) const {
+    return tilesetByGrid(WorldPosToGrid(pos));
 }
 
 bool OutdoorTerrain::isWaterByGrid(Vec2i gridPos) const {
@@ -194,7 +194,7 @@ bool OutdoorTerrain::isSlopeTooHighByPos(const Vec3f &pos) const {
 void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst) {
     std::array<int, 4> baseTileIds;
     for (int i = 0; i < 4; i++) {
-        dst->pTileTypes[i] = static_cast<TileSet>(src.tileTypes[i].tileset);
+        dst->pTileTypes[i] = static_cast<Tileset>(src.tileTypes[i].tileset);
         baseTileIds[i] = pTileTable->tileId(dst->pTileTypes[i], TILE_VARIANT_BASE1);
     }
 

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -32,6 +32,24 @@ static int mapToGlobalTileId(const std::array<int, 4> &baseIds, int localTileId)
     return baseIds[tilesetIndex] + tilesetOffset;
 }
 
+//----- (0047F44B) --------------------------------------------------------
+//----- (0047F458) --------------------------------------------------------
+Vec2i WorldPosToGrid(Vec3f worldPos) {
+    int worldX = worldPos.x;
+    int worldY = worldPos.y;
+
+    // sar is in original exe, resulting -880 / 512 = -1 and -880 sar 9 = -2.
+    int gridX = (worldX >> 9) + 64;
+    int gridY = 63 - (worldY >> 9);
+    return Vec2i(gridX, gridY);
+}
+
+//----- (0047F469) --------------------------------------------------------
+int GridCellToWorldPosX(int a1) { return (a1 - 64) << 9; }
+
+//----- (0047F476) --------------------------------------------------------
+int GridCellToWorldPosY(int a1) { return (64 - a1) << 9; }
+
 OutdoorTerrain::OutdoorTerrain() {
     pHeightmap = Image<uint8_t>::solid(128, 128, 0);
     pTilemap = Image<int16_t>::solid(128, 128, 0);

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -106,54 +106,6 @@ TileSet OutdoorTerrain::tileSetByGrid(Vec2i gridPos) const {
     return pTileTypes[tileSetIndex].tileset;
 }
 
-SoundId OutdoorTerrain::soundIdByGrid(Vec2i gridPos, bool isRunning) const {
-    // TODO(captainurist): this doesn't take seasons into account.
-    switch (tileSetByGrid(gridPos)) {
-    case TILE_SET_GRASS:
-        return isRunning ? SOUND_RunGrass : SOUND_WalkGrass;
-    case TILE_SET_SNOW:
-        return isRunning ? SOUND_RunSnow : SOUND_WalkSnow;
-    case TILE_SET_DESERT:
-        return isRunning ? SOUND_RunDesert : SOUND_WalkDesert;
-    case TILE_SET_COOLED_LAVA:
-        return isRunning ? SOUND_RunCooledLava : SOUND_WalkCooledLava;
-    case TILE_SET_INVALID: // Use dirt sounds for invalid tiles.
-    case TILE_SET_DIRT:
-        // Water sounds were used
-        return isRunning ? SOUND_RunDirt : SOUND_WalkDirt;
-    case TILE_SET_WATER:
-        // Dirt sounds were used
-        return isRunning ? SOUND_RunWater : SOUND_WalkWater;
-    case TILE_SET_BADLANDS:
-        return isRunning ? SOUND_RunBadlands : SOUND_WalkBadlands;
-    case TILE_SET_SWAMP:
-        return isRunning ? SOUND_RunSwamp : SOUND_WalkSwamp;
-    case TILE_SET_TROPICAL:
-        // TODO(Nik-RE-dev): is that correct?
-        return isRunning ? SOUND_RunGrass : SOUND_WalkGrass;
-    case TILE_SET_ROAD_GRASS_COBBLE:
-    case TILE_SET_ROAD_GRASS_DIRT:
-    case TILE_SET_ROAD_SNOW_COBBLE:
-    case TILE_SET_ROAD_SNOW_DIRT:
-    case TILE_SET_ROAD_SAND_COBBLE:
-    case TILE_SET_ROAD_SAND_DIRT:
-    case TILE_SET_ROAD_VOLCANO_COBBLE:
-    case TILE_SET_ROAD_VOLCANO_DIRT:
-    case TILE_SET_ROAD_CRACKED_COBBLE:
-    case TILE_SET_ROAD_CRACKED_DIRT:
-    case TILE_SET_ROAD_SWAMP_COBBLE:
-    case TILE_SET_ROAD_SWAMP_DIRT:
-    case TILE_SET_ROAD_TROPICAL_COBBLE:
-    case TILE_SET_ROAD_TROPICAL_DIRT:
-        return isRunning ? SOUND_RunRoad : SOUND_WalkRoad;
-    case TILE_SET_CITY:
-    case TILE_SET_ROAD_CITY_STONE:
-        // TODO(Nik-RE-dev): is that correct?
-    default:
-        return isRunning ? SOUND_RunGround : SOUND_WalkGround;
-    }
-}
-
 bool OutdoorTerrain::isWaterByGrid(Vec2i gridPos) const {
     return pTileTable->tiles[tileIdByGrid(gridPos)].uAttributes & TILE_WATER;
 }

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -4,6 +4,10 @@
 #include <algorithm>
 
 #include "Engine/Tables/TileTable.h"
+#include "Engine/Snapshots/CompositeSnapshots.h"
+#include "Engine/Snapshots/EntitySnapshots.h"
+
+#include "Library/Snapshots/CommonSnapshots.h"
 
 #include "Outdoor.h"
 
@@ -13,12 +17,6 @@ bool OutdoorTerrain::ZeroLandscape() {
     this->pTilemap.fill(90);
     this->pAttributemap.fill(0);
     return true;
-}
-
-//----- (0047F420) --------------------------------------------------------
-void OutdoorTerrain::LoadBaseTileIds() {
-    for (unsigned i = 0; i < 3; ++i)
-        pTileTypes[i].uTileID = pTileTable->tileIdForTileset(pTileTypes[i].tileset, 1);
 }
 
 void OutdoorTerrain::CreateDebugTerrain() {
@@ -176,6 +174,22 @@ bool OutdoorTerrain::isSlopeTooHighByPos(const Vec3f &pos) const {
     int y_min = std::min(y1, std::min(y2, y3));  // не верно при подъёме на склон
     int y_max = std::max(y1, std::max(y2, y3));
     return (y_max - y_min) > 512;
+}
+
+void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst) {
+    reconstruct(src.tileTypes, &dst->pTileTypes);
+    dst->LoadBaseTileIds();
+
+    reconstruct(src.heightMap, &dst->pHeightmap);
+    reconstruct(src.tileMap, &dst->pTilemap);
+    reconstruct(src.attributeMap, &dst->pAttributemap);
+    dst->recalculateNormals();
+}
+
+//----- (0047F420) --------------------------------------------------------
+void OutdoorTerrain::LoadBaseTileIds() {
+    for (unsigned i = 0; i < 3; ++i)
+        pTileTypes[i].uTileID = pTileTable->tileIdForTileset(pTileTypes[i].tileset, 1);
 }
 
 void OutdoorTerrain::recalculateNormals() {

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -31,14 +31,14 @@ void OutdoorTerrain::CreateDebugTerrain() {
 
 //----- (00488F2E) --------------------------------------------------------
 //----- (0047EE16) --------------------------------------------------------
-int OutdoorTerrain::heightByGrid(Vec2i gridPos) {
+int OutdoorTerrain::heightByGrid(Vec2i gridPos) const {
     if (gridPos.x < 0 || gridPos.x > 127 || gridPos.y < 0 || gridPos.y > 127)
         return 0;
 
     return 32 * pHeightmap[gridPos.y * 128 + gridPos.x];
 }
 
-int OutdoorTerrain::heightByPos(const Vec3f &pos) {
+int OutdoorTerrain::heightByPos(const Vec3f &pos) const {
     // TODO(captainurist): This should return float. But we'll need to retrace.
     int originz;          // ebx@11
     int lz;          // eax@11
@@ -54,7 +54,7 @@ int OutdoorTerrain::heightByPos(const Vec3f &pos) {
 
     Vec2i gridPos = WorldPosToGrid(pos);
 
-    OutdoorTileGeometry tile = pOutdoor->pTerrain.tileGeometryByGrid(gridPos);
+    TileGeometry tile = tileGeometryByGrid(gridPos);
 
     if (tile.v00.z != tile.v10.z || tile.v10.z != tile.v11.z || tile.v11.z != tile.v01.z) {
         // On a slope.
@@ -169,7 +169,7 @@ bool OutdoorTerrain::isWaterByPos(const Vec3f &pos) const {
 Vec3f OutdoorTerrain::normalByPos(const Vec3f &pos) const {
     Vec2i gridPos = WorldPosToGrid(pos);
 
-    OutdoorTileGeometry tile = pOutdoor->pTerrain.tileGeometryByGrid(gridPos);
+    TileGeometry tile = tileGeometryByGrid(gridPos);
 
     Vec3f side1, side2;
 
@@ -204,7 +204,7 @@ Vec3f OutdoorTerrain::normalByPos(const Vec3f &pos) const {
 bool OutdoorTerrain::isSlopeTooHighByPos(const Vec3f &pos) const {
     Vec2i gridPos = WorldPosToGrid(pos);
 
-    OutdoorTileGeometry tile = pOutdoor->pTerrain.tileGeometryByGrid(gridPos);
+    TileGeometry tile = tileGeometryByGrid(gridPos);
 
     int dx = std::abs(pos.x - tile.v00.x), dz = std::abs(tile.v00.y - pos.y);
 
@@ -237,18 +237,18 @@ bool OutdoorTerrain::isSlopeTooHighByPos(const Vec3f &pos) const {
     return (y_max - y_min) > 512;
 }
 
-OutdoorTileGeometry OutdoorTerrain::tileGeometryByGrid(Vec2i gridPos) const {
+OutdoorTerrain::TileGeometry OutdoorTerrain::tileGeometryByGrid(Vec2i gridPos) const {
     int x0 = GridCellToWorldPosX(gridPos.x);
     int y0 = GridCellToWorldPosY(gridPos.y);
     int x1 = GridCellToWorldPosX(gridPos.x + 1);
     int y1 = GridCellToWorldPosY(gridPos.y + 1);
 
-    int z00 = pOutdoor->pTerrain.heightByGrid(gridPos);
-    int z01 = pOutdoor->pTerrain.heightByGrid(gridPos + Vec2i(0, 1));
-    int z10 = pOutdoor->pTerrain.heightByGrid(gridPos + Vec2i(1, 0));
-    int z11 = pOutdoor->pTerrain.heightByGrid(gridPos + Vec2i(1, 1));
+    int z00 = heightByGrid(gridPos);
+    int z01 = heightByGrid(gridPos + Vec2i(0, 1));
+    int z10 = heightByGrid(gridPos + Vec2i(1, 0));
+    int z11 = heightByGrid(gridPos + Vec2i(1, 1));
 
-    OutdoorTileGeometry result;
+    TileGeometry result;
     result.v00 = Vec3f(x0, y0, z00);
     result.v01 = Vec3f(x0, y1, z01);
     result.v10 = Vec3f(x1, y0, z10);

--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -106,6 +106,10 @@ TileSet OutdoorTerrain::tileSetByGrid(Vec2i gridPos) const {
     return pTileTypes[tileSetIndex].tileset;
 }
 
+TileSet OutdoorTerrain::tileSetByPos(const Vec3f &pos) const {
+    return tileSetByGrid(WorldPosToGrid(pos));
+}
+
 bool OutdoorTerrain::isWaterByGrid(Vec2i gridPos) const {
     return pTileTable->tiles[tileIdByGrid(gridPos)].uAttributes & TILE_WATER;
 }

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <array>
-#include <vector>
 
 #include "Library/Geometry/Vec.h"
 
 #include "Engine/Data/TileEnums.h"
 
-#include "Media/Audio/SoundEnums.h"
+struct OutdoorLocation_MM7;
 
 struct OutdoorTileType {
     TileSet tileset = TILE_SET_INVALID;
@@ -17,7 +16,6 @@ struct OutdoorTileType {
 class OutdoorTerrain {
  public:
     bool ZeroLandscape();
-    void LoadBaseTileIds();
     void CreateDebugTerrain();
 
     int heightByGrid(Vec2i gridPos) const;
@@ -68,12 +66,11 @@ class OutdoorTerrain {
 
     std::array<OutdoorTileType, 4> pTileTypes; // [3] is road tileset.
     std::array<uint8_t, 128 * 128> pHeightmap = {};
-    std::array<uint8_t, 128 * 128> pTilemap = {};
+    std::array<uint8_t, 128 * 128> pTilemap = {}; // TODO(captainurist): place TILEIDS here on load!
     std::array<uint8_t, 128 * 128> pAttributemap = {};
     std::array<Vec3f, 128 * 128 * 2> pTerrainNormals;
 
-    // TODO(captainurist): make private, also reconstruct() functions belong to the classes themselves.
-    void recalculateNormals();
+    friend void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst);
 
  private:
     struct TileGeometry {
@@ -88,6 +85,8 @@ class OutdoorTerrain {
     };
 
  private:
+    void LoadBaseTileIds();
+    void recalculateNormals();
     TileGeometry tileGeometryByGrid(Vec2i gridPos) const;
     int mapToGlobalTileId(int localTileId) const;
 };

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -52,16 +52,16 @@ class OutdoorTerrain {
      * @return                          Terrain height at `gridPos`.
      * @offset 0x00488F2E, 0x0047EE16
      */
-    int heightByGrid(Pointi gridPos) const;
+    [[nodiscard]] int heightByGrid(Pointi gridPos) const;
 
     /**
      * @param pos                       World coordinates, only xy component is used by this function.
      * @return                          Terrain height at given position.
      * @offset 0x0048257A
      */
-    int heightByPos(const Vec3f &pos) const;
+    [[nodiscard]] int heightByPos(const Vec3f &pos) const;
 
-    Vec3i vertexByGridUnsafe(Pointi gridPos) const {
+    [[nodiscard]] Vec3i vertexByGridUnsafe(Pointi gridPos) const {
         Vec2i tmp = gridToWorld(gridPos);
         return Vec3i(tmp.x, tmp.y, 32 * _heightMap[gridPos]);
     }
@@ -70,35 +70,35 @@ class OutdoorTerrain {
      * @param gridPos                   Grid coordinates.
      * @return                          Tile id at `gridPos` that can then be used to get tile data from `TileTable`.
      */
-    int tileIdByGrid(Pointi gridPos) const;
+    [[nodiscard]] int tileIdByGrid(Pointi gridPos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Tile set for the tile at `gridPos`, or `Tileset_NULL` if the tile is invalid.
      */
-    Tileset tilesetByGrid(Pointi gridPos) const;
+    [[nodiscard]] Tileset tilesetByGrid(Pointi gridPos) const;
 
-    Tileset tilesetByPos(const Vec3f &pos) const;
+    [[nodiscard]] Tileset tilesetByPos(const Vec3f &pos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Whether the tile at `gridPos` is a water tile. Note that shore tiles are
      *                                  different from water tiles.
      */
-    bool isWaterByGrid(Pointi gridPos) const;
+    [[nodiscard]] bool isWaterByGrid(Pointi gridPos) const;
 
-    bool isWaterByPos(const Vec3f &pos) const;
+    [[nodiscard]] bool isWaterByPos(const Vec3f &pos) const;
 
-    bool isWaterOrShoreByGrid(Pointi gridPos) const;
+    [[nodiscard]] bool isWaterOrShoreByGrid(Pointi gridPos) const;
 
     /**
      * @param pos                       World coordinates, only xy component is used by this function.
      * @return                          Terrain normal at given position. Terrain normals always point up (`z > 0`).
      * @offset 0x0046DCC8
      */
-    Vec3f normalByPos(const Vec3f &pos) const;
+    [[nodiscard]] Vec3f normalByPos(const Vec3f &pos) const;
 
-    const std::array<Vec3f, 2> &normalsByGridUnsafe(Pointi gridPos) const {
+    [[nodiscard]] const std::array<Vec3f, 2> &normalsByGridUnsafe(Pointi gridPos) const {
         return _normalMap[gridPos];
     }
 
@@ -107,7 +107,7 @@ class OutdoorTerrain {
      * @return                          Whether terrain slope at given position is too high to be climbed or stood on.
      * @offset 0x004823F4
      */
-    bool isSlopeTooHighByPos(const Vec3f &pos) const;
+    [[nodiscard]] bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
     friend void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst);
 
@@ -122,7 +122,7 @@ class OutdoorTerrain {
     };
 
     void recalculateNormals();
-    TileGeometry tileGeometryByGrid(Pointi gridPos) const;
+    [[nodiscard]] TileGeometry tileGeometryByGrid(Pointi gridPos) const;
 
  private:
     std::array<Tileset, 4> _tilesets; // Tileset ids used in this location, [3] is road tileset.

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -2,7 +2,7 @@
 
 #include <array>
 
-#include "Library/Geometry/Vec.h"
+#include "Library/Geometry/Point.h"
 #include "Library/Image/Image.h"
 
 #include "Engine/Data/TileEnums.h"
@@ -11,7 +11,7 @@ struct OutdoorLocation_MM7;
 
 int GridCellToWorldPosX(int);
 int GridCellToWorldPosY(int);
-Vec2i WorldPosToGrid(Vec3f worldPos);
+Pointi WorldPosToGrid(Vec3f worldPos);
 
 class OutdoorTerrain {
  public:
@@ -24,30 +24,30 @@ class OutdoorTerrain {
      * @return                          Terrain height at `gridPos`.
      * @offset 0x00488F2E, 0x0047EE16
      */
-    int heightByGrid(Vec2i gridPos) const;
-
-    Vec3i vertexByGrid(Vec2i gridPos) const {
-        // TODO(captainurist): we do no bounds checks here, and shouldn't do any in other places.
-
-        return Vec3i(GridCellToWorldPosX(gridPos.x), GridCellToWorldPosY(gridPos.y), heightByGrid(gridPos));
-    }
+    int heightByGrid(Pointi gridPos) const;
 
     /**
+     * @param pos                       World coordinates, only xy component is used by this function.
+     * @return                          Terrain height at given position.
      * @offset 0x0048257A
      */
     int heightByPos(const Vec3f &pos) const;
+
+    Vec3i vertexByGrid(Pointi gridPos) const {
+        return Vec3i(GridCellToWorldPosX(gridPos.x), GridCellToWorldPosY(gridPos.y), heightByGrid(gridPos));
+    }
 
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Tile id at `gridPos` that can then be used to get tile data from `TileTable`.
      */
-    int tileIdByGrid(Vec2i gridPos) const;
+    int tileIdByGrid(Pointi gridPos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Tile set for the tile at `gridPos`, or `Tileset_NULL` if the tile is invalid.
      */
-    Tileset tilesetByGrid(Vec2i gridPos) const;
+    Tileset tilesetByGrid(Pointi gridPos) const;
 
     Tileset tilesetByPos(const Vec3f &pos) const;
 
@@ -56,11 +56,11 @@ class OutdoorTerrain {
      * @return                          Whether the tile at `gridPos` is a water tile. Note that shore tiles are
      *                                  different from water tiles.
      */
-    bool isWaterByGrid(Vec2i gridPos) const;
-
-    bool isWaterOrShoreByGrid(Vec2i gridPos) const;
+    bool isWaterByGrid(Pointi gridPos) const;
 
     bool isWaterByPos(const Vec3f &pos) const;
+
+    bool isWaterOrShoreByGrid(Pointi gridPos) const;
 
     /**
      * @param pos                       World coordinates, only xy component is used by this function.
@@ -69,8 +69,8 @@ class OutdoorTerrain {
      */
     Vec3f normalByPos(const Vec3f &pos) const;
 
-    const std::array<Vec3f, 2> &normalsByGrid(Vec2i gridPos) const {
-        return pTerrainNormals[gridPos.y][gridPos.x];
+    const std::array<Vec3f, 2> &normalsByGrid(Pointi gridPos) const {
+        return pTerrainNormals[gridPos];
     }
 
     /**
@@ -95,7 +95,7 @@ class OutdoorTerrain {
     };
 
     void recalculateNormals();
-    TileGeometry tileGeometryByGrid(Vec2i gridPos) const;
+    TileGeometry tileGeometryByGrid(Pointi gridPos) const;
 
  private:
     std::array<Tileset, 4> pTileTypes; // Tileset ids used in this location, [3] is road tileset.

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -39,6 +39,8 @@ class OutdoorTerrain {
      */
     TileSet tileSetByGrid(Vec2i gridPos) const;
 
+    TileSet tileSetByPos(const Vec3f &pos) const;
+
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Whether the tile at `gridPos` is a water tile. Note that shore tiles are

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -53,7 +53,6 @@ class OutdoorTerrain {
     bool isWaterByPos(const Vec3f &pos) const;
 
     /**
-     *
      * @param pos                       World coordinates, only xy component is used by this function.
      * @return                          Terrain normal at given position. Terrain normals always point up (`z > 0`).
      * @offset 0x0046DCC8
@@ -67,16 +66,23 @@ class OutdoorTerrain {
      */
     bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
-    std::array<OutdoorTileType, 4> pTileTypes;  // [3] is road tileset.
+    std::array<OutdoorTileType, 4> pTileTypes; // [3] is road tileset.
     std::array<uint8_t, 128 * 128> pHeightmap = {};
     std::array<uint8_t, 128 * 128> pTilemap = {};
     std::array<uint8_t, 128 * 128> pAttributemap = {};
     std::vector<Vec3f> pTerrainNormals;
-    std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
+    std::array<uint16_t, 128 * 128 * 2> pTerrainNormalIndices;
 
  private:
     struct TileGeometry {
-        Vec3f v00, v01, v10, v11; // Four vertices of the tile, v00 is at (x0, y0), v01 at (x0, y1), etc.
+        int x0 = 0;
+        int x1 = 0;
+        int y0 = 0;
+        int y1 = 0;
+        int z00 = 0;
+        int z01 = 0;
+        int z10 = 0;
+        int z11 = 0;
     };
 
  private:

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -33,8 +33,8 @@ class OutdoorTerrain {
      */
     int heightByPos(const Vec3f &pos) const;
 
-    Vec3i vertexByGrid(Pointi gridPos) const {
-        return Vec3i(GridCellToWorldPosX(gridPos.x), GridCellToWorldPosY(gridPos.y), heightByGrid(gridPos));
+    Vec3i vertexByGridUnsafe(Pointi gridPos) const {
+        return Vec3i(GridCellToWorldPosX(gridPos.x), GridCellToWorldPosY(gridPos.y), 32 * pHeightmap[gridPos]);
     }
 
     /**
@@ -69,7 +69,7 @@ class OutdoorTerrain {
      */
     Vec3f normalByPos(const Vec3f &pos) const;
 
-    const std::array<Vec3f, 2> &normalsByGrid(Pointi gridPos) const {
+    const std::array<Vec3f, 2> &normalsByGridUnsafe(Pointi gridPos) const {
         return pTerrainNormals[gridPos];
     }
 

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -70,15 +70,17 @@ class OutdoorTerrain {
     std::array<uint8_t, 128 * 128> pHeightmap = {};
     std::array<uint8_t, 128 * 128> pTilemap = {};
     std::array<uint8_t, 128 * 128> pAttributemap = {};
-    std::vector<Vec3f> pTerrainNormals;
-    std::array<uint16_t, 128 * 128 * 2> pTerrainNormalIndices;
+    std::array<Vec3f, 128 * 128 * 2> pTerrainNormals;
+
+    // TODO(captainurist): make private, also reconstruct() functions belong to the classes themselves.
+    void recalculateNormals();
 
  private:
     struct TileGeometry {
         int x0 = 0;
         int x1 = 0;
         int y0 = 0;
-        int y1 = 0;
+        int y1 = 0; // We have a retarded coordinate system, so y1 < y0, always.
         int z00 = 0;
         int z01 = 0;
         int z10 = 0;

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -37,9 +37,9 @@ class OutdoorTerrain {
      * @param gridPos                   Grid coordinates.
      * @return                          Tile set for the tile at `gridPos`, or `Tileset_NULL` if the tile is invalid.
      */
-    TileSet tileSetByGrid(Vec2i gridPos) const;
+    Tileset tilesetByGrid(Vec2i gridPos) const;
 
-    TileSet tileSetByPos(const Vec3f &pos) const;
+    Tileset tilesetByPos(const Vec3f &pos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
@@ -66,7 +66,7 @@ class OutdoorTerrain {
      */
     bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
-    std::array<TileSet, 4> pTileTypes; // Tileset ids used in this location, [3] is road tileset.
+    std::array<Tileset, 4> pTileTypes; // Tileset ids used in this location, [3] is road tileset.
     Image<uint8_t> pHeightmap; // Height map, to get actual height multiply by 32.
     Image<int16_t> pTilemap; // Tile id map, indices into the global tile table.
     Image<std::array<Vec3f, 2>> pTerrainNormals; // Terrain normal map, two normals per tile for two triangles.

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -14,22 +14,18 @@ struct OutdoorTileType {
     uint16_t uTileID = 0;
 };
 
-struct OutdoorTileGeometry {
-    Vec3f v00, v01, v10, v11; // Four vertices of the tile, v00 is at (x0, y0), v01 at (x0, y1), etc.
-};
-
 class OutdoorTerrain {
  public:
     bool ZeroLandscape();
     void LoadBaseTileIds();
     void CreateDebugTerrain();
 
-    int heightByGrid(Vec2i gridPos);
+    int heightByGrid(Vec2i gridPos) const;
 
     /**
      * @offset 0x0048257A
      */
-    int heightByPos(const Vec3f &pos);
+    int heightByPos(const Vec3f &pos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
@@ -74,9 +70,6 @@ class OutdoorTerrain {
      */
     bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
-    // TODO(captainurist): also move all the functions that use this method into this class.
-    OutdoorTileGeometry tileGeometryByGrid(Vec2i gridPos) const;
-
     std::array<OutdoorTileType, 4> pTileTypes;  // [3] is road tileset.
     std::array<uint8_t, 128 * 128> pHeightmap = {};
     std::array<uint8_t, 128 * 128> pTilemap = {};
@@ -85,5 +78,11 @@ class OutdoorTerrain {
     std::array<unsigned short, 128 * 128 * 2> pTerrainNormalIndices;
 
  private:
+    struct TileGeometry {
+        Vec3f v00, v01, v10, v11; // Four vertices of the tile, v00 is at (x0, y0), v01 at (x0, y1), etc.
+    };
+
+ private:
+    TileGeometry tileGeometryByGrid(Vec2i gridPos) const;
     int mapToGlobalTileId(int localTileId) const;
 };

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -3,6 +3,7 @@
 #include <array>
 
 #include "Library/Geometry/Vec.h"
+#include "Library/Image/Image.h"
 
 #include "Engine/Data/TileEnums.h"
 
@@ -15,7 +16,9 @@ struct OutdoorTileType {
 
 class OutdoorTerrain {
  public:
-    bool ZeroLandscape();
+    OutdoorTerrain();
+
+    void ZeroLandscape();
     void CreateDebugTerrain();
 
     int heightByGrid(Vec2i gridPos) const;
@@ -65,10 +68,9 @@ class OutdoorTerrain {
     bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
     std::array<OutdoorTileType, 4> pTileTypes; // [3] is road tileset.
-    std::array<uint8_t, 128 * 128> pHeightmap = {};
-    std::array<uint8_t, 128 * 128> pTilemap = {}; // TODO(captainurist): place TILEIDS here on load!
-    std::array<uint8_t, 128 * 128> pAttributemap = {};
-    std::array<Vec3f, 128 * 128 * 2> pTerrainNormals;
+    Image<uint8_t> pHeightmap;
+    Image<uint8_t> pTilemap; // TODO(captainurist): place TILEIDS here on load!
+    Image<std::array<Vec3f, 2>> pTerrainNormals;
 
     friend void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst);
 

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -11,8 +11,11 @@ struct TileData;
 struct OutdoorLocation_MM7;
 
 /**
+ * A note on grid coordinates. In grid coordinates Y-axis points south (down on the minimap), X-axis points east (right
+ * on the minimap), `(0, 0)` is NW (top-left) corner of the map.
+ *
  * @param gridPos                       Grid coordinates.
- * @return                              World coordinates of the grid's corner. XXX
+ * @return                              World coordinates of the grid cell's NW (top-left on the minimap) corner.
  * @offset 0x0047F469, 0x0047F476
  */
 inline Vec2i gridToWorld(Pointi gridPos) {
@@ -20,6 +23,9 @@ inline Vec2i gridToWorld(Pointi gridPos) {
 }
 
 /**
+ * A note on world coordinates. Y-axis points north (up on the minimap), X-axis points east (right on the minimap),
+ * `(0, 0)` is in the center of the map.
+ *
  * @param worldPos                      Position in world coordinates.
  * @return                              Grid cell coordinates that `worldPos` is in.
  * @offset 0x0047F44B, 0x0047F458

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -40,11 +40,6 @@ class OutdoorTerrain {
     TileSet tileSetByGrid(Vec2i gridPos) const;
 
     /**
-     * @offset 0x47EE49
-     */
-    SoundId soundIdByGrid(Vec2i gridPos, bool isRunning) const;
-
-    /**
      * @param gridPos                   Grid coordinates.
      * @return                          Whether the tile at `gridPos` is a water tile. Note that shore tiles are
      *                                  different from water tiles.

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -9,18 +9,17 @@
 
 struct OutdoorLocation_MM7;
 
-struct OutdoorTileType {
-    TileSet tileset = TILE_SET_INVALID;
-    uint16_t uTileID = 0;
-};
-
 class OutdoorTerrain {
  public:
     OutdoorTerrain();
 
-    void ZeroLandscape();
     void CreateDebugTerrain();
 
+    /**
+     * @param gridPos                   Grid coordinates.
+     * @return                          Terrain height at `gridPos`.
+     * @offset 0x00488F2E, 0x0047EE16
+     */
     int heightByGrid(Vec2i gridPos) const;
 
     /**
@@ -67,10 +66,10 @@ class OutdoorTerrain {
      */
     bool isSlopeTooHighByPos(const Vec3f &pos) const;
 
-    std::array<OutdoorTileType, 4> pTileTypes; // [3] is road tileset.
-    Image<uint8_t> pHeightmap;
-    Image<uint8_t> pTilemap; // TODO(captainurist): place TILEIDS here on load!
-    Image<std::array<Vec3f, 2>> pTerrainNormals;
+    std::array<TileSet, 4> pTileTypes; // Tileset ids used in this location, [3] is road tileset.
+    Image<uint8_t> pHeightmap; // Height map, to get actual height multiply by 32.
+    Image<int16_t> pTilemap; // Tile id map, indices into the global tile table.
+    Image<std::array<Vec3f, 2>> pTerrainNormals; // Terrain normal map, two normals per tile for two triangles.
 
     friend void reconstruct(const OutdoorLocation_MM7 &src, OutdoorTerrain *dst);
 
@@ -87,8 +86,6 @@ class OutdoorTerrain {
     };
 
  private:
-    void LoadBaseTileIds();
     void recalculateNormals();
     TileGeometry tileGeometryByGrid(Vec2i gridPos) const;
-    int mapToGlobalTileId(int localTileId) const;
 };

--- a/src/Engine/Graphics/OutdoorTerrain.h
+++ b/src/Engine/Graphics/OutdoorTerrain.h
@@ -7,6 +7,7 @@
 
 #include "Engine/Data/TileEnums.h"
 
+struct TileData;
 struct OutdoorLocation_MM7;
 
 /**
@@ -47,6 +48,8 @@ class OutdoorTerrain {
 
     void createDebugTerrain();
 
+    void changeSeason(int month);
+
     /**
      * @param gridPos                   Grid coordinates.
      * @return                          Terrain height at `gridPos`.
@@ -71,6 +74,13 @@ class OutdoorTerrain {
      * @return                          Tile id at `gridPos` that can then be used to get tile data from `TileTable`.
      */
     [[nodiscard]] int tileIdByGrid(Pointi gridPos) const;
+
+    /**
+     * @param gridPos                   Grid coordinates.
+     * @return                          Tile data from the global tile table for the tile at `gridPos`.
+     * @offset 0x47ED08
+     */
+    [[nodiscard]] const TileData &tileDataByGrid(Pointi gridPos) const;
 
     /**
      * @param gridPos                   Grid coordinates.
@@ -128,5 +138,6 @@ class OutdoorTerrain {
     std::array<Tileset, 4> _tilesets; // Tileset ids used in this location, [3] is road tileset.
     Image<uint8_t> _heightMap; // Height map, to get actual height multiply by 32.
     Image<int16_t> _tileMap; // Tile id map, indices into the global tile table.
+    Image<int16_t> _originalTileMap; // Same as above, but w/o seasonal changes.
     Image<std::array<Vec3f, 2>> _normalMap; // Terrain normal map, two normals per tile for two triangles.
 };

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1461,7 +1461,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
         // generate vertex locations
         for (int y = 0; y < 128; ++y)
             for (int x = 0; x < 128; ++x)
-                pTerrainVertices[y * 128 + x].vWorldPosition = pOutdoor->pTerrain.vertexByGrid({x, y}).toFloat();
+                pTerrainVertices[y * 128 + x].vWorldPosition = pOutdoor->pTerrain.vertexByGridUnsafe({x, y}).toFloat();
 
         // reserve first 7 layers for water tiles in unit 0
         auto wtrtexture = this->hd_water_tile_anim[0];
@@ -1528,7 +1528,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 }
 
                 // next calculate all vertices vertices
-                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGrid({x, y});
+                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGridUnsafe({x, y});
 
                 // calc each vertex
                 // [0] - x,y        n1
@@ -1939,7 +1939,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 // splat hits this square of terrain
                 bool fading = pOutdoor->pTerrain.isWaterOrShoreByGrid({loopx, loopy});
 
-                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGrid({loopx, loopy});
+                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGridUnsafe({loopx, loopy});
 
                 float Light_tile_dist = 0.0;
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1455,8 +1455,6 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
     // generate array and populate data
     if (terrainVAO == 0) {
         static RenderVertexSoft pTerrainVertices[128 * 128];
-        int blockScale = 512;
-        int heightScale = 32;
 
         // generate vertex locations
         for (int y = 0; y < 128; ++y)
@@ -1478,24 +1476,24 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 // map is 127 x 127 squares - each square has two triangles - each tri has 3 verts
 
                 // first find all required textures for terrain and add to map
-                auto tile = pOutdoor->getTileDescByGrid(x, y);
+                const auto &tile = pOutdoor->pTerrain.tileDataByGrid({x, y});
                 int tileunit = 0;
                 int tilelayer = 0;
 
                 // check if tile->name is already in list
-                auto mapiter = terraintexmap.find(tile->name);
+                auto mapiter = terraintexmap.find(tile.name);
                 if (mapiter != terraintexmap.end()) {
                     // if so, extract unit and layer
                     int unitlayer = mapiter->second;
                     tilelayer = unitlayer & 0xFF;
                     tileunit = (unitlayer & 0xFF00) >> 8;
-                } else if (tile->name == "wtrtyl") {
+                } else if (tile.name == "wtrtyl") {
                     // water tile
                     tileunit = 0;
                     tilelayer = 0;
                 } else {
                     // else need to add it
-                    auto thistexture = assets->getBitmap(tile->name);
+                    auto thistexture = assets->getBitmap(tile.name);
                     int width = thistexture->width();
                     // check size to see what unit it needs
                     int i;
@@ -1517,7 +1515,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
 
                         if (numterraintexloaded[i] < 256) {
                             // intsert into tex map
-                            terraintexmap.insert(std::make_pair(tile->name, encode));
+                            terraintexmap.insert(std::make_pair(tile.name, encode));
                             numterraintexloaded[i]++;
                         } else {
                             logger->warning("Texture layer full - draw terrain!");

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1879,7 +1879,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
     // loop over blood to lay
     for (unsigned i = 0; i < NumBloodsplats; ++i) {
         // approx location of bloodsplat
-        Vec2i gridPos = WorldPosToGrid(decal_builder->bloodsplat_container->pBloodsplats_to_apply[i].pos);
+        Vec2i gridPos = worldToGrid(decal_builder->bloodsplat_container->pBloodsplats_to_apply[i].pos);
         // use terrain squares in block surrounding to try and stack faces
 
         int scope = std::ceil(decal_builder->bloodsplat_container->pBloodsplats_to_apply[i].radius / 512);

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1532,12 +1532,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 }
 
                 // next calculate all vertices vertices
-                unsigned norm_idx = pOutdoor->pTerrain.pTerrainNormalIndices[(2 * x * 128) + (2 * y) + 2 /*+ 1*/];  // 2 is top tri // 3 is bottom
-                unsigned bottnormidx = pOutdoor->pTerrain.pTerrainNormalIndices[(2 * x * 128) + (2 * y) + 3];
-                assert(norm_idx < pOutdoor->pTerrain.pTerrainNormals.size());
-                assert(bottnormidx < pOutdoor->pTerrain.pTerrainNormals.size());
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[norm_idx];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[bottnormidx];
+                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[(2 * y * 128) + (2 * x)];
+                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[(2 * y * 128) + (2 * x) + 1];
 
                 // calc each vertex
                 // [0] - x,y        n1
@@ -1948,12 +1944,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 // splat hits this square of terrain
                 bool fading = pOutdoor->pTerrain.isWaterOrShoreByGrid({loopx, loopy});
 
-                unsigned norm_idx = pOutdoor->pTerrain.pTerrainNormalIndices[(2 * loopx * 128) + (2 * loopy) + 2];  // 2 is top tri // 3 is bottom
-                unsigned bottnormidx = pOutdoor->pTerrain.pTerrainNormalIndices[(2 * loopx * 128) + (2 * loopy) + 3];
-                assert(norm_idx < pOutdoor->pTerrain.pTerrainNormals.size());
-                assert(bottnormidx < pOutdoor->pTerrain.pTerrainNormals.size());
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[norm_idx];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[bottnormidx];
+                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[(2 * loopy * 128) + (2 * loopx)];
+                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[(2 * loopy * 128) + (2 * loopx) + 1];
 
                 float Light_tile_dist = 0.0;
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1459,13 +1459,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
         int heightScale = 32;
 
         // generate vertex locations
-        for (unsigned int y = 0; y < 128; ++y) {
-            for (unsigned int x = 0; x < 128; ++x) {
-                pTerrainVertices[y * 128 + x].vWorldPosition.x = (-64.0f + x) * blockScale;
-                pTerrainVertices[y * 128 + x].vWorldPosition.y = (64.0f - y) * blockScale;
-                pTerrainVertices[y * 128 + x].vWorldPosition.z = heightScale * pOutdoor->pTerrain.pHeightmap[y][x];
-            }
-        }
+        for (int y = 0; y < 128; ++y)
+            for (int x = 0; x < 128; ++x)
+                pTerrainVertices[y * 128 + x].vWorldPosition = pOutdoor->pTerrain.vertexByGrid({x, y}).toFloat();
 
         // reserve first 7 layers for water tiles in unit 0
         auto wtrtexture = this->hd_water_tile_anim[0];
@@ -1532,8 +1528,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 }
 
                 // next calculate all vertices vertices
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[y][x][0];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[y][x][1];
+                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGrid({x, y});
 
                 // calc each vertex
                 // [0] - x,y        n1
@@ -1544,9 +1539,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y))].v = 0;
                 terrshaderstore[6 * (x + (127 * y))].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y))].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y))].normx = norm->x;
-                terrshaderstore[6 * (x + (127 * y))].normy = norm->y;
-                terrshaderstore[6 * (x + (127 * y))].normz = norm->z;
+                terrshaderstore[6 * (x + (127 * y))].normx = norm.x;
+                terrshaderstore[6 * (x + (127 * y))].normy = norm.y;
+                terrshaderstore[6 * (x + (127 * y))].normz = norm.z;
                 terrshaderstore[6 * (x + (127 * y))].attribs = 0;
 
                 // [1] - x+1,y+1    n1
@@ -1557,9 +1552,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y)) + 1].v = 1;
                 terrshaderstore[6 * (x + (127 * y)) + 1].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y)) + 1].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y)) + 1].normx = norm->x;
-                terrshaderstore[6 * (x + (127 * y)) + 1].normy = norm->y;
-                terrshaderstore[6 * (x + (127 * y)) + 1].normz = norm->z;
+                terrshaderstore[6 * (x + (127 * y)) + 1].normx = norm.x;
+                terrshaderstore[6 * (x + (127 * y)) + 1].normy = norm.y;
+                terrshaderstore[6 * (x + (127 * y)) + 1].normz = norm.z;
                 terrshaderstore[6 * (x + (127 * y)) + 1].attribs = 0;
 
                 // [2] - x+1,y      n1
@@ -1570,9 +1565,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y)) + 2].v = 0;
                 terrshaderstore[6 * (x + (127 * y)) + 2].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y)) + 2].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y)) + 2].normx = norm->x;
-                terrshaderstore[6 * (x + (127 * y)) + 2].normy = norm->y;
-                terrshaderstore[6 * (x + (127 * y)) + 2].normz = norm->z;
+                terrshaderstore[6 * (x + (127 * y)) + 2].normx = norm.x;
+                terrshaderstore[6 * (x + (127 * y)) + 2].normy = norm.y;
+                terrshaderstore[6 * (x + (127 * y)) + 2].normz = norm.z;
                 terrshaderstore[6 * (x + (127 * y)) + 2].attribs = 0;
 
                 // [3] - x,y        n2
@@ -1583,9 +1578,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y)) + 3].v = 0;
                 terrshaderstore[6 * (x + (127 * y)) + 3].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y)) + 3].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y)) + 3].normx = norm2->x;
-                terrshaderstore[6 * (x + (127 * y)) + 3].normy = norm2->y;
-                terrshaderstore[6 * (x + (127 * y)) + 3].normz = norm2->z;
+                terrshaderstore[6 * (x + (127 * y)) + 3].normx = norm2.x;
+                terrshaderstore[6 * (x + (127 * y)) + 3].normy = norm2.y;
+                terrshaderstore[6 * (x + (127 * y)) + 3].normz = norm2.z;
                 terrshaderstore[6 * (x + (127 * y)) + 3].attribs = 0;
 
                 // [4] - x,y+1      n2
@@ -1596,9 +1591,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y)) + 4].v = 1;
                 terrshaderstore[6 * (x + (127 * y)) + 4].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y)) + 4].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y)) + 4].normx = norm2->x;
-                terrshaderstore[6 * (x + (127 * y)) + 4].normy = norm2->y;
-                terrshaderstore[6 * (x + (127 * y)) + 4].normz = norm2->z;
+                terrshaderstore[6 * (x + (127 * y)) + 4].normx = norm2.x;
+                terrshaderstore[6 * (x + (127 * y)) + 4].normy = norm2.y;
+                terrshaderstore[6 * (x + (127 * y)) + 4].normz = norm2.z;
                 terrshaderstore[6 * (x + (127 * y)) + 4].attribs = 0;
 
                 // [5] - x+1,y+1    n2
@@ -1609,9 +1604,9 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 terrshaderstore[6 * (x + (127 * y)) + 5].v = 1;
                 terrshaderstore[6 * (x + (127 * y)) + 5].texunit = tileunit;
                 terrshaderstore[6 * (x + (127 * y)) + 5].texturelayer = tilelayer;
-                terrshaderstore[6 * (x + (127 * y)) + 5].normx = norm2->x;
-                terrshaderstore[6 * (x + (127 * y)) + 5].normy = norm2->y;
-                terrshaderstore[6 * (x + (127 * y)) + 5].normz = norm2->z;
+                terrshaderstore[6 * (x + (127 * y)) + 5].normx = norm2.x;
+                terrshaderstore[6 * (x + (127 * y)) + 5].normy = norm2.y;
+                terrshaderstore[6 * (x + (127 * y)) + 5].normz = norm2.z;
                 terrshaderstore[6 * (x + (127 * y)) + 5].attribs = 0;
             }
         }
@@ -1944,28 +1939,27 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 // splat hits this square of terrain
                 bool fading = pOutdoor->pTerrain.isWaterOrShoreByGrid({loopx, loopy});
 
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[loopy][loopx][0];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[loopy][loopx][1];
+                const auto &[norm, norm2] = pOutdoor->pTerrain.normalsByGrid({loopx, loopy});
 
                 float Light_tile_dist = 0.0;
 
                 // top tri
-                float _f1 = norm->x * pOutdoor->vSunlight.x + norm->y * pOutdoor->vSunlight.y + norm->z * pOutdoor->vSunlight.z;
+                float _f1 = norm.x * pOutdoor->vSunlight.x + norm.y * pOutdoor->vSunlight.y + norm.z * pOutdoor->vSunlight.z;
                 int dimming_level = std::clamp(static_cast<int>(20.0f - floorf(20.0f * _f1 + 0.5f)), 0, 31);
 
                 decal_builder->ApplyBloodSplatToTerrain(fading, norm, &Light_tile_dist, VertexRenderList, i);
                 Planef plane;
-                plane.normal = *norm;
+                plane.normal = norm;
                 plane.dist = Light_tile_dist;
                 if (decal_builder->uNumSplatsThisFace > 0)
                     decal_builder->BuildAndApplyDecals(31 - dimming_level, LocationTerrain, plane, 3, VertexRenderList, 0, -1);
 
                 //bottom tri
-                float _f = norm2->x * pOutdoor->vSunlight.x + norm2->y * pOutdoor->vSunlight.y + norm2->z * pOutdoor->vSunlight.z;
+                float _f = norm2.x * pOutdoor->vSunlight.x + norm2.y * pOutdoor->vSunlight.y + norm2.z * pOutdoor->vSunlight.z;
                 dimming_level = std::clamp(static_cast<int>(20.0 - floorf(20.0 * _f + 0.5f)), 0, 31);
 
                 decal_builder->ApplyBloodSplatToTerrain(fading, norm2, &Light_tile_dist, (VertexRenderList + 3), i);
-                plane.normal = *norm2;
+                plane.normal = norm2;
                 plane.dist = Light_tile_dist;
                 if (decal_builder->uNumSplatsThisFace > 0)
                     decal_builder->BuildAndApplyDecals(31 - dimming_level, LocationTerrain, plane, 3, (VertexRenderList + 3), 0, -1);

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1463,7 +1463,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
             for (unsigned int x = 0; x < 128; ++x) {
                 pTerrainVertices[y * 128 + x].vWorldPosition.x = (-64.0f + x) * blockScale;
                 pTerrainVertices[y * 128 + x].vWorldPosition.y = (64.0f - y) * blockScale;
-                pTerrainVertices[y * 128 + x].vWorldPosition.z = heightScale * pOutdoor->pTerrain.pHeightmap[y * 128 + x];
+                pTerrainVertices[y * 128 + x].vWorldPosition.z = heightScale * pOutdoor->pTerrain.pHeightmap[y][x];
             }
         }
 
@@ -1532,8 +1532,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 }
 
                 // next calculate all vertices vertices
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[(2 * y * 128) + (2 * x)];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[(2 * y * 128) + (2 * x) + 1];
+                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[y][x][0];
+                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[y][x][1];
 
                 // calc each vertex
                 // [0] - x,y        n1
@@ -1944,8 +1944,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                 // splat hits this square of terrain
                 bool fading = pOutdoor->pTerrain.isWaterOrShoreByGrid({loopx, loopy});
 
-                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[(2 * loopy * 128) + (2 * loopx)];
-                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[(2 * loopy * 128) + (2 * loopx) + 1];
+                Vec3f *norm = &pOutdoor->pTerrain.pTerrainNormals[loopy][loopx][0];
+                Vec3f *norm2 = &pOutdoor->pTerrain.pTerrainNormals[loopy][loopx][1];
 
                 float Light_tile_dist = 0.0;
 

--- a/src/Engine/Graphics/Sprites.cpp
+++ b/src/Engine/Graphics/Sprites.cpp
@@ -10,6 +10,7 @@
 #include "Engine/Graphics/PaletteManager.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/LodSpriteCache.h"
+#include "Engine/Seasons.h"
 
 #include "Library/Logger/Logger.h"
 
@@ -213,82 +214,10 @@ void SpriteFrameTable::ResetPaletteIndexes() {
 }
 
 SpriteFrame *LevelDecorationChangeSeason(const DecorationDesc *desc, Duration t, int month) {
-    switch (month/*pParty->uCurrentMonth*/) {
-        // case 531 (tree60), 536 (tree65), 537 (tree66) have no autumn/winter
-        // sprites
-        case 11:
-        case 0:
-        case 1:  // winter
-        {
-            switch (desc->uSpriteID) {
-                // case 468:           //bush02    grows on swamps, which are
-                // evergreeen actually
-                case 548:  // flower10
-                case 547:  // flower09
-                case 541:  // flower03
-                case 539:  // flower01
-                    return nullptr;
-
-                case 483:  // tree01
-                case 486:  // tree04
-                case 492:  // tree10
-                {
-                    pSpriteFrameTable->InitializeSprite(desc->uSpriteID + 2);
-                    return pSpriteFrameTable->GetFrame(desc->uSpriteID + 2, t);
-                }
-
-                default:
-                    return pSpriteFrameTable->GetFrame(desc->uSpriteID, t);
-            }
-        }
-
-        case 2:
-        case 3:
-        case 4:  // spring
-        {
-            // switch (desc->uSpriteID) {}
-            return pSpriteFrameTable->GetFrame(desc->uSpriteID, t);
-        }
-
-        case 8:
-        case 9:
-        case 10:  // autumn
-        {
-            switch (desc->uSpriteID) {
-                // case 468: //bush02    grows on swamps, which are evergreeen
-                // actually
-                case 548:  // flower10
-                case 547:  // flower09
-                case 541:  // flower03
-                case 539:  // flower01
-                    return nullptr;
-
-                case 483:  // tree01
-                case 486:  // tree04
-                case 492:  // tree10
-                {
-                    pSpriteFrameTable->InitializeSprite(desc->uSpriteID + 1);
-                    return pSpriteFrameTable->GetFrame(desc->uSpriteID + 1, t);
-                }
-
-                default:
-                    return pSpriteFrameTable->GetFrame(desc->uSpriteID, t);
-            }
-        } break;
-
-        case 5:
-        case 6:
-        case 7:  // summer
-                 // all green by default
-        {
-            return pSpriteFrameTable->GetFrame(desc->uSpriteID, t);
-        }
-
-        default:
-            assert(/*pParty->uCurrentMonth*/month >= 0 && /*pParty->uCurrentMonth*/month < 12);
-    }
-    logger->warning("No sprite returned - LevelDecorationChangeSeason!");
-    return nullptr;
+    int spriteId = spriteIdForSeason(desc->uSpriteID, month);
+    if (spriteId != desc->uSpriteID)
+        pSpriteFrameTable->InitializeSprite(spriteId);
+    return pSpriteFrameTable->GetFrame(spriteId, t);
 }
 
 int SpriteFrame::GetPaletteIndex() {

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -226,7 +226,7 @@ void SpriteObject::updateObjectODM(unsigned int uLayingItemID) {
         }
 
         CollideOutdoorWithModels(false);
-        CollideOutdoorWithDecorations(WorldPosToGrid(pSpriteObjects[uLayingItemID].vPosition));
+        CollideOutdoorWithDecorations(worldToGrid(pSpriteObjects[uLayingItemID].vPosition));
         ObjectType casterType = pSpriteObjects[uLayingItemID].spell_caster_pid.type();
         if (casterType != OBJECT_Character) {
             CollideWithParty(false);

--- a/src/Engine/Seasons.cpp
+++ b/src/Engine/Seasons.cpp
@@ -7,7 +7,7 @@ int tileIdForSeason(int tileId, int month) {
     case 11:
     case 0:
     case 1: // winter
-        if (tileId >= 90 && tileId <= 113) { // TILE_SET_GRASS
+        if (tileId >= 90 && tileId <= 113) { // TILESET_GRASS
             if (tileId <= 95)  // some grastyl entries
                 return 348;
             return 348 + (tileId - 96);
@@ -20,7 +20,7 @@ int tileIdForSeason(int tileId, int month) {
     case 8:
     case 9:
     case 10: // autumn
-        if (tileId >= 90 && tileId <= 113)  // just convert all TILE_SET_GRASS to dirt
+        if (tileId >= 90 && tileId <= 113)  // just convert all TILESET_GRASS to dirt
             return 1;
         return tileId;
 

--- a/src/Engine/Seasons.cpp
+++ b/src/Engine/Seasons.cpp
@@ -1,0 +1,95 @@
+#include "Seasons.h"
+
+#include <cassert>
+
+int tileIdForSeason(int tileId, int month) {
+    switch (month) {
+    case 11:
+    case 0:
+    case 1: // winter
+        if (tileId >= 90 && tileId <= 113) { // TILE_SET_GRASS
+            if (tileId <= 95)  // some grastyl entries
+                return 348;
+            return 348 + (tileId - 96);
+        }
+        return tileId;
+
+    case 2:
+    case 3:
+    case 4: // spring
+    case 8:
+    case 9:
+    case 10: // autumn
+        if (tileId >= 90 && tileId <= 113)  // just convert all TILE_SET_GRASS to dirt
+            return 1;
+        return tileId;
+
+    default:
+        assert(false);
+        [[fallthrough]];
+    case 5:
+    case 6:
+    case 7: // summer
+        // All tiles are green grass by default.
+        return tileId;
+    }
+}
+
+int spriteIdForSeason(int spriteId, int month) {
+    switch (month) {
+    // case 531 (tree60), 536 (tree65), 537 (tree66) have no autumn/winter
+    // sprites
+    case 11:
+    case 0:
+    case 1: // winter
+        switch (spriteId) {
+        // case 468: // bush02    grows on swamps, which are evergreeen actually
+        case 548: // flower10
+        case 547: // flower09
+        case 541: // flower03
+        case 539: // flower01
+            return 0; // null sprite
+
+        case 483:  // tree01
+        case 486:  // tree04
+        case 492:  // tree10
+            return spriteId + 2;
+
+        default:
+            return spriteId;
+        }
+
+    case 2:
+    case 3:
+    case 4: // spring
+        return spriteId;
+
+    case 8:
+    case 9:
+    case 10: // autumn
+        switch (spriteId) {
+        // case 468: // bush02 grows on swamps, which are evergreeen actually
+        case 548: // flower10
+        case 547: // flower09
+        case 541: // flower03
+        case 539: // flower01
+            return 0; // null sprite
+
+        case 483: // tree01
+        case 486: // tree04
+        case 492: // tree10
+            return spriteId + 1;
+
+        default:
+            return spriteId;
+        }
+
+    default:
+        assert(false);
+        [[fallthrough]];
+    case 5:
+    case 6:
+    case 7:
+        return spriteId;
+    }
+}

--- a/src/Engine/Seasons.h
+++ b/src/Engine/Seasons.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int tileIdForSeason(int tileId, int month);
+int spriteIdForSeason(int spriteId, int month);

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -364,9 +364,7 @@ void reconstruct(const OutdoorLocation_MM7 &src, OutdoorLocation *dst) {
     reconstruct(src.heightMap, &dst->pTerrain.pHeightmap);
     reconstruct(src.tileMap, &dst->pTerrain.pTilemap);
     reconstruct(src.attributeMap, &dst->pTerrain.pAttributemap);
-
-    reconstruct(src.normalMap, &dst->pTerrain.pTerrainNormalIndices);
-    reconstruct(src.normals, &dst->pTerrain.pTerrainNormals);
+    dst->pTerrain.recalculateNormals();
 
     dst->pBModels.clear();
     for (size_t i = 0; i < src.models.size(); i++) {

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -357,14 +357,7 @@ void reconstruct(const OutdoorLocation_MM7 &src, OutdoorLocation *dst) {
     reconstruct(src.fileName, &dst->location_filename);
     reconstruct(src.desciption, &dst->location_file_description);
     reconstruct(src.skyTexture, &dst->sky_texture_filename);
-    // src.groundTilesetUnused is just dropped
-    reconstruct(src.tileTypes, &dst->pTerrain.pTileTypes);
-    dst->pTerrain.LoadBaseTileIds();
-
-    reconstruct(src.heightMap, &dst->pTerrain.pHeightmap);
-    reconstruct(src.tileMap, &dst->pTerrain.pTilemap);
-    reconstruct(src.attributeMap, &dst->pTerrain.pAttributemap);
-    dst->pTerrain.recalculateNormals();
+    reconstruct(src, &dst->pTerrain);
 
     dst->pBModels.clear();
     for (size_t i = 0; i < src.models.size(); i++) {

--- a/src/Engine/Snapshots/CompositeSnapshots.h
+++ b/src/Engine/Snapshots/CompositeSnapshots.h
@@ -13,6 +13,7 @@
  * Struct fields are laid out in the order in which they are laid out in binary files.
  */
 
+// TODO(captainurist): snapshot/reconstruct functions belong to the classes themselves. Also drop raw* functions.
 
 class Blob;
 class BSPModel;
@@ -88,9 +89,9 @@ struct OutdoorLocation_MM7 {
     std::array<uint8_t, 128 * 128> heightMap;
     std::array<uint8_t, 128 * 128> tileMap;
     std::array<uint8_t, 128 * 128> attributeMap;
-    uint32_t normalCount;
+    uint32_t normalCount; // Number of elements in `normals`.
     std::array<uint32_t , 128 * 128 * 2> someOtherMap; // Not used in OE, not even sure what this is.
-    std::array<uint16_t, 128 * 128 * 2> normalMap;
+    std::array<uint16_t, 128 * 128 * 2> normalMap; // Indices into `normals`, unused as we recalculate normals on load.
     std::vector<Vec3f> normals;
     std::vector<BSPModelData_MM7> models;
     std::vector<BSPModelExtras_MM7> modelExtras;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1797,11 +1797,6 @@ void reconstruct(const PersistentVariables_MM7 &src, PersistentVariables *dst) {
     dst->decorVars = src.decorVars;
 }
 
-void reconstruct(const OutdoorTileType_MM7 &src, OutdoorTileType *dst) {
-    dst->tileset = static_cast<TileSet>(src.tileset);
-    dst->uTileID = src.tileId;
-}
-
 void snapshot(const SaveGameHeader &src, SaveGameHeader_MM7 *dst) {
     memzero(dst);
 

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -297,7 +297,7 @@ void reconstruct(const TileData_MM7 &src, TileData *dst) {
         dst->name.insert(0, "h"); // mm7 uses hd water tiles with legacy names
 
     dst->uTileID = src.tileId;
-    dst->tileset = static_cast<TileSet>(src.tileSet);
+    dst->tileset = static_cast<Tileset>(src.tileset);
     dst->uSection = static_cast<TileVariant>(src.section);
     dst->uAttributes = static_cast<TileFlags>(src.attributes);
 }

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -176,7 +176,7 @@ struct TileData_MM7 {
     std::array<char, 16> tileName;
     uint16_t tileId;
     uint16_t bitmapId;
-    uint16_t tileSet;
+    uint16_t tileset;
     uint16_t section;
     uint16_t attributes;
 };

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1360,8 +1360,6 @@ struct OutdoorTileType_MM7 {
 static_assert(sizeof(OutdoorTileType_MM7) == 4);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(OutdoorTileType_MM7)
 
-void reconstruct(const OutdoorTileType_MM7 &src, OutdoorTileType *dst);
-
 
 struct SaveGameHeader_MM7 {
     std::array<char, 20> name;

--- a/src/Engine/Tables/TileTable.cpp
+++ b/src/Engine/Tables/TileTable.cpp
@@ -2,6 +2,7 @@
 
 #include "Engine/AssetsManager.h"
 #include "Engine/Random/Random.h"
+#include "Engine/Data/TileEnumFunctions.h"
 
 TileTable *pTileTable;
 
@@ -23,7 +24,7 @@ int TileTable::tileIdForTileset(TileSet terrain_type, bool nonRandom) {
     } else if (v5 < 48) {
         return tileId(terrain_type, TILE_VARIANT_BASE4_NE);
     }
-    return tileId(terrain_type, vrng->randomSample(allSpecialTileSects()));
+    return tileId(terrain_type, vrng->randomSample(allSpecialTileVariants()));
 }
 
 //----- (00487F84) --------------------------------------------------------

--- a/src/Engine/Tables/TileTable.cpp
+++ b/src/Engine/Tables/TileTable.cpp
@@ -7,11 +7,11 @@
 TileTable *pTileTable;
 
 //----- (00487ED6) --------------------------------------------------------
-int TileTable::tileIdForTileset(TileSet terrain_type, bool nonRandom) {
+int TileTable::tileIdForTileset(Tileset terrain_type, bool nonRandom) {
     int v5;  // edx@3
     int v6;  // edx@11
 
-    if (nonRandom || terrain_type > TILE_SET_TROPICAL) {
+    if (nonRandom || terrain_type > TILESET_TROPICAL) {
         return tileId(terrain_type, TILE_VARIANT_BASE1);
     }
     v5 = vrng->random(50);
@@ -28,7 +28,7 @@ int TileTable::tileIdForTileset(TileSet terrain_type, bool nonRandom) {
 }
 
 //----- (00487F84) --------------------------------------------------------
-int TileTable::tileId(TileSet tileset, TileVariant section) {
+int TileTable::tileId(Tileset tileset, TileVariant section) {
     for (size_t i = 0; i < tiles.size(); ++i) {
         if ((tiles[i].tileset == tileset) &&
             (tiles[i].uSection == section))

--- a/src/Engine/Tables/TileTable.h
+++ b/src/Engine/Tables/TileTable.h
@@ -5,8 +5,8 @@
 #include "Engine/Data/TileData.h"
 
 struct TileTable {
-    int tileIdForTileset(TileSet tileset, bool nonRandom);
-    int tileId(TileSet tileset, TileVariant section);
+    int tileIdForTileset(Tileset tileset, bool nonRandom);
+    int tileId(Tileset tileset, TileVariant section);
 
     std::vector<TileData> tiles; // Tile by id.
 };

--- a/src/Library/Config/AnyConfigEntry.cpp
+++ b/src/Library/Config/AnyConfigEntry.cpp
@@ -34,6 +34,9 @@ void AnyConfigEntry::setValue(std::any value) {
         return;
 
     _value = std::move(value);
+
+    for (const auto &[_, listener] : _listeners)
+        listener();
 }
 
 std::string AnyConfigEntry::defaultString() const {

--- a/src/Library/Config/AnyConfigEntry.h
+++ b/src/Library/Config/AnyConfigEntry.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <any>
 #include <vector>
+#include <utility>
 
 #include "ConfigFwd.h"
 
@@ -51,6 +52,14 @@ class AnyConfigEntry {
         return _description;
     }
 
+    void addListener(void *ctx, std::function<void()> listener) {
+        _listeners.emplace_back(ctx, std::move(listener));
+    }
+
+    void removeListeners(void *ctx) {
+        std::erase_if(_listeners, [ctx] (const auto &pair) { return pair.first == ctx;});
+    }
+
  protected:
     Validator validator() const {
         return _validator;
@@ -64,4 +73,5 @@ class AnyConfigEntry {
     std::any _defaultValue;
     std::any _value;
     Validator _validator = nullptr;
+    std::vector<std::pair<void *, std::function<void()>>> _listeners;
 };

--- a/src/Library/Config/ConfigEntry.h
+++ b/src/Library/Config/ConfigEntry.h
@@ -4,6 +4,7 @@
 #include <climits>
 #include <string>
 #include <utility>
+#include <concepts>
 
 #include "Library/Serialization/Serialization.h"
 
@@ -13,7 +14,8 @@
 
 template <class T>
 class ConfigEntry : public AnyConfigEntry {
- public:
+    using base_type = AnyConfigEntry;
+ public: // NOLINT: why are you complaining?
     ConfigEntry(const ConfigEntry &other) = delete; // non-copyable
     ConfigEntry(ConfigEntry &&other) = delete; // non-movable
 
@@ -64,6 +66,15 @@ class ConfigEntry : public AnyConfigEntry {
         decrement();
         if (value() == oldValue)
             setValue(INT_MAX);
+    }
+
+    using base_type::addListener;
+
+    template<std::invocable<T> Listener>
+    void addListener(void *ctx, Listener listener) {
+        addListener(ctx, [this, listener = std::move(listener)] {
+            listener(value());
+        });
     }
 
  private:

--- a/src/Library/Image/Image.h
+++ b/src/Library/Image/Image.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "Library/Color/Color.h"
+#include "Library/Geometry/Point.h"
 #include "Library/Geometry/Size.h"
 
 #include "Utility/Memory/FreeDeleter.h"
@@ -61,6 +62,14 @@ class ImageBase {
 
     [[nodiscard]] std::span<const T> operator[](ssize_t y) const {
         return const_cast<ImageBase &>(*this)[y];
+    }
+
+    [[nodiscard]] T &operator[](Pointi point) {
+        return (*this)[point.y][point.x];
+    }
+
+    [[nodiscard]] const T &operator[](Pointi point) const {
+        return const_cast<ImageBase &>(*this)[point];
     }
 
     explicit operator bool() const {

--- a/src/Library/Image/Image.h
+++ b/src/Library/Image/Image.h
@@ -164,6 +164,16 @@ class Image : public detail::ImageBase<T, std::unique_ptr<T, FreeDeleter>> {
         return result;
     }
 
+    /**
+     * Creates a copy of another image.
+     *
+     * @param other                     Image to copy.
+     * @return                          Newly allocated `Image` containing a copy of `other`.
+     */
+    static Image copy(const Image &other) {
+        return copy(other.width(), other.height(), other.pixels().data());
+    }
+
     // The rest is inherited from ImageBase.
 };
 

--- a/src/Library/Image/Image.h
+++ b/src/Library/Image/Image.h
@@ -73,6 +73,10 @@ class ImageBase {
         _pixels.reset();
     }
 
+    void fill(const T &color) {
+        std::fill_n(pixels().data(), pixels().size(), color);
+    }
+
  protected: // Directly accessible from derived classes.
     ssize_t _width = 0;
     ssize_t _height = 0;


### PR DESCRIPTION
* Everything terrain-related moved to `OutdoorTerrain`.
* `OutdoorTerrain` doesn't expose its fields now.
* Renamed tileset-related vars/classes/enums b/c "tileset" is a real word X).
* Clicking on `toggle seasons` now toggles seasons, no need to reload.
* Walk sounds & food requirements now respect seasons.