### PR TITLE
Fix textures on GLES

### DIFF
--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -1,5 +1,7 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
+    precision highp sampler2D;
     precision highp usamplerBuffer;
 #endif
 

--- a/resources/shaders/glbillbshader.frag
+++ b/resources/shaders/glbillbshader.frag
@@ -2,7 +2,6 @@
     precision highp int;
     precision highp float;
     precision highp sampler2D;
-    precision highp usamplerBuffer;
 #endif
 
 in vec4 colour;
@@ -20,7 +19,7 @@ struct FogParam {
 };
 
 uniform sampler2D texture0;
-uniform usamplerBuffer palbuf;
+uniform sampler2D paltex2D;
 uniform FogParam fog;
 uniform float gamma;
 
@@ -29,11 +28,11 @@ float getFogRatio(FogParam fogpar, float dist);
 void main() {
     vec4 fragcol = texture(texture0, texuv);
     int index = int(fragcol.r * 255.0);
-    vec4 newcol = vec4(texelFetch(palbuf, int(256 * paletteid + index)));
+    vec4 newcol = vec4(texelFetch(paltex2D, ivec2(index, paletteid), 0));
 
     if (paletteid > 0)
         if (index > 0)
-            fragcol = vec4(newcol.r / 255.0, newcol.g / 255.0, newcol.b / 255.0, 1.0);
+            fragcol = vec4(newcol.r, newcol.g, newcol.b, 1.0);
 
     fragcol *= colour;
 

--- a/resources/shaders/glbspshader.frag
+++ b/resources/shaders/glbspshader.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
     precision highp sampler2DArray;
 #endif

--- a/resources/shaders/gldecalshader.frag
+++ b/resources/shaders/gldecalshader.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
 #endif
 

--- a/resources/shaders/glforcepershader.frag
+++ b/resources/shaders/glforcepershader.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
 #endif
 

--- a/resources/shaders/gllinesshader.frag
+++ b/resources/shaders/gllinesshader.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
 #endif
 

--- a/resources/shaders/gloutbuild.frag
+++ b/resources/shaders/gloutbuild.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
     precision highp sampler2DArray;
 #endif

--- a/resources/shaders/glterrain.frag
+++ b/resources/shaders/glterrain.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
     precision highp sampler2DArray;
 #endif

--- a/resources/shaders/gltextshader.frag
+++ b/resources/shaders/gltextshader.frag
@@ -1,4 +1,5 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
 #endif
 

--- a/resources/shaders/gltwodshader.frag
+++ b/resources/shaders/gltwodshader.frag
@@ -20,7 +20,7 @@ void main() {
 
     if (paletteid > 0)
         if (index > 0)
-            fragcol = vec4(newcol.r / 255.0, newcol.g / 255.0, newcol.b / 255.0, 1.0);
+            fragcol = vec4(newcol.r, newcol.g, newcol.b, 1.0);
 
     FragColour =  fragcol * colour;
 }

--- a/resources/shaders/gltwodshader.frag
+++ b/resources/shaders/gltwodshader.frag
@@ -1,6 +1,7 @@
 #ifdef GL_ES
+    precision highp int;
     precision highp float;
-    precision highp usamplerBuffer;
+    precision highp sampler2D;
 #endif
 
 in vec4 colour;
@@ -10,12 +11,12 @@ flat in int paletteid;
 out vec4 FragColour;
 
 uniform sampler2D texture0;
-uniform usamplerBuffer palbuf;
+uniform sampler2D paltex2D;
 
 void main() {
     vec4 fragcol = texture(texture0, texuv);
     int index = int(fragcol.r * 255.0);
-    vec4 newcol = vec4(texelFetch(palbuf, int(256 * paletteid + index)));
+    vec4 newcol = vec4(texelFetch(paltex2D, ivec2(index, paletteid), 0));
 
     if (paletteid > 0)
         if (index > 0)

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -2568,7 +2568,7 @@ void OpenGLRenderer::DrawBillboards() {
         glEnableVertexAttribArray(5);
     }
 
-    GLint paltex2D_id = 9;
+    constexpr GLint paltex2D_id = 1;
     if (paltex2D == 0) {
         std::span<Color> palettes = pPaletteManager->paletteData();
         glActiveTexture(GL_TEXTURE0 + paltex2D_id);
@@ -2596,6 +2596,7 @@ void OpenGLRenderer::DrawBillboards() {
     billbshader.use();
 
     // set sampler to palette
+    glActiveTexture(GL_TEXTURE0 + paltex2D_id);
     glBindTexture(GL_TEXTURE_2D, paltex2D);
     glUniform1i(billbshader.uniformLocation("paltex2D"), paltex2D_id);
 
@@ -5019,7 +5020,7 @@ void OpenGLRenderer::DrawTwodVerts() {
         glEnableVertexAttribArray(4);
     }
 
-    GLint paltex2D_id = 9;
+    constexpr GLint paltex2D_id = 1;
     if (paltex2D == 0) {
         std::span<Color> palettes = pPaletteManager->paletteData();
         glActiveTexture(GL_TEXTURE0 + paltex2D_id);
@@ -5046,6 +5047,7 @@ void OpenGLRenderer::DrawTwodVerts() {
     twodshader.use();
 
     // set sampler to palette
+    glActiveTexture(GL_TEXTURE0 + paltex2D_id);
     glBindTexture(GL_TEXTURE_2D, paltex2D);
     glUniform1i(twodshader.uniformLocation("paltex2D"), paltex2D_id);
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -2568,17 +2568,16 @@ void OpenGLRenderer::DrawBillboards() {
         glEnableVertexAttribArray(5);
     }
 
-    if (palbuf == 0) {
-        // generate palette buffer texture
+    GLint paltex2D_id = 9;
+    if (paltex2D == 0) {
         std::span<Color> palettes = pPaletteManager->paletteData();
-        glGenBuffers(1, &palbuf);
-        glBindBuffer(GL_TEXTURE_BUFFER, palbuf);
-        glBufferData(GL_TEXTURE_BUFFER, palettes.size_bytes(), palettes.data(), GL_STATIC_DRAW);
-
-        glGenTextures(1, &paltex);
-        glBindTexture(GL_TEXTURE_BUFFER, paltex);
-        glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8UI, palbuf);
-        glBindBuffer(GL_TEXTURE_BUFFER, 0);
+        glActiveTexture(GL_TEXTURE0 + paltex2D_id);
+        glGenTextures(1, &paltex2D);
+        glBindTexture(GL_TEXTURE_2D, paltex2D);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1000, 0,
+            GL_RGBA, GL_UNSIGNED_BYTE, palettes.data());
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     }
 
     // update buffer
@@ -2597,10 +2596,8 @@ void OpenGLRenderer::DrawBillboards() {
     billbshader.use();
 
     // set sampler to palette
-    glUniform1i(billbshader.uniformLocation("palbuf"), GLint(1));
-    glActiveTexture(GL_TEXTURE0 + 1);
-    glBindTexture(GL_TEXTURE_BUFFER, paltex);
-    glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8UI, palbuf);
+    glUniform1i(billbshader.uniformLocation("paltex2D"), paltex2D_id);
+
     glActiveTexture(GL_TEXTURE0);
 
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -2574,7 +2574,7 @@ void OpenGLRenderer::DrawBillboards() {
         glActiveTexture(GL_TEXTURE0 + paltex2D_id);
         glGenTextures(1, &paltex2D);
         glBindTexture(GL_TEXTURE_2D, paltex2D);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1000, 0,
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, palettes.size() / 256, 0,
             GL_RGBA, GL_UNSIGNED_BYTE, palettes.data());
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -2596,6 +2596,7 @@ void OpenGLRenderer::DrawBillboards() {
     billbshader.use();
 
     // set sampler to palette
+    glBindTexture(GL_TEXTURE_2D, paltex2D);
     glUniform1i(billbshader.uniformLocation("paltex2D"), paltex2D_id);
 
     glActiveTexture(GL_TEXTURE0);
@@ -5024,7 +5025,7 @@ void OpenGLRenderer::DrawTwodVerts() {
         glActiveTexture(GL_TEXTURE0 + paltex2D_id);
         glGenTextures(1, &paltex2D);
         glBindTexture(GL_TEXTURE_2D, paltex2D);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1000, 0,
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, palettes.size() / 256, 0,
             GL_RGBA, GL_UNSIGNED_BYTE, palettes.data());
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -5045,7 +5046,9 @@ void OpenGLRenderer::DrawTwodVerts() {
     twodshader.use();
 
     // set sampler to palette
-    glUniform1i(twodshader.uniformLocation("paltex2Df"), paltex2D_id);
+    glBindTexture(GL_TEXTURE_2D, paltex2D);
+    glUniform1i(twodshader.uniformLocation("paltex2D"), paltex2D_id);
+
     glActiveTexture(GL_TEXTURE0);
 
     // glEnable(GL_TEXTURE_2D);

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.h
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.h
@@ -205,7 +205,7 @@ class OpenGLRenderer : public BaseRenderer {
 
     // billboards shader
     GLuint billbVBO{}, billbVAO{};
-    GLuint palbuf{}, paltex{}, paltex2D{};
+    GLuint paltex2D{};
 
     // decal shader
     GLuint decalVBO{}, decalVAO{};

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.h
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.h
@@ -205,7 +205,7 @@ class OpenGLRenderer : public BaseRenderer {
 
     // billboards shader
     GLuint billbVBO{}, billbVAO{};
-    GLuint palbuf{}, paltex{};
+    GLuint palbuf{}, paltex{}, paltex2D{};
 
     // decal shader
     GLuint decalVBO{}, decalVAO{};


### PR DESCRIPTION
Further to #1929, I found that some textures were still broken, e.g. knights in the tutorial area.

It looks like TexelFetch is returning 0 for any lookup with a high palette number. I think this is because of this -- https://community.khronos.org/t/i-just-dont-manage-to-use-texelfetch/63271/3 . I.E. the palette texture is too big to be used as a 1D texture on some hardware, and TexelFetch just returns zero above a certain offset.

This PR implements the palette as a 2D texture, and fixes the problem. I have not seen any adverse effects.