### PR TITLE
Fix crash due to Armageddon decoration rocks and prettify them

### DIFF
--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -4536,10 +4536,10 @@ void evaluateAoeDamage() {
             pSpriteObj = &pSpriteObjects[attackerId];
             attackerType = pSpriteObjects[attackerId].spell_caster_pid.type();
             attackerId = pSpriteObjects[attackerId].spell_caster_pid.id();
-	        if (pSpriteObj->uType == SPRITE_SPELL_EARTH_ROCK_BLAST_IMPACT && attackerType == OBJECT_None)
-				// This is triggered by the rock blast decorations Armageddon spawns.
-				// If let through, they can trigger the assert near the end of the loop.
-		        continue;
+            // This is triggered by the rock blast decorations Armageddon spawns.
+            // If let through, they can trigger the assert near the end of the loop.
+            if (pSpriteObj->uType == SPRITE_SPELL_EARTH_ROCK_BLAST_IMPACT && attackerType == OBJECT_None)
+                continue;
         }
 
         if (attack.isMelee) {

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -4536,6 +4536,10 @@ void evaluateAoeDamage() {
             pSpriteObj = &pSpriteObjects[attackerId];
             attackerType = pSpriteObjects[attackerId].spell_caster_pid.type();
             attackerId = pSpriteObjects[attackerId].spell_caster_pid.id();
+	        if (pSpriteObj->uType == SPRITE_SPELL_EARTH_ROCK_BLAST_IMPACT && attackerType == OBJECT_None)
+				// This is triggered by the rock blast decorations Armageddon spawns.
+				// If let through, they can trigger the assert near the end of the loop.
+		        continue;
         }
 
         if (attack.isMelee) {

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2898,11 +2898,25 @@ void CastSpellInfoHelpers::castSpell() {
                     if (pParty->bTurnBasedModeOn) {
                         ++pTurnEngine->pending_actions;
                     }
-                    for (unsigned i = 0; i < 50; i++) {
-                        Vec3f rand(grng->random(4096) - 2048, grng->random(4096) - 2048, 0);
+
+                    // Some flying Rocks as decoration:
+                    static const int rocksCount = 50,
+                        rocksRadius = 2048,
+                        rocksSpeedMin = 500,
+                        rocksSpeedMax = 1000,
+                        rocksRadiusSqr = rocksRadius * rocksRadius,
+                        rocksBoundingBox = rocksRadius * 4000 / 3141;
+                    const auto getCoord = []{ return grng->randomInSegment(-rocksBoundingBox, rocksBoundingBox); };
+                    unsigned i = 0;
+                    while ( i < rocksCount ) {
+                        Vec3f rand(getCoord(), getCoord(), 0);
+                        if (rand.lengthSqr() > rocksRadiusSqr)
+                            continue;
                         int terr_height = pOutdoor->pTerrain.heightByPos(pParty->pos + rand);
                         SpriteObject::dropItemAt(SPRITE_SPELL_EARTH_ROCK_BLAST,
-                                                 {rand.x + pParty->pos.x, rand.y + pParty->pos.y, terr_height + 16.0f}, grng->random(500) + 500);
+                                {rand.x + pParty->pos.x, rand.y + pParty->pos.y, terr_height + 16.0f},
+                                grng->randomInSegment(rocksSpeedMin, rocksSpeedMax));
+                        i++;
                     }
                     break;
                 }

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2900,10 +2900,10 @@ void CastSpellInfoHelpers::castSpell() {
                     }
 
                     // Some flying Rocks as decoration:
-                    static const int rocksCount = 50,
-                        rocksRadius = 2048,
-                        rocksSpeedMin = 500,
-                        rocksSpeedMax = 1000,
+                    static const int rocksCount = 250,
+                        rocksRadius = 3200,
+                        rocksSpeedMin = 200,
+                        rocksSpeedMax = 1400,
                         rocksRadiusSqr = rocksRadius * rocksRadius,
                         rocksBoundingBox = rocksRadius * 4000 / 3141;
                     const auto getCoord = []{ return grng->randomInSegment(-rocksBoundingBox, rocksBoundingBox); };

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2900,7 +2900,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
 
                     // Some flying Rocks as decoration:
-                    static constexpr int rocksCount = 250,
+                    constexpr int rocksCount = 250,
                         rocksRadius = 3200,
                         rocksSpeedMin = 300,
                         rocksSpeedMax = 1400,

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2900,13 +2900,12 @@ void CastSpellInfoHelpers::castSpell() {
                     }
 
                     // Some flying Rocks as decoration:
-                    static const int rocksCount = 250,
+                    static constexpr int rocksCount = 250,
                         rocksRadius = 3200,
-                        rocksSpeedMin = 200,
+                        rocksSpeedMin = 300,
                         rocksSpeedMax = 1400,
-                        rocksRadiusSqr = rocksRadius * rocksRadius,
-                        rocksBoundingBox = rocksRadius * 4000 / 3141;
-                    const auto getCoord = []{ return grng->randomInSegment(-rocksBoundingBox, rocksBoundingBox); };
+                        rocksRadiusSqr = rocksRadius * rocksRadius;
+                    const auto getCoord = []{ return vrng->randomInSegment(-rocksRadius, rocksRadius); };
                     unsigned i = 0;
                     while ( i < rocksCount ) {
                         Vec3f rand(getCoord(), getCoord(), 0);
@@ -2915,7 +2914,7 @@ void CastSpellInfoHelpers::castSpell() {
                         int terr_height = pOutdoor->pTerrain.heightByPos(pParty->pos + rand);
                         SpriteObject::dropItemAt(SPRITE_SPELL_EARTH_ROCK_BLAST,
                                 {rand.x + pParty->pos.x, rand.y + pParty->pos.y, terr_height + 16.0f},
-                                grng->randomInSegment(rocksSpeedMin, rocksSpeedMax));
+                                vrng->randomInSegment(rocksSpeedMin, rocksSpeedMax));
                         i++;
                     }
                     break;

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 1228eeec432bda29cef221608ca3adf2864e10ca
+        GIT_TAG 20a2e9c1e7c06ce58363833b6ca8404563246a1e
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 20a2e9c1e7c06ce58363833b6ca8404563246a1e
+        GIT_TAG 22f1c23b12c401a5beb1d7548bfd5ed6bbc83270
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -389,7 +389,7 @@ GAME_TEST(Prs, Pr1325) {
     auto vialsTape = tapes.mapItemCount(ITEM_REAGENT_VIAL_OF_TROLL_BLOOD);
     auto deadTape = actorTapes.countByState(AIState::Dead);
     test.playTraceFromTestData("pr_1325.mm7", "pr_1325.json");
-    EXPECT_EQ(vialsTape.delta(), +6);
+    EXPECT_EQ(vialsTape.delta(), +4);
     EXPECT_EQ(deadTape.delta(), +84); // Too much armageddon...
 }
 


### PR DESCRIPTION
Here's my take on fixing #1966 in case you want to see it in this form. Detailed commit history intentional.

Be aware that I don't understand much about the inter-meshing between the sprite and spell systems, so @pskelton 's approach to teach the sprites themselves that they're dummies may or may not be still necessary in some form...

Reasoning and visuals: `@see`[^1] issue.

[^1]: Kdoc notation - my joke