### PR TITLE
Nicer display of very large party gold amounts

### DIFF
--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -792,7 +792,11 @@ void GameUI_DrawFoodAndGold() {
         text_y = _44100D_should_alter_right_panel() != 0 ? 381 : 322;
 
         pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r087{}", pParty->GetFood()), 0, uGameUIFontShadow);
-        pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", pParty->GetGold()), 0, uGameUIFontShadow);
+        int gold = pParty->GetGold();
+        if (gold < 1000000)
+            pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", gold), 0, uGameUIFontShadow);
+        else
+            pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{:.3f}M", gold * 1e-6), 0, uGameUIFontShadow);
         // force to render all queued text now so it wont be delayed and drawn over things it isn't supposed to, like item in hand or nuklear
         render->EndTextNew();
     }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -784,6 +784,12 @@ void GameUI_DrawRightPanelItems() {
     }
 }
 
+static std::string toCompactString(int value) {
+    std::string result = value < 1000000 ? fmt::format("{}", value) : fmt::format("{:.4g}M", value * 1e-6);
+    assert(result.size() <= 6);
+    return result;
+}
+
 //----- (0041AEBB) --------------------------------------------------------
 void GameUI_DrawFoodAndGold() {
     int text_y;  // esi@2
@@ -791,12 +797,8 @@ void GameUI_DrawFoodAndGold() {
     if (uGameState != GAME_STATE_FINAL_WINDOW) {
         text_y = _44100D_should_alter_right_panel() != 0 ? 381 : 322;
 
-        pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r087{}", pParty->GetFood()), 0, uGameUIFontShadow);
-        int gold = pParty->GetGold();
-        if (gold < 1000000)
-            pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", gold), 0, uGameUIFontShadow);
-        else
-            pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{:.3f}M", gold * 1e-6), 0, uGameUIFontShadow);
+        pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r087{}", toCompactString(pParty->GetFood())), 0, uGameUIFontShadow);
+        pPrimaryWindow->DrawText(assets->pFontSmallnum.get(), {0, text_y}, uGameUIFontMain, fmt::format("\r028{}", toCompactString(pParty->GetGold())), 0, uGameUIFontShadow);
         // force to render all queued text now so it wont be delayed and drawn over things it isn't supposed to, like item in hand or nuklear
         render->EndTextNew();
     }


### PR DESCRIPTION
Very minor, but I noticed: Party gold over a million[^1] starts painting digits outside the mask's box (MM7 does it too).

Before: 
![image](https://github.com/user-attachments/assets/71551c8f-69bc-45f1-9090-f53a80445a3a)

After: 
![image](https://github.com/user-attachments/assets/680ce6f4-3c1c-4c51-b6ea-238cff84b71e)


Bank not affected. The change doesn't completely prevent seeing the exact amount: mouse hover already provides the exact sum of party gold and bank balance, and if you're in the habit of depositing only powers of 10, then the math is easy...

As for code duplication: I'm sure the optimizer will see and take that chance to branch only around the format call, so I didn't bother to do so myself.

[^1]: The Wishing Well in Land of Giants can get you there quickly....