### PR TITLE
Replace any Spirit Lash cast by monsters with Bless

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -582,12 +582,18 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
         }
     }
 
-    if (engine->_currentLoadedMapId == MapId::MAP_LINCOLN) {
-        // reduce maximum allowed radius in the Lincoln to stop act actors getting stuck in tight corridors
-        for (auto& act : pActors) {
-            act.radius = std::min(act.radius, static_cast<uint16_t>(140));
+    // OE fix - reduce maximum allowed radius in the Lincoln to stop act actors getting stuck in tight corridors.
+    if (engine->_currentLoadedMapId == MAP_LINCOLN) {
+        for (Actor& actor : pActors) {
+            actor.radius = std::min(actor.radius, static_cast<uint16_t>(140));
         }
     }
+
+    // OE fix - replace spirit lash with bless for clerics of the moon in the temple of baa.
+    if (engine->_currentLoadedMapId == MAP_TEMPLE_OF_BAA)
+        for (Actor& actor : pActors)
+            if (actor.monsterInfo.spell2Id == SPELL_SPIRIT_SPIRIT_LASH)
+                actor.monsterInfo.spell2Id = SPELL_SPIRIT_BLESS;
 
     bDialogueUI_InitializeActor_NPC_ID = 0;
     engine->_transitionMapId = MAP_INVALID;

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 7f5d31048eddaa50a96d7b5f6b125955086d3d01
+        GIT_TAG 24a41e14236f91ea33d3a91dddea59b5d20578f8
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -761,3 +761,14 @@ GAME_TEST(Issues, Issue1990) {
     EXPECT_GE(powerTape.back(), 5);
     EXPECT_LT(powerTape.back(), 20); // Potion power ended as initialized to 5-19.
 }
+
+GAME_TEST(Issues, Issue1997) {
+    // Temple of Baa Clerics casting Spirit Lash did trigger assert.
+    // We've replaced spirit lash with bless.
+    auto blessTape = actorTapes.countByBuff(ACTOR_BUFF_BLESS);
+    auto mapTape = tapes.map();
+    test.playTraceFromTestData("issue_1997.mm7", "issue_1997.json");
+    EXPECT_EQ(mapTape, tape(MAP_TEMPLE_OF_BAA));
+    EXPECT_EQ(blessTape.front(), 0);
+    EXPECT_GT(blessTape.back(), 0); // Bless was cast at least once.
+}


### PR DESCRIPTION
... all kudos to @pskelton who found out the Clerics of the Moon have that spell deviating from their standard definition, which has Bless.

Fixes #1997 

Needs test data: https://github.com/OpenEnroth/OpenEnroth_TestData/pull/73