### PR TITLE
LUA console config list and reset, and improved set/get/toggle

### DIFF
--- a/resources/scripts/_definitions/def_common.lua
+++ b/resources/scripts/_definitions/def_common.lua
@@ -38,21 +38,19 @@
 
 --- CONFIG Bindings
 
---- @class ConfigInfo
---- @field section string
---- @field name string
---- @field description string
+--- @class ConfigEntry
 --- @field value string
 --- @field default string
+--- @field name string
+--- @field section string
+--- @field description string
+--- @field path string
+--- @field reset fun()
+--- @field toggle fun()
 
 --- @class ConfigBindings
---- @field locateEntry fun(param1: string, param2?: string): any
---- @field setEntryValue fun(entry: any, value: string)
---- @field resetEntryValue fun(entry: any)
---- @field toggleEntryValue fun(entry: any)
---- @field entryValue fun(entry: any): string
---- @field entryPath fun(entry: any): string
---- @field listEntries fun(sectionName: string, filter: string): ConfigInfo[]
+--- @field entry fun(param1: string, param2?: string): ConfigEntry
+--- @field list fun(sectionName: string, filter: string): ConfigEntry[]
 
 --- OVERLAY Bindings
 --- @class Overlay

--- a/resources/scripts/_definitions/def_common.lua
+++ b/resources/scripts/_definitions/def_common.lua
@@ -38,9 +38,19 @@
 
 --- CONFIG Bindings
 
+--- @class ConfigInfo
+--- @field section string
+--- @field name string
+--- @field type string
+--- @field description string
+--- @field value string
+--- @field default string
+
 --- @class ConfigBindings
 --- @field setConfig fun(section: string, configName: string, value: any)
 --- @field getConfig fun(section: string, configName?: string): string
+--- @field resetConfig fun(section: string, configName?: string): string?
+--- @field listConfigs fun(section: string, filter: string): table<ConfigInfo>
 
 --- OVERLAY Bindings
 --- @class Overlay

--- a/resources/scripts/_definitions/def_common.lua
+++ b/resources/scripts/_definitions/def_common.lua
@@ -41,16 +41,18 @@
 --- @class ConfigInfo
 --- @field section string
 --- @field name string
---- @field type string
 --- @field description string
 --- @field value string
 --- @field default string
 
 --- @class ConfigBindings
---- @field setConfig fun(section: string, configName: string, value: any)
---- @field getConfig fun(section: string, configName?: string): string
---- @field resetConfig fun(section: string, configName?: string): string?
---- @field listConfigs fun(section: string, filter: string): table<ConfigInfo>
+--- @field locateEntry fun(param1: string, param2?: string): any
+--- @field setEntryValue fun(entry: any, value: string)
+--- @field resetEntryValue fun(entry: any)
+--- @field toggleEntryValue fun(entry: any)
+--- @field entryValue fun(entry: any): string
+--- @field entryPath fun(entry: any): string
+--- @field listEntries fun(sectionName: string, filter: string): ConfigInfo[]
 
 --- OVERLAY Bindings
 --- @class Overlay

--- a/resources/scripts/dev/cheat_command_overlay.lua
+++ b/resources/scripts/dev/cheat_command_overlay.lua
@@ -46,7 +46,7 @@ local function createCheatCommandEntry(configValue)
     if arguments[1] == "config" and arguments[2] == "toggle" then
         local configName = arguments[3]
         drawFunction = function (entry)
-            local valueString = Config.entryValue(Config.locateEntry(configName))
+            local valueString = Config.entry(configName).value
             local color = Utilities.toBoolean(valueString) and enabledColor or disabledColor
             imgui.pushStyleColor(imgui.ImGuiCol.ButtonHovered, color.r, color.g, color.b, color.a)
             color = Utilities.toBoolean(valueString) and enabledHoveredColor or disabledHoveredColor
@@ -69,7 +69,7 @@ end
 CheatOverlay.init = function ()
     local numberOfCommands = 40
     for i = 1, numberOfCommands do
-        local command = Config.entryValue(Config.locateEntry("cheat_commands", string.format("command%02d", i)))
+        local command = Config.entry("cheat_commands", string.format("command%02d", i)).value
         if command and not Utilities.isEmpty(command) then
             table.insert(availableCommands, createCheatCommandEntry(command))
         end

--- a/resources/scripts/dev/cheat_command_overlay.lua
+++ b/resources/scripts/dev/cheat_command_overlay.lua
@@ -46,7 +46,7 @@ local function createCheatCommandEntry(configValue)
     if arguments[1] == "config" and arguments[2] == "toggle" then
         local configName = arguments[3]
         drawFunction = function (entry)
-            local valueString = Config.getConfig(configName)
+            local valueString = Config.entryValue(Config.locateEntry(configName))
             local color = Utilities.toBoolean(valueString) and enabledColor or disabledColor
             imgui.pushStyleColor(imgui.ImGuiCol.ButtonHovered, color.r, color.g, color.b, color.a)
             color = Utilities.toBoolean(valueString) and enabledHoveredColor or disabledHoveredColor
@@ -69,7 +69,7 @@ end
 CheatOverlay.init = function ()
     local numberOfCommands = 40
     for i = 1, numberOfCommands do
-        local command = Config.getConfig("cheat_commands", string.format("command%02d", i))
+        local command = Config.entryValue(Config.locateEntry("cheat_commands", string.format("command%02d", i)))
         if command and not Utilities.isEmpty(command) then
             table.insert(availableCommands, createCheatCommandEntry(command))
         end

--- a/resources/scripts/dev/commands/command_manager.lua
+++ b/resources/scripts/dev/commands/command_manager.lua
@@ -70,7 +70,7 @@ local CommandManager = {
                 local par = #params > 0 and params[1] or "default"
                 local newCallback = callback[par]
                 if newCallback == nil then
-                    local message = "Invalid parameter at position " .. index .. " - Here's a list of valid values:\n"
+                    local message = "Invalid parameter '" .. par .. "' at position " .. index .. " - Here's a list of valid values:\n"
                     for key, _ in pairs(callback) do
                         if key ~= "default" then
                             message = message .. key .. "\n"

--- a/resources/scripts/dev/commands/config_command.lua
+++ b/resources/scripts/dev/commands/config_command.lua
@@ -8,11 +8,11 @@ local Config = require "bindings.config"
 local function getConfig(param1, param2)
     local entry = nil
     if param2 == nil then
-        entry = Config.locateEntry(param1)
+        entry = Config.entry(param1)
     else
-        entry = Config.locateEntry(param1, param2)
+        entry = Config.entry(param1, param2)
     end
-    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
+    return entry.path .. ": " .. entry.value, true
 end
 
 ---Change the value of the configEntry
@@ -25,14 +25,14 @@ local function setConfig(param1, param2, param3)
     local entry = nil
     local value = ""
     if param3 == nil then
-        entry = Config.locateEntry(param1)
+        entry = Config.entry(param1)
         value = param2
     else
-        entry = Config.locateEntry(param1, param2)
+        entry = Config.entry(param1, param2)
         value = param3
     end
-    Config.setEntryValue(entry, value)
-    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
+    entry.value = value
+    return entry.path .. ": " .. entry.value, true
 end
 
 ---Reset the value of a configEntry to its default
@@ -43,12 +43,12 @@ end
 local function resetConfig(param1, param2)
     local entry = nil
     if param2 == nil then
-        entry = Config.locateEntry(param1)
+        entry = Config.entry(param1)
     else
-        entry = Config.locateEntry(param1, param2)
+        entry = Config.entry(param1, param2)
     end
-    Config.resetEntryValue(entry)
-    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
+    entry:reset()
+    return entry.path .. ": " .. entry.value, true
 end
 
 ---Toggle the boolean config value
@@ -59,12 +59,12 @@ end
 local function toggleConfig(param1, param2)
     local entry = nil
     if param2 == nil then
-        entry = Config.locateEntry(param1)
+        entry = Config.entry(param1)
     else
-        entry = Config.locateEntry(param1, param2)
+        entry = Config.entry(param1, param2)
     end
-    Config.toggleEntryValue(entry)
-    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
+    entry:toggle()
+    return entry.path .. ": " .. entry.value, true
 end
 
 ---List all matching configEntries
@@ -75,11 +75,11 @@ end
 local function listConfigs(param1, param2)
     local matches = nil
     if param1 == nil then
-        matches = Config.listEntries("", "")
+        matches = Config.list("", "")
     elseif param2 == nil then
-        matches = Config.listEntries("", param1)
+        matches = Config.list("", param1)
     else
-        matches = Config.listEntries(param1, param2)
+        matches = Config.list(param1, param2)
     end
 
     local count = #matches
@@ -87,20 +87,20 @@ local function listConfigs(param1, param2)
     if count == 0 then
         return "No matches", false
     elseif count == 1 then
-        local config = matches[1]
-        message = message .. "section: " .. config.section .. "\n"
-        message = message .. "name: " .. config.name .. "\n"
-        message = message .. "description: " .. config.description .. "\n"
-        message = message .. "default: " .. config.default .. "\n"
-        message = message .. "value: " .. config.value .. "\n"
+        local entry = matches[1]
+        message = message .. "section: " .. entry.section .. "\n"
+        message = message .. "name: " .. entry.name .. "\n"
+        message = message .. "description: " .. entry.description .. "\n"
+        message = message .. "default: " .. entry.default .. "\n"
+        message = message .. "value: " .. entry.value .. "\n"
     else
         local sectionHeader = nil
-        for _, config in pairs(matches) do
-            if (config.section ~= sectionHeader) then
-                sectionHeader = config.section
+        for _, entry in pairs(matches) do
+            if (entry.section ~= sectionHeader) then
+                sectionHeader = entry.section
                 message = message .. "[" .. sectionHeader .. "]\n"
             end
-            message = message .. "  " .. config.name .. ": " .. config.value .. "\n"
+            message = message .. "  " .. entry.name .. ": " .. entry.value .. "\n"
         end
     end
     return message, true

--- a/resources/scripts/dev/commands/config_command.lua
+++ b/resources/scripts/dev/commands/config_command.lua
@@ -11,12 +11,12 @@ local function getConfig(param1, param2)
     local message = ""
     if param2 ~= nil then
         value = Config.getConfig(param1, param2)
-        message = param1 .. "." .. param2 .. ": "
+        message = param1 .. "." .. param2
     else
         value = Config.getConfig(param1)
-        message = param1 .. ": "
+        message = param1
     end
-    return message .. tostring(value), true
+    return message .. ": " .. value, true
 end
 
 ---Change the value of the configEntry
@@ -31,34 +31,138 @@ local function setConfig(param1, param2, param3)
     if param3 ~= nil then
         Config.setConfig(param1, param2, param3)
         value = Config.getConfig(param1, param2)
-        message = param1 .. "." .. param2 .. ": "
+        message = param1 .. "." .. param2
     else
         Config.setConfig(param1, param2)
         value = Config.getConfig(param1)
-        message = param1 .. ": "
+        message = param1
     end
-    return message .. tostring(value), true
+    return message .. ": " .. tostring(value), true
 end
 
 ---Toggle the boolean config value
----@param entry string       - name of the config entry
+---@param param1 string      - config entry name OR config section name
+---@param param2? string      - config entry name if you are passing in section name as the first parameter, nil otherwise
 ---@return string            - the message sent back to the console
 ---@return boolean           - flag that tells if the command has been successful
-local function toggleConfig(entry)
-    local currentValueStr = Config.getConfig(entry)
-    local value = Utilities.toBoolean(currentValueStr)
-    return setConfig(entry, tostring(not value))
+local function toggleConfig(param1, param2)
+    local currentValueStr = ""
+    local message = ""
+    local configInfo = nil
+    if param2 ~= nil then
+        currentValueStr = Config.getConfig(param1, param2)
+        configInfo = Config.listConfigs(param1, param2)
+        message = param1 .. "." .. param2
+    else
+        currentValueStr = Config.getConfig(param1)
+        configInfo = Config.listConfigs(param1, "")
+        message = param1
+    end
+
+    if configInfo[1].type ~= "boolean" then
+        return message .. " is not a boolean!", false
+    end
+
+    local value = tostring(not Utilities.toBoolean(currentValueStr))
+    if param2 ~= nil then
+        return setConfig(param1, param2, value)
+    else
+        return setConfig(param1, value)
+    end
+end
+
+---Reset the value of a configEntry to its default
+---@param param1 string      - config entry name OR config section name
+---@param param2? string      - config entry name if you are passing in section name as the first parameter, new value otherwise
+---@return string            - the message sent back to the console
+---@return boolean           - flag that tells if the command has been successful
+local function resetConfig(param1, param2)
+    local oldValue = nil
+    local newValue = nil
+    local message = ""
+    if param2 ~= nil then
+        oldValue = Config.getConfig(param1, param2)
+        newValue = Config.resetConfig(param1, param2)
+        message = param1 .. "." .. param2
+    else
+        oldValue = Config.getConfig(param1)
+        newValue = Config.resetConfig(param1)
+        message = param1
+    end
+    return message .. ": " .. tostring(oldValue) .. " -> " .. tostring(newValue), true
+end
+
+---List all matching configEntries
+---@param param1? string     - partial name or value of the config entry OR section of the config entry
+---@param param2? string    - partial name or value of the config entry if you are passing in section name as the first parameter
+---@return string            - the message sent back to the console
+---@return boolean           - flag that tells if any entries were found
+local function listConfigs(param1, param2)
+    local message = ""
+    if not param1 then
+        param1 = ""
+    end
+    if not param2 then
+        param2 = ""
+    end
+    local matches = Config.listConfigs(param1, param2)
+    local count = #matches
+    if count == 0 then
+        return "No matches", false
+    elseif count == 1 then
+        local config = matches[1]
+        message = message .. "section: " .. config.section .. "\n"
+        message = message .. "name: " .. config.name .. "\n"
+        message = message .. "type: " .. config.type .. "\n"
+        message = message .. "description: " .. config.description .. "\n"
+        message = message .. "default: " .. config.default .. "\n"
+        message = message .. "value: " .. config.value .. "\n"
+    else
+        local sectionHeader = nil
+        for _, config in pairs(matches) do
+            if (config.section ~= sectionHeader) then
+                sectionHeader = config.section
+                message = message .. "[" .. sectionHeader .. "]\n"
+            end
+            message = message .. "  " .. config.name .. ": " .. config.value .. "\n"
+        end
+    end
+    return message, true
 end
 
 local subCommands = {
     get = getConfig,
     set = setConfig,
     toggle = toggleConfig,
+    reset = resetConfig,
+    list = listConfigs,
 }
 
 return {
     name = "config",
-    description = "Change any game config value.",
-    details = "",
+    description = "Show or change any game config value.",
+    details = [[
+'get', 'set', 'reset' and 'toggle' require an exact name of a
+    config entry, optionally prefixed by the section name.
+    When the section is omitted and the entry name exists in
+    several sections, the choice is by internal ordering.
+'set' requires an additional parameter for the value,
+    which MUST be convertible to the appropriate type.
+'list' accepts an optional filter prefixed by an optional section
+       name. Specifying a section limits the filter (which can
+       still be omitted) to that section, otherwise the filter
+       is applied to all settings.
+    The filter can can be:
+    - missing to list an entire section / all settings,
+    - an exact value (quoting string or enum values)
+      to list all settings having that value,
+    - 'default' or '!default'
+      to filter by settings that are at their default or not,
+    - or a partial config entry name (unquoted)
+      to list all matching settings.
+    All matches are listed by section headers,
+        unless the match is unique, in which case
+        all attributes of the entry are listed.
+]],
     callback = subCommands
 }

--- a/resources/scripts/dev/commands/config_command.lua
+++ b/resources/scripts/dev/commands/config_command.lua
@@ -1,5 +1,4 @@
 local Config = require "bindings.config"
-local Utilities = require "utils"
 
 ---Get the value of a configEntry
 ---@param param1 string         - config entry name OR config section name
@@ -7,16 +6,13 @@ local Utilities = require "utils"
 ---@return string               - the message sent back to the console
 ---@return boolean              - flag that tells if the command has been successful
 local function getConfig(param1, param2)
-    local value = nil
-    local message = ""
-    if param2 ~= nil then
-        value = Config.getConfig(param1, param2)
-        message = param1 .. "." .. param2
+    local entry = nil
+    if param2 == nil then
+        entry = Config.locateEntry(param1)
     else
-        value = Config.getConfig(param1)
-        message = param1
+        entry = Config.locateEntry(param1, param2)
     end
-    return message .. ": " .. value, true
+    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
 end
 
 ---Change the value of the configEntry
@@ -26,94 +22,74 @@ end
 ---@return string            - the message sent back to the console
 ---@return boolean           - flag that tells if the command has been successful
 local function setConfig(param1, param2, param3)
-    local value = nil
-    local message = ""
-    if param3 ~= nil then
-        Config.setConfig(param1, param2, param3)
-        value = Config.getConfig(param1, param2)
-        message = param1 .. "." .. param2
+    local entry = nil
+    local value = ""
+    if param3 == nil then
+        entry = Config.locateEntry(param1)
+        value = param2
     else
-        Config.setConfig(param1, param2)
-        value = Config.getConfig(param1)
-        message = param1
+        entry = Config.locateEntry(param1, param2)
+        value = param3
     end
-    return message .. ": " .. tostring(value), true
-end
-
----Toggle the boolean config value
----@param param1 string      - config entry name OR config section name
----@param param2? string      - config entry name if you are passing in section name as the first parameter, nil otherwise
----@return string            - the message sent back to the console
----@return boolean           - flag that tells if the command has been successful
-local function toggleConfig(param1, param2)
-    local currentValueStr = ""
-    local message = ""
-    local configInfo = nil
-    if param2 ~= nil then
-        currentValueStr = Config.getConfig(param1, param2)
-        configInfo = Config.listConfigs(param1, param2)
-        message = param1 .. "." .. param2
-    else
-        currentValueStr = Config.getConfig(param1)
-        configInfo = Config.listConfigs(param1, "")
-        message = param1
-    end
-
-    if configInfo[1].type ~= "boolean" then
-        return message .. " is not a boolean!", false
-    end
-
-    local value = tostring(not Utilities.toBoolean(currentValueStr))
-    if param2 ~= nil then
-        return setConfig(param1, param2, value)
-    else
-        return setConfig(param1, value)
-    end
+    Config.setEntryValue(entry, value)
+    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
 end
 
 ---Reset the value of a configEntry to its default
 ---@param param1 string      - config entry name OR config section name
----@param param2? string      - config entry name if you are passing in section name as the first parameter, new value otherwise
+---@param param2? string     - config entry name if you are passing in section name as the first parameter, nil otherwise
 ---@return string            - the message sent back to the console
 ---@return boolean           - flag that tells if the command has been successful
 local function resetConfig(param1, param2)
-    local oldValue = nil
-    local newValue = nil
-    local message = ""
-    if param2 ~= nil then
-        oldValue = Config.getConfig(param1, param2)
-        newValue = Config.resetConfig(param1, param2)
-        message = param1 .. "." .. param2
+    local entry = nil
+    if param2 == nil then
+        entry = Config.locateEntry(param1)
     else
-        oldValue = Config.getConfig(param1)
-        newValue = Config.resetConfig(param1)
-        message = param1
+        entry = Config.locateEntry(param1, param2)
     end
-    return message .. ": " .. tostring(oldValue) .. " -> " .. tostring(newValue), true
+    Config.resetEntryValue(entry)
+    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
+end
+
+---Toggle the boolean config value
+---@param param1 string      - config entry name OR config section name
+---@param param2? string     - config entry name if you are passing in section name as the first parameter, nil otherwise
+---@return string            - the message sent back to the console
+---@return boolean           - flag that tells if the command has been successful
+local function toggleConfig(param1, param2)
+    local entry = nil
+    if param2 == nil then
+        entry = Config.locateEntry(param1)
+    else
+        entry = Config.locateEntry(param1, param2)
+    end
+    Config.toggleEntryValue(entry)
+    return Config.entryPath(entry) .. ": " .. Config.entryValue(entry), true
 end
 
 ---List all matching configEntries
 ---@param param1? string     - partial name or value of the config entry OR section of the config entry
----@param param2? string    - partial name or value of the config entry if you are passing in section name as the first parameter
+---@param param2? string     - partial name or value of the config entry if you are passing in section name as the first parameter
 ---@return string            - the message sent back to the console
 ---@return boolean           - flag that tells if any entries were found
 local function listConfigs(param1, param2)
-    local message = ""
-    if not param1 then
-        param1 = ""
+    local matches = nil
+    if param1 == nil then
+        matches = Config.listEntries("", "")
+    elseif param2 == nil then
+        matches = Config.listEntries("", param1)
+    else
+        matches = Config.listEntries(param1, param2)
     end
-    if not param2 then
-        param2 = ""
-    end
-    local matches = Config.listConfigs(param1, param2)
+
     local count = #matches
+    local message = ""
     if count == 0 then
         return "No matches", false
     elseif count == 1 then
         local config = matches[1]
         message = message .. "section: " .. config.section .. "\n"
         message = message .. "name: " .. config.name .. "\n"
-        message = message .. "type: " .. config.type .. "\n"
         message = message .. "description: " .. config.description .. "\n"
         message = message .. "default: " .. config.default .. "\n"
         message = message .. "value: " .. config.value .. "\n"

--- a/src/Scripting/ConfigBindings.cpp
+++ b/src/Scripting/ConfigBindings.cpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <string>
 #include <ranges>
+#include <vector>
 
 #include "Engine/Engine.h"
 
@@ -12,7 +13,11 @@
 sol::table ConfigBindings::createBindingTable(sol::state_view &solState) const {
     return solState.create_table_with(
         "setConfig", sol::overload(setConfigValue1, setConfigValue2),
-        "getConfig", sol::overload(configValue1, configValue2)
+        "getConfig", sol::overload(configValue1, configValue2),
+        "resetConfig", sol::overload(resetConfigValue1, resetConfigValue2),
+        "listConfigs", sol::as_function([&solState](const char *section, const char *filter) {
+                return listConfigValues(solState, section, filter);
+            })
     );
 }
 
@@ -62,4 +67,104 @@ AnyConfigEntry *ConfigBindings::locateEntry2(std::string_view entryName) {
     }
 
     return entries[0];
+}
+
+std::optional<std::string> ConfigBindings::resetConfigValue1(std::string_view sectionName, std::string_view entryName) {
+    ConfigSection *section = engine->config->section(sectionName);
+    if (!section)
+        return std::nullopt;
+
+    AnyConfigEntry *configEntry = section->entry(entryName);
+    if (!configEntry)
+        return std::nullopt;
+
+    configEntry->setValue(configEntry->defaultValue());
+    return configEntry->defaultString();
+}
+
+std::optional<std::string> ConfigBindings::resetConfigValue2(std::string_view entryName) {
+    for (auto &&section : engine->config->sections()) {
+        AnyConfigEntry *configEntry = section->entry(entryName);
+        if (configEntry != nullptr) {
+            configEntry->setValue(configEntry->defaultValue());
+            return configEntry->defaultString();
+        }
+    }
+
+    return std::nullopt;
+}
+
+sol::table ConfigBindings::listConfigValues(sol::state_view &solState, std::string_view sectionName, std::string_view filter) {
+    sol::table result = solState.create_table();
+    for (AnyConfigEntry *entry : findConfigEntries(sectionName, filter)) {
+        result.add(solState.create_table_with(
+                "section", entry->section()->name(),
+                "name", entry->name(),
+                "type", configEntryTypeName(entry),
+                "description", entry->description(),
+                "value", entry->string(),
+                "default", entry->defaultString()
+        ));
+    }
+    return result;
+}
+
+std::vector<AnyConfigEntry *> ConfigBindings::findConfigEntries(std::string_view sectionName, std::string_view filter) {
+    std::vector<AnyConfigEntry *> result;
+    ConfigSection *sectionFilter = nullptr;
+    std::string valueFilter;
+    bool defaultFilter, filterByDefault = false, filterByName = false;
+    std::string name(filter.empty() ? sectionName : filter);
+
+    if (!sectionName.empty()) {
+        for (ConfigSection *section : engine->config->sections()) {
+            if (section->name() == sectionName) {
+                sectionFilter = section;
+                if (filter.empty()) name = "";  // sectionFilter was actually the section name, so no name/value filtering within sectionFilter
+                break;
+            }
+        }
+    }
+
+    if (name.empty()) {
+        // Ensure numeric test below is skipped
+    } else if (name == "default") {
+        defaultFilter = true;
+        filterByDefault = true;
+    } else if (name == "!default") {
+        defaultFilter = false;
+        filterByDefault = true;
+    } else if (name == "false" || name == "true") {
+        valueFilter = name;
+    } else if (name.starts_with('"') && name.ends_with('"')) {
+        valueFilter = name.substr(1, name.size() - 2);
+    } else if (name.find_first_not_of("0123456789") == std::string::npos) {
+        valueFilter = name;
+    } else {
+        filterByName = true;
+    }
+
+    for (ConfigSection *section : engine->config->sections()) {
+        if (sectionFilter && section != sectionFilter)
+            continue;
+        for (AnyConfigEntry *entry : section->entries()) {
+            if (filterByDefault && (entry->string() == entry->defaultString()) != defaultFilter)
+                continue;
+            if (filterByName && entry->name().find(name) == std::string::npos)
+                continue;
+            if (!valueFilter.empty() && entry->string() != valueFilter)
+                continue;
+            result.emplace_back(entry);
+        }
+    }
+    return result;
+}
+
+std::string ConfigBindings::configEntryTypeName(AnyConfigEntry *entry) {
+    if (entry->type() == typeid(bool)) return "boolean";
+    if (entry->type() == typeid(int)) return "integer";
+    if (entry->type() == typeid(float)) return "float";
+    if (entry->type() == typeid(std::string)) return "string";
+    if (entry->type() == typeid(PlatformKey)) return "key";
+    return "unknown";
 }

--- a/src/Scripting/ConfigBindings.cpp
+++ b/src/Scripting/ConfigBindings.cpp
@@ -12,44 +12,29 @@
 
 sol::table ConfigBindings::createBindingTable(sol::state_view &solState) const {
     return solState.create_table_with(
-        "setConfig", sol::overload(setConfigValue1, setConfigValue2),
-        "getConfig", sol::overload(configValue1, configValue2),
-        "resetConfig", sol::overload(resetConfigValue1, resetConfigValue2),
-        "listConfigs", sol::as_function([&solState](const char *section, const char *filter) {
-                return listConfigValues(solState, section, filter);
-            })
+        "locateEntry", sol::overload(&locateConfigEntry1, &locateConfigEntry2),
+        "setEntryValue", &setEntryValue,
+        "resetEntryValue", resetEntryValue,
+        "toggleEntryValue", toggleEntryValue,
+        "entryValue", &entryValue,
+        "entryPath", &entryPath,
+        "listEntries", sol::as_function([solState] (std::optional<std::string_view> sectionName, std::optional<std::string_view> filter) mutable {
+            sol::table result = solState.create_table();
+            for (AnyConfigEntry *entry : listEntries(sectionName ? *sectionName : "", filter ? *filter : "")) {
+                result.add(solState.create_table_with(
+                    "section", entry->section()->name(),
+                    "name", entry->name(),
+                    "description", entry->description(),
+                    "value", entry->string(),
+                    "default", entry->defaultString()
+                ));
+            }
+            return result;
+        })
     );
 }
 
-void ConfigBindings::setConfigValue1(std::string_view sectionName, std::string_view entryName, std::string_view value) {
-    locateEntry1(sectionName, entryName)->setString(value);
-}
-
-void ConfigBindings::setConfigValue2(std::string_view entryName, std::string_view value) {
-    locateEntry2(entryName)->setString(value);
-}
-
-std::string ConfigBindings::configValue1(std::string_view sectionName, std::string_view entryName) {
-    return locateEntry1(sectionName, entryName)->string();
-}
-
-std::string ConfigBindings::configValue2(std::string_view entryName) {
-    return locateEntry2(entryName)->string();
-}
-
-AnyConfigEntry *ConfigBindings::locateEntry1(std::string_view sectionName, std::string_view entryName) {
-    ConfigSection *section = engine->config->section(sectionName);
-    if (!section)
-        throw Exception("Can't find config section '{}'", sectionName);
-
-    AnyConfigEntry *entry = section->entry(entryName);
-    if (!entry)
-        throw Exception("Can't find config entry '{}.{}'", sectionName, entryName);
-
-    return entry;
-}
-
-AnyConfigEntry *ConfigBindings::locateEntry2(std::string_view entryName) {
+AnyConfigEntry *ConfigBindings::locateConfigEntry1(std::string_view entryName) {
     gch::small_vector<AnyConfigEntry *, 16> entries;
 
     for (const ConfigSection *section : engine->config->sections())
@@ -69,102 +54,74 @@ AnyConfigEntry *ConfigBindings::locateEntry2(std::string_view entryName) {
     return entries[0];
 }
 
-std::optional<std::string> ConfigBindings::resetConfigValue1(std::string_view sectionName, std::string_view entryName) {
+AnyConfigEntry *ConfigBindings::locateConfigEntry2(std::string_view sectionName, std::string_view entryName) {
     ConfigSection *section = engine->config->section(sectionName);
     if (!section)
-        return std::nullopt;
+        throw Exception("Can't find config section '{}'", sectionName);
 
-    AnyConfigEntry *configEntry = section->entry(entryName);
-    if (!configEntry)
-        return std::nullopt;
+    AnyConfigEntry *entry = section->entry(entryName);
+    if (!entry)
+        throw Exception("Can't find config entry '{}.{}'", sectionName, entryName);
 
-    configEntry->setValue(configEntry->defaultValue());
-    return configEntry->defaultString();
+    return entry;
 }
 
-std::optional<std::string> ConfigBindings::resetConfigValue2(std::string_view entryName) {
-    for (auto &&section : engine->config->sections()) {
-        AnyConfigEntry *configEntry = section->entry(entryName);
-        if (configEntry != nullptr) {
-            configEntry->setValue(configEntry->defaultValue());
-            return configEntry->defaultString();
-        }
-    }
-
-    return std::nullopt;
+void ConfigBindings::setEntryValue(AnyConfigEntry *entry, std::string_view value) {
+    if (!entry)
+        throw Exception("Can't set value of a null config entry.");
+    entry->setString(value);
 }
 
-sol::table ConfigBindings::listConfigValues(sol::state_view &solState, std::string_view sectionName, std::string_view filter) {
-    sol::table result = solState.create_table();
-    for (AnyConfigEntry *entry : findConfigEntries(sectionName, filter)) {
-        result.add(solState.create_table_with(
-                "section", entry->section()->name(),
-                "name", entry->name(),
-                "type", configEntryTypeName(entry),
-                "description", entry->description(),
-                "value", entry->string(),
-                "default", entry->defaultString()
-        ));
-    }
-    return result;
+void ConfigBindings::resetEntryValue(AnyConfigEntry *entry) {
+    if (!entry)
+        throw Exception("Can't reset value of a null config entry.");
+    entry->reset();
 }
 
-std::vector<AnyConfigEntry *> ConfigBindings::findConfigEntries(std::string_view sectionName, std::string_view filter) {
-    std::vector<AnyConfigEntry *> result;
-    ConfigSection *sectionFilter = nullptr;
-    std::string valueFilter;
-    bool defaultFilter, filterByDefault = false, filterByName = false;
-    std::string name(filter.empty() ? sectionName : filter);
+void ConfigBindings::toggleEntryValue(AnyConfigEntry *entry) {
+    if (!entry)
+        throw Exception("Can't toggle value of a null config entry.");
+    if (entry->type() != typeid(bool))
+        throw Exception("Can't toggle value of a non-boolean config entry.");
+    entry->setValue(!std::any_cast<bool>(entry->value()));
+}
 
-    if (!sectionName.empty()) {
-        for (ConfigSection *section : engine->config->sections()) {
-            if (section->name() == sectionName) {
-                sectionFilter = section;
-                if (filter.empty()) name = "";  // sectionFilter was actually the section name, so no name/value filtering within sectionFilter
-                break;
-            }
-        }
-    }
+std::string ConfigBindings::entryValue(AnyConfigEntry *entry) {
+    if (!entry)
+        throw Exception("Can't get value of a null config entry.");
+    return entry->string();
+}
 
-    if (name.empty()) {
-        // Ensure numeric test below is skipped
-    } else if (name == "default") {
-        defaultFilter = true;
-        filterByDefault = true;
-    } else if (name == "!default") {
-        defaultFilter = false;
-        filterByDefault = true;
-    } else if (name == "false" || name == "true") {
-        valueFilter = name;
-    } else if (name.starts_with('"') && name.ends_with('"')) {
-        valueFilter = name.substr(1, name.size() - 2);
-    } else if (name.find_first_not_of("0123456789") == std::string::npos) {
-        valueFilter = name;
+std::string ConfigBindings::entryPath(AnyConfigEntry *entry) {
+    if (!entry)
+        throw Exception("Can't get path of a null config entry.");
+    if (!entry->section())
+        throw Exception("Can't get path of an orphaned config entry.");
+    return entry->section()->name() + "." + entry->name();
+}
+
+std::vector<AnyConfigEntry *> ConfigBindings::listEntries(std::string_view sectionName, std::string_view filter) {
+    std::vector<ConfigSection *> sections;
+    if (sectionName.empty()) {
+        sections = engine->config->sections();
+    } else if (ConfigSection *section = engine->config->section(sectionName)) {
+        sections = {section};
     } else {
-        filterByName = true;
+        throw Exception("Can't find config section '{}'", sectionName);
     }
 
-    for (ConfigSection *section : engine->config->sections()) {
-        if (sectionFilter && section != sectionFilter)
-            continue;
+    bool filterIsDefault = filter == "default";
+    bool filterIsRegular = filter != "default" && filter != "!default";
+
+    std::vector<AnyConfigEntry *> result;
+    for (ConfigSection *section : sections) {
         for (AnyConfigEntry *entry : section->entries()) {
-            if (filterByDefault && (entry->string() == entry->defaultString()) != defaultFilter)
+            if (!filterIsRegular && (entry->string() == entry->defaultString()) != filterIsDefault)
                 continue;
-            if (filterByName && entry->name().find(name) == std::string::npos)
-                continue;
-            if (!valueFilter.empty() && entry->string() != valueFilter)
+            if (filterIsRegular && entry->name().find(filter) == std::string::npos && entry->string() != filter)
                 continue;
             result.emplace_back(entry);
         }
     }
     return result;
-}
-
-std::string ConfigBindings::configEntryTypeName(AnyConfigEntry *entry) {
-    if (entry->type() == typeid(bool)) return "boolean";
-    if (entry->type() == typeid(int)) return "integer";
-    if (entry->type() == typeid(float)) return "float";
-    if (entry->type() == typeid(std::string)) return "string";
-    if (entry->type() == typeid(PlatformKey)) return "key";
-    return "unknown";
 }

--- a/src/Scripting/ConfigBindings.h
+++ b/src/Scripting/ConfigBindings.h
@@ -3,6 +3,7 @@
 #include "IBindings.h"
 
 #include <string>
+#include <vector>
 
 class AnyConfigEntry;
 
@@ -11,11 +12,17 @@ class ConfigBindings : public IBindings {
     virtual sol::table createBindingTable(sol::state_view &solState) const override;
 
  private:
-    [[nodiscard]] static void setConfigValue1(std::string_view sectionName, std::string_view entryName, std::string_view value);
-    [[nodiscard]] static void setConfigValue2(std::string_view entryName, std::string_view value);
+    static void setConfigValue1(std::string_view sectionName, std::string_view entryName, std::string_view value);
+    static void setConfigValue2(std::string_view entryName, std::string_view value);
     [[nodiscard]] static std::string configValue1(std::string_view sectionName, std::string_view entryName);
     [[nodiscard]] static std::string configValue2(std::string_view entryName);
+    [[nodiscard]] static std::optional<std::string> resetConfigValue1(std::string_view sectionName, std::string_view entryName);
+    [[nodiscard]] static std::optional<std::string> resetConfigValue2(std::string_view entryName);
 
     [[nodiscard]] static AnyConfigEntry *locateEntry1(std::string_view sectionName, std::string_view entryName);
     [[nodiscard]] static AnyConfigEntry *locateEntry2(std::string_view entryName);
+
+    [[nodiscard]] static sol::table listConfigValues(sol::state_view &solState, std::string_view sectionName, std::string_view filter);
+    [[nodiscard]] static std::vector<AnyConfigEntry *> findConfigEntries(std::string_view sectionName, std::string_view filter);
+    [[nodiscard]] static std::string configEntryTypeName(AnyConfigEntry *entry);
 };

--- a/src/Scripting/ConfigBindings.h
+++ b/src/Scripting/ConfigBindings.h
@@ -12,17 +12,13 @@ class ConfigBindings : public IBindings {
     virtual sol::table createBindingTable(sol::state_view &solState) const override;
 
  private:
-    static void setConfigValue1(std::string_view sectionName, std::string_view entryName, std::string_view value);
-    static void setConfigValue2(std::string_view entryName, std::string_view value);
-    [[nodiscard]] static std::string configValue1(std::string_view sectionName, std::string_view entryName);
-    [[nodiscard]] static std::string configValue2(std::string_view entryName);
-    [[nodiscard]] static std::optional<std::string> resetConfigValue1(std::string_view sectionName, std::string_view entryName);
-    [[nodiscard]] static std::optional<std::string> resetConfigValue2(std::string_view entryName);
+    [[nodiscard]] static AnyConfigEntry *locateConfigEntry1(std::string_view entryName);
+    [[nodiscard]] static AnyConfigEntry *locateConfigEntry2(std::string_view sectionName, std::string_view entryName);
 
-    [[nodiscard]] static AnyConfigEntry *locateEntry1(std::string_view sectionName, std::string_view entryName);
-    [[nodiscard]] static AnyConfigEntry *locateEntry2(std::string_view entryName);
-
-    [[nodiscard]] static sol::table listConfigValues(sol::state_view &solState, std::string_view sectionName, std::string_view filter);
-    [[nodiscard]] static std::vector<AnyConfigEntry *> findConfigEntries(std::string_view sectionName, std::string_view filter);
-    [[nodiscard]] static std::string configEntryTypeName(AnyConfigEntry *entry);
+    static void setEntryValue(AnyConfigEntry *entry, std::string_view value);
+    static void resetEntryValue(AnyConfigEntry *entry);
+    static void toggleEntryValue(AnyConfigEntry *entry);
+    [[nodiscard]] static std::string entryValue(AnyConfigEntry *entry);
+    [[nodiscard]] static std::string entryPath(AnyConfigEntry *entry);
+    [[nodiscard]] static std::vector<AnyConfigEntry *> listEntries(std::string_view sectionName, std::string_view filter);
 };

--- a/src/Scripting/ConfigBindings.h
+++ b/src/Scripting/ConfigBindings.h
@@ -12,13 +12,11 @@ class ConfigBindings : public IBindings {
     virtual sol::table createBindingTable(sol::state_view &solState) const override;
 
  private:
-    [[nodiscard]] static AnyConfigEntry *locateConfigEntry1(std::string_view entryName);
-    [[nodiscard]] static AnyConfigEntry *locateConfigEntry2(std::string_view sectionName, std::string_view entryName);
+    [[nodiscard]] static AnyConfigEntry *entry1(std::string_view entryName);
+    [[nodiscard]] static AnyConfigEntry *entry2(std::string_view sectionName, std::string_view entryName);
+    [[nodiscard]] static std::vector<AnyConfigEntry *> list(std::string_view sectionName, std::string_view filter);
 
-    static void setEntryValue(AnyConfigEntry *entry, std::string_view value);
-    static void resetEntryValue(AnyConfigEntry *entry);
-    static void toggleEntryValue(AnyConfigEntry *entry);
-    [[nodiscard]] static std::string entryValue(AnyConfigEntry *entry);
-    [[nodiscard]] static std::string entryPath(AnyConfigEntry *entry);
-    [[nodiscard]] static std::vector<AnyConfigEntry *> listEntries(std::string_view sectionName, std::string_view filter);
+    [[nodiscard]] static std::string path(AnyConfigEntry *entry);
+    [[nodiscard]] static std::string sectionName(AnyConfigEntry *entry);
+    static void toggle(AnyConfigEntry *entry);
 };


### PR DESCRIPTION
Things with console `config` are **much** better since #2010, but there are two minor quirks remaining:
- `config toggle title` shouldn't really change the window title to "true" or "false"
- The `toggle` subcommand doesn't follow the same section-optional pattern as the rest

This fixes both points and adds the `config reset [section] entry` and `config list [section] [filter]` commands. Some help in `help config` on what those filters can do. Highlights: `config list "F10"` = "which commands is the F10 key assigned to?" or `config list !default` = "which entries have I changed from their default?"

There's more to be said, but I keep forgetting - ask.

Oh, I had screenshots prepared...
<details>

![image](https://github.com/user-attachments/assets/062db712-0923-4c2a-97ad-c782b7e4b3b8)
![image](https://github.com/user-attachments/assets/29f4b234-5ec6-40ad-a78d-89c9ddaf8800)

</details>

Note - the last few lines in there are to: a) show myself type checking is just fine, plus b) a completely separate issue.