### PR TITLE
Fix #1966

### DIFF
--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -938,6 +938,7 @@ bool processSpellImpact(unsigned int uLayingItemID, Pid pid) {
         }
 
         case SPRITE_SPELL_EARTH_ROCK_BLAST: {
+            if (object->uSpellID == SPELL_NONE) return 1;
             if (pid.type() == OBJECT_Face || pid.type() == OBJECT_Decoration || pid.type() == OBJECT_None) {
                 return 1;
             }


### PR DESCRIPTION
The empty rock blast effect was colliding and attempting to cause AOE damage