### PR TITLE
Fix textures on GLES

### DIFF
--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,6 +1,8 @@
 #ifdef GL_ES
     precision highp float;
     precision highp usamplerBuffer;
+    precision highp int;
+    precision highp sampler2D;
 #endif
 
 in vec4 colour;


### PR DESCRIPTION
When GLES is used, many textures appear blank or have incorrect colours. This can be seen in the starting area -- most noticeably, most people have completely blank textures. This occurs due to data type problems with the input arguments, which are fixed by this PR.