### PR TITLE
Fix potion mixing

### DIFF
--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -267,7 +267,7 @@ void ItemTable::Initialize(GameResourceManager *resourceManager) {
 void ItemTable::LoadPotions(const Blob &potions) {
     //    char Text[90];
     char *test_string;
-    uint8_t potion_value;
+    ItemId potion_value;
 
     std::vector<char *> tokens;
     std::string txtRaw(potions.string_view());
@@ -290,12 +290,12 @@ void ItemTable::LoadPotions(const Blob &potions) {
         for (ItemId column : Segment(ITEM_FIRST_REAL_POTION, ITEM_LAST_REAL_POTION)) {
             int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
             char *currValue = tokens[flatPotionId + 7];
-            potion_value = atoi(currValue);
-            if (!potion_value && currValue[0] == 'E') {
+            potion_value = (ItemId)atoi(currValue);
+            if (potion_value == ITEM_NULL && currValue[0] == 'E') {
                 // values like "E{x}" represent damage level {x} when using invalid potion combination
-                potion_value = atoi(currValue + 1);
+                potion_value = (ItemId)atoi(currValue + 1);
             }
-            this->potionCombination[row][column] = (ItemId)potion_value;
+            this->potionCombination[row][column] = potion_value;
         }
 
         test_string = strtok(NULL, "\r") + 1;

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -288,12 +288,18 @@ void ItemTable::LoadPotions(const Blob &potions) {
             return;
         }
         for (ItemId column : Segment(ITEM_FIRST_REAL_POTION, ITEM_LAST_REAL_POTION)) {
-            int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
-            char *currValue = tokens[flatPotionId + 7];
-            potion_value = (ItemId)atoi(currValue);
-            if (potion_value == ITEM_NULL && currValue[0] == 'E') {
-                // values like "E{x}" represent damage level {x} when using invalid potion combination
-                potion_value = (ItemId)atoi(currValue + 1);
+            if (row == ITEM_POTION_SHIELD && column == ITEM_POTION_HARDEN_ITEM || column == ITEM_POTION_SHIELD && row == ITEM_POTION_HARDEN_ITEM) {
+                // Fix a vanilla bug that GrayFace fixes in a way OE doesn't see: Mixing a Potion of Water Resistance
+                potion_value = ITEM_POTION_WATER_RESISTANCE;
+            } else {
+                int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
+                char *currValue = tokens[flatPotionId + 7];
+                potion_value = (ItemId)atoi(currValue);
+                if(potion_value == ITEM_NULL && currValue[0] == 'E')
+                {
+                    // values like "E{x}" represent damage level {x} when using invalid potion combination
+                    potion_value = (ItemId)atoi(currValue + 1);
+                }
             }
             this->potionCombination[row][column] = potion_value;
         }

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -294,11 +294,10 @@ void ItemTable::LoadPotions(const Blob &potions) {
             } else {
                 int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
                 char *currValue = tokens[flatPotionId + 7];
-                potion_value = (ItemId)atoi(currValue);
-                if(potion_value == ITEM_NULL && currValue[0] == 'E')
-                {
+                potion_value = static_cast<ItemId>(atoi(currValue));
+                if (potion_value == ITEM_NULL && currValue[0] == 'E') {
                     // values like "E{x}" represent damage level {x} when using invalid potion combination
-                    potion_value = (ItemId)atoi(currValue + 1);
+                    potion_value = static_cast<ItemId>(atoi(currValue + 1));
                 }
             }
             this->potionCombination[row][column] = potion_value;

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -288,17 +288,12 @@ void ItemTable::LoadPotions(const Blob &potions) {
             return;
         }
         for (ItemId column : Segment(ITEM_FIRST_REAL_POTION, ITEM_LAST_REAL_POTION)) {
-            if (row == ITEM_POTION_SHIELD && column == ITEM_POTION_HARDEN_ITEM || column == ITEM_POTION_SHIELD && row == ITEM_POTION_HARDEN_ITEM) {
-                // Fix a vanilla bug that GrayFace fixes in a way OE doesn't see: Mixing a Potion of Water Resistance
-                potion_value = ITEM_POTION_WATER_RESISTANCE;
-            } else {
-                int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
-                char *currValue = tokens[flatPotionId + 7];
-                potion_value = static_cast<ItemId>(atoi(currValue));
-                if (potion_value == ITEM_NULL && currValue[0] == 'E') {
-                    // values like "E{x}" represent damage level {x} when using invalid potion combination
-                    potion_value = static_cast<ItemId>(atoi(currValue + 1));
-                }
+            int flatPotionId = std::to_underlying(column) - std::to_underlying(ITEM_FIRST_REAL_POTION);
+            char *currValue = tokens[flatPotionId + 7];
+            potion_value = static_cast<ItemId>(atoi(currValue));
+            if (potion_value == ITEM_NULL && currValue[0] == 'E') {
+                // values like "E{x}" represent damage level {x} when using invalid potion combination
+                potion_value = static_cast<ItemId>(atoi(currValue + 1));
             }
             this->potionCombination[row][column] = potion_value;
         }

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 07fa51717bbcc06cc999af3d4dc1707ee1d99abd
+        GIT_TAG 1d19ce28fe8aa71817febb50886689e9b9e02c69
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -706,7 +706,7 @@ GAME_TEST(Issues, Issue1977) {
     auto resultTape = tapes.hasItem(ITEM_POTION_WATER_RESISTANCE);
     auto component1Tape = tapes.hasItem(ITEM_POTION_SHIELD);
     auto component2Tape = tapes.hasItem(ITEM_POTION_HARDEN_ITEM);
-    test.playTraceFromTestData("issue_1977.mm7", "issue_1977.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
+    test.playTraceFromTestData("issue_1977.mm7", "issue_1977.json");
     EXPECT_EQ(resultTape, tape(false, true));       // Got a white potion
     EXPECT_EQ(component1Tape, tape(true, false));   // Used up components
     EXPECT_EQ(component2Tape, tape(true, false));

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -698,3 +698,16 @@ GAME_TEST(Issues, Issue1966) {
     // Some rocks should have hit monsters - this is what was triggering the assertion.
     EXPECT_GT(std::ranges::count(spritesTape.flattened(), SPRITE_SPELL_EARTH_ROCK_BLAST_IMPACT), 10);
 }
+
+GAME_TEST(Issues, Issue1977) {
+    // Mix a potion of water resistance: explodes without fix.
+    // Disabling RNG checks on playback to actually see results even if the explosion uses a `grng` call.
+    // Pre-fix output still ignores the EXPECT's below, playTrace terminates comparing character 3's hp.
+    auto resultTape = tapes.hasItem(ITEM_POTION_WATER_RESISTANCE);
+    auto component1Tape = tapes.hasItem(ITEM_POTION_SHIELD);
+    auto component2Tape = tapes.hasItem(ITEM_POTION_HARDEN_ITEM);
+    test.playTraceFromTestData("issue_1977.mm7", "issue_1977.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
+    EXPECT_EQ(resultTape, tape(false, true));       // Got a white potion
+    EXPECT_EQ(component1Tape, tape(true, false));   // Used up components
+    EXPECT_EQ(component2Tape, tape(true, false));
+}


### PR DESCRIPTION
Fixes #1977
Reformatted into separate commits for the two things this does:
* Fixes most potion mixing from fire resistance up by changing `uint8_t` to `ItemId`.
* ~Fixes the Water Resistance recipe using a hardcoded check, as OE doesn't pick up this kind of GrayFace patches.~

<details><summary>Fun i had poking at this</summary>

![image](https://github.com/user-attachments/assets/49a0cbc7-41cf-4d28-afee-e5666986baaf)
![image](https://github.com/user-attachments/assets/c0959a40-ba29-45c4-a73f-c396554be858)

</details>

Q:
* ~cast style? Aren't `ItemId(x)` or `static_cast<ItemId>(x)` the more modern ones? Remember, I learned in the 80es.~
* ~rename variable? to? `mixed_potion`?~