### PR TITLE
New inventory

### DIFF
--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -160,12 +160,13 @@ EventTraceGameState EngineTraceStateAccessor::makeGameState() {
         traceCharacter.speed = character.GetActualSpeed();
         traceCharacter.luck = character.GetActualLuck();
 
-        for (int index : character.pEquipment)
-            if (index > 0)
-                traceCharacter.equipment.emplace_back(toDebugString(character.pInventoryItemList[index - 1]));
-        for (int index : character.pInventoryMatrix)
-            if (index > 0)
-                traceCharacter.backpack.emplace_back(toDebugString(character.pInventoryItemList[index - 1]));
+        for (ItemSlot slot : allItemSlots())
+            if (InventoryConstEntry entry = character.inventory.entry(slot))
+                traceCharacter.equipment.emplace_back(toDebugString(*entry));
+        for (int y = 0; y < character.inventory.gridSize().h; y++)
+            for (int x = 0; x < character.inventory.gridSize().w; x++)
+                if (InventoryConstEntry entry = character.inventory.entry(Pointi(x, y)); entry && entry.geometry().topLeft() == Pointi(x, y))
+                    traceCharacter.backpack.emplace_back(toDebugString(*entry));
     }
     return result;
 }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1376,8 +1376,7 @@ void RegeneratePartyHealthMana() {
         // Item regeneration
         for (ItemSlot idx : allItemSlots()) {
             if (character.HasItemEquipped(idx)) {
-                unsigned _idx = character.pEquipment[idx];
-                Item equppedItem = character.pInventoryItemList[_idx - 1];
+                Item equppedItem = *character.inventory.entry(idx);
                 if (!isRegular(equppedItem.itemId)) {
                     if (equppedItem.itemId == ITEM_RELIC_ETHRICS_STAFF) {
                         character.health -= ticks5;
@@ -1428,7 +1427,7 @@ void RegeneratePartyHealthMana() {
         // Lich mana/health drain/regen.
         if (character.classType == CLASS_LICH) {
             bool lich_has_jar = false;
-            for (const Item &item : character.pInventoryItemList)
+            for (const Item &item : character.inventory.items())
                 if (item.itemId == ITEM_QUEST_LICH_JAR_FULL && item.lichJarCharacterIndex == character.getCharacterIndex())
                     lich_has_jar = true;
 

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -767,6 +767,6 @@ void BaseRenderer::updateRenderDimensions() {
         outputRender = outputPresent;
 }
 
-int BaseRenderer::QueryEquipmentHitMap(Pointi screenPos) {
-    return _equipmentHitMap.query(screenPos, 0);
+int BaseRenderer::QueryEquipmentHitMap(Pointi screenPos, int defaultValue) {
+    return _equipmentHitMap.query(screenPos, defaultValue);
 }

--- a/src/Engine/Graphics/Renderer/BaseRenderer.h
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.h
@@ -45,7 +45,7 @@ class BaseRenderer : public Renderer {
     virtual void ClearZBuffer() override;
     virtual void ZDrawTextureAlpha(float u, float v, GraphicsImage *pTexture, int zVal) override;
 
-    virtual int QueryEquipmentHitMap(Pointi screenPos) override;
+    virtual int QueryEquipmentHitMap(Pointi screenPos, int defaultValue) override;
 
     bool Reinitialize(bool firstInit) override;
 

--- a/src/Engine/Graphics/Renderer/Renderer.h
+++ b/src/Engine/Graphics/Renderer/Renderer.h
@@ -183,9 +183,10 @@ class Renderer {
      * Query the equipment hit map for hit testing.
      *
      * @param screenPos                 Screen position to query (absolute screen coordinates).
-     * @return                          Item ID at the position, or 0 if no equipment found.
+     * @param defaultValue              Default value to return.
+     * @return                          Item ID at the position, or `defaultValue` if no equipment found.
      */
-    virtual int QueryEquipmentHitMap(Pointi screenPos) = 0;
+    virtual int QueryEquipmentHitMap(Pointi screenPos, int defaultValue) = 0;
 
     std::shared_ptr<GameConfig> config = nullptr;
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -3039,7 +3039,6 @@ int Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster, const V
     if (pMonster->aiState == Fleeing) pMonster->attributes |= ACTOR_FLEEING;
     bool hit_will_stun = false, hit_will_paralyze = false;
     if (!projectileSprite) {
-        int main_hand_idx = character->pEquipment[ITEM_SLOT_MAIN_HAND];
         IsAdditionalDamagePossible = true;
         if (character->HasItemEquipped(ITEM_SLOT_MAIN_HAND)) {
             CharacterSkillType main_hand_skill = character->GetMainHandItem()->GetPlayerSkillType();

--- a/src/Engine/Objects/CMakeLists.txt
+++ b/src/Engine/Objects/CMakeLists.txt
@@ -14,7 +14,9 @@ set(ENGINE_OBJECTS_SOURCES
         ObjectList.cpp
         Character.cpp
         CharacterEnumFunctions.cpp
-        SpriteObject.cpp)
+        SpriteObject.cpp
+        TalkAnimation.cpp
+        Inventory.cpp)
 
 set(ENGINE_OBJECTS_HEADERS
         Actor.h
@@ -44,9 +46,21 @@ set(ENGINE_OBJECTS_HEADERS
         SpriteEnums.h
         SpriteEnumFunctions.h
         TalkAnimation.h
-        TalkAnimation.cpp)
+        Inventory.h)
 
 add_library(engine_objects STATIC ${ENGINE_OBJECTS_SOURCES} ${ENGINE_OBJECTS_HEADERS})
 target_check_style(engine_objects)
 
 target_link_libraries(engine_objects PUBLIC engine gui library_random library_color utility)
+
+if(OE_BUILD_TESTS)
+    set(TEST_ENGINE_OBJECTS_SOURCES
+            Tests/Inventory_ut.cpp)
+
+    add_library(test_engine_objects OBJECT ${TEST_ENGINE_OBJECTS_SOURCES})
+    target_link_libraries(test_engine_objects PUBLIC testing_unit engine_objects)
+
+    target_check_style(test_engine_objects)
+
+    target_link_libraries(OpenEnroth_GameTest PUBLIC test_engine_objects)
+endif()

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6325,11 +6325,6 @@ void Character::OnInventoryLeftClick() {
                 // take out
                 Pointi pos = entry.geometry().topLeft();
                 Item tmp = inventory.take(entry);
-                //Item tmpItem = *item;
-                //int oldinvMatrixIndex = invMatrixIndex;
-                //invMatrixIndex = GetItemMainInventoryIndex(invMatrixIndex);
-                //int invItemIndex = this->GetItemListAtInventoryIndex(invMatrixIndex);
-                //this->RemoveItemAtInventoryIndex(invMatrixIndex);
 
                 // try to add where we clicked
                 if (!inventory.tryAdd(pos, pParty->pPickedItem)) {

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "Inventory.h"
 #include "Engine/Data/HouseEnums.h"
 #include "Engine/Objects/NPCEnums.h"
 #include "Engine/Objects/ActorEnums.h"
@@ -113,7 +114,7 @@ class Character {
     static constexpr unsigned int INVENTORY_SLOTS_HEIGHT = 9;
 
     // Maximum number of items the character inventory can hold.
-    static constexpr unsigned int INVENTORY_SLOT_COUNT = INVENTORY_SLOTS_WIDTH * INVENTORY_SLOTS_HEIGHT;
+    // static constexpr unsigned int INVENTORY_SLOT_COUNT = INVENTORY_SLOTS_WIDTH * INVENTORY_SLOTS_HEIGHT;
 
     Character();
     void Zero();
@@ -239,23 +240,7 @@ class Character {
      */
     int getLearningPercent() const;
 
-    /**
-     * @offset 0x492528
-     */
-    bool canFitItem(unsigned int uSlot, ItemId uItemID) const;
-
-    /**
-     * @offset 0x4925E6
-     */
-    int findFreeInventoryListSlot() const;
-    int CreateItemInInventory(unsigned int uSlot, ItemId uItemID);
     bool HasSkill(CharacterSkillType skill) const;
-    void WearItem(ItemId uItemID);
-    int AddItem(int uSlot, ItemId uItemID);
-    int AddItem2(int uSlot, Item *Src);
-    int CreateItemInInventory2(unsigned int index, Item *Src);
-    void PutItemAtInventoryIndex(ItemId uItemID, int itemListPos, int uSlot);
-    void RemoveItemAtInventoryIndex(unsigned int uSlot);
     bool CanAct() const;
     bool CanSteal() const;
     bool CanEquip_RaceAndAlignmentCheck(ItemId uItemID) const;
@@ -275,13 +260,10 @@ class Character {
      * @offset 0x494A25
      */
     void playEmotion(CharacterPortrait newPortrait, Duration duration);
-    void ItemsPotionDmgBreak(int enchant_count);
-    unsigned int GetItemListAtInventoryIndex(int inout_item_cell);
-    unsigned int GetItemMainInventoryIndex(int inout_item_cell);
-    Item *GetItemAtInventoryIndex(int inout_item_cell);
+    void ItemsPotionDmgBreak(int count);
     int GetConditionDaysPassed(Condition condition) const;
     bool NothingOrJustBlastersEquipped() const;
-    void SalesProcess(unsigned int inventory_idnx, int item_index, HouseId houseId);  // 0x4BE2DD
+    void SalesProcess(InventoryEntry entry, HouseId houseId);  // 0x4BE2DD
     bool Recover(Duration dt);
     bool CanCastSpell(unsigned int uRequiredMana);
     void SpendMana(unsigned int uRequiredMana);
@@ -402,10 +384,7 @@ class Character {
     IndexedBitset<1, 512> _achievedAwardsBits;
     IndexedArray<bool, SPELL_FIRST_REGULAR, SPELL_LAST_REGULAR> bHaveSpell;
     IndexedArray<bool, ATTRIBUTE_FIRST_STAT, ATTRIBUTE_LAST_STAT> _pureStatPotionUsed;
-    std::array<Item, INVENTORY_SLOT_COUNT> pInventoryItemList;
-    std::array<int, INVENTORY_SLOT_COUNT> pInventoryMatrix; // 0 => empty cell
-                                                            // positive => subtract 1 to get an index into pInventoryItemList.
-                                                            // negative => negate & subtract 1 to get a real index into pInventoryMatrix.
+    CharacterInventory inventory;
     int16_t sResFireBase;
     int16_t sResAirBase;
     int16_t sResWaterBase;
@@ -437,8 +416,6 @@ class Character {
     int health;
     int mana;
     unsigned int uBirthYear;
-    IndexedArray<unsigned int, ITEM_SLOT_FIRST_VALID, ITEM_SLOT_LAST_VALID> pEquipment; // 0 => empty,
-                                                                                        // non-zero => subtract 1 to get an index into pInventoryItemList.
     MagicSchool lastOpenedSpellbookPage;
     SpellId uQuickSpell;
     IndexedBitset<1, 512> _characterEventBits;

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -110,11 +110,8 @@ class CharacterConditions {
 
 class Character {
  public:
-    static constexpr unsigned int INVENTORY_SLOTS_WIDTH = 14;
+    static constexpr unsigned int INVENTORY_SLOTS_WIDTH = 14; // TODO(captainurist): drop these consts, they don't belong here.
     static constexpr unsigned int INVENTORY_SLOTS_HEIGHT = 9;
-
-    // Maximum number of items the character inventory can hold.
-    // static constexpr unsigned int INVENTORY_SLOT_COUNT = INVENTORY_SLOTS_WIDTH * INVENTORY_SLOTS_HEIGHT;
 
     Character();
     void Zero();

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -156,198 +156,25 @@ bool Chest::ChestUI_WritePointedObjectStatusString() {
     Chest *chest = &vChests[pGUIWindow_CurrentChest->chestId()];
 
     Pointi mousePos = mouse->position();
-    Sizei chestSize = chestTable[chest->chestTypeId].size;
     // TODO(captainurist): need to use mouse->pickedItemOffset here?
     Pointi inventoryPos = mapToInventoryGrid(mousePos, chestTable[chest->chestTypeId].inventoryOffset);
 
-    int invMatrixIndex = inventoryPos.x + (chestSize.w * inventoryPos.y);
-
-    if (Recti(Pointi(0, 0), chestSize).contains(inventoryPos)) {
-        int chestindex = chest->inventoryMatrix[invMatrixIndex];
-        if (chestindex < 0) {
-            invMatrixIndex = (-(chestindex + 1));
-            chestindex = chest->inventoryMatrix[invMatrixIndex];
-        }
-
-        if (chestindex) {
-            int itemindex = chestindex - 1;
-            Item *item = &chest->items[itemindex];
-
-            ///////////////////////////////////////////////
-            // normal picking
-
-            engine->_statusBar->setPermanent(item->GetDisplayName());
-            uLastPointedObjectID = Pid::dummy();
-            return 1;
-
-            ////////////////////////////////////////////////////
-
-            // per pixel transparency check tests
-            /*
-
-            auto img = assets->GetImage_16BitColorKey(item->GetIconName(),
-            colorTable.TealMask);
-
-            int imgwidth = img->GetWidth();
-            int imgheight = img->GetHeight();
-            auto pixels = (int32_t*)img->GetPixels(IMAGE_FORMAT_A8R8G8B8);
-
-            assert(pixels != nullptr, "Cannot get pixels");
-
-            if (imgwidth < 14)
-                    imgwidth = 14;
-
-            int v12 = imgwidth - 14;
-            v12 = v12 & 0xFFFFFFE0;
-             int v13 = v12 + 32;
-
-            if (imgheight < 14)
-                    imgheight = 14;
-
-            int chest_offs_x =
-            42;//pChestPixelOffsetX[(int)pGUIWindow_CurrentMenu->par1C].uChestBitmapID];
-            int chest_offs_y = 34; //
-            pChestPixelOffsetY[(int)pGUIWindow_CurrentMenu->par1C].uChestBitmapID];
-
-            int imgX = chest_offs_x + 32 * (invMatrixIndex % chestwidth) +
-            ((signed int)(v13 - imgwidth) / 2);
-
-            int imgY = chest_offs_y + 32 * (invMatrixIndex / chestheight) +
-                    ((signed int)(((imgheight - 14) & 0xFFFFFFE0) + 32 -
-            imgheight) / 2);
-
-            int pix_chk_x = pX-imgX;
-            int pix_chk_y = pY-imgY;
-
-            if (pix_chk_x > 0 && pix_chk_x <= imgwidth && pix_chk_y > 0 &&
-            pix_chk_y <= imgheight) {
-
-                    pixels += pix_chk_x + pix_chk_y*imgwidth;
-
-                    if (*pixels & 0xFF000000) {
-                            engine->_statusBar->setPermanent(item->GetDisplayName());
-                            uLastPointedObjectID = 1;
-                            return 1;
-                    }
-            }
-
-            */
-        }
-    }
-    return 0;
-}
-
-bool Chest::CanPlaceItemAt(int test_cell_position, ItemId item_id, int uChestID) {
-    Sizei chestSize = chestTable[vChests[uChestID].chestTypeId].size;
-    Pointi testPos = Pointi(test_cell_position % chestSize.w, test_cell_position / chestSize.w);
-
-    Sizei itemSize = pItemTable->itemSizes[item_id];
-    assert(itemSize.h > 0 && itemSize.w > 0 && "Items should have nonzero dimensions");
-
-    if (Recti(Pointi(0, 0), chestSize).contains(Recti(testPos, itemSize))) {
-        for (int x = 0; x < itemSize.w; x++) {
-            for (int y = 0; y < itemSize.h; y++) {
-                if (vChests[uChestID].inventoryMatrix[y * chestSize.w + x + test_cell_position] != 0) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-    return false;
-}
-
-int Chest::FindFreeItemSlot(int uChestID) {
-    int item_count = 0;
-    int max_items = chestTable[vChests[uChestID].chestTypeId].size.h *
-                    chestTable[vChests[uChestID].chestTypeId].size.w;
-
-    if (max_items <= 0) {
-        item_count = -1;
+    const InventoryEntry *entry = chest->inventory.gridItem(inventoryPos);
+    if (entry) {
+        engine->_statusBar->setPermanent(entry->item().GetDisplayName());
+        uLastPointedObjectID = Pid::dummy();
+        return 1;
     } else {
-        while (vChests[uChestID].items[item_count].itemId != ITEM_NULL) {
-            ++item_count;
-            if (item_count >= max_items) {
-                item_count = -1;
-                break;
-            }
-        }
+        return 0;
     }
-    return item_count;
 }
 
-int Chest::PutItemInChest(int position, Item *put_item, int uChestID) {
-    int firstFreeSlot = FindFreeItemSlot(uChestID);
+void Chest::PlaceItems(int uChestID) { // only used for setup
+    Chest &chest = vChests[uChestID];
 
-    int max_size = chestTable[vChests[uChestID].chestTypeId].size.w *
-                   chestTable[vChests[uChestID].chestTypeId].size.h;
-    int chest_width = chestTable[vChests[uChestID].chestTypeId].size.w;
-    int test_pos = max_size;
-
-    if (firstFreeSlot == -1) return 0;
-
-    if (position != -1) {
-        if (CanPlaceItemAt(position, put_item->itemId, uChestID)) {
-            test_pos = position;
-        } else {
-            position = -1;  // try another position?? is this the right behavior
-        }
-    }
-
-    if (position == -1) {  // no position specified
-        for (int _i = 0; _i < max_size; _i++) {
-            if (Chest::CanPlaceItemAt(_i, put_item->itemId, pGUIWindow_CurrentChest->chestId())) {
-                test_pos = _i;  // found somewhere to place item
-                break;
-            }
-        }
-
-        if (test_pos == max_size) {  // limits check no room
-            if (pParty->hasActiveCharacter()) {
-                pParty->activeCharacter().playReaction(SPEECH_NO_ROOM);
-            }
-            return 0;
-        }
-    }
-
-    Sizei itemSize = put_item->inventorySize();
-    assert(itemSize.h > 0 && itemSize.w > 0 && "Items should have nonzero dimensions");
-
-    // set inventory indices - memset was eratic??
-    for (int x = 0; x < itemSize.w; x++) {
-        for (int y = 0; y < itemSize.h; y++) {
-            vChests[uChestID].inventoryMatrix[y * chest_width + x + test_pos] = (-1 - test_pos);
-        }
-    }
-
-    vChests[uChestID].inventoryMatrix[test_pos] = firstFreeSlot + 1;
-    vChests[uChestID].items[firstFreeSlot] = *put_item;
-    vChests[uChestID].items[firstFreeSlot].placedInChest = true;
-
-    return (test_pos + 1);
-}
-
-void Chest::PlaceItemAt(unsigned int put_cell_pos, unsigned int item_at_cell, int uChestID) {  // only used for setup?
-    vChests[uChestID].items[item_at_cell].postGenerate(ITEM_SOURCE_CHEST);
-
-    ItemId uItemID = vChests[uChestID].items[item_at_cell].itemId;
-    Sizei itemSize = pItemTable->itemSizes[uItemID];
-
-    int chest_cell_width = chestTable[vChests[uChestID].chestTypeId].size.w;
-    int chest_cell_row_pos = 0;
-    for (int i = 0; i < itemSize.h; ++i) {
-        for (int j = 0; j < itemSize.w; ++j)
-            vChests[uChestID].inventoryMatrix[put_cell_pos + chest_cell_row_pos + j] = (int16_t)-(put_cell_pos + 1);
-        chest_cell_row_pos += chest_cell_width;
-    }
-    vChests[uChestID].inventoryMatrix[put_cell_pos] = item_at_cell + 1;
-    vChests[uChestID].items[item_at_cell].placedInChest = true;
-}
-
-void Chest::PlaceItems(int uChestID) {  // only sued for setup
     char chest_cells_map[144];   // [sp+Ch] [bp-A0h]@1
 
-    int uChestArea = chestTable[vChests[uChestID].chestTypeId].size.w * chestTable[vChests[uChestID].chestTypeId].size.h;
+    int uChestArea = chestTable[chest.chestTypeId].size.w * chestTable[chest.chestTypeId].size.h;
     memset(chest_cells_map, 0, 144);
     // fill cell map at random positions
     for (int items_counter = 0; items_counter < uChestArea; ++items_counter) {
@@ -364,27 +191,34 @@ void Chest::PlaceItems(int uChestID) {  // only sued for setup
         chest_cells_map[random_chest_pos] = items_counter;
     }
 
-    for (int items_counter = 0; items_counter < uChestArea; ++items_counter) {
-        ItemId chest_item_id = vChests[uChestID].items[items_counter].itemId;
-        assert(!isRandomItem(chest_item_id) && "Checking that generated items are valid");
-        if (chest_item_id != ITEM_NULL && !vChests[uChestID].items[items_counter].placedInChest) {
-            int test_position = 0;
-            while (!Chest::CanPlaceItemAt((uint8_t)chest_cells_map[test_position], chest_item_id, uChestID)) {
-                ++test_position;
-                if (test_position >= uChestArea) break;
-            }
-            if (test_position < uChestArea) {
-                Chest::PlaceItemAt((uint8_t)chest_cells_map[test_position], items_counter, uChestID);
-                vChests[uChestID].items[items_counter].placedInChest = true;
-                if (vChests[uChestID].flags & CHEST_OPENED) {
-                    vChests[uChestID].items[items_counter].SetIdentified();
-                }
-            } else {
-                logger->trace("Cannot place item with id {} in the chest!", std::to_underlying(chest_item_id));
+    Sizei chestSize = chest.inventory.gridSize();
+    for (InventoryEntry *entry : chest.inventory.entries()) {
+        if (entry->zone() != INVENTORY_ZONE_HIDDEN)
+            continue;
+
+        assert(!isRandomItem(entry->item().itemId) && "Checking that generated items are valid");
+
+        Sizei itemSize = entry->item().inventorySize();
+        for (int i = 0; i < uChestArea; i++) {
+            Pointi pos(chest_cells_map[i] % chestSize.w, chest_cells_map[i] / chestSize.w);
+
+            if (chest.inventory.canAddGridItem(pos, itemSize)) {
+                // TODO(captainurist): this is a weird place to call postGenerate, and we won't call it for items that
+                //                     end up buried. But it's here b/c we don't want to break the traces, at least now.
+                //                     Redo this properly and write a small test.
+                entry->item().postGenerate(ITEM_SOURCE_CHEST);
+                entry = chest.inventory.addGridItem(pos, chest.inventory.takeItem(entry));
+                if (chest.flags & CHEST_OPENED)
+                    entry->item().SetIdentified();
+                break;
             }
         }
+
+        if (entry->zone() == INVENTORY_ZONE_HIDDEN)
+            logger->trace("Cannot place item with id {} in the chest!", std::to_underlying(entry->item().itemId));
     }
-    vChests[uChestID].SetInitialized(true);
+
+    chest.SetInitialized(true);
 }
 
 void Chest::toggleFlag(int uChestID, ChestFlag uFlag, bool bValue) {
@@ -396,76 +230,47 @@ void Chest::toggleFlag(int uChestID, ChestFlag uFlag, bool bValue) {
     }
 }
 
-void RemoveItemAtChestIndex(int index) {
-    Chest *chest = &vChests[pGUIWindow_CurrentChest->chestId()];
-
-    int chestindex = chest->inventoryMatrix[index];
-    Item *item_in_slot = &chest->items[chestindex - 1];
-
-    Sizei itemSize = item_in_slot->inventorySize();
-
-    int chestwidth = chestTable[chest->chestTypeId].size.w;
-
-    item_in_slot->Reset();
-
-    // blank inventory indices - memset was eratic??
-    for (int x = 0; x < itemSize.w; x++) {
-        for (int y = 0; y < itemSize.h; y++) {
-            chest->inventoryMatrix[y * chestwidth + x + index] = 0;
-        }
-    }
-}
-
 void Chest::OnChestLeftClick() {
     int uChestID = pGUIWindow_CurrentChest->chestId();
     Chest *chest = &vChests[uChestID];
 
-    Sizei chestSize = chestTable[chest->chestTypeId].size;
-
     Pointi mousePos = mouse->position();
-
     Pointi inventoryPos = mapToInventoryGrid(mousePos + mouse->pickedItemOffset, chestTable[chest->chestTypeId].inventoryOffset);
-    int invMatrixIndex = inventoryPos.x + (chestSize.w * inventoryPos.y);
 
-    if (Recti(Pointi(0, 0), chestSize).contains(inventoryPos)) {
-        if (pParty->pPickedItem.itemId != ITEM_NULL) {  // item held
-            if (Chest::PutItemInChest(invMatrixIndex, &pParty->pPickedItem, uChestID)) {
-                mouse->RemoveHoldingItem();
-            }
+    if (pParty->pPickedItem.itemId != ITEM_NULL) {  // item held
+        std::optional<Pointi> pos;
+        if (chest->inventory.canAddGridItem(inventoryPos, pParty->pPickedItem.inventorySize())) {
+            pos = inventoryPos;
         } else {
-            int chestindex = chest->inventoryMatrix[invMatrixIndex];
-            if (chestindex < 0) {
-                invMatrixIndex = (-(chestindex + 1));
-                chestindex = chest->inventoryMatrix[invMatrixIndex];
+            pos = chest->inventory.findGridSpace(pParty->pPickedItem);
+        }
+
+        if (pos) {
+            chest->inventory.addGridItem(*pos, pParty->pPickedItem);
+            mouse->RemoveHoldingItem();
+        }
+    } else {
+        if (InventoryEntry *entry = chest->inventory.gridItem(inventoryPos)) {
+            Item item = chest->inventory.takeItem(entry);
+
+            if (item.isGold()) {
+                pParty->partyFindsGold(item.goldAmount, GOLD_RECEIVE_SHARE);
+            } else {
+                Pointi offset = mousePos + mouse->pickedItemOffset - chestTable[chest->chestTypeId].inventoryOffset - (inventoryPos * 32);
+
+                GraphicsImage *tex = assets->getImage_Alpha(item.GetIconName());
+                offset -= Pointi(itemOffset(tex->width()), itemOffset(tex->height()));
+
+                pParty->setHoldingItem(item, -offset);
             }
 
-            if (chestindex > 0) {
-                int itemindex = chestindex - 1;
-                chest->items[itemindex].placedInChest = false;
-                if (chest->items[itemindex].isGold()) {
-                    pParty->partyFindsGold(chest->items[itemindex].goldAmount, GOLD_RECEIVE_SHARE);
-                } else {
-                    // calc offsets of where on the item was clicked
-                    // first need index of top left corner of the item
-                    Pointi corner(invMatrixIndex % chestSize.w, invMatrixIndex / chestSize.w);
-                    Pointi offset = mousePos + mouse->pickedItemOffset - chestTable[chest->chestTypeId].inventoryOffset - (corner * 32);
-
-                    const Item &item = chest->items[itemindex];
-                    GraphicsImage *tex = assets->getImage_Alpha(item.GetIconName());
-                    offset -= Pointi(itemOffset(tex->width()), itemOffset(tex->height()));
-
-                    pParty->setHoldingItem(item, -offset);
-                }
-
-                RemoveItemAtChestIndex(invMatrixIndex);
-                if (engine->config->gameplay.ChestTryPlaceItems.value() == 2)
-                    Chest::PlaceItems(uChestID);
-            }
+            if (engine->config->gameplay.ChestTryPlaceItems.value() == 2)
+                Chest::PlaceItems(uChestID);
         }
     }
 }
 
-void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using spacebar
+void Chest::GrabItem(bool all) {  // new function to grab items from chest using spacebar
     if (pParty->pPickedItem.itemId != ITEM_NULL || !pParty->hasActiveCharacter()) {
         return;
     }
@@ -478,31 +283,24 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
     int chestId = pGUIWindow_CurrentChest->chestId();
     Chest *chest = &vChests[chestId];
 
-    // loop through chest pInvetoryIndices
-    for (int loop = 0; loop < 140; loop++) {
-        int chestindex = chest->inventoryMatrix[loop];
-        if (chestindex <= 0) continue;  // no item here
-
-        int itemindex = chestindex - 1;
-        Item chestitem = chest->items[itemindex];
-        chestitem.placedInChest = false;
-        if (chestitem.isGold()) {
-            pParty->partyFindsGold(chestitem.goldAmount, GOLD_RECEIVE_SHARE);
-            goldamount += chestitem.goldAmount;
+    for (InventoryEntry *entry : chest->inventory.entries()) {
+        if (entry->item().isGold()) {
+            pParty->partyFindsGold(entry->item().goldAmount, GOLD_RECEIVE_SHARE);
+            goldamount += entry->item().goldAmount;
             goldcount++;
         } else {  // this should add item to invetory of active char - if that fails set as holding item and break
-            if (pParty->hasActiveCharacter() && (InventSlot = pParty->activeCharacter().AddItem(-1, chestitem.itemId)) != 0) {  // can place
-                pParty->activeCharacter().pInventoryItemList[InventSlot - 1] = chestitem;
+            if (pParty->hasActiveCharacter() && (InventSlot = pParty->activeCharacter().AddItem(-1, entry->item().itemId)) != 0) {  // can place
+                pParty->activeCharacter().pInventoryItemList[InventSlot - 1] = entry->item();
                 grabcount++;
-                engine->_statusBar->setEvent(LSTR_YOU_FOUND_AN_ITEM_S, pItemTable->items[chestitem.itemId].unidentifiedName);
+                engine->_statusBar->setEvent(LSTR_YOU_FOUND_AN_ITEM_S, pItemTable->items[entry->item().itemId].unidentifiedName);
             } else {  // no room so set as holding item
-                pParty->setHoldingItem(chestitem);
-                RemoveItemAtChestIndex(loop);
+                pParty->setHoldingItem(entry->item());
+                chest->inventory.takeItem(entry);
                 pParty->activeCharacter().playReaction(SPEECH_NO_ROOM);
                 break;
             }
         }
-        RemoveItemAtChestIndex(loop);
+        chest->inventory.takeItem(entry);
         if (all == false)  // only grab 1 item
             break;
     }
@@ -521,34 +319,37 @@ void Chest::GrabItem(bool all) {  // new fucntion to grab items from chest using
 void GenerateItemsInChest() {
     MapInfo *currMapInfo = &pMapStats->pInfos[engine->_currentLoadedMapId];
     for (int i = 0; i < 20; ++i) {
-        for (int j = 0; j < 140; ++j) {
-            Item *currItem = &vChests[i].items[j];
-            if (isRandomItem(currItem->itemId)) {
-                currItem->placedInChest = false;
+        for (InventoryEntry *entry : vChests[i].inventory.entries()) {
+            if (isRandomItem(entry->item().itemId)) {
                 int additionaItemCount = grng->random(5);  // additional items in chect
                 additionaItemCount++;  // + 1 because it's the item at pChests[i].igChestItems[j] and the additional ones
                 ItemTreasureLevel resultTreasureLevel = grng->randomSample(
-                    RemapTreasureLevel(randomItemTreasureLevel(currItem->itemId), currMapInfo->mapTreasureLevel));
+                    RemapTreasureLevel(randomItemTreasureLevel(entry->item().itemId), currMapInfo->mapTreasureLevel));
+
                 if (resultTreasureLevel != ITEM_TREASURE_LEVEL_7) {
                     for (int k = 0; k < additionaItemCount; k++) {
+                        Item item;
                         int whatToGenerateProb = grng->random(100);
                         if (whatToGenerateProb < 20) {
-                            currItem->Reset();
+                            // Do nothing.
                         } else if (whatToGenerateProb < 60) {  // generate gold
-                            currItem->generateGold(resultTreasureLevel);
+                            item.generateGold(resultTreasureLevel);
                         } else {
-                            pItemTable->generateItem(resultTreasureLevel, RANDOM_ITEM_ANY, currItem);
+                            pItemTable->generateItem(resultTreasureLevel, RANDOM_ITEM_ANY, &item);
                         }
-
-                        for (int m = 0; m < 140; m++) {
-                            if (vChests[i].items[m].itemId == ITEM_NULL) {
-                                currItem = &vChests[i].items[m];
-                                break;
+                        if (item.itemId != ITEM_NULL) {
+                            if (entry) {
+                                entry->item() = item;
+                                entry = nullptr;
+                            } else {
+                                vChests[i].inventory.addHiddenItem(item);
                             }
                         }
                     }
                 } else {
-                    currItem->GenerateArtifact();
+                    Item item;
+                    item.GenerateArtifact();
+                    vChests[i].inventory.addHiddenItem(item);
                 }
             }
         }

--- a/src/Engine/Objects/Chest.h
+++ b/src/Engine/Objects/Chest.h
@@ -9,6 +9,7 @@
 #include "Library/Geometry/Vec.h"
 
 #include "ChestEnums.h"
+#include "Inventory.h"
 
 struct Chest {
     inline bool Initialized() const {
@@ -35,12 +36,12 @@ struct Chest {
 
     uint16_t chestTypeId = 0;
     ChestFlags flags;
-    std::array<Item, 140> items;
-    std::array<int16_t, 140> inventoryMatrix = {{}};  // 0x13b4 why is this a short?
 
     // Chest position, OE addition. Recalculated on level load in UpdateChestPositions. It's used to display
     // trap explosions in the same place regardless of which chest face was clicked.
     std::optional<Vec3f> position;
+
+    ChestInventory inventory;
 };
 
 void RemoveItemAtChestIndex(int index);

--- a/src/Engine/Objects/Inventory.cpp
+++ b/src/Engine/Objects/Inventory.cpp
@@ -1,0 +1,225 @@
+#include "Inventory.h"
+
+#include <cassert>
+
+#include "Engine/Snapshots/EntitySnapshots.h"
+#include "Library/Snapshots/CommonSnapshots.h"
+#include "Engine/Tables/ChestTable.h"
+#include "Library/Logger/Logger.h"
+
+Inventory::Inventory(Sizei storageSize, int capacity) : _gridSize(storageSize), _capacity(capacity) {
+    assert(storageSize.w > 0 && storageSize.h > 0);
+    assert(storageSize.w * storageSize.h <= MAX_ITEMS);
+    assert(capacity > 0);
+    assert(capacity <= MAX_ITEMS);
+}
+
+InventoryEntry *Inventory::gridItem(Pointi position) {
+    if (!gridRect().contains(position))
+        return nullptr;
+
+    int xy = position.y * _gridSize.w + position.x;
+    int index = _grid[xy];
+    if (index == 0)
+        return nullptr;
+
+    InventoryEntry *result = nullptr;
+    if (index > 0) {
+        result = &_entries[index - 1];
+    } else {
+        xy = -index - 1;
+        assert(xy >= 0 && xy < position.y * _gridSize.w + position.x);
+        index = _grid[xy];
+        assert(index > 0);
+        result = &_entries[index - 1];
+    }
+
+    assert(result);
+    assert(result->_item.itemId != ITEM_NULL);
+    assert(result->_zone == INVENTORY_ZONE_GRID);
+    return result;
+}
+
+InventoryEntry *Inventory::equippedItem(ItemSlot slot) {
+    int index = _equipment[slot];
+    if (index == 0)
+        return nullptr;
+
+    InventoryEntry *result = &_entries[index - 1];
+    assert(result->_item.itemId != ITEM_NULL);
+    assert(result->_zone == INVENTORY_ZONE_EQUIPMENT);
+    return result;
+}
+
+bool Inventory::canAddGridItem(Pointi position, Sizei size) const {
+    assert(size.h > 0 && size.w > 0);
+
+    if (!gridRect().contains(Recti(position, size)))
+        return false;
+
+    if (_size >= _capacity)
+        return false;
+
+    return isGridFree(position, size);
+}
+
+InventoryEntry *Inventory::addGridItem(Pointi position, const Item &item) {
+    assert(item.itemId != ITEM_NULL);
+    assert(canAddGridItem(position, item.inventorySize()));
+
+    int index = findFreeIndex();
+    assert(index != -1); // Can store item => we should have free indices.
+
+    return addGridItemAtIndex(position, item, index);
+}
+
+bool Inventory::canAddEquippedItem(ItemSlot slot) const {
+    return _size < _capacity && _equipment[slot] == 0;
+}
+
+InventoryEntry *Inventory::addEquippedItem(ItemSlot slot, const Item &item) {
+    assert(item.itemId != ITEM_NULL);
+    assert(canAddEquippedItem(slot));
+
+    int index = findFreeIndex();
+    assert(index != -1); // Can equip item => we should have free indices.
+
+    InventoryEntry &entry = _entries[index];
+    entry._item = item;
+    entry._zone = INVENTORY_ZONE_EQUIPMENT;
+    entry._position = Pointi();
+    entry._slot = slot;
+    _size++;
+
+    checkInvariants();
+    return &entry;
+}
+
+bool Inventory::canAddHiddenItem() const {
+    return _size < _capacity;
+}
+
+InventoryEntry *Inventory::addHiddenItem(const Item &item) {
+    assert(item.itemId != ITEM_NULL);
+    assert(canAddHiddenItem());
+
+    int index = findFreeIndex();
+    assert(index != -1);
+
+    return addHiddenItemAtIndex(item, index);
+}
+
+Item Inventory::takeItem(InventoryEntry *entry) {
+    assert(entry >= _entries.data() && entry < _entries.data() + _entries.size()); // Should be our item.
+    assert(entry->_item.itemId != ITEM_NULL);
+
+    if (entry->_zone == INVENTORY_ZONE_GRID) {
+        int xy = entry->_position.y * _gridSize.w + entry->_position.x;
+        assert(xy >= 0 && xy < _gridSize.w * _gridSize.h);
+
+        Sizei itemSize = entry->_item.inventorySize();
+        for (int y = 0; y < itemSize.h; y++, xy += _gridSize.w - itemSize.w)
+            for (int x = 0; x < itemSize.w; x++, xy++)
+                _grid[xy] = 0;
+    }
+
+    Item result = entry->_item;
+    entry->_item = Item();
+    entry->_zone = INVENTORY_ZONE_HIDDEN;
+    entry->_position = Pointi(0, 0);
+    entry->_slot = ITEM_SLOT_INVALID;
+    _size--;
+
+    checkInvariants();
+    return result;
+}
+
+[[nodiscard]] std::optional<Pointi> Inventory::findGridSpace(Sizei size) const {
+    assert(size.w > 0 && size.h > 0);
+
+    if (_size >= _capacity)
+        return std::nullopt;
+
+    if (_gridSize.w < size.w || _gridSize.h < size.h)
+        return std::nullopt;
+
+    for (int x = 0, xx = _gridSize.w - size.w; x < xx; x++)
+        for (int y = 0, yy = _gridSize.h - size.h; y < yy; y++)
+            if (isGridFree(Pointi(x, y), size))
+                return Pointi(x, y);
+
+    return std::nullopt;
+}
+
+InventoryEntry *Inventory::findEntry(ItemId itemId) {
+    for (auto &entry : _entries)
+        if (entry._item.itemId == itemId)
+            return &entry;
+    return nullptr;
+}
+
+int Inventory::findFreeIndex() const {
+    auto pos = std::ranges::find_if(_entries, [](const InventoryEntry &entry) { return entry._item.itemId == ITEM_NULL; });
+    return pos == _entries.end() ? -1 : pos - _entries.begin();
+}
+
+bool Inventory::isGridFree(Pointi position, Sizei size) const {
+    assert(gridRect().contains(Recti(position, size)));
+    for (int y = 0, xy = position.y * _gridSize.w + position.x; y < size.h; y++, xy += _gridSize.w - size.w)
+        for (int x = 0; x < size.w; x++, xy++)
+            if (_grid[xy] != 0)
+                return false;
+    return true;
+}
+
+InventoryEntry *Inventory::addGridItemAtIndex(Pointi position, const Item &item, int index) {
+    int cornerXy = position.y * _gridSize.w + position.x;
+    Sizei itemSize = item.inventorySize();
+    for (int y = 0, xy = cornerXy; y < itemSize.h; y++, xy += _gridSize.w - itemSize.w)
+        for (int x = 0; x < itemSize.w; x++, xy++)
+            _grid[xy] = -cornerXy - 1;
+    _grid[cornerXy] = index + 1;
+
+    InventoryEntry &entry = _entries[index];
+    entry._item = item;
+    entry._zone = INVENTORY_ZONE_GRID;
+    entry._position = position;
+    entry._slot = ITEM_SLOT_INVALID;
+    _size++;
+
+    checkInvariants();
+    return &entry;
+}
+
+InventoryEntry *Inventory::addHiddenItemAtIndex(const Item &item, int index) {
+    InventoryEntry &entry = _entries[index];
+    entry._item = item;
+    entry._zone = INVENTORY_ZONE_HIDDEN;
+    entry._position = Pointi();
+    entry._slot = ITEM_SLOT_INVALID;
+    _size++;
+
+    checkInvariants();
+    return &entry;
+}
+
+void Inventory::checkInvariants() const {
+#ifndef NDEBUG
+    for (int xy = 0; xy < _gridSize.w * _gridSize.h; xy++) {
+        if (_grid[xy] == 0)
+            continue;
+
+        if (_grid[xy] > 0) {
+            int index = _grid[xy] - 1;
+            assert(_entries[index]._zone == INVENTORY_ZONE_GRID);
+            assert(_entries[index]._position == Pointi(xy % _gridSize.w, xy / _gridSize.w));
+            assert(_entries[index]._item.itemId != ITEM_NULL);
+        }
+
+        if (_grid[xy] < 0) {
+            int mainXy = -_grid[xy] - 1;
+            assert(_grid[mainXy] > 0);
+        }
+    }
+#endif
+}

--- a/src/Engine/Objects/Inventory.cpp
+++ b/src/Engine/Objects/Inventory.cpp
@@ -7,9 +7,9 @@
 #include "Engine/Tables/ChestTable.h"
 #include "Library/Logger/Logger.h"
 
-Inventory::Inventory(Sizei storageSize, int capacity) : _gridSize(storageSize), _capacity(capacity) {
-    assert(storageSize.w > 0 && storageSize.h > 0);
-    assert(storageSize.w * storageSize.h <= MAX_ITEMS);
+Inventory::Inventory(Sizei gridSize, int capacity) : _gridSize(gridSize), _capacity(capacity) {
+    assert(gridSize.w > 0 && gridSize.h > 0);
+    assert(gridSize.w * gridSize.h <= MAX_ITEMS);
     assert(capacity > 0);
     assert(capacity <= MAX_ITEMS);
 }

--- a/src/Engine/Objects/Inventory.cpp
+++ b/src/Engine/Objects/Inventory.cpp
@@ -14,44 +14,46 @@ Inventory::Inventory(Sizei gridSize, int capacity) : _gridSize(gridSize), _capac
     assert(capacity <= MAX_ITEMS);
 }
 
-InventoryEntry *Inventory::gridItem(Pointi position) {
+InventoryEntry Inventory::entry(Pointi position) {
     if (!gridRect().contains(position))
-        return nullptr;
+        return {};
 
     int xy = position.y * _gridSize.w + position.x;
     int index = _grid[xy];
     if (index == 0)
-        return nullptr;
+        return {};
 
-    InventoryEntry *result = nullptr;
-    if (index > 0) {
-        result = &_entries[index - 1];
-    } else {
+    if (index < 0) {
         xy = -index - 1;
         assert(xy >= 0 && xy < position.y * _gridSize.w + position.x);
         index = _grid[xy];
         assert(index > 0);
-        result = &_entries[index - 1];
     }
 
-    assert(result);
-    assert(result->_item.itemId != ITEM_NULL);
-    assert(result->_zone == INVENTORY_ZONE_GRID);
-    return result;
+    index--;
+    assert(_records[index].item.itemId != ITEM_NULL);
+    assert(_records[index].zone == INVENTORY_ZONE_GRID);
+    return InventoryEntry(this, index);
 }
 
-InventoryEntry *Inventory::equippedItem(ItemSlot slot) {
+InventoryEntry Inventory::entry(ItemSlot slot) {
     int index = _equipment[slot];
     if (index == 0)
-        return nullptr;
+        return {};
 
-    InventoryEntry *result = &_entries[index - 1];
-    assert(result->_item.itemId != ITEM_NULL);
-    assert(result->_zone == INVENTORY_ZONE_EQUIPMENT);
-    return result;
+    index--;
+    assert(_records[index].item.itemId != ITEM_NULL);
+    assert(_records[index].zone == INVENTORY_ZONE_EQUIPMENT);
+    return InventoryEntry(this, index);
 }
 
-bool Inventory::canAddGridItem(Pointi position, Sizei size) const {
+InventoryEntry Inventory::entry(int index) {
+    if (index < 0 || index >= _capacity || _records[index].item.itemId == ITEM_NULL)
+        return {};
+    return InventoryEntry(this, index);
+}
+
+bool Inventory::canAdd(Pointi position, Sizei size) const {
     assert(size.h > 0 && size.w > 0);
 
     if (!gridRect().contains(Recti(position, size)))
@@ -63,78 +65,79 @@ bool Inventory::canAddGridItem(Pointi position, Sizei size) const {
     return isGridFree(position, size);
 }
 
-InventoryEntry *Inventory::addGridItem(Pointi position, const Item &item) {
+InventoryEntry Inventory::add(Pointi position, const Item &item) {
     assert(item.itemId != ITEM_NULL);
-    assert(canAddGridItem(position, item.inventorySize()));
+    assert(canAdd(position, item.inventorySize()));
 
     int index = findFreeIndex();
     assert(index != -1); // Can store item => we should have free indices.
 
-    return addGridItemAtIndex(position, item, index);
+    return addAt(position, item, index);
 }
 
-bool Inventory::canAddEquippedItem(ItemSlot slot) const {
+bool Inventory::canEquip(ItemSlot slot) const {
     return _size < _capacity && _equipment[slot] == 0;
 }
 
-InventoryEntry *Inventory::addEquippedItem(ItemSlot slot, const Item &item) {
+InventoryEntry Inventory::equip(ItemSlot slot, const Item &item) {
     assert(item.itemId != ITEM_NULL);
-    assert(canAddEquippedItem(slot));
+    assert(canEquip(slot));
 
     int index = findFreeIndex();
     assert(index != -1); // Can equip item => we should have free indices.
 
-    InventoryEntry &entry = _entries[index];
-    entry._item = item;
-    entry._zone = INVENTORY_ZONE_EQUIPMENT;
-    entry._position = Pointi();
-    entry._slot = slot;
+    _equipment[slot] = index + 1;
+
+    InventoryRecord &record = _records[index];
+    record.item = item;
+    record.zone = INVENTORY_ZONE_EQUIPMENT;
+    record.position = Pointi();
+    record.slot = slot;
     _size++;
 
     checkInvariants();
-    return &entry;
+    return InventoryEntry(this, index);
 }
 
-bool Inventory::canAddHiddenItem() const {
+bool Inventory::canStash() const {
     return _size < _capacity;
 }
 
-InventoryEntry *Inventory::addHiddenItem(const Item &item) {
+InventoryEntry Inventory::stash(const Item &item) {
     assert(item.itemId != ITEM_NULL);
-    assert(canAddHiddenItem());
+    assert(canStash());
 
     int index = findFreeIndex();
     assert(index != -1);
 
-    return addHiddenItemAtIndex(item, index);
+    return stashAt(item, index);
 }
 
-Item Inventory::takeItem(InventoryEntry *entry) {
-    assert(entry >= _entries.data() && entry < _entries.data() + _entries.size()); // Should be our item.
-    assert(entry->_item.itemId != ITEM_NULL);
+Item Inventory::take(InventoryEntry entry) {
+    assert(entry);
+    assert(entry._inventory == this);
 
-    if (entry->_zone == INVENTORY_ZONE_GRID) {
-        int xy = entry->_position.y * _gridSize.w + entry->_position.x;
+    if (entry.zone() == INVENTORY_ZONE_GRID) {
+        Recti geometry = entry.geometry();
+        int xy = geometry.y * _gridSize.w + geometry.x;
         assert(xy >= 0 && xy < _gridSize.w * _gridSize.h);
 
-        Sizei itemSize = entry->_item.inventorySize();
-        for (int y = 0; y < itemSize.h; y++, xy += _gridSize.w - itemSize.w)
-            for (int x = 0; x < itemSize.w; x++, xy++)
+        for (int y = 0; y < geometry.h; y++, xy += _gridSize.w - geometry.w)
+            for (int x = 0; x < geometry.w; x++, xy++)
                 _grid[xy] = 0;
+    } else if (entry.zone() == INVENTORY_ZONE_EQUIPMENT) {
+        _equipment[entry.slot()] = 0;
     }
 
-    Item result = entry->_item;
-    entry->_item = Item();
-    entry->_zone = INVENTORY_ZONE_HIDDEN;
-    entry->_position = Pointi(0, 0);
-    entry->_slot = ITEM_SLOT_INVALID;
+    Item result = entry.item();
+    _records[entry.index()] = {};
     _size--;
 
     checkInvariants();
     return result;
 }
 
-[[nodiscard]] std::optional<Pointi> Inventory::findGridSpace(Sizei size) const {
+std::optional<Pointi> Inventory::findSpace(Sizei size) const {
     assert(size.w > 0 && size.h > 0);
 
     if (_size >= _capacity)
@@ -143,24 +146,25 @@ Item Inventory::takeItem(InventoryEntry *entry) {
     if (_gridSize.w < size.w || _gridSize.h < size.h)
         return std::nullopt;
 
-    for (int x = 0, xx = _gridSize.w - size.w; x < xx; x++)
-        for (int y = 0, yy = _gridSize.h - size.h; y < yy; y++)
+    for (int y = 0, yy = _gridSize.h - size.h + 1; y < yy; y++)
+        for (int x = 0, xx = _gridSize.w - size.w + 1; x < xx; x++)
             if (isGridFree(Pointi(x, y), size))
                 return Pointi(x, y);
 
     return std::nullopt;
 }
 
-InventoryEntry *Inventory::findEntry(ItemId itemId) {
-    for (auto &entry : _entries)
-        if (entry._item.itemId == itemId)
-            return &entry;
-    return nullptr;
+InventoryEntry Inventory::find(ItemId itemId) {
+    for (int i = 0; i < _capacity; i++)
+        if (_records[i].item.itemId == itemId)
+            return InventoryEntry(this, i);
+    return {};
 }
 
 int Inventory::findFreeIndex() const {
-    auto pos = std::ranges::find_if(_entries, [](const InventoryEntry &entry) { return entry._item.itemId == ITEM_NULL; });
-    return pos == _entries.end() ? -1 : pos - _entries.begin();
+    // TODO(captainurist): _capacity
+    auto pos = std::ranges::find_if(_records, [](const InventoryRecord &data) { return data.item.itemId == ITEM_NULL; });
+    return pos == _records.end() ? -1 : pos - _records.begin();
 }
 
 bool Inventory::isGridFree(Pointi position, Sizei size) const {
@@ -172,7 +176,7 @@ bool Inventory::isGridFree(Pointi position, Sizei size) const {
     return true;
 }
 
-InventoryEntry *Inventory::addGridItemAtIndex(Pointi position, const Item &item, int index) {
+InventoryEntry Inventory::addAt(Pointi position, const Item &item, int index) {
     int cornerXy = position.y * _gridSize.w + position.x;
     Sizei itemSize = item.inventorySize();
     for (int y = 0, xy = cornerXy; y < itemSize.h; y++, xy += _gridSize.w - itemSize.w)
@@ -180,46 +184,67 @@ InventoryEntry *Inventory::addGridItemAtIndex(Pointi position, const Item &item,
             _grid[xy] = -cornerXy - 1;
     _grid[cornerXy] = index + 1;
 
-    InventoryEntry &entry = _entries[index];
-    entry._item = item;
-    entry._zone = INVENTORY_ZONE_GRID;
-    entry._position = position;
-    entry._slot = ITEM_SLOT_INVALID;
+    InventoryRecord &record = _records[index];
+    record.item = item;
+    record.zone = INVENTORY_ZONE_GRID;
+    record.position = position;
+    record.slot = ITEM_SLOT_INVALID;
     _size++;
 
     checkInvariants();
-    return &entry;
+    return InventoryEntry(this, index);
 }
 
-InventoryEntry *Inventory::addHiddenItemAtIndex(const Item &item, int index) {
-    InventoryEntry &entry = _entries[index];
-    entry._item = item;
-    entry._zone = INVENTORY_ZONE_HIDDEN;
-    entry._position = Pointi();
-    entry._slot = ITEM_SLOT_INVALID;
+InventoryEntry Inventory::stashAt(const Item &item, int index) {
+    InventoryRecord &record = _records[index];
+    record.item = item;
+    record.zone = INVENTORY_ZONE_STASH;
+    record.position = Pointi();
+    record.slot = ITEM_SLOT_INVALID;
     _size++;
 
     checkInvariants();
-    return &entry;
+    return InventoryEntry(this, index);
 }
 
 void Inventory::checkInvariants() const {
 #ifndef NDEBUG
+    // Check size.
+    int actualSize = 0;
+    for (int i = 0; i < MAX_ITEMS; i++)
+        if (_records[i].item.itemId != ITEM_NULL)
+            actualSize++;
+    assert(_size == actualSize);
+
+    // Check that we don't touch tail entries.
+    for (int i = _capacity; i < MAX_ITEMS; i++)
+        assert(_records[i].item.itemId == ITEM_NULL);
+
+    // Check that grid looks valid.
     for (int xy = 0; xy < _gridSize.w * _gridSize.h; xy++) {
         if (_grid[xy] == 0)
             continue;
 
         if (_grid[xy] > 0) {
             int index = _grid[xy] - 1;
-            assert(_entries[index]._zone == INVENTORY_ZONE_GRID);
-            assert(_entries[index]._position == Pointi(xy % _gridSize.w, xy / _gridSize.w));
-            assert(_entries[index]._item.itemId != ITEM_NULL);
+            assert(_records[index].zone == INVENTORY_ZONE_GRID);
+            assert(_records[index].position == Pointi(xy % _gridSize.w, xy / _gridSize.w));
+            assert(_records[index].item.itemId != ITEM_NULL);
         }
 
         if (_grid[xy] < 0) {
             int mainXy = -_grid[xy] - 1;
             assert(_grid[mainXy] > 0);
         }
+    }
+
+    // Check that equipment looks valid.
+    for (ItemSlot i : allItemSlots()) {
+        if (_equipment[i] == 0)
+            continue;
+        int index = _equipment[i] - 1;
+        assert(_records[index].zone == INVENTORY_ZONE_EQUIPMENT);
+        assert(_records[index].item.itemId != ITEM_NULL);
     }
 #endif
 }

--- a/src/Engine/Objects/Inventory.h
+++ b/src/Engine/Objects/Inventory.h
@@ -5,7 +5,9 @@
 #include <ranges>
 #include <optional>
 #include <span>
+#include <type_traits>
 
+#include "Inventory.h"
 #include "Library/Geometry/Size.h"
 #include "Library/Geometry/Point.h"
 #include "Library/Geometry/Rect.h"
@@ -42,27 +44,29 @@ using enum InventoryZone;
 /**
  * Lightweight, pointer‑like descriptor giving `const` access to an item owned by an `Inventory`.
  *
- * `InventoryConstEntry` can be in an invalid state. Check for validity with `operator bool` before calling any of the
- * methods!
+ * `InventoryConstEntry` can be in an invalid state, `index()` will return `-1` in this case, all other methods will
+ * assert. Check for validity with `operator bool`.
  */
 class InventoryConstEntry {
  public:
     InventoryConstEntry() = default;
 
     [[nodiscard]] inline explicit operator bool() const;
-
-    [[nodiscard]] inline const Item &item() const;
-
+    [[nodiscard]] inline const Item *operator->() const;
+    [[nodiscard]] inline const Item &operator*() const;
+    [[nodiscard]] inline const Item *get() const;
     [[nodiscard]] inline InventoryZone zone() const;
-
     [[nodiscard]] inline Recti geometry() const;
-
     [[nodiscard]] inline ItemSlot slot() const;
-
     [[nodiscard]] inline int index() const;
 
     [[nodiscard]] bool operator!() const {
         return !static_cast<bool>(*this);
+    }
+
+    InventoryConstEntry &operator=(std::nullptr_t) {
+        *this = InventoryConstEntry();
+        return *this;
     }
 
  protected:
@@ -83,8 +87,21 @@ class InventoryEntry : public InventoryConstEntry {
  public:
     InventoryEntry() = default;
 
-    [[nodiscard]] Item &item() const {
-        return const_cast<Item &>(InventoryConstEntry::item());
+    [[nodiscard]] Item *operator->() const {
+        return const_cast<Item *>(InventoryConstEntry::operator->());
+    }
+
+    [[nodiscard]] Item &operator*() const {
+        return const_cast<Item &>(InventoryConstEntry::operator*());
+    }
+
+    [[nodiscard]] Item *get() const {
+        return const_cast<Item *>(InventoryConstEntry::get());
+    }
+
+    InventoryEntry &operator=(std::nullptr_t) {
+        *this = InventoryEntry();
+        return *this;
     }
 
  protected:
@@ -109,15 +126,15 @@ class Inventory {
     static constexpr std::size_t MAX_ITEMS = 140;
 
     /**
-     * Constructs a 1x1 inventory that can hold `MAX_ITEMS` items.
-     */
-    Inventory() : Inventory(Sizei(1, 1), MAX_ITEMS) {}
-
-    /**
      * @param gridSize                  Size of inventory's grid, WxH must be less or equal to `MAX_ITEMS`.
      * @param capacity                  Inventory capacity, must be less or equal to `MAX_ITEMS`.
      */
     explicit Inventory(Sizei gridSize, int capacity);
+
+    /**
+     * Constructs a 1x1 inventory that can hold `MAX_ITEMS` items.
+     */
+    Inventory() : Inventory(Sizei(1, 1), MAX_ITEMS) {}
 
     /**
      * @return                          How many items are currently held in this inventory object.
@@ -149,33 +166,36 @@ class Inventory {
     }
 
     /**
-     * @return                          A range of `InventoryEntry` objects for items in this inventory. Returned
-     *                                  entries are never invalid.
+     * @param self                      `*this`.
+     * @return                          A range of `InventoryEntry` or `InventoryConstEntry` objects for items in this
+     *                                  inventory. Returned entries are never invalid.
      */
-    [[nodiscard]] auto entries() {
-        return std::views::iota(0, _capacity)
-            | std::views::filter([this](int i) { return _records[i].item.itemId != ITEM_NULL; })
-            | std::views::transform([this](int i) { return InventoryEntry(this, i); });
+    [[nodiscard]] auto entries(this auto &&self) {
+        return std::views::iota(0, self._capacity)
+            | std::views::filter([&self](int i) { return self._records[i].item.itemId != ITEM_NULL; })
+            | std::views::transform([&self](int i) { return std::conditional_t<std::is_const_v<std::remove_reference_t<decltype(self)>>, InventoryConstEntry, InventoryEntry>(&self, i); });
     }
 
     /**
-     * @return                          A range of `InventoryConstEntry` objects for items in this inventory. Returned
-     *                                  entries are never invalid.
-     */
-    [[nodiscard]] auto entries() const {
-        return std::views::iota(0, _capacity)
-            | std::views::filter([this](int i) { return _records[i].item.itemId != ITEM_NULL; })
-            | std::views::transform([this](int i) { return InventoryConstEntry(this, i); });
-    }
-
-    /**
+     * @param self                      `*this`.
      * @return                          A range of `Item` objects for items in this inventory. Returned items are never
      *                                  `ITEM_NULL`.
      */
     [[nodiscard]] auto items(this auto &&self) {
         return self.availableRecords()
-            | std::views::filter([](auto &&data) { return data.item.itemId != ITEM_NULL; })
-            | std::views::transform([](auto &&data) { return data.item; });
+            | std::views::filter([](auto &&record) { return record.item.itemId != ITEM_NULL; })
+            | std::views::transform(&InventoryRecord::item);
+    }
+
+    /**
+     * @param self                      `*this`.
+     * @param itemId                    Item id to filter for.
+     * @return                          A range of `Item` objects for items in this inventory with the given `itemId`.
+     */
+    [[nodiscard]] auto items(this auto &&self, ItemId itemId) {
+        return self.availableRecords()
+            | std::views::filter([itemId](auto &&record) { return record.item.itemId == itemId; })
+            | std::views::transform(&InventoryRecord::item);
     }
 
     /**
@@ -209,13 +229,25 @@ class Inventory {
     }
 
     [[nodiscard]] bool canAdd(Pointi position, Sizei size) const;
+    [[nodiscard]] bool canAdd(Pointi position, const Item &item) const {
+        return canAdd(position, item.inventorySize());
+    }
+    [[nodiscard]] bool canAdd(Sizei size) const;
+    [[nodiscard]] bool canAdd(const Item &item) const {
+        return canAdd(item.inventorySize());
+    }
     InventoryEntry add(Pointi position, const Item &item);
+    InventoryEntry add(const Item &item);
+    InventoryEntry tryAdd(Pointi position, const Item &item);
+    InventoryEntry tryAdd(const Item &item);
 
     [[nodiscard]] bool canEquip(ItemSlot slot) const;
     InventoryEntry equip(ItemSlot slot, const Item &item);
+    InventoryEntry tryEquip(ItemSlot slot, const Item &item);
 
     [[nodiscard]] bool canStash() const;
     InventoryEntry stash(const Item &item);
+    InventoryEntry tryStash(const Item &item);
 
     Item take(InventoryEntry entry);
 
@@ -228,6 +260,8 @@ class Inventory {
     [[nodiscard]] InventoryConstEntry find(ItemId itemId) const {
         return const_cast<Inventory *>(this)->find(itemId);
     }
+
+    void clear();
 
     friend void snapshot(const ChestInventory &src, Chest_MM7 *dst);
     friend void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId);
@@ -247,6 +281,7 @@ class Inventory {
     [[nodiscard]] int findFreeIndex() const;
     [[nodiscard]] bool isGridFree(Pointi position, Sizei size) const;
     InventoryEntry addAt(Pointi position, const Item &item, int index);
+    InventoryEntry equipAt(ItemSlot slot, const Item &item, int index);
     InventoryEntry stashAt(const Item &item, int index);
     void checkInvariants() const;
 
@@ -267,11 +302,11 @@ class Inventory {
     /** All items in inventory. `ITEM_NULL` means the slot is empty. */
     std::array<InventoryRecord, MAX_ITEMS> _records;
 
-    /** Backpack grid. 0 means empty cell. Positive number is an index into `_entries` plus one. Negative number is
+    /** Backpack grid. 0 means empty cell. Positive number is an index into `_records` plus one. Negative number is
      * an index into the main slot in `_grid` minus one. */
     std::array<int, MAX_ITEMS> _grid = {{}};
 
-    /** Equipment array. Positive number is an index into `_entries` plus one. Zero means empty. */
+    /** Equipment array. Positive number is an index into `_records` plus one. Zero means empty. */
     IndexedArray<int, ITEM_SLOT_FIRST_VALID, ITEM_SLOT_LAST_VALID> _equipment = {{}};
 };
 
@@ -281,20 +316,28 @@ class Inventory {
  */
 class ChestInventory : private Inventory {
  public:
-    using Inventory::Inventory;
+    // Using Inventory::MAX_ITEMS here because chests can be filled to the brim with stuff beyond the obvious
+    // capacity=WxH limit, and I believe this wasn't enforced in any way by the engine.
+    explicit ChestInventory(Sizei size): Inventory(size, MAX_ITEMS) {}
+    ChestInventory(): ChestInventory(Sizei(1, 1)) {}
+
     using Inventory::size;
     using Inventory::capacity;
     using Inventory::gridSize;
     using Inventory::gridRect;
     using Inventory::entries;
+    using Inventory::items;
     using Inventory::entry;
     using Inventory::canAdd;
     using Inventory::add;
+    using Inventory::tryAdd;
     using Inventory::canStash;
     using Inventory::stash;
+    using Inventory::tryStash;
     using Inventory::take;
     using Inventory::findSpace;
     using Inventory::find;
+    using Inventory::clear;
 
     friend void snapshot(const ChestInventory &src, Chest_MM7 *dst);
     friend void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId);
@@ -309,7 +352,8 @@ class ChestInventory : private Inventory {
  */
 class CharacterInventory : private Inventory {
  public:
-    using Inventory::Inventory;
+    CharacterInventory(): Inventory(Sizei(14, 9), 14 * 9) {}
+
     using Inventory::size;
     using Inventory::capacity;
     using Inventory::gridSize;
@@ -319,11 +363,14 @@ class CharacterInventory : private Inventory {
     using Inventory::entry;
     using Inventory::canAdd;
     using Inventory::add;
+    using Inventory::tryAdd;
     using Inventory::canEquip;
     using Inventory::equip;
+    using Inventory::tryEquip;
     using Inventory::take;
     using Inventory::findSpace;
     using Inventory::find;
+    using Inventory::clear;
 
     friend void snapshot(const CharacterInventory &src, Character_MM7 *dst);
     friend void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<int> characterIndex);
@@ -334,7 +381,7 @@ class CharacterInventory : private Inventory {
 
 
 //
-// InventoryConstEntry implementation follow.
+// InventoryConstEntry implementation follows.
 //
 
 InventoryConstEntry::InventoryConstEntry(const Inventory *inventory, int index) : _inventory(inventory), _index(index) {
@@ -346,25 +393,33 @@ InventoryConstEntry::operator bool() const {
     return _inventory && _inventory->_records[_index].item.itemId != ITEM_NULL;
 }
 
-const Item &InventoryConstEntry::item() const {
+const Item *InventoryConstEntry::operator->() const {
     assert(!!*this);
-    return _inventory->_records[_index].item;
+    return get();
+}
+
+const Item &InventoryConstEntry::operator*() const {
+    assert(!!*this);
+    return *get();
+}
+
+inline const Item *InventoryConstEntry::get() const {
+    return *this ? &_inventory->_records[_index].item : nullptr;
 }
 
 InventoryZone InventoryConstEntry::zone() const {
-    assert(!!*this);
-    return _inventory->_records[_index].zone;
+    return *this ? _inventory->_records[_index].zone : INVENTORY_ZONE_STASH;
 }
 
 Recti InventoryConstEntry::geometry() const {
-    assert(!!*this);
+    if (!*this)
+        return {};
     const auto &data = _inventory->_records[_index];
     return data.zone == INVENTORY_ZONE_GRID ? Recti(data.position, data.item.inventorySize()) : Recti();
 }
 
 ItemSlot InventoryConstEntry::slot() const {
-    assert(!!*this);
-    return _inventory->_records[_index].slot;
+    return *this ? _inventory->_records[_index].slot : ITEM_SLOT_INVALID;
 }
 
 int InventoryConstEntry::index() const {

--- a/src/Engine/Objects/Inventory.h
+++ b/src/Engine/Objects/Inventory.h
@@ -81,7 +81,16 @@ class Inventory {
  public:
     static constexpr std::size_t MAX_ITEMS = 140;
 
-    explicit Inventory(Sizei storageSize = Sizei(1, 1), int capacity = MAX_ITEMS);
+    /**
+     * Constructs a 1x1 inventory that can hold `MAX_ITEMS` items.
+     */
+    Inventory() : Inventory(Sizei(1, 1), MAX_ITEMS) {}
+
+    /**
+     * @param gridSize                  Size of inventory's grid, WxH must be less or equal to `MAX_ITEMS`.
+     * @param capacity                  Inventory capacity, must be less or equal to `MAX_ITEMS`.
+     */
+    explicit Inventory(Sizei gridSize, int capacity);
 
     /**
      * @return                          How many items are currently held in this inventory object.
@@ -91,7 +100,7 @@ class Inventory {
     }
 
     /**
-     * @return                          How many items can this inventory object hold, it's always `WxH`.
+     * @return                          How many items can this inventory object hold.
      */
     [[nodiscard]] int capacity() const {
         return _capacity;

--- a/src/Engine/Objects/Inventory.h
+++ b/src/Engine/Objects/Inventory.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <array>
+#include <ranges>
+#include <optional>
+
+#include "Library/Geometry/Size.h"
+#include "Library/Geometry/Point.h"
+#include "Library/Geometry/Rect.h"
+
+#include "Library/Binary/BinaryTags.h"
+
+#include "ItemEnums.h"
+#include "Item.h"
+
+struct Chest_MM7;
+class ChestInventory;
+
+enum class InventoryZone {
+    /** Item is effectively hidden. Applies only to chest inventory. MM7 had chests that were filled to the brim with
+     * stuff, so that there was simply not enough chest space to place all the items, and some items ended up hidden.
+     * See `chest_try_place_items` config option. */
+    INVENTORY_ZONE_HIDDEN = 0,
+
+    /** Item is stored in the inventory grid. */
+    INVENTORY_ZONE_GRID = 1,
+
+    /** Item is worn by a character. Applies only to character inventory. */
+    INVENTORY_ZONE_EQUIPMENT = 2,
+};
+using enum InventoryZone;
+
+struct InventoryEntry {
+ public:
+    InventoryEntry() = default;
+
+    /**
+     * @returns                         Item in this entry. If you got this entry from one of `Inventory` methods,
+     *                                  it will never be `ITEM_NULL`.
+     */
+    [[nodiscard]] const Item &item() const {
+        return _item;
+    }
+
+    [[nodiscard]] Item &item() {
+        return _item;
+    }
+
+    /**
+     * @returns                         Where is the item located.
+     */
+    [[nodiscard]] InventoryZone zone() const {
+        return _zone;
+    }
+
+    /**
+     * @returns                         Only for items in grid - item geometry in inventory cells.
+     */
+    [[nodiscard]] Recti geometry() const {
+        return _zone == INVENTORY_ZONE_GRID ? Recti(_position, _item.inventorySize()) : Recti();
+    }
+
+    /**
+     * @returns                         Only for equipped items - item slot.
+     */
+    [[nodiscard]] ItemSlot slot() const {
+        return _slot;
+    }
+
+ private:
+    friend class Inventory;
+
+ private:
+    Item _item;
+    InventoryZone _zone = INVENTORY_ZONE_HIDDEN;
+    Pointi _position;
+    ItemSlot _slot = ITEM_SLOT_INVALID;
+};
+
+class Inventory {
+ public:
+    static constexpr std::size_t MAX_ITEMS = 140;
+
+    explicit Inventory(Sizei storageSize = Sizei(1, 1), int capacity = MAX_ITEMS);
+
+    /**
+     * @return                          How many items are currently held in this inventory object.
+     */
+    [[nodiscard]] int size() const {
+        return _size;
+    }
+
+    /**
+     * @return                          How many items can this inventory object hold, it's always `WxH`.
+     */
+    [[nodiscard]] int capacity() const {
+        return _capacity;
+    }
+
+    /**
+     * @return                          Size of this inventory's grid, in cells.
+     */
+    [[nodiscard]] Sizei gridSize() const {
+        return _gridSize;
+    }
+
+    /**
+     * @return                          Rect for this inventory's grid, in cells. Mainly useful for checks like
+     *                                  `inventory.gridRect().contains(pos)`.
+     */
+    [[nodiscard]] Recti gridRect() const {
+        return Recti(Pointi(), _gridSize);
+    }
+
+    /**
+     * @return                          A range of `InventoryEntry *` pointers for items in this inventory. Returned
+     *                                  pointers are never null, and items are never `ITEM_NULL`.
+     */
+    [[nodiscard]] auto entries(this auto &&self) {
+        return self._entries
+            | std::views::filter([](auto &&entry) { return entry._item.itemId != ITEM_NULL; })
+            | std::views::transform([](auto &&entry) { return std::addressof(entry); });
+    }
+
+    /**
+     * @return                          A range of `Item` objects for items in this inventory. Returned items are never
+     *                                  `ITEM_NULL`.
+     */
+    [[nodiscard]] auto items(this auto &&self) {
+        return self._entries
+            | std::views::filter([](auto &&entry) { return entry._item.itemId != ITEM_NULL; })
+            | std::views::transform([](auto &&entry) { return entry._item; });
+    }
+
+    /**
+     * @param position                  Grid position to look up an item.
+     * @return                          Item at provided grip position, or `nullptr` if `position` is out of bounds or
+     *                                  if the grid at `position` is empty.
+     */
+    [[nodiscard]] InventoryEntry *gridItem(Pointi position);
+    [[nodiscard]] const InventoryEntry *gridItem(Pointi position) const {
+        return const_cast<Inventory *>(this)->gridItem(position);
+    }
+
+    /**
+     * @param slot                      Equipment slot to look up an item.
+     * @return                          Item equipped in `slot`, or `nullptr` if nothing is equipped in `slot`.
+     */
+    [[nodiscard]] InventoryEntry *equippedItem(ItemSlot slot);
+    [[nodiscard]] const InventoryEntry *equippedItem(ItemSlot slot) const {
+        return const_cast<Inventory *>(this)->equippedItem(slot);
+    }
+
+    [[nodiscard]] bool canAddGridItem(Pointi position, Sizei size) const;
+    InventoryEntry *addGridItem(Pointi position, const Item &item);
+
+    [[nodiscard]] bool canAddEquippedItem(ItemSlot slot) const;
+    InventoryEntry *addEquippedItem(ItemSlot slot, const Item &item);
+
+    [[nodiscard]] bool canAddHiddenItem() const;
+    InventoryEntry *addHiddenItem(const Item &item);
+
+    Item takeItem(InventoryEntry *entry);
+
+    [[nodiscard]] std::optional<Pointi> findGridSpace(Sizei size) const;
+    [[nodiscard]] std::optional<Pointi> findGridSpace(const Item &item) const {
+        return findGridSpace(item.inventorySize());
+    }
+
+    [[nodiscard]] InventoryEntry *findEntry(ItemId itemId);
+    [[nodiscard]] const InventoryEntry *findEntry(ItemId itemId) const {
+        return const_cast<Inventory *>(this)->findEntry(itemId);
+    }
+
+    friend void snapshot(const ChestInventory &src, Chest_MM7 *dst);
+    friend void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId);
+
+ private:
+    int findFreeIndex() const;
+    bool isGridFree(Pointi position, Sizei size) const;
+    InventoryEntry *addGridItemAtIndex(Pointi position, const Item &item, int index);
+    InventoryEntry *addHiddenItemAtIndex(const Item &item, int index);
+    void checkInvariants() const;
+
+ private:
+    /** Inventory storage area size in cells. */
+    Sizei _gridSize;
+
+    /** Number of items in this inventory. */
+    int _size = 0;
+
+    /** Max number of items that can be stuffed into this inventory. */
+    int _capacity = 0;
+
+    /** All items in inventory. `ITEM_NULL` means the slot is empty. */
+    std::array<InventoryEntry, MAX_ITEMS> _entries;
+
+    /** Backpack grid. 0 means empty cell. Positive number is an index into `_entries` plus one. Negative number is
+     * an index into the main slot in `_grid` minus one. */
+    std::array<int, MAX_ITEMS> _grid = {{}};
+
+    /** Equipment array. Positive number is an index into `_entries` plus one. Zero means empty. */
+    IndexedArray<int, ITEM_SLOT_FIRST_VALID, ITEM_SLOT_LAST_VALID> _equipment = {{}};
+};
+
+class ChestInventory : private Inventory {
+ public:
+    using Inventory::Inventory;
+    using Inventory::size;
+    using Inventory::capacity;
+    using Inventory::gridSize;
+    using Inventory::gridRect;
+    using Inventory::entries;
+    using Inventory::items;
+    using Inventory::gridItem;
+    using Inventory::canAddGridItem;
+    using Inventory::addGridItem;
+    using Inventory::canAddHiddenItem;
+    using Inventory::addHiddenItem;
+    using Inventory::takeItem;
+    using Inventory::findGridSpace;
+    using Inventory::findEntry;
+
+    friend void snapshot(const ChestInventory &src, Chest_MM7 *dst);
+    friend void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId);
+
+ private:
+    friend class Inventory;
+};

--- a/src/Engine/Objects/Item.h
+++ b/src/Engine/Objects/Item.h
@@ -132,7 +132,6 @@ struct Item {
     int numCharges = 0; // Number of wand charges, wand disappears when this gets down to 0.
     int maxCharges = 0; // Max charges in a wand. This is used when recharging.
     ItemFlags flags = 0; // Item flags.
-    ItemSlot equippedSlot = ITEM_SLOT_INVALID; // For equipped items - where is it equipped.
     int lichJarCharacterIndex = -1; // Only for full lich jars. 0-based index of the character whose earthly remains are stored in it.
                                     // Or whatever it is that's in the lich jar.
     Time enchantmentExpirationTime; // Enchantment expiration time, if this item is temporarily enchanted. Note that

--- a/src/Engine/Objects/Item.h
+++ b/src/Engine/Objects/Item.h
@@ -135,8 +135,6 @@ struct Item {
     ItemSlot equippedSlot = ITEM_SLOT_INVALID; // For equipped items - where is it equipped.
     int lichJarCharacterIndex = -1; // Only for full lich jars. 0-based index of the character whose earthly remains are stored in it.
                                     // Or whatever it is that's in the lich jar.
-    bool placedInChest = false; // OE addition, whether the item was placed in the chest inventory area. Some chests
-                                // are generated with more items than chest space, and this flag is used to track it.
     Time enchantmentExpirationTime; // Enchantment expiration time, if this item is temporarily enchanted. Note that
                                     // both special and attribute enchantments can be temporary, but in MM7 we only have
                                     // special temporary enchantments.

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -77,7 +77,7 @@ struct SpriteObject {
     Duration timeSinceCreated;
     Duration tempLifetime;
     int16_t field_22_glow_radius_multiplier = 1;
-    Item containing_item;
+    Item containing_item; // For arrows this contains the bow that was used, enchantments are checked on impact.
     SpellId uSpellID = SPELL_NONE;
     int spell_level = 0;
     CharacterSkillMastery spell_skill = CHARACTER_SKILL_MASTERY_NONE;

--- a/src/Engine/Objects/Tests/Inventory_ut.cpp
+++ b/src/Engine/Objects/Tests/Inventory_ut.cpp
@@ -3,6 +3,7 @@
 #include "Engine/Objects/Inventory.h"
 
 GAME_TEST(Inventory, Initialization) {
+    // Sanity checks for Inventory construction.
     Inventory inventory(Sizei(5, 5), 50);
     EXPECT_EQ(inventory.gridSize(), Sizei(5, 5));
     EXPECT_EQ(inventory.size(), 0);
@@ -10,15 +11,16 @@ GAME_TEST(Inventory, Initialization) {
 }
 
 GAME_TEST(Inventory, Storage) {
+    // Checking that adding an item to grid works and provides expected results.
     Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
 
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
-    EXPECT_TRUE(inventory.canAdd(Pointi(0, 0), sword.inventorySize()));
+    EXPECT_TRUE(inventory.canAdd(Pointi(0, 0), sword));
 
     InventoryEntry storedSword = inventory.add(Pointi(0, 0), sword);
     ASSERT_TRUE(storedSword);
-    EXPECT_EQ(storedSword.item().itemId, ITEM_CRUDE_LONGSWORD);
+    EXPECT_EQ(storedSword->itemId, ITEM_CRUDE_LONGSWORD);
     EXPECT_EQ(storedSword.zone(), INVENTORY_ZONE_GRID);
     EXPECT_EQ(storedSword.slot(), ITEM_SLOT_INVALID);
     EXPECT_EQ(storedSword.geometry(), Recti(Pointi(0, 0), sword.inventorySize()));
@@ -26,6 +28,7 @@ GAME_TEST(Inventory, Storage) {
 }
 
 GAME_TEST(Inventory, StorageCells) {
+    // Checking that items properly occupy grid cells.
     Inventory inventory(Sizei(9, 9), Inventory::MAX_ITEMS);
 
     Item helm;
@@ -41,6 +44,7 @@ GAME_TEST(Inventory, StorageCells) {
 }
 
 GAME_TEST(Inventory, CrazyBigItem) {
+    // Checking that we can add an item with size == inventory size.
     Inventory inventory(Sizei(2, 2), Inventory::MAX_ITEMS);
 
     Item helm;
@@ -55,13 +59,14 @@ GAME_TEST(Inventory, CrazyBigItem) {
 }
 
 GAME_TEST(Inventory, StorageFull) {
+    // Checking that we can't add items to an inventory that's full.
     Inventory inventory(Sizei(1, 1), 1);
 
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
     InventoryEntry storedRing = inventory.add(Pointi(0, 0), ring);
-    EXPECT_EQ(storedRing.item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(storedRing->itemId, ITEM_BRASS_RING);
 
     EXPECT_FALSE(inventory.canAdd(Pointi(0, 0), Sizei(1, 1)));
     EXPECT_FALSE(inventory.findSpace(Sizei(1, 1)));
@@ -71,6 +76,7 @@ GAME_TEST(Inventory, StorageFull) {
 }
 
 GAME_TEST(Inventory, Equipment) {
+    // Checking that equipping items works and provides expected results.
     Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
@@ -78,14 +84,15 @@ GAME_TEST(Inventory, Equipment) {
     EXPECT_TRUE(inventory.canEquip(ITEM_SLOT_RING1));
     InventoryEntry equippedRing = inventory.equip(ITEM_SLOT_RING1, ring);
     ASSERT_TRUE(equippedRing);
-    EXPECT_EQ(equippedRing.item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(equippedRing->itemId, ITEM_BRASS_RING);
     EXPECT_EQ(equippedRing.zone(), INVENTORY_ZONE_EQUIPMENT);
     EXPECT_EQ(equippedRing.slot(), ITEM_SLOT_RING1);
     EXPECT_TRUE(equippedRing.geometry().isEmpty());
     EXPECT_EQ(inventory.size(), 1);
 }
 
-GAME_TEST(Inventory, Burial) {
+GAME_TEST(Inventory, Stashing) {
+    // Checking that stashing items works and provides expected results.
     Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
@@ -93,7 +100,7 @@ GAME_TEST(Inventory, Burial) {
     EXPECT_TRUE(inventory.canStash());
     InventoryEntry buriedRing = inventory.stash(ring);
     ASSERT_TRUE(buriedRing);
-    EXPECT_EQ(buriedRing.item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(buriedRing->itemId, ITEM_BRASS_RING);
     EXPECT_EQ(buriedRing.zone(), INVENTORY_ZONE_STASH);
     EXPECT_EQ(buriedRing.slot(), ITEM_SLOT_INVALID);
     EXPECT_TRUE(buriedRing.geometry().isEmpty());
@@ -101,6 +108,7 @@ GAME_TEST(Inventory, Burial) {
 }
 
 GAME_TEST(Inventory, TakeItem) {
+    // Checking that taking an item from inventory works.
     Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
@@ -110,4 +118,46 @@ GAME_TEST(Inventory, TakeItem) {
     EXPECT_EQ(returnedSword.itemId, ITEM_CRUDE_LONGSWORD);
     EXPECT_EQ(inventory.size(), 0);
     EXPECT_FALSE(inventory.entry(ITEM_SLOT_MAIN_HAND));
+}
+
+GAME_TEST(Inventory, Iteration) {
+    // Checking that loops over inventory items with `Item &` compile.
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
+
+    for (Item &item : inventory.items()) {
+        EXPECT_FALSE(true);
+    }
+
+    for (Item &item : inventory.items(ITEM_ARTIFACT_ELFBANE)) {
+        EXPECT_FALSE(true);
+    }
+}
+
+GAME_TEST(Inventory, AddOrder) {
+    // MM7 adds items to inventory by columns, so we check that our code does the same.
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
+
+    InventoryEntry ring0 = inventory.add(Item(ITEM_BRASS_RING));
+    InventoryEntry ring1 = inventory.add(Item(ITEM_ANGELS_RING));
+    InventoryEntry dagger = inventory.add(Item(ITEM_DAGGER));
+    InventoryEntry sword = inventory.add(Item(ITEM_CRUDE_LONGSWORD));
+
+    EXPECT_EQ(ring0.geometry(), Recti(0, 0, 1, 1));
+    EXPECT_EQ(ring1.geometry(), Recti(0, 1, 1, 1));
+    EXPECT_EQ(dagger.geometry(), Recti(0, 2, 1, 3));
+    EXPECT_EQ(sword.geometry(), Recti(1, 0, 1, 5));
+}
+
+GAME_TEST(Inventory, EntryInvalidation) {
+    // Checking that taking out an item from under an `InventoryEntry` invalidates the entry.
+    Inventory inventory;
+    InventoryEntry entry = inventory.add(Pointi(0, 0), Item(ITEM_BRASS_RING));
+
+    Item item = inventory.take(entry);
+    EXPECT_EQ(item.itemId, ITEM_BRASS_RING);
+
+    EXPECT_FALSE(entry);
+    EXPECT_EQ(entry.geometry(), Recti());
+    EXPECT_EQ(entry.slot(), ITEM_SLOT_INVALID);
+    EXPECT_EQ(entry.zone(), INVENTORY_ZONE_STASH);
 }

--- a/src/Engine/Objects/Tests/Inventory_ut.cpp
+++ b/src/Engine/Objects/Tests/Inventory_ut.cpp
@@ -1,0 +1,113 @@
+#include "Testing/Game/GameTest.h"
+
+#include "Engine/Objects/Inventory.h"
+
+GAME_TEST(Inventory, Initialization) {
+    Inventory inventory(Sizei(5, 5), 50);
+    EXPECT_EQ(inventory.gridSize(), Sizei(5, 5));
+    EXPECT_EQ(inventory.size(), 0);
+    EXPECT_EQ(inventory.capacity(), 50);
+}
+
+GAME_TEST(Inventory, Storage) {
+    Inventory inventory(Sizei(5, 5));
+
+    Item sword;
+    sword.itemId = ITEM_CRUDE_LONGSWORD;
+    EXPECT_TRUE(inventory.canAddGridItem(Pointi(0, 0), sword.inventorySize()));
+
+    InventoryEntry *storedSword = inventory.addGridItem(Pointi(0, 0), sword);
+    ASSERT_NE(storedSword, nullptr);
+    EXPECT_EQ(storedSword->item().itemId, ITEM_CRUDE_LONGSWORD);
+    EXPECT_EQ(storedSword->zone(), INVENTORY_ZONE_GRID);
+    EXPECT_EQ(storedSword->slot(), ITEM_SLOT_INVALID);
+    EXPECT_EQ(storedSword->geometry(), Recti(Pointi(0, 0), sword.inventorySize()));
+    EXPECT_EQ(inventory.size(), 1);
+}
+
+GAME_TEST(Inventory, StorageCells) {
+    Inventory inventory(Sizei(9, 9));
+
+    Item helm;
+    helm.itemId = ITEM_FULL_HELM; // Size = 2x2.
+    inventory.addGridItem(Pointi(2, 2), helm);
+
+    for (int x = 0; x < 9; x++) {
+        for (int y = 0; y < 9; y++) {
+            Pointi pos(x, y);
+            EXPECT_EQ(inventory.canAddGridItem(pos, Sizei(1, 1)), !Recti(Pointi(2, 2), Sizei(2, 2)).contains(pos));
+        }
+    }
+}
+
+GAME_TEST(Inventory, CrazyBigItem) {
+    Inventory inventory(Sizei(2, 2));
+
+    Item helm;
+    helm.itemId = ITEM_FULL_HELM; // Size = 2x2, fills whole inventory.
+    inventory.addGridItem(Pointi(0, 0), helm);
+
+    for (int x = 0; x < 2; x++) {
+        for (int y = 0; y < 2; y++) {
+            EXPECT_EQ(inventory.canAddGridItem(Pointi(x, y), Sizei(1, 1)), false);
+        }
+    }
+}
+
+GAME_TEST(Inventory, StorageFull) {
+    Inventory inventory(Sizei(1, 1), 1);
+
+    Item ring;
+    ring.itemId = ITEM_BRASS_RING;
+
+    InventoryEntry *storedRing = inventory.addGridItem(Pointi(0, 0), ring);
+    EXPECT_EQ(storedRing->item().itemId, ITEM_BRASS_RING);
+
+    EXPECT_FALSE(inventory.canAddGridItem(Pointi(0, 0), Sizei(1, 1)));
+    EXPECT_FALSE(inventory.findGridSpace(Sizei(1, 1)));
+    EXPECT_EQ(inventory.size(), inventory.capacity());
+    EXPECT_FALSE(inventory.canAddEquippedItem(ITEM_SLOT_RING1));
+    EXPECT_FALSE(inventory.canAddHiddenItem());
+}
+
+GAME_TEST(Inventory, Equipment) {
+    Inventory inventory(Sizei(5, 5));
+    Item ring;
+    ring.itemId = ITEM_BRASS_RING;
+
+    EXPECT_TRUE(inventory.canAddEquippedItem(ITEM_SLOT_RING1));
+    InventoryEntry *equippedRing = inventory.addEquippedItem(ITEM_SLOT_RING1, ring);
+    ASSERT_NE(equippedRing, nullptr);
+    EXPECT_EQ(equippedRing->item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(equippedRing->zone(), INVENTORY_ZONE_EQUIPMENT);
+    EXPECT_EQ(equippedRing->slot(), ITEM_SLOT_RING1);
+    EXPECT_TRUE(equippedRing->geometry().isEmpty());
+    EXPECT_EQ(inventory.size(), 1);
+}
+
+GAME_TEST(Inventory, Burial) {
+    Inventory inventory(Sizei(5, 5));
+    Item ring;
+    ring.itemId = ITEM_BRASS_RING;
+
+    EXPECT_TRUE(inventory.canAddHiddenItem());
+    InventoryEntry *buriedRing = inventory.addHiddenItem(ring);
+    ASSERT_NE(buriedRing, nullptr);
+    EXPECT_EQ(buriedRing->item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(buriedRing->zone(), INVENTORY_ZONE_HIDDEN);
+    EXPECT_EQ(buriedRing->slot(), ITEM_SLOT_INVALID);
+    EXPECT_TRUE(buriedRing->geometry().isEmpty());
+    EXPECT_EQ(inventory.size(), 1);
+}
+
+GAME_TEST(Inventory, TakeItem) {
+    Inventory inventory(Sizei(5, 5));
+    Item sword;
+    sword.itemId = ITEM_CRUDE_LONGSWORD;
+
+    InventoryEntry *equippedSword = inventory.addEquippedItem(ITEM_SLOT_MAIN_HAND, sword);
+    Item returnedSword = inventory.takeItem(equippedSword);
+    EXPECT_EQ(returnedSword.itemId, ITEM_CRUDE_LONGSWORD);
+    EXPECT_EQ(inventory.size(), 0);
+    EXPECT_EQ(inventory.equippedItem(ITEM_SLOT_MAIN_HAND), nullptr);
+}

--- a/src/Engine/Objects/Tests/Inventory_ut.cpp
+++ b/src/Engine/Objects/Tests/Inventory_ut.cpp
@@ -10,7 +10,7 @@ GAME_TEST(Inventory, Initialization) {
 }
 
 GAME_TEST(Inventory, Storage) {
-    Inventory inventory(Sizei(5, 5));
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
 
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
@@ -26,7 +26,7 @@ GAME_TEST(Inventory, Storage) {
 }
 
 GAME_TEST(Inventory, StorageCells) {
-    Inventory inventory(Sizei(9, 9));
+    Inventory inventory(Sizei(9, 9), Inventory::MAX_ITEMS);
 
     Item helm;
     helm.itemId = ITEM_FULL_HELM; // Size = 2x2.
@@ -41,7 +41,7 @@ GAME_TEST(Inventory, StorageCells) {
 }
 
 GAME_TEST(Inventory, CrazyBigItem) {
-    Inventory inventory(Sizei(2, 2));
+    Inventory inventory(Sizei(2, 2), Inventory::MAX_ITEMS);
 
     Item helm;
     helm.itemId = ITEM_FULL_HELM; // Size = 2x2, fills whole inventory.
@@ -71,7 +71,7 @@ GAME_TEST(Inventory, StorageFull) {
 }
 
 GAME_TEST(Inventory, Equipment) {
-    Inventory inventory(Sizei(5, 5));
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
@@ -86,7 +86,7 @@ GAME_TEST(Inventory, Equipment) {
 }
 
 GAME_TEST(Inventory, Burial) {
-    Inventory inventory(Sizei(5, 5));
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
@@ -101,7 +101,7 @@ GAME_TEST(Inventory, Burial) {
 }
 
 GAME_TEST(Inventory, TakeItem) {
-    Inventory inventory(Sizei(5, 5));
+    Inventory inventory(Sizei(5, 5), Inventory::MAX_ITEMS);
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
 

--- a/src/Engine/Objects/Tests/Inventory_ut.cpp
+++ b/src/Engine/Objects/Tests/Inventory_ut.cpp
@@ -14,14 +14,14 @@ GAME_TEST(Inventory, Storage) {
 
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
-    EXPECT_TRUE(inventory.canAddGridItem(Pointi(0, 0), sword.inventorySize()));
+    EXPECT_TRUE(inventory.canAdd(Pointi(0, 0), sword.inventorySize()));
 
-    InventoryEntry *storedSword = inventory.addGridItem(Pointi(0, 0), sword);
-    ASSERT_NE(storedSword, nullptr);
-    EXPECT_EQ(storedSword->item().itemId, ITEM_CRUDE_LONGSWORD);
-    EXPECT_EQ(storedSword->zone(), INVENTORY_ZONE_GRID);
-    EXPECT_EQ(storedSword->slot(), ITEM_SLOT_INVALID);
-    EXPECT_EQ(storedSword->geometry(), Recti(Pointi(0, 0), sword.inventorySize()));
+    InventoryEntry storedSword = inventory.add(Pointi(0, 0), sword);
+    ASSERT_TRUE(storedSword);
+    EXPECT_EQ(storedSword.item().itemId, ITEM_CRUDE_LONGSWORD);
+    EXPECT_EQ(storedSword.zone(), INVENTORY_ZONE_GRID);
+    EXPECT_EQ(storedSword.slot(), ITEM_SLOT_INVALID);
+    EXPECT_EQ(storedSword.geometry(), Recti(Pointi(0, 0), sword.inventorySize()));
     EXPECT_EQ(inventory.size(), 1);
 }
 
@@ -30,12 +30,12 @@ GAME_TEST(Inventory, StorageCells) {
 
     Item helm;
     helm.itemId = ITEM_FULL_HELM; // Size = 2x2.
-    inventory.addGridItem(Pointi(2, 2), helm);
+    inventory.add(Pointi(2, 2), helm);
 
     for (int x = 0; x < 9; x++) {
         for (int y = 0; y < 9; y++) {
             Pointi pos(x, y);
-            EXPECT_EQ(inventory.canAddGridItem(pos, Sizei(1, 1)), !Recti(Pointi(2, 2), Sizei(2, 2)).contains(pos));
+            EXPECT_EQ(inventory.canAdd(pos, Sizei(1, 1)), !Recti(Pointi(2, 2), Sizei(2, 2)).contains(pos));
         }
     }
 }
@@ -45,11 +45,11 @@ GAME_TEST(Inventory, CrazyBigItem) {
 
     Item helm;
     helm.itemId = ITEM_FULL_HELM; // Size = 2x2, fills whole inventory.
-    inventory.addGridItem(Pointi(0, 0), helm);
+    inventory.add(Pointi(0, 0), helm);
 
     for (int x = 0; x < 2; x++) {
         for (int y = 0; y < 2; y++) {
-            EXPECT_EQ(inventory.canAddGridItem(Pointi(x, y), Sizei(1, 1)), false);
+            EXPECT_EQ(inventory.canAdd(Pointi(x, y), Sizei(1, 1)), false);
         }
     }
 }
@@ -60,14 +60,14 @@ GAME_TEST(Inventory, StorageFull) {
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
-    InventoryEntry *storedRing = inventory.addGridItem(Pointi(0, 0), ring);
-    EXPECT_EQ(storedRing->item().itemId, ITEM_BRASS_RING);
+    InventoryEntry storedRing = inventory.add(Pointi(0, 0), ring);
+    EXPECT_EQ(storedRing.item().itemId, ITEM_BRASS_RING);
 
-    EXPECT_FALSE(inventory.canAddGridItem(Pointi(0, 0), Sizei(1, 1)));
-    EXPECT_FALSE(inventory.findGridSpace(Sizei(1, 1)));
+    EXPECT_FALSE(inventory.canAdd(Pointi(0, 0), Sizei(1, 1)));
+    EXPECT_FALSE(inventory.findSpace(Sizei(1, 1)));
     EXPECT_EQ(inventory.size(), inventory.capacity());
-    EXPECT_FALSE(inventory.canAddEquippedItem(ITEM_SLOT_RING1));
-    EXPECT_FALSE(inventory.canAddHiddenItem());
+    EXPECT_FALSE(inventory.canEquip(ITEM_SLOT_RING1));
+    EXPECT_FALSE(inventory.canStash());
 }
 
 GAME_TEST(Inventory, Equipment) {
@@ -75,13 +75,13 @@ GAME_TEST(Inventory, Equipment) {
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
-    EXPECT_TRUE(inventory.canAddEquippedItem(ITEM_SLOT_RING1));
-    InventoryEntry *equippedRing = inventory.addEquippedItem(ITEM_SLOT_RING1, ring);
-    ASSERT_NE(equippedRing, nullptr);
-    EXPECT_EQ(equippedRing->item().itemId, ITEM_BRASS_RING);
-    EXPECT_EQ(equippedRing->zone(), INVENTORY_ZONE_EQUIPMENT);
-    EXPECT_EQ(equippedRing->slot(), ITEM_SLOT_RING1);
-    EXPECT_TRUE(equippedRing->geometry().isEmpty());
+    EXPECT_TRUE(inventory.canEquip(ITEM_SLOT_RING1));
+    InventoryEntry equippedRing = inventory.equip(ITEM_SLOT_RING1, ring);
+    ASSERT_TRUE(equippedRing);
+    EXPECT_EQ(equippedRing.item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(equippedRing.zone(), INVENTORY_ZONE_EQUIPMENT);
+    EXPECT_EQ(equippedRing.slot(), ITEM_SLOT_RING1);
+    EXPECT_TRUE(equippedRing.geometry().isEmpty());
     EXPECT_EQ(inventory.size(), 1);
 }
 
@@ -90,13 +90,13 @@ GAME_TEST(Inventory, Burial) {
     Item ring;
     ring.itemId = ITEM_BRASS_RING;
 
-    EXPECT_TRUE(inventory.canAddHiddenItem());
-    InventoryEntry *buriedRing = inventory.addHiddenItem(ring);
-    ASSERT_NE(buriedRing, nullptr);
-    EXPECT_EQ(buriedRing->item().itemId, ITEM_BRASS_RING);
-    EXPECT_EQ(buriedRing->zone(), INVENTORY_ZONE_HIDDEN);
-    EXPECT_EQ(buriedRing->slot(), ITEM_SLOT_INVALID);
-    EXPECT_TRUE(buriedRing->geometry().isEmpty());
+    EXPECT_TRUE(inventory.canStash());
+    InventoryEntry buriedRing = inventory.stash(ring);
+    ASSERT_TRUE(buriedRing);
+    EXPECT_EQ(buriedRing.item().itemId, ITEM_BRASS_RING);
+    EXPECT_EQ(buriedRing.zone(), INVENTORY_ZONE_STASH);
+    EXPECT_EQ(buriedRing.slot(), ITEM_SLOT_INVALID);
+    EXPECT_TRUE(buriedRing.geometry().isEmpty());
     EXPECT_EQ(inventory.size(), 1);
 }
 
@@ -105,9 +105,9 @@ GAME_TEST(Inventory, TakeItem) {
     Item sword;
     sword.itemId = ITEM_CRUDE_LONGSWORD;
 
-    InventoryEntry *equippedSword = inventory.addEquippedItem(ITEM_SLOT_MAIN_HAND, sword);
-    Item returnedSword = inventory.takeItem(equippedSword);
+    InventoryEntry equippedSword = inventory.equip(ITEM_SLOT_MAIN_HAND, sword);
+    Item returnedSword = inventory.take(equippedSword);
     EXPECT_EQ(returnedSword.itemId, ITEM_CRUDE_LONGSWORD);
     EXPECT_EQ(inventory.size(), 0);
-    EXPECT_EQ(inventory.equippedItem(ITEM_SLOT_MAIN_HAND), nullptr);
+    EXPECT_FALSE(inventory.entry(ITEM_SLOT_MAIN_HAND));
 }

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -87,6 +87,8 @@ struct Party {
      */
     void setHoldingItem(const Item &item, Pointi offset = {});
 
+    Item takeHoldingItem();
+
     /**
     * Sets _activeCharacter to the first character that can act
     * Added to fix some nzi access problems

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -226,7 +226,10 @@ void reconstruct(const IndoorDelta_MM7 &src, IndoorLocation *dst) {
         }
     }
 
-    reconstruct(src.chests, &vChests);
+    vChests.resize(src.chests.size());
+    for (size_t i = 0; i < src.chests.size(); ++i)
+        reconstruct(src.chests[i], &vChests[i], tags::context<int>(i));
+
     reconstruct(src.doors, &dst->pDoors);
     reconstruct(src.doorsData, &dst->ptr_0002B4_doors_ddata);
 
@@ -506,7 +509,11 @@ void reconstruct(const OutdoorDelta_MM7 &src, OutdoorLocation *dst) {
         pActors[i].id = i;
 
     reconstruct(src.spriteObjects, &pSpriteObjects);
-    reconstruct(src.chests, &vChests);
+
+    vChests.resize(src.chests.size());
+    for (size_t i = 0; i < src.chests.size(); ++i)
+        reconstruct(src.chests[i], &vChests[i], tags::context<int>(i));
+
     reconstruct(src.eventVariables, &engine->_persistentVariables);
     reconstruct(src.locationTime, &dst->loc_time);
 }

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1640,7 +1640,10 @@ void snapshot(const ChestInventory &src, Chest_MM7 *dst) {
 
 void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId) {
     Sizei size = chestTable[src.chestTypeId].size;
-    *dst = ChestInventory(size);
+
+    // Using Inventory::MAX_ITEMS here because chests can be filled to the brim with stuff beyond the obvious
+    // capacity=WxH limit, and I believe this wasn't enforced in any way by the engine.
+    *dst = ChestInventory(size, Inventory::MAX_ITEMS);
 
     std::array<bool, 140> processed = {{}};
     std::array<Item, 140> items;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1135,6 +1135,12 @@ void reconstruct(const Character_MM7 &src, Character *dst) {
     dst->uNumFireSpikeCasts = src.numFireSpikeCasts;
 }
 
+void snapshot(const CharacterInventory &src, Character_MM7 *dst) {
+}
+
+void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<int> characterIndex) {
+}
+
 void snapshot(const IconFrameData &src, IconFrameData_MM7 *dst) {
     memzero(dst);
 
@@ -1633,8 +1639,8 @@ void reconstruct(const Chest_MM7 &src, Chest *dst, ContextTag<int> chestId) {
 }
 
 void snapshot(const ChestInventory &src, Chest_MM7 *dst) {
-    for (size_t i = 0; i < src._entries.size(); i++)
-        snapshot(src._entries[i].item(), &dst->items[i]);
+    for (size_t i = 0; i < src._records.size(); i++)
+        snapshot(src._records[i].item, &dst->items[i]);
     snapshot(src._grid, &dst->inventoryMatrix, tags::cast<int, int16_t>);
 }
 
@@ -1677,9 +1683,9 @@ void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> ches
                     continue;
                 }
 
-                if (dst->canAddGridItem({x, y}, items[index].inventorySize())) {
+                if (dst->canAdd({x, y}, items[index].inventorySize())) {
                     processed[index] = true;
-                    dst->addGridItemAtIndex({x, y}, items[index], index); // We need to preserve item indices.
+                    dst->addAt({x, y}, items[index], index); // We need to preserve item indices.
                 }
             }
         }
@@ -1687,7 +1693,7 @@ void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> ches
 
     for (size_t i = 0; i < items.size(); i++)
         if (!processed[i] && items[i].itemId != ITEM_NULL)
-            dst->addHiddenItemAtIndex(items[i], i); // We need to preserve item indices.
+            dst->stashAt(items[i], i); // We need to preserve item indices.
 }
 
 void reconstruct(const BLVLight_MM7 &src, BLVLight *dst) {

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -2,10 +2,11 @@
 
 #include <array>
 
+#include "Engine/Objects/ItemEnums.h"
+
 #include "Library/Geometry/Vec.h"
 #include "Library/Geometry/Plane.h"
 #include "Library/Geometry/BBox.h"
-
 #include "Library/Binary/BinarySerialization.h"
 
 /**
@@ -245,7 +246,7 @@ struct Item_MM7 {
 static_assert(sizeof(Item_MM7) == 0x24);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Item_MM7)
 
-void snapshot(const Item &src, Item_MM7 *dst);
+void snapshot(const Item &src, Item_MM7 *dst, ContextTag<ItemSlot> slot);
 void reconstruct(const Item_MM7 &src, Item *dst);
 
 
@@ -416,7 +417,7 @@ static_assert(sizeof(Character_MM7) == 0x1B3C);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Character_MM7)
 
 void snapshot(const Character &src, Character_MM7 *dst);
-void reconstruct(const Character_MM7 &src, Character *dst);
+void reconstruct(const Character_MM7 &src, Character *dst, ContextTag<int> characterIndex);
 void snapshot(const CharacterInventory &src, Character_MM7 *dst);
 void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<int> characterIndex);
 

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -37,6 +37,7 @@ struct BLVSector;
 struct BSPNode;
 class CharacterConditions;
 struct Chest;
+class ChestInventory;
 struct DecorationDesc;
 struct FontHeader;
 struct GUICharMetric;
@@ -237,7 +238,7 @@ struct Item_MM7 {
     uint8_t equippedSlot;
     uint8_t maxCharges;
     uint8_t lichJarCharacterIndex; // Only for full lich jars. 1-based index of the character whose essence it stored in it.
-    uint8_t placedInChest; // Unknown unused 8-bit field, was repurposed.
+    uint8_t _pad;
     int64_t enchantmentExpirationTime;
 };
 static_assert(sizeof(Item_MM7) == 0x24);
@@ -1064,7 +1065,9 @@ static_assert(sizeof(Chest_MM7) == 5324);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(Chest_MM7)
 
 void snapshot(const Chest &src, Chest_MM7 *dst);
-void reconstruct(const Chest_MM7 &src, Chest *dst);
+void reconstruct(const Chest_MM7 &src, Chest *dst, ContextTag<int> chestId);
+void snapshot(const ChestInventory &src, Chest_MM7 *dst);
+void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> chestId);
 
 
 struct BLVLight_MM6 {

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -36,6 +36,7 @@ struct BLVMapOutline;
 struct BLVSector;
 struct BSPNode;
 class CharacterConditions;
+class CharacterInventory;
 struct Chest;
 class ChestInventory;
 struct DecorationDesc;
@@ -416,6 +417,8 @@ MM_DECLARE_MEMCOPY_SERIALIZABLE(Character_MM7)
 
 void snapshot(const Character &src, Character_MM7 *dst);
 void reconstruct(const Character_MM7 &src, Character *dst);
+void snapshot(const CharacterInventory &src, Character_MM7 *dst);
+void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<int> characterIndex);
 
 
 struct PartyTimeStruct_MM7 {

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -331,10 +331,10 @@ void GUIWindow_MagicGuild::houseScreenClick() {
                         return;
                     }
 
-                    int itemSlot = pParty->activeCharacter().AddItem(-1, boughtItem. itemId);
-                    if (itemSlot) {
+                    std::optional<Pointi> pos = pParty->activeCharacter().inventory.findSpace(boughtItem);
+                    if (pos) {
                         boughtItem.SetIdentified();
-                        pParty->activeCharacter().pInventoryItemList[itemSlot - 1] = boughtItem;
+                        pParty->activeCharacter().inventory.add(*pos, boughtItem);
                         _transactionPerformed = true;
                         pParty->TakeGold(uPriceItemService);
                         boughtItem.Reset();

--- a/src/GUI/UI/ItemGrid.cpp
+++ b/src/GUI/UI/ItemGrid.cpp
@@ -22,5 +22,10 @@ int itemOffset(int dimension) {
 
 Pointi mapToInventoryGrid(Pointi mousePos, Pointi inventoryTopLeft) {
     Pointi relativePos = mousePos - inventoryTopLeft;
+    // TODO(captainurist): divIntDown is >> 5
     return Pointi(divIntDown(relativePos.x, 32), divIntDown(relativePos.y, 32));
+}
+
+Pointi mapFromInventoryGrid(Pointi gridPos, Pointi inventoryTopLeft) {
+    return gridPos * 32 + inventoryTopLeft;
 }

--- a/src/GUI/UI/ItemGrid.h
+++ b/src/GUI/UI/ItemGrid.h
@@ -20,3 +20,5 @@ int itemOffset(int dimension);
  *                                      position is out of grid.
  */
 Pointi mapToInventoryGrid(Pointi mousePos, Pointi inventoryTopLeft);
+
+Pointi mapFromInventoryGrid(Pointi gridPos, Pointi inventoryTopLeft);

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -414,15 +414,11 @@ void oracleDialogue() {
             if (pParty->pCharacters[i].classType == CLASS_LICH) {
                 bool have_vessels_soul = false;
                 for (Character &player : pParty->pCharacters) {
-                    for (int idx = 0; idx < Character::INVENTORY_SLOT_COUNT; idx++) {
-                        if (player.pInventoryItemList[idx].itemId == ITEM_QUEST_LICH_JAR_FULL) {
-                            if (player.pInventoryItemList[idx].lichJarCharacterIndex == -1) {
-                                item = &player.pInventoryItemList[idx];
-                            }
-                            if (player.pInventoryItemList[idx].lichJarCharacterIndex == i) {
-                                have_vessels_soul = true;
-                            }
-                        }
+                    for (Item &jar : player.inventory.items(ITEM_QUEST_LICH_JAR_FULL)) {
+                        if (jar.lichJarCharacterIndex == -1)
+                            item = &jar;
+                        if (jar.lichJarCharacterIndex == i)
+                            have_vessels_soul = true;
                     }
                 }
 

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -1026,7 +1026,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
         // TODO(captainurist): need to also z-draw arms and wrists.
         render->DrawTextureNew(pPaperdoll_BodyX / 640.0f, pPaperdoll_BodyY / 480.0f, paperdoll_dbods[uPlayerID]);
         if (!bRingsShownInCharScreen)
-            render->ZDrawTextureAlpha(pPaperdoll_BodyX / 640.0f, pPaperdoll_BodyY / 480.0f, paperdoll_dbods[uPlayerID], player->pEquipment[ITEM_SLOT_ARMOUR]);
+            render->ZDrawTextureAlpha(pPaperdoll_BodyX / 640.0f, pPaperdoll_BodyY / 480.0f, paperdoll_dbods[uPlayerID], player->inventory.entry(ITEM_SLOT_ARMOUR).index());
 
         // hands aren't in two handed grip pose
         if (!bTwoHandedGrip) {
@@ -1046,7 +1046,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
             if (item->itemId == ITEM_BLASTER)
                 texture = assets->getImage_Alpha("item64v1");
 
-            CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_MAIN_HAND], texture, !bRingsShownInCharScreen);
+            CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_MAIN_HAND).index(), texture, !bRingsShownInCharScreen);
         }
     } else {
         // bow
@@ -1055,7 +1055,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
             item_X = pPaperdoll_BodyX + paperdoll_Weapon[pBodyComplection][2][0] - pItemTable->items[item->itemId].paperdollAnchorOffset.x;
             item_Y = pPaperdoll_BodyY + paperdoll_Weapon[pBodyComplection][2][1] - pItemTable->items[item->itemId].paperdollAnchorOffset.y;
 
-            CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_BOW], nullptr, !bRingsShownInCharScreen);
+            CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_BOW).index(), nullptr, !bRingsShownInCharScreen);
         }
 
         // cloak
@@ -1067,7 +1067,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 item_Y = pPaperdoll_BodyY + paperdoll_Cloak[pBodyComplection][index][1];
 
                 GraphicsImage *texture = paperdoll_cloak_texture[pBodyComplection][index];
-                CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_CLOAK], texture, !bRingsShownInCharScreen);
+                CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_CLOAK).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1083,7 +1083,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 item_Y = pPaperdoll_BodyY + paperdoll_Armor_Coord[pBodyComplection][index][1];
 
                 GraphicsImage *texture = paperdoll_armor_texture[pBodyComplection][index][0];
-                CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_ARMOUR], texture, !bRingsShownInCharScreen);
+                CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_ARMOUR).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1102,7 +1102,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                     texture = paperdoll_boots_texture[pBodyComplection][index];
                 }
 
-                CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_BOOTS], texture, !bRingsShownInCharScreen);
+                CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_BOOTS).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1130,7 +1130,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 else
                     texture = paperdoll_belt_texture[pBodyComplection - 2][index];
 
-                CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_BELT], texture, !bRingsShownInCharScreen);
+                CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_BELT).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1154,7 +1154,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 }
 
                 if (texture)
-                    CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_ARMOUR], texture, !bRingsShownInCharScreen);
+                    CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_ARMOUR).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1169,7 +1169,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                     item_Y = pPaperdoll_BodyY + paperdoll_CloakCollar[pBodyComplection][index][1];
 
                     GraphicsImage *texture = paperdoll_cloak_collar_texture[pBodyComplection][index];
-                    CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_CLOAK], texture, !bRingsShownInCharScreen);
+                    CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_CLOAK).index(), texture, !bRingsShownInCharScreen);
                 }
             }
         }
@@ -1196,7 +1196,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 else
                     texture = paperdoll_dbrds[11];
 
-                CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_HELMET], texture, !bRingsShownInCharScreen);
+                CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_HELMET).index(), texture, !bRingsShownInCharScreen);
             }
         }
 
@@ -1210,7 +1210,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
             if (item->itemId == ITEM_BLASTER)
                 texture = assets->getImage_Alpha("item64v1");
 
-            CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_MAIN_HAND], texture, !bRingsShownInCharScreen);
+            CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_MAIN_HAND).index(), texture, !bRingsShownInCharScreen);
         }
 
         // offhand's item
@@ -1246,7 +1246,7 @@ void CharacterUI_DrawPaperdoll(Character *player) {
                 }
             }
 
-            CharacterUI_DrawItem(item_X, item_Y, item, player->pEquipment[ITEM_SLOT_OFF_HAND], nullptr, !bRingsShownInCharScreen);
+            CharacterUI_DrawItem(item_X, item_Y, item, player->inventory.entry(ITEM_SLOT_OFF_HAND).index(), nullptr, !bRingsShownInCharScreen);
         }
     }
 
@@ -1290,18 +1290,17 @@ void CharacterUI_InventoryTab_Draw(Character *player, bool Cover_Strip) {
     CharacterUI_DrawPickedItemUnderlay({ 14, 17 });
     render->ResetUIClipRect();
 
-    for (unsigned i = 0; i < 126; ++i) {
-        if (player->pInventoryMatrix[i] <= 0) continue;
-        if (player->pInventoryItemList[player->pInventoryMatrix[i] - 1].itemId == ITEM_NULL)
+    for (InventoryEntry entry : player->inventory.entries()) {
+        if (entry.zone() != INVENTORY_ZONE_GRID)
             continue;
-        unsigned int uCellY = 32 * (i / 14) + 17;
-        unsigned int uCellX = 32 * (i % 14) + 14;
 
-        GraphicsImage *pTexture = assets->getImage_Alpha(player->pInventoryItemList[player->pInventoryMatrix[i] - 1].GetIconName());
+        Pointi cellPos = mapFromInventoryGrid(entry.geometry().topLeft(), Pointi(14, 17));
+
+        GraphicsImage *pTexture = assets->getImage_Alpha(entry->GetIconName());
 
         signed int X_offset = itemOffset(pTexture->width());
         signed int Y_offset = itemOffset(pTexture->height());
-        CharacterUI_DrawItem(uCellX + X_offset, uCellY + Y_offset, &(player->pInventoryItemList[player->pInventoryMatrix[i] - 1]), Cover_Strip);
+        CharacterUI_DrawItem(cellPos.x + X_offset, cellPos.y + Y_offset, entry.get(), Cover_Strip);
     }
 }
 
@@ -1343,7 +1342,7 @@ static void CharacterUI_DrawItem(int x, int y, Item *item, int id, GraphicsImage
         render->BlendTextures(x, y, item_texture, enchantment_texture, platform->tickCount() / 10, 0, 255);
     } else if (item->IsBroken()) {
         render->DrawTransparentRedShade(x / 640.0f, y / 480.0f, item_texture);
-    } else if (!item->IsIdentified() && (engine->config->gameplay.ShowUndentifiedItem.value() || id)) {
+    } else if (!item->IsIdentified() && (engine->config->gameplay.ShowUndentifiedItem.value() || id)) { // TODO(captainurist): after my changes id==0 is a valid item id
         render->DrawTransparentGreenShade(x / 640.0f, y / 480.0f, item_texture);
     } else {
         render->DrawTextureNew(x / 640.0f, y / 480.0f, item_texture);
@@ -1364,22 +1363,22 @@ void CharacterUI_DrawPaperdollWithRingOverlay(Character *player) {
                                 ui_exit_cancel_button_background);
 
     for (unsigned i = 0; i < 6; ++i) {
-        if (!player->pEquipment[ringSlot(i)]) continue;
-        static int pPaperdollRingsX[6] = {0x1EA, 0x21A, 0x248,
-                                          0x1EA, 0x21A, 0x248};
-        static int pPaperdollRingsY[6] = {0x0CA, 0x0CA, 0x0CA,
-                                          0x0FA, 0x0FA, 0x0FA};
+        InventoryEntry entry = player->inventory.entry(ringSlot(i));
+        if (!entry)
+            continue;
+
+        static int pPaperdollRingsX[6] = {0x1EA, 0x21A, 0x248, 0x1EA, 0x21A, 0x248};
+        static int pPaperdollRingsY[6] = {0x0CA, 0x0CA, 0x0CA, 0x0FA, 0x0FA, 0x0FA};
+
         CharacterUI_DrawItem(
             pPaperdollRingsX[i], pPaperdollRingsY[i],
-            &player->pInventoryItemList[player->pEquipment[ringSlot(i)] - 1],
-            player->pEquipment[ringSlot(i)]);
+            entry.get(),
+            entry.index());
     }
-    if (player->pEquipment[ITEM_SLOT_AMULET])
-        CharacterUI_DrawItem(493, 91, player->GetAmuletItem(),
-                             player->pEquipment[ITEM_SLOT_AMULET]);
-    if (player->pEquipment[ITEM_SLOT_GAUNTLETS])
-        CharacterUI_DrawItem(586, 88, player->GetGloveItem(),
-                             player->pEquipment[ITEM_SLOT_GAUNTLETS]);
+    if (InventoryEntry entry = player->inventory.entry(ITEM_SLOT_AMULET))
+        CharacterUI_DrawItem(493, 91, entry.get(), entry.index());
+    if (InventoryEntry entry = player->inventory.entry(ITEM_SLOT_GAUNTLETS))
+        CharacterUI_DrawItem(586, 88, entry.get(), entry.index());
 }
 
 //----- (0043BCA7) --------------------------------------------------------
@@ -1761,33 +1760,21 @@ void OnPaperdollLeftClick() {
     int slot = 32;
     ItemSlot pos = ITEM_SLOT_INVALID;
 
-    Item *pitem = NULL;  // condesnse with this??
-                            // pitem.Reset();
-
     // uint16_t v5; // ax@7
     // int equippos; // esi@27
     // int v8; // eax@29
-    int v17;  // eax@44
     CharacterSkillType pSkillType = CHARACTER_SKILL_INVALID;
 
-    int v23;  // eax@62
-    int v26;  // eax@69
-    int v34;  // esi@90
-
-    //  unsigned int v48; // [sp+30h] [bp-1Ch]@88
-    ItemId v50;  // [sp+38h] [bp-14h]@50
-    // int v51; // [sp+3Ch] [bp-10h]@1
-    int freeslot;  // [sp+40h] [bp-Ch]@5
     ItemType pEquipType = ITEM_TYPE_NONE;
     CastSpellInfo *pSpellInfo;
 
-    int twohandedequip = 0;
+    InventoryEntry twohandedequip;
     Item _this;  // [sp+Ch] [bp-40h]@1
     _this.Reset();
-    int mainhandequip = pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND];
-    unsigned int shieldequip = pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND];
+    InventoryEntry mainhandequip = pParty->activeCharacter().inventory.entry(ITEM_SLOT_MAIN_HAND);
+    InventoryEntry shieldequip = pParty->activeCharacter().inventory.entry(ITEM_SLOT_OFF_HAND);
 
-    if (mainhandequip && pParty->activeCharacter().pInventoryItemList[mainhandequip - 1].type() == ITEM_TYPE_TWO_HANDED) {
+    if (mainhandequip && mainhandequip->type() == ITEM_TYPE_TWO_HANDED) {
         twohandedequip = mainhandequip;
     }
 
@@ -1810,7 +1797,7 @@ void OnPaperdollLeftClick() {
             }
         } else {
             if ((pSkillType == CHARACTER_SKILL_SHIELD || pSkillType == CHARACTER_SKILL_SWORD || pSkillType == CHARACTER_SKILL_DAGGER) && mainhandequip &&
-                pParty->activeCharacter().pInventoryItemList[mainhandequip - 1].GetPlayerSkillType() == CHARACTER_SKILL_SPEAR) {
+                mainhandequip->GetPlayerSkillType() == CHARACTER_SKILL_SPEAR) {
                 // cant use spear in one hand till master
                 if (pParty->activeCharacter().getActualSkillValue(CHARACTER_SKILL_SPEAR).mastery() < CHARACTER_SKILL_MASTERY_MASTER) {
                     pParty->activeCharacter().playReaction(SPEECH_CANT_EQUIP);
@@ -1871,27 +1858,20 @@ void OnPaperdollLeftClick() {
                     // equippos = 0;
 
                     for (ItemSlot equippos : allRingSlots()) {
-                        if (!pParty->activeCharacter().pEquipment[equippos]) {
-                            freeslot = pParty->activeCharacter().findFreeInventoryListSlot();
-                            if (freeslot >= 0) {  // drop ring into free space
-                                pParty->pPickedItem.equippedSlot = equippos;
-                                pParty->activeCharacter().pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pParty->activeCharacter().pEquipment[equippos] = freeslot + 1;
-                                mouse->RemoveHoldingItem();
-                                return;
-                            }
+                        if (pParty->activeCharacter().inventory.canEquip(equippos)) {
+                            pParty->activeCharacter().inventory.equip(equippos, pParty->takeHoldingItem());
+                            return;
                         }
                     }
 
                     // cant fit rings so swap out
-                    freeslot = pParty->activeCharacter().pEquipment[ringSlot(5)] - 1;  // slot of last ring
-                    _this = pParty->pPickedItem;  // copy hold item to this
-                    pParty->activeCharacter().pInventoryItemList[freeslot].equippedSlot = ITEM_SLOT_INVALID;
-                    pParty->pPickedItem.Reset();  // drop holding item
-                    pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[freeslot]); // set holding item to ring to swap out
-                    _this.equippedSlot = ITEM_SLOT_RING6;
-                    pParty->activeCharacter().pInventoryItemList[freeslot] = _this;  // swap from this in
-                    pParty->activeCharacter().pEquipment[ringSlot(5)] = freeslot + 1;  // anchor
+                    InventoryEntry freeslot = pParty->activeCharacter().inventory.entry(ITEM_SLOT_RING6);  // slot of last ring
+                    if (!freeslot)
+                        return; // TODO(captainurist): no ring in ITEM_SLOT_RING6, but also no space in inventory, what do we do in this case?
+
+                    Item tmp = pParty->activeCharacter().inventory.take(freeslot);
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_RING6, pParty->takeHoldingItem());
+                    pParty->setHoldingItem(tmp);
                     return;
 
                 } else {  // rings displayed if in ring area
@@ -1905,25 +1885,16 @@ void OnPaperdollLeftClick() {
                     }
 
                     if (pos != ITEM_SLOT_INVALID) {  // we have a position to aim for
-                        pitem = pParty->activeCharacter().GetItem(pos);
-                        if (!pitem) {  // no item in slot so just drop
-                            freeslot = pParty->activeCharacter().findFreeInventoryListSlot();
-                            if (freeslot >= 0) {  // drop ring into free space
-                                pParty->pPickedItem.equippedSlot = pos;
-                                pParty->activeCharacter().pInventoryItemList[freeslot] = pParty->pPickedItem;
-                                pParty->activeCharacter().pEquipment[pos] = freeslot + 1;
-                                mouse->RemoveHoldingItem();
+                        InventoryEntry entry = pParty->activeCharacter().inventory.entry(pos);
+                        if (!entry) {  // no item in slot so just drop
+                            if (pParty->activeCharacter().inventory.canEquip(pos)) {  // drop ring into free space
+                                pParty->activeCharacter().inventory.equip(pos, pParty->takeHoldingItem());
                                 return;
                             }
                         } else {  // item so swap out
-                            freeslot = pParty->activeCharacter().pEquipment[pos] - 1; // slot of ring selected
-                            _this = pParty->pPickedItem;  // copy hold item to this
-                            pParty->activeCharacter().pInventoryItemList[freeslot].equippedSlot = ITEM_SLOT_INVALID;
-                            pParty->pPickedItem.Reset();  // drop holding item
-                            pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[freeslot]); // set holding item to ring to swap out
-                            _this.equippedSlot = pos;
-                            pParty->activeCharacter().pInventoryItemList[freeslot] = _this;  // swap from this in
-                            pParty->activeCharacter().pEquipment[pos] = freeslot + 1;  // anchor
+                            Item tmp = pParty->activeCharacter().inventory.take(entry);
+                            pParty->activeCharacter().inventory.equip(pos, pParty->takeHoldingItem());
+                            pParty->setHoldingItem(tmp);
                             return;
                         }
                     } else {  // not click on right area so exit
@@ -1944,39 +1915,24 @@ void OnPaperdollLeftClick() {
                     return;
                 }
                 if (shieldequip) {  // смена щита щитом
-                    --shieldequip;
-                    _this = pParty->pPickedItem;
-                    pParty->activeCharacter().pInventoryItemList[shieldequip].equippedSlot = ITEM_SLOT_INVALID;
-                    pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[shieldequip]);
-                    _this.equippedSlot = ITEM_SLOT_OFF_HAND;
-                    pParty->activeCharacter().pInventoryItemList[shieldequip] = _this;
-                    pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = shieldequip + 1;
-                    if (twohandedequip == 0) {
+                    Item tmp = pParty->activeCharacter().inventory.take(shieldequip);
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_OFF_HAND, pParty->takeHoldingItem());
+                    pParty->setHoldingItem(tmp);
+                    if (!twohandedequip) {
                         return;
                     }
                 } else {
-                    freeslot = pParty->activeCharacter().findFreeInventoryListSlot();
-                    if (freeslot < 0) return;
-                    if (!twohandedequip) {  // обычная установка щита на пустую
-                                            // руку
-                        pParty->pPickedItem.equippedSlot = ITEM_SLOT_OFF_HAND;
-                        v17 = freeslot + 1;
-                        pParty->activeCharacter().pInventoryItemList[freeslot] = pParty->pPickedItem;
-                        pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = v17;
-                        mouse->RemoveHoldingItem();
+                    if (!pParty->activeCharacter().inventory.canEquip(ITEM_SLOT_OFF_HAND))
+                        return;
+                    if (!twohandedequip) {  // обычная установка щита на пустую руку
+                        pParty->activeCharacter().inventory.equip(ITEM_SLOT_OFF_HAND, pParty->takeHoldingItem());
                         return;
                     }
-                    mainhandequip--;  //ставим щит когда держит двуручный меч
-                    _this = pParty->pPickedItem;
-                    pParty->activeCharacter().pInventoryItemList[mainhandequip].equippedSlot = ITEM_SLOT_INVALID;
-                    pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[mainhandequip]);
-                    _this.equippedSlot = ITEM_SLOT_OFF_HAND;
-                    pParty->activeCharacter().pInventoryItemList[freeslot] = _this;
-                    pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = freeslot + 1;
+                    // ставим щит когда держит двуручный меч
+                    Item tmp = pParty->activeCharacter().inventory.take(twohandedequip);
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_OFF_HAND, pParty->takeHoldingItem());
+                    pParty->setHoldingItem(tmp);
                 }
-                pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = 0;
                 return;
                 // -------------------------taken in hand(взять в руку)-------------------------------------------
             case ITEM_TYPE_SINGLE_HANDED:
@@ -1989,62 +1945,41 @@ void OnPaperdollLeftClick() {
                     pParty->activeCharacter().playReaction(SPEECH_CANT_EQUIP);
                     return;
                 }
-                v50 = ITEM_NULL;
                 // dagger at expert or sword at master in left hand
                 if (pSkillType == CHARACTER_SKILL_DAGGER && (pParty->activeCharacter().getActualSkillValue(CHARACTER_SKILL_DAGGER).mastery() >= CHARACTER_SKILL_MASTERY_EXPERT)
                     || pSkillType == CHARACTER_SKILL_SWORD && (pParty->activeCharacter().getActualSkillValue(CHARACTER_SKILL_SWORD).mastery() >= CHARACTER_SKILL_MASTERY_MASTER)) {
                     if (mouse->position().x >= 560) {
                         if (!twohandedequip) {
                             if (shieldequip) {
-                                --shieldequip;
-                                _this = pParty->pPickedItem;
-                                pParty->activeCharacter().pInventoryItemList[shieldequip].equippedSlot = ITEM_SLOT_INVALID;
-                                pParty->pPickedItem.Reset();
-                                pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[shieldequip]);
-                                _this.equippedSlot = ITEM_SLOT_OFF_HAND;
-                                pParty->activeCharacter().pInventoryItemList[shieldequip] = _this;
-                                pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = shieldequip + 1;
+                                Item tmp = pParty->activeCharacter().inventory.take(shieldequip);
+                                pParty->activeCharacter().inventory.equip(ITEM_SLOT_OFF_HAND, pParty->takeHoldingItem());
+                                pParty->setHoldingItem(tmp);
                                 if (pEquipType != ITEM_TYPE_WAND) {
                                     return;
                                 }
-                                v50 = _this.itemId;
                                 break;
                             }
-                            v23 = pParty->activeCharacter().findFreeInventoryListSlot();
-                            if (v23 < 0) return;
-                            pParty->pPickedItem.equippedSlot = ITEM_SLOT_OFF_HAND;
-                            pParty->activeCharacter().pInventoryItemList[v23] = pParty->pPickedItem;
-                            pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = v23 + 1;
-                            mouse->RemoveHoldingItem();
+                            if (!pParty->activeCharacter().inventory.canEquip(ITEM_SLOT_OFF_HAND))
+                                return;
+                            pParty->activeCharacter().inventory.equip(ITEM_SLOT_OFF_HAND, pParty->takeHoldingItem());
                             if (pEquipType != ITEM_TYPE_WAND) return;
-                            v50 = pParty->activeCharacter().pInventoryItemList[v23].itemId;
                             break;
                         }
                     }
                 }
                 if (!mainhandequip) {
-                    v26 = pParty->activeCharacter().findFreeInventoryListSlot();
-                    if (v26 < 0) return;
-                    pParty->pPickedItem.equippedSlot = ITEM_SLOT_MAIN_HAND;
-                    pParty->activeCharacter().pInventoryItemList[v26] = pParty->pPickedItem;
-                    pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = v26 + 1;
-                    mouse->RemoveHoldingItem();
+                    if (!pParty->activeCharacter().inventory.canEquip(ITEM_SLOT_MAIN_HAND)) return;
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_MAIN_HAND, pParty->takeHoldingItem());
                     if (pEquipType != ITEM_TYPE_WAND) return;
                     break;
                 }
-                --mainhandequip;
-                _this = pParty->pPickedItem;
-                pParty->activeCharacter().pInventoryItemList[mainhandequip].equippedSlot = ITEM_SLOT_INVALID;
-                pParty->pPickedItem.Reset();
-                pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[mainhandequip]);
-                _this.equippedSlot = ITEM_SLOT_MAIN_HAND;
-                pParty->activeCharacter().pInventoryItemList[mainhandequip] = _this;
-                pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = mainhandequip + 1;
-                if (pEquipType == ITEM_TYPE_WAND) v50 = _this.itemId;
-                if (twohandedequip) {
-                    pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = 0;
+
+                {
+                    Item tmp = pParty->activeCharacter().inventory.take(mainhandequip);
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_MAIN_HAND, pParty->takeHoldingItem());
+                    pParty->setHoldingItem(tmp);
+                    break;
                 }
-                break;
                 // ---------------------------take two hands(взять двумя
                 // руками)---------------------------------
             case ITEM_TYPE_TWO_HANDED:
@@ -2062,33 +1997,18 @@ void OnPaperdollLeftClick() {
                         pAudioPlayer->playUISound(SOUND_error);
                         return;
                     }
-                    --mainhandequip;
-                    _this = pParty->pPickedItem;
-                    pParty->activeCharacter().pInventoryItemList[mainhandequip].equippedSlot = ITEM_SLOT_INVALID;
-                    pParty->pPickedItem.Reset();
-                    pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[mainhandequip]);
-                    _this.equippedSlot = ITEM_SLOT_MAIN_HAND;
-                    pParty->activeCharacter().pInventoryItemList[mainhandequip] = _this;
-                    pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = mainhandequip + 1;
+                    Item tmp = pParty->activeCharacter().inventory.take(mainhandequip);
+                    pParty->activeCharacter().inventory.equip(ITEM_SLOT_MAIN_HAND, pParty->takeHoldingItem());
+                    pParty->setHoldingItem(tmp);
                 } else {
-                    freeslot = pParty->activeCharacter().findFreeInventoryListSlot();
-                    if (freeslot >= 0) {
+                    if (pParty->activeCharacter().inventory.canEquip(ITEM_SLOT_MAIN_HAND)) {
                         if (shieldequip) {  // взять двуручный меч когда есть
                                             // щит(замещение щитом)
-                            shieldequip--;
-                            _this = pParty->pPickedItem;
-                            pParty->activeCharacter().pInventoryItemList[shieldequip].equippedSlot = ITEM_SLOT_INVALID;
-                            pParty->pPickedItem.Reset();
-                            pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[shieldequip]);
-                            _this.equippedSlot = ITEM_SLOT_MAIN_HAND;
-                            pParty->activeCharacter().pInventoryItemList[freeslot] = _this;
-                            pParty->activeCharacter().pEquipment[ITEM_SLOT_OFF_HAND] = 0;
-                            pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = freeslot + 1;
+                            Item tmp = pParty->activeCharacter().inventory.take(shieldequip);
+                            pParty->activeCharacter().inventory.equip(ITEM_SLOT_MAIN_HAND, pParty->takeHoldingItem());
+                            pParty->setHoldingItem(tmp);
                         } else {
-                            pParty->pPickedItem.equippedSlot = ITEM_SLOT_MAIN_HAND;
-                            pParty->activeCharacter().pInventoryItemList[freeslot] = pParty->pPickedItem;
-                            pParty->activeCharacter().pEquipment[ITEM_SLOT_MAIN_HAND] = freeslot + 1;
-                            mouse->RemoveHoldingItem();
+                            pParty->activeCharacter().inventory.equip(ITEM_SLOT_MAIN_HAND, pParty->takeHoldingItem());
                         }
                     }
                 }
@@ -2133,10 +2053,11 @@ void OnPaperdollLeftClick() {
             }
         }
 
+        InventoryEntry entry;
         if (pos != ITEM_SLOT_INVALID)
-            pitem = pParty->activeCharacter().GetItem(pos);
+            entry = pParty->activeCharacter().inventory.entry(pos);
 
-        if (!pitem) return;
+        if (!entry) return;
         // pParty->activeCharacter().get
 
         // enchant / recharge item
@@ -2151,9 +2072,9 @@ void OnPaperdollLeftClick() {
             pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
             pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
             pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
-            pSpellInfo->targetInventoryIndex = pParty->activeCharacter().pEquipment[pos];
+            pSpellInfo->targetInventoryIndex = entry.index();
 
-            ptr_50C9A4_ItemToEnchant = pitem;
+            ptr_50C9A4_ItemToEnchant = entry.get();
             IsEnchantingInProgress = false;
             engine->_messageQueue->clear();
             mouse->SetCursorImage("MICON1");
@@ -2162,9 +2083,7 @@ void OnPaperdollLeftClick() {
             AfterEnchClickEventTimeout = Duration::fromRealtimeSeconds(2);
         } else {
             if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
-                pParty->setHoldingItem(*pitem);
-                pParty->activeCharacter().pEquipment[pitem->equippedSlot] = 0;
-                pitem->Reset();
+                pParty->setHoldingItem(pParty->activeCharacter().inventory.take(entry));
 
                 // pParty->setHoldingItem(&pParty->activeCharacter().pInventoryItemList[v34
                 // - 1]);
@@ -2196,14 +2115,14 @@ void OnPaperdollLeftClick() {
         // player->pEquipment.uGlove);
 
     } else {  // z picking as before
-        v34 = 0;
-        v34 = render->QueryEquipmentHitMap(mouse->position()) & 0xFFFF;
+        int v34 = render->QueryEquipmentHitMap(mouse->position(), -1);
+        InventoryEntry entry = pParty->activeCharacter().inventory.entry(v34);
 
-        if (v34) {
+        if (entry) {
             // v36 = v34 - 1;
             // v38 = &pCharacters[pParty->_activeCharacter]->pInventoryItemList[v34 - 1];
-            pEquipType = pParty->activeCharacter().pInventoryItemList[v34 - 1].type();
-            if (pParty->activeCharacter().pInventoryItemList[v34 - 1].itemId == ITEM_QUEST_WETSUIT) {
+            pEquipType = entry->type();
+            if (entry->itemId == ITEM_QUEST_WETSUIT) {
                 if (engine->IsUnderwater()) {
                     pAudioPlayer->playUISound(SOUND_error);
                     return;
@@ -2224,8 +2143,7 @@ void OnPaperdollLeftClick() {
                 pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
                 pSpellInfo->targetInventoryIndex = v34 - 1;
 
-                ptr_50C9A4_ItemToEnchant =
-                    &pParty->activeCharacter().pInventoryItemList[v34 - 1];
+                ptr_50C9A4_ItemToEnchant = entry.get();
                 IsEnchantingInProgress = false;
                 engine->_messageQueue->clear();
                 mouse->SetCursorImage("MICON1");
@@ -2234,17 +2152,12 @@ void OnPaperdollLeftClick() {
                 AfterEnchClickEventTimeout = Duration::fromRealtimeSeconds(2);
             } else {
                 if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
-                    pParty->setHoldingItem(pParty->activeCharacter().pInventoryItemList[v34 - 1]);
-                    pParty->activeCharacter().pEquipment[pParty->activeCharacter().pInventoryItemList[v34 - 1].equippedSlot] = 0;
-                    pParty->activeCharacter().pInventoryItemList[v34 - 1].Reset();
+                    pParty->setHoldingItem(pParty->activeCharacter().inventory.take(entry));
                 }
             }
         } else {  // снять лук
-            if (pParty->activeCharacter().pEquipment[ITEM_SLOT_BOW]) {
-                _this = pParty->activeCharacter().pInventoryItemList[pParty->activeCharacter().pEquipment[ITEM_SLOT_BOW] - 1];
-                pParty->setHoldingItem(_this);
-                _this.Reset();
-                pParty->activeCharacter().pEquipment[ITEM_SLOT_BOW] = 0;
+            if (InventoryEntry entry = pParty->activeCharacter().inventory.entry(ITEM_SLOT_BOW)) {
+                pParty->setHoldingItem(pParty->activeCharacter().inventory.take(entry));
             }
         }
     }

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -51,7 +51,7 @@ void GUIWindow_Chest::Update() {
             if (entry.zone() != INVENTORY_ZONE_GRID)
                 continue;
 
-            auto item_texture = assets->getImage_ColorKey(entry.item().GetIconName());
+            auto item_texture = assets->getImage_ColorKey(entry->GetIconName());
             int X_offset = itemOffset(item_texture->width());
             int Y_offset = itemOffset(item_texture->height());
             int itemPixelPosX = chest_offs_x + 32 * entry.geometry().x + X_offset;

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -47,15 +47,15 @@ void GUIWindow_Chest::Update() {
         CharacterUI_DrawPickedItemUnderlay({ chest_offs_x, chest_offs_y });
         render->ResetUIClipRect();
 
-        for (InventoryEntry *entry : vChests[uChestID].inventory.entries()) {
-            if (entry->zone() != INVENTORY_ZONE_GRID)
+        for (InventoryEntry entry : vChests[uChestID].inventory.entries()) {
+            if (entry.zone() != INVENTORY_ZONE_GRID)
                 continue;
 
-            auto item_texture = assets->getImage_ColorKey(entry->item().GetIconName());
+            auto item_texture = assets->getImage_ColorKey(entry.item().GetIconName());
             int X_offset = itemOffset(item_texture->width());
             int Y_offset = itemOffset(item_texture->height());
-            int itemPixelPosX = chest_offs_x + 32 * entry->geometry().x + X_offset;
-            int itemPixelPosY = chest_offs_y + 32 * entry->geometry().y + Y_offset;
+            int itemPixelPosX = chest_offs_x + 32 * entry.geometry().x + X_offset;
+            int itemPixelPosY = chest_offs_y + 32 * entry.geometry().y + Y_offset;
 
             assert(0 < itemPixelPosX && itemPixelPosX < 640);
             assert(0 < itemPixelPosY && itemPixelPosY < 480);

--- a/src/GUI/UI/UIChest.cpp
+++ b/src/GUI/UI/UIChest.cpp
@@ -47,19 +47,19 @@ void GUIWindow_Chest::Update() {
         CharacterUI_DrawPickedItemUnderlay({ chest_offs_x, chest_offs_y });
         render->ResetUIClipRect();
 
-        for (int item_counter = 0; item_counter < chestWidthCells * chestHeghtCells; ++item_counter) {
-            int chest_item_index = vChests[uChestID].inventoryMatrix[item_counter];
-            if (chest_item_index > 0) {
-                auto item_texture = assets->getImage_ColorKey(vChests[uChestID].items[chest_item_index - 1].GetIconName());
-                int X_offset = itemOffset(item_texture->width());
-                int Y_offset = itemOffset(item_texture->height());
-                int itemPixelPosX = chest_offs_x + 32 * (item_counter % chestWidthCells) + X_offset;
-                int itemPixelPosY = chest_offs_y + 32 * (item_counter / chestHeghtCells) + Y_offset;
+        for (InventoryEntry *entry : vChests[uChestID].inventory.entries()) {
+            if (entry->zone() != INVENTORY_ZONE_GRID)
+                continue;
 
-                assert(0 < itemPixelPosX && itemPixelPosX < 640);
-                assert(0 < itemPixelPosY && itemPixelPosY < 480);
-                render->DrawTextureNew(itemPixelPosX / 640.0f, itemPixelPosY / 480.0f, item_texture);
-            }
+            auto item_texture = assets->getImage_ColorKey(entry->item().GetIconName());
+            int X_offset = itemOffset(item_texture->width());
+            int Y_offset = itemOffset(item_texture->height());
+            int itemPixelPosX = chest_offs_x + 32 * entry->geometry().x + X_offset;
+            int itemPixelPosY = chest_offs_y + 32 * entry->geometry().y + Y_offset;
+
+            assert(0 < itemPixelPosX && itemPixelPosX < 640);
+            assert(0 < itemPixelPosY && itemPixelPosY < 480);
+            render->DrawTextureNew(itemPixelPosX / 640.0f, itemPixelPosY / 480.0f, item_texture);
         }
 
         render->DrawTextureNew(pBtn_ExitCancel->uX / 640.0f, pBtn_ExitCancel->uY / 480.0f, ui_exit_cancel_button_background);

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -760,7 +760,7 @@ bool PartyCreationUI_LoopInternal() {
             }
         }
         pItemTable->generateItem(ITEM_TREASURE_LEVEL_2, RANDOM_ITEM_RING, &item);
-        pParty->pCharacters[i].AddItem2(-1, &item);
+        pParty->pCharacters[i].inventory.add(item);
 
         pParty->pCharacters[i].health = pParty->pCharacters[i].GetMaxHealth();
         pParty->pCharacters[i].mana = pParty->pCharacters[i].GetMaxMana();
@@ -769,67 +769,67 @@ bool PartyCreationUI_LoopInternal() {
 
             switch (j) {
             case CHARACTER_SKILL_STAFF:
-                pParty->pCharacters[i].AddItem(-1, ITEM_STAFF);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_STAFF));
                 break;
             case CHARACTER_SKILL_SWORD:
-                pParty->pCharacters[i].AddItem(-1, ITEM_CRUDE_LONGSWORD);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_CRUDE_LONGSWORD));
                 break;
             case CHARACTER_SKILL_DAGGER:
-                pParty->pCharacters[i].AddItem(-1, ITEM_DAGGER);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_DAGGER));
                 break;
             case CHARACTER_SKILL_AXE:
-                pParty->pCharacters[i].AddItem(-1, ITEM_CRUDE_AXE);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_CRUDE_AXE));
                 break;
             case CHARACTER_SKILL_SPEAR:
-                pParty->pCharacters[i].AddItem(-1, ITEM_CRUDE_SPEAR);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_CRUDE_SPEAR));
                 break;
             case CHARACTER_SKILL_BOW:
-                pParty->pCharacters[i].AddItem(-1, ITEM_CROSSBOW);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_CROSSBOW));
                 break;
             case CHARACTER_SKILL_MACE:
-                pParty->pCharacters[i].AddItem(-1, ITEM_MACE);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_MACE));
                 break;
             case CHARACTER_SKILL_BLASTER:
                 logger->error("No blasters at startup :p");
                 break;
             case CHARACTER_SKILL_SHIELD:
-                pParty->pCharacters[i].AddItem(-1, ITEM_WOODEN_BUCKLER);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_WOODEN_BUCKLER));
                 break;
             case CHARACTER_SKILL_LEATHER:
-                pParty->pCharacters[i].AddItem(-1, ITEM_LEATHER_ARMOR);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_LEATHER_ARMOR));
                 break;
             case CHARACTER_SKILL_CHAIN:
-                pParty->pCharacters[i].AddItem(-1, ITEM_CHAIN_MAIL);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_CHAIN_MAIL));
                 break;
             case CHARACTER_SKILL_PLATE:
-                pParty->pCharacters[i].AddItem(-1, ITEM_PLATE_ARMOR);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_PLATE_ARMOR));
                 break;
             case CHARACTER_SKILL_FIRE:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_FIRE_BOLT);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_FIRE_BOLT));
                 pParty->pCharacters[i].bHaveSpell[SPELL_FIRE_TORCH_LIGHT] = true;
                 break;
             case CHARACTER_SKILL_AIR:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_FEATHER_FALL);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_FEATHER_FALL));
                 pParty->pCharacters[i].bHaveSpell[SPELL_AIR_WIZARD_EYE] = true;
                 break;
             case CHARACTER_SKILL_WATER:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_POISON_SPRAY);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_POISON_SPRAY));
                 pParty->pCharacters[i].bHaveSpell[SPELL_WATER_AWAKEN] = true;
                 break;
             case CHARACTER_SKILL_EARTH:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_SLOW);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_SLOW));
                 pParty->pCharacters[i].bHaveSpell[SPELL_EARTH_STUN] = true;
                 break;
             case CHARACTER_SKILL_SPIRIT:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_BLESS);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_BLESS));
                 pParty->pCharacters[i].bHaveSpell[SPELL_SPIRIT_DETECT_LIFE] = true;
                 break;
             case CHARACTER_SKILL_MIND:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_MIND_BLAST);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_MIND_BLAST));
                 pParty->pCharacters[i].bHaveSpell[SPELL_MIND_REMOVE_FEAR] = true;
                 break;
             case CHARACTER_SKILL_BODY:
-                pParty->pCharacters[i].AddItem(-1, ITEM_SPELLBOOK_HEAL);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_SPELLBOOK_HEAL));
                 pParty->pCharacters[i].bHaveSpell[SPELL_BODY_CURE_WEAKNESS] = true;
                 break;
             case CHARACTER_SKILL_LIGHT:
@@ -845,26 +845,24 @@ bool PartyCreationUI_LoopInternal() {
             case CHARACTER_SKILL_PERCEPTION:
             case CHARACTER_SKILL_TRAP_DISARM:
             case CHARACTER_SKILL_LEARNING:
-                pParty->pCharacters[i].AddItem(-1, ITEM_POTION_BOTTLE);
-                pParty->pCharacters[i].AddItem(-1, grng->randomSample(allLevel1Reagents()));
+                pParty->pCharacters[i].inventory.add(Item(ITEM_POTION_BOTTLE));
+                pParty->pCharacters[i].inventory.add(Item(grng->randomSample(allLevel1Reagents())));
                 break;
             case CHARACTER_SKILL_DODGE:
-                pParty->pCharacters[i].AddItem(-1, ITEM_LEATHER_BOOTS);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_LEATHER_BOOTS));
                 break;
             case CHARACTER_SKILL_UNARMED:
-                pParty->pCharacters[i].AddItem(-1, ITEM_GAUNTLETS);
+                pParty->pCharacters[i].inventory.add(Item(ITEM_GAUNTLETS));
                 break;
             case CHARACTER_SKILL_CLUB:
-                // pParty->pCharacters[i].AddItem(-1, ITEM_CLUB);
+                // pParty->pCharacters[i].inventory.add(-1, ITEM_CLUB);
                 break;
             default:
                 break;
             }
 
-            for (Item &inventoryItem : pParty->pCharacters[i].pInventoryItemList) {
-                if (inventoryItem.itemId != ITEM_NULL)
-                    inventoryItem.SetIdentified();
-            }
+            for (InventoryEntry entry : pParty->pCharacters[i].inventory.entries())
+                entry->SetIdentified();
         }
     }
 

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -855,7 +855,7 @@ bool PartyCreationUI_LoopInternal() {
                 pParty->pCharacters[i].inventory.add(Item(ITEM_GAUNTLETS));
                 break;
             case CHARACTER_SKILL_CLUB:
-                // pParty->pCharacters[i].inventory.add(-1, ITEM_CLUB);
+                // pParty->pCharacters[i].inventory.add(Item(ITEM_CLUB));
                 break;
             default:
                 break;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1888,28 +1888,12 @@ void UI_OnMouseRightClick(Pointi mousePos) {
             } else {
                 // this could be put into a chest function
 
-                int chestheight =
-                    9;  // pChestHeightsByType[pChests[(int)pGUIWindow_CurrentMenu->par1C].uChestBitmapID];
-                int chestwidth = 9;
-                int inventoryYCoord = (pY - 34) / 32;  // use pchestoffsets??
+                int inventoryYCoord = (pY - 34) / 32;  // TODO(captainurist): use pchestoffsets
                 int inventoryXCoord = (pX - 42) / 32;
-                int invMatrixIndex =
-                    inventoryXCoord + (chestheight * inventoryYCoord);
 
-                if (inventoryYCoord >= 0 && inventoryYCoord < chestheight &&
-                    inventoryXCoord >= 0 && inventoryXCoord < chestwidth) {
-                    int chestindex = vChests[pGUIWindow_CurrentChest->chestId()].inventoryMatrix[invMatrixIndex];
-                    if (chestindex < 0) {
-                        invMatrixIndex = (-(chestindex + 1));
-                        chestindex = vChests[pGUIWindow_CurrentChest->chestId()].inventoryMatrix[invMatrixIndex];
-                    }
-
-                    if (chestindex) {
-                        int itemindex = chestindex - 1;
-
-                        GameUI_DrawItemInfo(&vChests[pGUIWindow_CurrentChest->chestId()].items[itemindex]);
-                    }
-                }
+                InventoryEntry *entry = vChests[pGUIWindow_CurrentChest->chestId()].inventory.gridItem({inventoryXCoord, inventoryYCoord});
+                if (entry)
+                    GameUI_DrawItemInfo(&entry->item());
             }
             break;
         }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1891,9 +1891,9 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                 int inventoryYCoord = (pY - 34) / 32;  // TODO(captainurist): use pchestoffsets
                 int inventoryXCoord = (pX - 42) / 32;
 
-                InventoryEntry *entry = vChests[pGUIWindow_CurrentChest->chestId()].inventory.gridItem({inventoryXCoord, inventoryYCoord});
+                InventoryEntry entry = vChests[pGUIWindow_CurrentChest->chestId()].inventory.entry({inventoryXCoord, inventoryYCoord});
                 if (entry)
-                    GameUI_DrawItemInfo(&entry->item());
+                    GameUI_DrawItemInfo(&entry.item());
             }
             break;
         }

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -46,14 +46,6 @@ void Io::Mouse::setPosition(Pointi position) {
     }
 }
 
-void Io::Mouse::RemoveHoldingItem() {
-    pParty->pPickedItem.Reset();
-    if (this->cursor_name != "MICON2") {
-        SetCursorImage("MICON1");
-    }
-    pickedItemOffset = {};
-}
-
 void Io::Mouse::SetCursorBitmapFromItemID(ItemId uItemID) {
     SetCursorImage(pItemTable->items[uItemID].iconName);
 }

--- a/src/Io/Mouse.h
+++ b/src/Io/Mouse.h
@@ -21,7 +21,6 @@ class Mouse {
     Pointi position() const;
     void setPosition(Pointi position);
 
-    void RemoveHoldingItem();
     void SetCursorBitmapFromItemID(ItemId uItemID);
     void SetCurrentCursorBitmap();
     void SetCursorImage(std::string_view name);

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -107,13 +107,13 @@ void GameBindings::_registerPartyBindings(sol::state_view &solState, sol::table 
             }
         }),
         "getCharacterInfo", sol::as_function([this, &solState](int characterIndex, QueryTable queryTable) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
+            if (Character *character = getCharacterByIndex(characterIndex - 1)) {
                 return _characterInfoQueryTable->createTable(*character, queryTable);
             }
             return sol::make_object(solState, sol::lua_nil);
         }),
         "setCharacterInfo", sol::as_function([](int characterIndex, const sol::object &info) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
+            if (Character *character = getCharacterByIndex(characterIndex - 1)) {
                 const sol::table &table = info.as<sol::table>();
                 for (auto &&val : table) {
                     std::string_view key = val.first.as<std::string_view>();
@@ -152,13 +152,12 @@ void GameBindings::_registerPartyBindings(sol::state_view &solState, sol::table 
             }
         }),
         "addItemToInventory", sol::as_function([](int characterIndex, ItemId itemId) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
-                return character->AddItem(-1, itemId) != 0;
-            }
+            if (Character *character = getCharacterByIndex(characterIndex - 1))
+                return !!character->inventory.tryAdd(Item(itemId));
             return false;
         }),
         "addCustomItemToInventory", sol::as_function([](int characterIndex, sol::table itemTable) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
+            if (Character *character = getCharacterByIndex(characterIndex - 1)) {
                 Item item;
                 for (auto &&pair : itemTable) {
                     std::string_view key = pair.first.as<std::string_view>();
@@ -168,7 +167,7 @@ void GameBindings::_registerPartyBindings(sol::state_view &solState, sol::table 
                         item.lichJarCharacterIndex = pair.second.as<int>() - 1; // character index in lua is 1-based
                     }
                 }
-                return character->AddItem2(-1, &item) != 0;
+                return !!character->inventory.tryAdd(item);
             }
             return false;
         }),
@@ -178,12 +177,12 @@ void GameBindings::_registerPartyBindings(sol::state_view &solState, sol::table 
             }
         }),
         "playCharacterAwardSound", sol::as_function([](int characterIndex) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
+            if (Character *character = getCharacterByIndex(characterIndex - 1)) {
                 character->PlayAwardSound_Anim();
             }
         }),
         "clearCondition", sol::as_function([](int characterIndex, std::optional<Condition> conditionToClear) {
-            if (Character *character = getCharacterByIndex(characterIndex - 1); character != nullptr) {
+            if (Character *character = getCharacterByIndex(characterIndex - 1)) {
                 if (conditionToClear) {
                     character->conditions.Reset(*conditionToClear);
                 } else {

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -66,27 +66,14 @@ GAME_TEST(Issues, Issue198) {
     // Check that items can't end up out of bounds of character's inventory.
     test.playTraceFromTestData("issue_198.mm7", "issue_198.json");
 
-    auto forEachInventoryItem = [](auto &&callback) {
-        for (const Character &character : pParty->pCharacters) {
-            for (int inventorySlot = 0; inventorySlot < Character::INVENTORY_SLOT_COUNT; inventorySlot++) {
-                int itemIndex = character.pInventoryMatrix[inventorySlot];
-                if (itemIndex <= 0)
-                    continue; // Empty or non-primary cell.
+    for (const Character &character : pParty->pCharacters) {
+        for (InventoryConstEntry entry : character.inventory.entries()) {
+            Recti geometry = entry.geometry();
 
-                int x = inventorySlot % Character::INVENTORY_SLOTS_WIDTH;
-                int y = inventorySlot / Character::INVENTORY_SLOTS_WIDTH;
-
-                callback(character.pInventoryItemList[itemIndex - 1], x, y);
-            }
+            EXPECT_LE(geometry.x + geometry.w, Character::INVENTORY_SLOTS_WIDTH);
+            EXPECT_LE(geometry.y + geometry.h, Character::INVENTORY_SLOTS_HEIGHT);
         }
-    };
-
-    forEachInventoryItem([](const Item &item, int x, int y) {
-        Sizei itemSize = item.inventorySize();
-
-        EXPECT_LE(x + itemSize.w, Character::INVENTORY_SLOTS_WIDTH);
-        EXPECT_LE(y + itemSize.h, Character::INVENTORY_SLOTS_HEIGHT);
-    });
+    }
 }
 
 // 200

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -446,12 +446,10 @@ GAME_TEST(Issues, Issue677) {
 
 GAME_TEST(Issues, Issue680) {
     // Chest items duplicate sometimes
-    auto chestItemsCount = tapes.custom([] { return std::count_if(vChests[4].items.cbegin(), vChests[4].items.cend(), [&](Item item) { return item.itemId != ITEM_NULL; }); });
+    auto chestItemsCount = tapes.custom([] { return vChests[4].inventory.size(); });
     test.playTraceFromTestData("issue_680.mm7", "issue_680.json");
-    // Make sure we havent gained any duplicates
-    EXPECT_EQ(chestItemsCount.front(), chestItemsCount.back());
-    // And that items were added and removed
-    EXPECT_GE(chestItemsCount.size(), 2);
+    EXPECT_EQ(chestItemsCount.front(), chestItemsCount.back()); // Make sure we havent gained any duplicates.
+    EXPECT_GE(chestItemsCount.size(), 2); // And that items were added and removed.
 }
 
 GAME_TEST(Issues, Issue681) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -152,7 +152,7 @@ GAME_TEST(Issues, Issue571) {
 
 GAME_TEST(Issues, Issue573) {
     // Make Recharge Item effect non-decreasing
-    auto chargeTape = tapes.custom([] {  return pParty->pCharacters[1].pInventoryItemList[33].numCharges; });
+    auto chargeTape = tapes.custom([] {  return pParty->pCharacters[1].inventory.entry(33)->numCharges; });
     auto manaTape = tapes.custom([] { return pParty->pCharacters[0].mana; });
     auto itemsTape = tapes.totalItemCount();
     test.playTraceFromTestData("issue_573.mm7", "issue_573.json");

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -22,7 +22,7 @@
 #include "Media/Audio/AudioPlayer.h"
 
 static bool characterHasJar(int charIndex, int jarIndex) {
-    for (const Item &item : pParty->pCharacters[charIndex].pInventoryItemList)
+    for (const Item &item : pParty->pCharacters[charIndex].inventory.items())
         if (item.itemId == ITEM_QUEST_LICH_JAR_FULL && item.lichJarCharacterIndex == jarIndex)
             return true;
     return false;

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -924,8 +924,8 @@ GAME_TEST(Issues, Issue1990) {
     // Test opening the Tularean Forest half-hidden chest, which generates a black potion.
     auto screenTape = tapes.screen();
     auto powerTape = tapes.custom([] {
-        InventoryEntry *entry = vChests[6].inventory.findEntry(ITEM_POTION_PURE_MIGHT);
-        return entry ? entry->item().potionPower : -1;
+        InventoryEntry entry = vChests[6].inventory.find(ITEM_POTION_PURE_MIGHT);
+        return entry ? entry.item().potionPower : -1;
     });
     test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_CHEST)); // We have opened the chest.

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -307,8 +307,8 @@ GAME_TEST(Issues, Issue1685) {
     jar2.itemId = ITEM_QUEST_LICH_JAR_FULL;
     jar2.lichJarCharacterIndex = 1;
 
-    pParty->pCharacters[0].AddItem2(-1, &jar1);
-    pParty->pCharacters[1].AddItem2(-1, &jar2);
+    pParty->pCharacters[0].inventory.add(jar1);
+    pParty->pCharacters[1].inventory.add(jar2);
 
     EXPECT_EQ(jar1.GetIdentifiedName(), "Kolya's Jar");
     EXPECT_EQ(jar2.GetIdentifiedName(), "Nicholas' Jar");
@@ -719,6 +719,34 @@ GAME_TEST(Issues, Issue1947) {
     EXPECT_GT(pSpriteObjects[4].containing_item.maxCharges, 0);
 }
 
+GAME_TEST(Prs, Pr1953) {
+    // Items were duplicated when trying to wear armor on top of existing armor.
+    game.startNewGame();
+
+    Character &char0 = pParty->pCharacters[0];
+    char0.inventory.clear();
+    char0.inventory.add(Item(ITEM_LEATHER_ARMOR));
+    char0.inventory.equip(ITEM_SLOT_ARMOUR, Item(ITEM_ROYAL_LEATHER));
+
+    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
+    game.tick();
+    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
+    game.tick();
+    game.pressAndReleaseKey(PlatformKey::KEY_I); // Open inventory.
+    game.tick();
+    game.pressAndReleaseButton(BUTTON_LEFT, 20, 20); // Pick up leather armor.
+    game.tick();
+    EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_LEATHER_ARMOR);
+    EXPECT_EQ(char0.inventory.size(), 1);
+    game.pressAndReleaseButton(BUTTON_LEFT, 600, 60); // Wear it, replacing royal leather that's worn.
+    game.tick(1);
+    EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_ROYAL_LEATHER);
+    EXPECT_EQ(char0.inventory.size(), 1);
+    ASSERT_FALSE(char0.inventory.entry(Pointi(0, 0)));
+    ASSERT_TRUE(char0.inventory.entry(ITEM_SLOT_ARMOUR));
+    EXPECT_EQ(char0.inventory.entry(ITEM_SLOT_ARMOUR)->itemId, ITEM_LEATHER_ARMOR);
+}
+
 GAME_TEST(Issues, Issue1956) {
     // Crash shortly after entering Land of Giants
     test.playTraceFromTestData("issue_1956.mm7", "issue_1956.json");
@@ -790,10 +818,8 @@ GAME_TEST(Issues, Issue1961) {
     test.startTaping();
 
     // Prepare an item to enchant.
-    pParty->pCharacters[3].pInventoryItemList.fill(Item());
-    pParty->pCharacters[3].pInventoryMatrix.fill(0);
-    pParty->pCharacters[3].AddItem(-1, ITEM_GOLDEN_CHAIN_MAIL);
-    const Item &chainmail = pParty->pCharacters[3].pInventoryItemList[0];
+    pParty->pCharacters[3].inventory.clear();
+    const Item &chainmail = *pParty->pCharacters[3].inventory.add(Pointi(0, 0), Item(ITEM_GOLDEN_CHAIN_MAIL));
     EXPECT_EQ(chainmail.itemId, ITEM_GOLDEN_CHAIN_MAIL);
 
     // Learn enchant item.
@@ -925,7 +951,7 @@ GAME_TEST(Issues, Issue1990) {
     auto screenTape = tapes.screen();
     auto powerTape = tapes.custom([] {
         InventoryEntry entry = vChests[6].inventory.find(ITEM_POTION_PURE_MIGHT);
-        return entry ? entry.item().potionPower : -1;
+        return entry ? entry->potionPower : -1;
     });
     test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_CHEST)); // We have opened the chest.

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -923,11 +923,12 @@ GAME_TEST(Issues, Issue1989) {
 GAME_TEST(Issues, Issue1990) {
     // Test opening the Tularean Forest half-hidden chest, which generates a black potion.
     auto screenTape = tapes.screen();
-    auto potionTape = tapes.custom([] { return vChests[6].items[6].itemId; });
-    auto powerTape = tapes.custom([] { return vChests[6].items[6].potionPower; });
+    auto powerTape = tapes.custom([] {
+        InventoryEntry *entry = vChests[6].inventory.findEntry(ITEM_POTION_PURE_MIGHT);
+        return entry ? entry->item().potionPower : -1;
+    });
     test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_CHEST)); // We have opened the chest.
-    EXPECT_EQ(potionTape, tape(ITEM_POTION_PURE_MIGHT));
     EXPECT_EQ(powerTape.front(), 0); // Potion power started as uninitialized.
     EXPECT_GE(powerTape.back(), 5);
     EXPECT_LT(powerTape.back(), 20); // Potion power ended as initialized to 5-19.

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -116,9 +116,8 @@ GAME_TEST(Issues, Issue2066) {
     game.startNewGame();
     test.startTaping();
 
-    pParty->pCharacters[0].pInventoryItemList.fill(Item());
-    pParty->pCharacters[0].pInventoryMatrix.fill(0);
-    pParty->pCharacters[0].AddItem(-1, ITEM_LEATHER_ARMOR); // Add leather armor at (0, 0).
+    pParty->pCharacters[0].inventory.clear();
+    pParty->pCharacters[0].inventory.add(Pointi(0, 0), Item(ITEM_LEATHER_ARMOR)); // Add leather armor at (0, 0).
 
     game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
     game.tick();

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -44,9 +44,9 @@ TestTape<int> CommonTapeRecorder::totalItemCount() {
     return custom([]{
         int result = 0;
         for (const Character &character : pParty->pCharacters)
-            for (const Item &item : character.pInventoryItemList)
-                result += item.itemId != ITEM_NULL;
-        result += pParty->pPickedItem.itemId != ITEM_NULL;
+            result += character.inventory.size();
+        if (pParty->pPickedItem.itemId != ITEM_NULL)
+            result++;
         return result;
     });
 }
@@ -55,8 +55,7 @@ TestTape<int> CommonTapeRecorder::totalItemCount(ItemId itemId) {
     return custom([itemId] {
         int result = 0;
         for (const Character &character : pParty->pCharacters)
-            for (const Item &item : character.pInventoryItemList)
-                result += item.itemId == itemId;
+            result += std::ranges::distance(character.inventory.items(itemId));
         result += pParty->pPickedItem.itemId == itemId;
         return result;
     });


### PR DESCRIPTION
Depends on #2092.

Introduced `Inventory` class, implemented `ChestInventory` and `CharacterInventory` on top of it. Dropped all the index juggling we had scattered around the codebase. Checking if inventory is valid on load.

For a lot of saves that we have inventory is not valid:
* We have duplicated items in some of the chests.
* We have character inventory slots that are blocked but invisible (same thing as what was happening to overflowing chests).

For duplicate items, I'm dropping the duplicates. Hidden items in character inventory are also dropped. For chests the old logic is applied – depending on what's set in options the new items appear as you clear the chest.

I'll do a couple more rounds of cleanup once this is merged.