### PR TITLE
Use only BSP-rendered faces in Vis::PickIndoorFaces_Mouse

### DIFF
--- a/src/Engine/Graphics/BspRenderer.cpp
+++ b/src/Engine/Graphics/BspRenderer.cpp
@@ -196,12 +196,17 @@ void BspRenderer::AddSector(int sectorId) {
 }
 
 
-//----- (0043F953) --------------------------------------------------------
-void BspRenderer::Init() {
+void BspRenderer::Clear() {
     // reset lists
     num_faces = 0;
     num_nodes = 0;
     uNumVisibleNotEmptySectors = 0;
+}
+
+
+//----- (0043F953) --------------------------------------------------------
+void BspRenderer::Render() {
+    Clear();
 
     if (pBLVRenderParams->uPartySectorID) {
         // set to current sector - using eye sector here because feet can be in other sector on horizontal portal

--- a/src/Engine/Graphics/BspRenderer.h
+++ b/src/Engine/Graphics/BspRenderer.h
@@ -27,7 +27,8 @@ struct BspFace {
 
 struct BspRenderer {
  public:
-    void Init();
+    void Clear();
+    void Render();
 
     // TODO(yoctozepto): hide these
     unsigned int num_faces = 0;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -146,7 +146,7 @@ void PrepareDrawLists_BLV() {
     //pStationaryLightsStack->uNumLightsActive = 0;
     engine->StackPartyTorchLight();
 
-    pBspRenderer->Init();
+    pBspRenderer->Render();
 
     render->DrawSpriteObjects();
     pOutdoor->PrepareActorsDrawList();
@@ -945,6 +945,7 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     uCurrentlyLoadedLevelType = LEVEL_INDOOR;
     pBLVRenderParams->uPartySectorID = 0;
     pBLVRenderParams->uPartyEyeSectorID = 0;
+    pBspRenderer->Clear();
 
     engine->SetUnderwater(isMapUnderwater(mapid));
 


### PR DESCRIPTION
This requires clearing the BSP renderer when loading a new level as this function gets triggered before it gets called to render.