### PR TITLE
Fix crash claiming bounty

### DIFF
--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -193,10 +193,10 @@ void GUIWindow_TownHall::bountyHuntingDialogueOptionClicked() {
 std::string GUIWindow_TownHall::bountyHuntingText() {
     assert(!_bountyHuntText.empty());
 
-	// This happens when you claim a bounty and revisit the town hall the same month.
-	// Assumes _bountyHuntText is already containing the "someone has already" text (pNPCTopics[353]).
-	if (_bountyHuntMonsterId == MONSTER_INVALID)
-		return fmt::format("{::}{}{::}", colorTable.Scarlet.tag(), _bountyHuntText, colorTable.White.tag());
+    // This happens when you claim a bounty and revisit the town hall the same month.
+    // Assumes _bountyHuntText is already containing the "someone has already" text (pNPCTopics[353]).
+    if (_bountyHuntMonsterId == MONSTER_INVALID)
+        return fmt::format("{::}{}{::}", colorTable.Scarlet.tag(), _bountyHuntText, colorTable.White.tag());
 
     // TODO(captainurist): what do we do with exceptions inside fmt?
     std::string name = fmt::format("{::}{}{::}", colorTable.PaleCanary.tag(), pMonsterStats->infos[_bountyHuntMonsterId].name, colorTable.White.tag());

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -192,7 +192,11 @@ void GUIWindow_TownHall::bountyHuntingDialogueOptionClicked() {
 
 std::string GUIWindow_TownHall::bountyHuntingText() {
     assert(!_bountyHuntText.empty());
-    assert(_bountyHuntMonsterId != MONSTER_INVALID);
+
+	// This happens when you claim a bounty and revisit the town hall the same month.
+	// Assumes _bountyHuntText is already containing the "someone has already" text (pNPCTopics[353]).
+	if (_bountyHuntMonsterId == MONSTER_INVALID)
+		return fmt::format("{::}{}{::}", colorTable.Scarlet.tag(), _bountyHuntText, colorTable.White.tag());
 
     // TODO(captainurist): what do we do with exceptions inside fmt?
     std::string name = fmt::format("{::}{}{::}", colorTable.PaleCanary.tag(), pMonsterStats->infos[_bountyHuntMonsterId].name, colorTable.White.tag());


### PR DESCRIPTION
Fixes #1958. Visuals intentionally differ from original...

Feel free to solve the issue any way you like, this is just a convenience offer.
Also: I hereby authorize anybody with at least Contributor status to pilfer anything I have shown within this account's repos without attibution. Happy to help, but y'all know you way around much better than me, so take what you like and ignore what's BS.

<details><summary>Screenshots</summary>

This PR:
![image](https://github.com/user-attachments/assets/276d0f70-fe51-4958-bd43-4891bd58764e)

Original:
![image](https://github.com/user-attachments/assets/51caed93-0c8a-483b-9ede-028c0232b8ec)

(and no I can't show the entire original screen, wine borks the scaling something bad)
</details>