### PR TITLE
Fix enemy AI Meteor Shower bug

### DIFF
--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -347,7 +347,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 sprite.spellCasterAbility = ABILITY_SPELL1;
 
                 spriteId = sprite.Create(yaw, pitch, pObjectList->pObjects[sprite.uObjectDescID].uSpeed, 0);
-                i = grng->random(1024) - 512;
+                j = grng->random(1024) - 512;
                 k = grng->random(1024) - 512;
             }
             if (spriteId != -1) {


### PR DESCRIPTION
Fixes #1972
Facit of analysis (see issue): Can't hurt, matches player's version of the spell, and to actually demo the difference I'd need to do another play-through - or await the LoD map reset..