### PR TITLE
Fix potions spawning in chests

### DIFF
--- a/src/Engine/Objects/Item.cpp
+++ b/src/Engine/Objects/Item.cpp
@@ -822,7 +822,7 @@ void Item::postGenerate(ItemSource source) {
     }
 
     if (type() == ITEM_TYPE_POTION && itemId != ITEM_POTION_BOTTLE && potionPower == 0) {
-        if (source == ITEM_SOURCE_MAP) {
+        if (source == ITEM_SOURCE_MAP || source == ITEM_SOURCE_CHEST) {
             potionPower = grng->random(15) + 5;
         } else if (source == ITEM_SOURCE_MONSTER) {
             potionPower = 2 * grng->random(4) + 2; // TODO(captainurist): change to 2d4+2.

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 496315b109e9972e1beaac3f736d4a9e4665f4cd
+        GIT_TAG 7f5d31048eddaa50a96d7b5f6b125955086d3d01
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -22,6 +22,7 @@
 #include "Engine/Graphics/BspRenderer.h"
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Evt/EvtInterpreter.h"
+#include "Engine/Objects/Chest.h"
 
 // 1500
 
@@ -749,8 +750,14 @@ GAME_TEST(Issues, Issue1983) {
 }
 
 GAME_TEST(Issues, Issue1990) {
-    // Test opening the Tularean Forest half-hidden chest, which generates a black potion:
-    EXPECT_NO_THROW(
-        test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
-    );
+    // Test opening the Tularean Forest half-hidden chest, which generates a black potion.
+    auto screenTape = tapes.screen();
+    auto potionTape = tapes.custom([] { return vChests[6].igChestItems[6].itemId; });
+    auto powerTape = tapes.custom([] { return vChests[6].igChestItems[6].potionPower; });
+    test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
+    EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_CHEST)); // We have opened the chest.
+    EXPECT_EQ(potionTape, tape(ITEM_POTION_PURE_MIGHT));
+    EXPECT_EQ(powerTape.front(), 0); // Potion power started as uninitialized.
+    EXPECT_GE(powerTape.back(), 5);
+    EXPECT_LT(powerTape.back(), 20); // Potion power ended as initialized to 5-19.
 }

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -747,3 +747,10 @@ GAME_TEST(Issues, Issue1983) {
     EXPECT_CONTAINS(textsTape.flattened(), [] (std::string_view text) { return text.contains("Water Resistance Recipe") && text.contains("is beyond my meager knowledge"); });
     EXPECT_CONTAINS(textsTape.flattened(), [] (std::string_view text) { return text.contains("Letter from Mr. Stantley") && text.contains("is beyond my meager knowledge"); });
 }
+
+GAME_TEST(Issues, Issue1990) {
+    // Test opening the Tularean Forest half-hidden chest, which generates a black potion:
+    EXPECT_NO_THROW(
+        test.playTraceFromTestData("issue_1990.mm7", "issue_1990.json");
+    );
+}


### PR DESCRIPTION
Fixes #1990
Waits for test data https://github.com/OpenEnroth/OpenEnroth_TestData/pull/69

Say, isn't there a way to properly catch an assert from a game test - such that the long time for the trace dump to console and the core dump is saved? This is selective, but feels a little wrong when it runs in milliseconds with the fix and ten seconds without...
