### PR TITLE
Offset item picking and placement

### DIFF
--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -51,6 +51,7 @@
 #include "GUI/UI/UISpell.h"
 #include "GUI/UI/UIDialogue.h"
 #include "GUI/UI/Books/AutonotesBook.h"
+#include "GUI/UI/ItemGrid.h"
 
 #include "Library/Logger/Logger.h"
 
@@ -650,7 +651,7 @@ int Character::CreateItemInInventory(unsigned int uSlot, ItemId uItemID) {
 
         return 0;
     } else {  // place items
-        PutItemArInventoryIndex(uItemID, freeSlot, uSlot);
+        PutItemAtInventoryIndex(uItemID, freeSlot, uSlot);
         this->pInventoryItemList[freeSlot].uItemID = uItemID;
     }
 
@@ -738,7 +739,7 @@ int Character::CreateItemInInventory2(unsigned int index,
     if (freeSlot == -1) {  // no room
         result = 0;
     } else {
-        PutItemArInventoryIndex(Src->uItemID, freeSlot, index);
+        PutItemAtInventoryIndex(Src->uItemID, freeSlot, index);
         pInventoryItemList[freeSlot] = *Src;
         result = freeSlot + 1;
     }
@@ -747,7 +748,7 @@ int Character::CreateItemInInventory2(unsigned int index,
 }
 
 //----- (0049298B) --------------------------------------------------------
-void Character::PutItemArInventoryIndex(
+void Character::PutItemAtInventoryIndex(
     ItemId uItemID, int itemListPos,
     int index) {  // originally accepted ItemGen *but needed only its uItemID
 
@@ -6553,113 +6554,115 @@ void DamageCharacterFromMonster(Pid uObjID, ActorAbility dmgSource, signed int t
 }
 
 void Character::OnInventoryLeftClick() {
-    ItemId pickedItemId;  // esi@12
-    unsigned int invItemIndex;  // eax@12
-    unsigned int itemPos;       // eax@18
-    ItemGen tmpItem;            // [sp+Ch] [bp-3Ch]@1
+    if (current_character_screen_window != WINDOW_CharacterWindow_Inventory) {
+        return;
+    }
 
-    CastSpellInfo *pSpellInfo;
+    int pY;
+    int pX;
+    mouse->GetClickPos(&pX, &pY);
 
-    if (current_character_screen_window == WINDOW_CharacterWindow_Inventory) {
-        int pY;
-        int pX;
-        mouse->GetClickPos(&pX, &pY);
+    int inventoryXCoord = (pX + mouse->pickedItemOffsetX - 14) / 32;
+    int inventoryYCoord = (pY + mouse->pickedItemOffsetY - 17) / 32;
+    int invMatrixIndex = inventoryXCoord + (INVENTORY_SLOTS_WIDTH * inventoryYCoord);
 
-        int inventoryYCoord = (pY - 17) / 32;
-        int inventoryXCoord = (pX - 14) / 32;
-        int invMatrixIndex = inventoryXCoord + (INVENTORY_SLOTS_WIDTH * inventoryYCoord);
+    if (inventoryYCoord >= 0 && inventoryYCoord < INVENTORY_SLOTS_HEIGHT &&
+        inventoryXCoord >= 0 && inventoryXCoord < INVENTORY_SLOTS_WIDTH) {
+        if (IsEnchantingInProgress) {
+            unsigned int enchantedItemPos = this->GetItemListAtInventoryIndex(invMatrixIndex);
 
-        if (inventoryYCoord >= 0 && inventoryYCoord < INVENTORY_SLOTS_HEIGHT &&
-            inventoryXCoord >= 0 && inventoryXCoord < INVENTORY_SLOTS_WIDTH) {
-            if (IsEnchantingInProgress) {
-                unsigned int enchantedItemPos = this->GetItemListAtInventoryIndex(invMatrixIndex);
+            if (enchantedItemPos) {
+                /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
+                    *0x7Fu;
+                    *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
+                    *pParty->activeCharacterIndex() - 1;
+                    *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
+                    *enchantedItemPos - 1;
+                    *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
+                    *invMatrixIndex;*/
+                CastSpellInfo* pSpellInfo;
+                pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
+                pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
+                pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
+                pSpellInfo->targetInventoryIndex = enchantedItemPos - 1;
+                ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
+                IsEnchantingInProgress = false;
 
-                if (enchantedItemPos) {
-                    /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
-                     *0x7Fu;
-                     *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                     *pParty->activeCharacterIndex() - 1;
-                     *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-                     *enchantedItemPos - 1;
-                     *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-                     *invMatrixIndex;*/
-                    pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
-                    pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
-                    pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
-                    pSpellInfo->targetInventoryIndex = enchantedItemPos - 1;
-                    ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
-                    IsEnchantingInProgress = false;
+                engine->_messageQueue->clear();
 
-                    engine->_messageQueue->clear();
-
-                    mouse->SetCursorImage("MICON1");
-                    AfterEnchClickEventId = UIMSG_Escape;
-                    AfterEnchClickEventSecondParam = 0;
-                    AfterEnchClickEventTimeout = Duration::fromRealtimeSeconds(2);
-                }
-
-                return;
+                mouse->SetCursorImage("MICON1");
+                AfterEnchClickEventId = UIMSG_Escape;
+                AfterEnchClickEventSecondParam = 0;
+                AfterEnchClickEventTimeout = Duration::fromRealtimeSeconds(2);
             }
 
-            if (ptr_50C9A4_ItemToEnchant)
-                return;
+            return;
+        }
 
-            pickedItemId = pParty->pPickedItem.uItemID;
-            invItemIndex = this->GetItemListAtInventoryIndex(invMatrixIndex);
+        if (ptr_50C9A4_ItemToEnchant)
+            return;
 
-            if (pickedItemId == ITEM_NULL) {  // no hold item
-                if (!invItemIndex) {
-                    return;
-                } else {
-                    pParty->pPickedItem = this->pInventoryItemList[invItemIndex - 1];
-                    this->RemoveItemAtInventoryIndex(invMatrixIndex);
-                    pickedItemId = pParty->pPickedItem.uItemID;
-                    mouse->SetCursorImage(pItemTable->pItems[pickedItemId].iconName);
-                    return;
-                }
-            } else {  // hold item
-                if (invItemIndex) {
-                    ItemGen *invItemPtr = &this->pInventoryItemList[invItemIndex - 1];
-                    tmpItem = *invItemPtr;
-                    int oldinvMatrixIndex = invMatrixIndex;
-                    invMatrixIndex = GetItemMainInventoryIndex(invMatrixIndex);
-                    this->RemoveItemAtInventoryIndex(oldinvMatrixIndex);
-                    int emptyIndex = this->AddItem2(invMatrixIndex, &pParty->pPickedItem);
+        auto item = this->GetItemAtInventoryIndex(invMatrixIndex);
+        if (!item && pParty->pPickedItem.uItemID == ITEM_NULL) {
+            return; // nothing to do
+        }
 
+        // calc offsets of where on the item was clicked
+        // first need index of top left corner of the item
+        int cornerInd = GetItemMainInventoryIndex(invMatrixIndex);
+        int cornerX = cornerInd % INVENTORY_SLOTS_WIDTH;
+        int cornerY = cornerInd / INVENTORY_SLOTS_WIDTH;
+        int itemXOffset = pX + mouse->pickedItemOffsetX - 14 - (cornerX * 32);
+        int itemYOffset = pY + mouse->pickedItemOffsetY - 17 - (cornerY * 32);
+
+        if (item) {
+            auto tex = assets->getImage_Alpha(item->GetIconName());
+            itemXOffset -= itemOffset(tex->width());
+            itemYOffset -= itemOffset(tex->height());
+        }
+
+        if (pParty->pPickedItem.uItemID == ITEM_NULL) {
+            // pick up the item
+            pParty->setHoldingItem(item, -itemXOffset, -itemYOffset);
+            this->RemoveItemAtInventoryIndex(invMatrixIndex);
+            return;
+        } else {
+            if (item) {
+                // swap items
+                ItemGen tmpItem = *item;
+                int oldinvMatrixIndex = invMatrixIndex;
+                this->RemoveItemAtInventoryIndex(invMatrixIndex);
+                invMatrixIndex = GetItemMainInventoryIndex(invMatrixIndex);
+                int invItemIndex = this->GetItemListAtInventoryIndex(invMatrixIndex);
+
+                // try to add where we clicked
+                int emptyIndex = this->AddItem2(invMatrixIndex, &pParty->pPickedItem);
+                if (!emptyIndex) {
+                    // try to add anywhere
+                    emptyIndex = this->AddItem2(-1, &pParty->pPickedItem);
                     if (!emptyIndex) {
-                        emptyIndex = this->AddItem2(-1, &pParty->pPickedItem);
-                        if (!emptyIndex) {
-                            this->PutItemArInventoryIndex(tmpItem.uItemID, invItemIndex - 1, invMatrixIndex);
-                            *invItemPtr = tmpItem;
-                            return;
-                        }
-                    }
-
-                    pParty->pPickedItem = tmpItem;
-                    mouse->SetCursorImage(pParty->pPickedItem.GetIconName());
-                    return;
-                } else {
-                    itemPos = this->AddItem(invMatrixIndex, pickedItemId);
-
-                    if (itemPos) {
-                        this->pInventoryItemList[itemPos - 1] = pParty->pPickedItem;
-                        mouse->RemoveHoldingItem();
+                        // failed to add, put back the old item
+                        this->PutItemAtInventoryIndex(tmpItem.uItemID, invItemIndex - 1, invMatrixIndex);
                         return;
                     }
-
-                    // itemPos = this->AddItem(-1, pickedItemId);
-
-                    // if ( itemPos ) {
-                    //    memcpy(&this->pInventoryItemList[itemPos-1],
-                    // &pParty->pPickedItem, sizeof(ItemGen));
-                    //    pMouse->RemoveHoldingItem();
-                    //       return;
-                    // }
                 }
-            }  // held item or no
-        }  // limits
-    }      // char wind
-}  // func
+
+                mouse->RemoveHoldingItem();
+                pParty->setHoldingItem(&tmpItem);
+                return;
+            } else {
+                // place picked item
+                int itemPos = this->AddItem(invMatrixIndex, pParty->pPickedItem.uItemID);
+
+                if (itemPos) {
+                    this->pInventoryItemList[itemPos - 1] = pParty->pPickedItem;
+                    mouse->RemoveHoldingItem();
+                    return;
+                }
+            }
+        }
+    }
+}
 
 bool Character::IsWeak() const {
     return this->conditions.Has(CONDITION_WEAK);

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -253,7 +253,7 @@ class Character {
     int AddItem(int uSlot, ItemId uItemID);
     int AddItem2(int uSlot, ItemGen *Src);
     int CreateItemInInventory2(unsigned int index, ItemGen *Src);
-    void PutItemArInventoryIndex(ItemId uItemID, int itemListPos, int uSlot);
+    void PutItemAtInventoryIndex(ItemId uItemID, int itemListPos, int uSlot);
     void RemoveItemAtInventoryIndex(unsigned int uSlot);
     bool CanAct() const;
     bool CanSteal() const;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -189,10 +189,12 @@ int Party::canActCount() const {
     return result;
 }
 
-void Party::setHoldingItem(ItemGen *pItem) {
+void Party::setHoldingItem(ItemGen *pItem, int offsetX, int offsetY) {
     placeHeldItemInInventoryOrDrop();
     pPickedItem = *pItem;
     mouse->SetCursorBitmapFromItemID(pPickedItem.uItemID);
+    mouse->pickedItemOffsetX = offsetX;
+    mouse->pickedItemOffsetY = offsetY;
 }
 
 void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems entering shops

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -79,7 +79,7 @@ struct Party {
     /**
      * @offset 0x4936E1
      */
-    void setHoldingItem(ItemGen *pItem);
+    void setHoldingItem(ItemGen *pItem, int offsetX = 0, int offsetY = 0);
 
     /**
     * Sets _activeCharacter to the first character that can act

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -260,6 +260,7 @@ void CharacterUI_InventoryTab_Draw(Character *player, bool a2);
 void CharacterUI_DrawPaperdoll(Character *player);
 void CharacterUI_DrawPaperdollWithRingOverlay(Character *player);
 void CharacterUI_ReleaseButtons();
+void CharacterUI_DrawPickedItemUnderlay(Vec2i offset);
 
 /**
  * @offset 0x417AD4

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -10,6 +10,7 @@
 #include "Engine/AssetsManager.h"
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
+#include "Engine/Objects/Character.h"
 #include "Engine/Objects/CharacterEnumFunctions.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/Viewport.h"
@@ -1284,6 +1285,10 @@ void CharacterUI_InventoryTab_Draw(Character *player, bool Cover_Strip) {
         render->DrawTextureNew(8 / 640.0f, 305 / 480.0f, ui_character_inventory_background_strip);
     }
 
+    render->SetUIClipRect({ 14, 17, 32 * 14, 32 * 9 });
+    CharacterUI_DrawPickedItemUnderlay({ 14, 17 });
+    render->ResetUIClipRect();
+
     for (unsigned i = 0; i < 126; ++i) {
         if (player->pInventoryMatrix[i] <= 0) continue;
         if (player->pInventoryItemList[player->pInventoryMatrix[i] - 1].uItemID == ITEM_NULL)
@@ -1296,6 +1301,23 @@ void CharacterUI_InventoryTab_Draw(Character *player, bool Cover_Strip) {
         signed int X_offset = itemOffset(pTexture->width());
         signed int Y_offset = itemOffset(pTexture->height());
         CharacterUI_DrawItem(uCellX + X_offset, uCellY + Y_offset, &(player->pInventoryItemList[player->pInventoryMatrix[i] - 1]), Cover_Strip);
+    }
+}
+
+void CharacterUI_DrawPickedItemUnderlay(Vec2i offset) {
+    if (pParty->pPickedItem.uItemID != ITEM_NULL) {
+        // draw shadow of position
+        int pY;
+        int pX;
+        mouse->GetClickPos(&pX, &pY);
+
+        int inventoryXCoord = (pX + mouse->pickedItemOffsetX - offset.x) / 32;
+        int inventoryYCoord = (pY + mouse->pickedItemOffsetY - offset.y) / 32;
+        auto img = assets->getImage_Alpha(pParty->pPickedItem.GetIconName());
+        int itemWidth = GetSizeInInventorySlots(img->width());
+        int itemHeight = GetSizeInInventorySlots(img->height());
+
+        render->FillRectFast(inventoryXCoord * 32 + offset.x, inventoryYCoord * 32 + offset.y, itemWidth * 32, itemHeight * 32, Color(96, 96, 96, 128));
     }
 }
 

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -49,6 +49,10 @@ void GUIWindow_Chest::Update() {
         GraphicsImage *chest_background = assets->getImage_ColorKey(fmt::format("chest{:02}", pChestList->vChests[chestBitmapId].uTextureID));
         render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, chest_background);
 
+        render->SetUIClipRect({ chest_offs_x, chest_offs_y, 32 * chestWidthCells, 32 * chestHeghtCells });
+        CharacterUI_DrawPickedItemUnderlay({ chest_offs_x, chest_offs_y });
+        render->ResetUIClipRect();
+
         for (int item_counter = 0; item_counter < chestWidthCells * chestHeghtCells; ++item_counter) {
             int chest_item_index = vChests[uChestID].pInventoryIndices[item_counter];
             if (chest_item_index > 0) {
@@ -63,6 +67,7 @@ void GUIWindow_Chest::Update() {
                 render->DrawTextureNew(itemPixelPosX / 640.0f, itemPixelPosY / 480.0f, item_texture);
             }
         }
+
         render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, ui_exit_cancel_button_background);
     }
 }

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -678,7 +678,6 @@ void createHouseUI(HouseId houseId) {
 // TODO(Nik-RE-dev): looks like this function is not needed anymore
 void BackToHouseMenu() {
     auto pMouse = EngineIocContainer::ResolveMouse();
-    pMouse->ClearPickedItem();
     // TODO(Nik-RE-dev): Looks like it's artifact of MM6
 #if 0
     if (window_SpeakInHouse && window_SpeakInHouse->houseId() == 165 &&

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -40,6 +40,8 @@ void Io::Mouse::RemoveHoldingItem() {
     if (this->cursor_name != "MICON2") {
         SetCursorImage("MICON1");
     }
+    pickedItemOffsetX = 0;
+    pickedItemOffsetY = 0;
 }
 
 void Io::Mouse::SetCursorBitmapFromItemID(ItemId uItemID) {
@@ -190,8 +192,8 @@ void Io::Mouse::DrawPickedItem() {
     GraphicsImage *pTexture = assets->getImage_Alpha(pParty->pPickedItem.GetIconName());
     if (!pTexture) return;
 
-	float posX = (uMouseX + pickedItemOffsetX) / 640.0f;
-	float posY = (uMouseY + pickedItemOffsetY) / 480.0f;
+    float posX = (uMouseX + pickedItemOffsetX) / 640.0f;
+    float posY = (uMouseY + pickedItemOffsetY) / 480.0f;
 
     if (pParty->pPickedItem.IsBroken()) {
         render->DrawTransparentRedShade(posX, posY, pTexture);

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -115,8 +115,6 @@ void Io::Mouse::DrawCursor() {
     if (pParty->pPickedItem.uItemID != ITEM_NULL) {
         DrawPickedItem();
     } else {
-        ClearPickedItem();
-
         // for other cursor img ie target mouse
         if (this->cursor_img) {
             platform->setCursorShown(false);
@@ -185,8 +183,6 @@ void Io::Mouse::DrawCursor() {
     */
 }
 
-void Io::Mouse::ClearPickedItem() { pPickedItem = nullptr; }
-
 void Io::Mouse::DrawPickedItem() {
     if (pParty->pPickedItem.uItemID == ITEM_NULL)
         return;
@@ -194,12 +190,15 @@ void Io::Mouse::DrawPickedItem() {
     GraphicsImage *pTexture = assets->getImage_Alpha(pParty->pPickedItem.GetIconName());
     if (!pTexture) return;
 
+	float posX = (uMouseX + pickedItemOffsetX) / 640.0f;
+	float posY = (uMouseY + pickedItemOffsetY) / 480.0f;
+
     if (pParty->pPickedItem.IsBroken()) {
-        render->DrawTransparentRedShade(uMouseX / 640.0f, uMouseY / 480.0f, pTexture);
+        render->DrawTransparentRedShade(posX, posY, pTexture);
     } else if (!pParty->pPickedItem.IsIdentified()) {
-        render->DrawTransparentGreenShade(uMouseX / 640.0f, uMouseY / 480.0f, pTexture);
+        render->DrawTransparentGreenShade(posX, posY, pTexture);
     } else {
-        render->DrawTextureNew(uMouseX / 640.0f, uMouseY / 480.0f, pTexture);
+        render->DrawTextureNew(posX, posY, pTexture);
     }
 }
 

--- a/src/Io/Mouse.h
+++ b/src/Io/Mouse.h
@@ -16,7 +16,6 @@ class Mouse {
     inline Mouse() : cursor_img(nullptr) {
         pCursorBitmap_sysmem = nullptr;
         pCursorBitmap2_sysmem = nullptr;
-        pPickedItem = nullptr;
         uMouseX = 0;
         uMouseY = 0;
     }
@@ -32,7 +31,6 @@ class Mouse {
     Pointi GetCursorPos();
     void Initialize();
     void DrawCursor();
-    void ClearPickedItem();
     void DrawPickedItem();
     void SetMousePosition(int x, int y);
 
@@ -49,9 +47,8 @@ class Mouse {
     GraphicsImage *cursor_img = nullptr;
     uint16_t *pCursorBitmap_sysmem = nullptr;
     uint8_t *pCursorBitmap2_sysmem = nullptr;
-    GraphicsImage *pPickedItem = nullptr;
-    int uCursorWithItemX = 0;
-    int uCursorWithItemY = 0;
+    int pickedItemOffsetX = 0;
+    int pickedItemOffsetY = 0;
     Pointi pCursorBitmapPos{};
     std::string cursor_name;
     int uMouseX = 0;


### PR DESCRIPTION
#1904 will need merging first

Minor UX improvement
When picking or placing items in inventory or chest, item will be grabbed from where it was clicked now and not just snap to mouse position. Also adds a shadow underlay as to where the item will be placed.
![Screenshot 2025-01-28 134817](https://github.com/user-attachments/assets/037dd66f-e2a0-4ce4-acb8-58a843c7abfb)

