### PR TITLE
Configurable horizontal displacement of spells cast by the party

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -267,6 +267,10 @@ class GameConfig : public Config {
         Bool DestroyDischargedWands = { this, "destroy_discharged_wands", false,
             "Destroy wands when they reach 0 charges." };
 
+        // Previous versions used a hardcoded distance of 16 per character
+        Float SpellSourceDisplacement = {this, "party_spell_displacement", 16.0f, &ValidateSpellSourceDisplacement,
+             "Determines how far the visual source of a spell cast by a party member is displaced horizontally, per party member."};
+
      private:
         static int ValidateMaxFlightHeight(int max_flight_height) {
             if (max_flight_height <= 0 || max_flight_height > 16192)
@@ -309,6 +313,9 @@ class GameConfig : public Config {
         }
         static int ValidateMaxActiveAIActors(int num) {
             return std::clamp(num, 30, 500);
+        }
+        static float ValidateSpellSourceDisplacement(float num) {
+            return std::clamp(num, 0.0f, 50.0f);
         }
     };
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -923,16 +923,17 @@ void Actor::GetDirectionInfo(Pid uObj1ID, Pid uObj2ID,
         }
         case OBJECT_Character: {
             out1 = pParty->pos + Vec3f(0, 0, pParty->height / 3);
+            float displace = engine->config->gameplay.SpellSourceDisplacement.value();
             if (id1 == 0) {
                 // Do nothing.
             } else if (id1 == 4) {
-                out1 += Vec3f::fromPolar(24, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3f::fromPolar(displace * 1.5f, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
             } else if (id1 == 3) {
-                out1 += Vec3f::fromPolar(8, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3f::fromPolar(displace * 0.5f, pParty->_viewYaw - TrigLUT.uIntegerHalfPi, 0);
             } else if (id1 == 2) {
-                out1 += Vec3f::fromPolar(8, pParty->_viewYaw + TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3f::fromPolar(displace * 0.5f, pParty->_viewYaw + TrigLUT.uIntegerHalfPi, 0);
             } else if (id1 == 1) {
-                out1 += Vec3f::fromPolar(24, pParty->_viewYaw + TrigLUT.uIntegerHalfPi, 0);
+                out1 += Vec3f::fromPolar(displace * 1.5f, pParty->_viewYaw + TrigLUT.uIntegerHalfPi, 0);
             }
             break;
         }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -75,20 +75,21 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
     _lastParticleTime = pMiscTimer->time();
 
     // move sprite so it looks like it originates from char portrait
+    float displace = engine->config->gameplay.SpellSourceDisplacement.value();
     switch (which_char) {
         case 0:
             break;  // do nothing
         case 1:
-            vPosition += Vec3f::fromPolar(24, uFacing + TrigLUT.uIntegerHalfPi, 0);
+            vPosition += Vec3f::fromPolar(displace * 1.5f, uFacing + TrigLUT.uIntegerHalfPi, 0);
             break;
         case 2:
-            vPosition += Vec3f::fromPolar(8, uFacing + TrigLUT.uIntegerHalfPi, 0);
+            vPosition += Vec3f::fromPolar(displace * 0.5f, uFacing + TrigLUT.uIntegerHalfPi, 0);
             break;
         case 3:
-            vPosition += Vec3f::fromPolar(8, uFacing - TrigLUT.uIntegerHalfPi, 0);
+            vPosition += Vec3f::fromPolar(displace * 0.5f, uFacing - TrigLUT.uIntegerHalfPi, 0);
             break;
         case 4:
-            vPosition += Vec3f::fromPolar(24, uFacing - TrigLUT.uIntegerHalfPi, 0);
+            vPosition += Vec3f::fromPolar(displace * 1.5f, uFacing - TrigLUT.uIntegerHalfPi, 0);
             break;
         default:
             assert(false);


### PR DESCRIPTION
Closes #1959 

By default nothing changes - I would prefer a default of 10 per character (-15,-5,5-15 instead of -24,-8,8,24), but didn't want to endanger game tests.

<details><summary>Screenies</summary>

![image](https://github.com/user-attachments/assets/27e51c2b-d343-4c00-a2bd-49b3dd01ba7f)
![image](https://github.com/user-attachments/assets/07f447da-b555-46a9-a3ff-5e0be3e9a898)
![image](https://github.com/user-attachments/assets/3e4f0223-0d88-4652-8135-137a91ecde9f)
![image](https://github.com/user-attachments/assets/c1000a52-0ee7-478d-92d4-995c2c36a2b4)
![image](https://github.com/user-attachments/assets/12c1bb62-2a91-4d9d-9146-c92c5758df6b)
![image](https://github.com/user-attachments/assets/b7626555-ad0d-4711-9bfd-1ce8f4f745c6)

</details>

OK maybe that comment line 270 is redundant.