### PR TITLE
Retracing & resolving TODOs for OutdoorTerrain

### DIFF
--- a/src/Engine/Graphics/OutdoorTerrain.cpp
+++ b/src/Engine/Graphics/OutdoorTerrain.cpp
@@ -238,15 +238,11 @@ void OutdoorTerrain::recalculateNormals() {
             Vec3f b2 = Vec3f(tile.v0.x, tile.v0.y, tile.z00) - Vec3f(tile.v1.x, tile.v0.y, tile.z10);
             Vec3f b1 = Vec3f(tile.v1.x, tile.v1.y, tile.z11) - Vec3f(tile.v1.x, tile.v0.y, tile.z10);
 
-            // TODO(captainurist): use normalize() & retrace.
-
             Vec3f an = cross(a2, a1);
-            float amag = an.length();
-            an /= amag;
+            an.normalize();
 
             Vec3f bn = cross(b2, b1);
-            float bmag = bn.length();
-            bn /= bmag;
+            bn.normalize();
 
             assert(an.z > 0);
             assert(bn.z > 0);

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG ff928b498b0913e1721fe7fdf23751fec101d884
+        GIT_TAG df41f35cd10e772210ed3126aad5efd59828340d
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Test data PR https://github.com/OpenEnroth/OpenEnroth_TestData/pull/55 - only 735b retraced