### PR TITLE
Config option: Set application icon

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,13 +83,13 @@ jobs:
           if [ "${{matrix.architecture}}" = "x86" ]; then
             sudo apt-get install -y gcc-13-multilib g++-13-multilib lld
             sudo apt-get install -y libglu1-mesa-dev:i386
-            sudo apt-get install -y libsdl2-dev:i386
+            sudo apt-get install -y libsdl2-dev:i386 libsdl2-image-dev:i386
             sudo apt-get install -y libdwarf-dev:i386 libelf-dev:i386
           fi
           if [ "${{matrix.architecture}}" = "x86_64" ]; then
             sudo apt-get install -y gcc-13 g++-13 lld
             sudo apt-get install -y libglu1-mesa-dev
-            sudo apt-get install -y libsdl2-dev
+            sudo apt-get install -y libsdl2-dev libsdl2-image-dev
             sudo apt-get install -y libdwarf-dev libelf-dev
           fi
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -16,7 +16,7 @@ By default, we are using prebuilt dependencies, and they are resolved automatica
 
 The only exception is Linux, where we're using SDL2 from the distribution, so you will need to install a development versions of SDL2 before building OpenEnroth. E.g. on Ubuntu:
 ```bash
-sudo apt-get install SDL2 SDL2-devel
+sudo apt-get install SDL2 SDL2-devel libsdl2-image-2.0-0 libsdl2-image-dev
 ```
 
 Additional dependencies:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Getting Started on Ubuntu Linux
    * Run `innoextract -e -d <target-folder> <mm7-gog-folder>/setup_mm_7.exe`, where `<target-folder>` is the folder where you want to have game data extracted from the mm7 installer.
    * Check the files in `<target-folder>`, it should now contain the `app` subfolder. This is where game assets were extracted into.
 
-2. Install OpenEnroth dependencies with `sudo apt-get install libsdl2-dev libdwarf-dev libelf-dev`.
+2. Install OpenEnroth dependencies with `sudo apt-get install libsdl2-dev libsdl2-image-dev libdwarf-dev libelf-dev`.
 
 3. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
 

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -632,6 +632,9 @@ class GameConfig : public Config {
         String Title = String(this, "title", "OpenEnroth", &ValidateTitle,
             "Game window title.");
 
+        String Icon = String(this, "icon_file_name", "",
+            "An image file to use as the application's icon.");
+
         Int Display = {this, "display", 0,
             "Display number as exposed by SDL. "
             "Order is platform-specific, e.g. on windows 0 is main display."};

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -124,6 +124,7 @@ void GameWindowHandler::UpdateWindowFromConfig(const GameConfig *config) {
     window->setPosition(pos);
     window->resize(size);
     window->setTitle(config->window.Title.value());
+    window->setIcon(config->window.Icon.value());
     window->setGrabsMouse(config->window.MouseGrab.value());
     window->setWindowMode(mode);
     window->setResizable(config->window.Resizable.value());

--- a/src/Library/Platform/Interface/PlatformWindow.h
+++ b/src/Library/Platform/Interface/PlatformWindow.h
@@ -32,6 +32,8 @@ class PlatformWindow {
     virtual void setTitle(const std::string &title) = 0;
     virtual std::string title() const = 0;
 
+    virtual void setIcon(const std::string &fileName) = 0;
+
     virtual void resize(const Sizei &size) = 0;
     virtual Sizei size() const = 0;
 

--- a/src/Library/Platform/Null/NullWindow.cpp
+++ b/src/Library/Platform/Null/NullWindow.cpp
@@ -24,6 +24,9 @@ std::string NullWindow::title() const {
     return _title;
 }
 
+void NullWindow::setIcon(const std::string &fileName) {
+}
+
 void NullWindow::resize(const Sizei &size) {
     _size = size;
 }

--- a/src/Library/Platform/Null/NullWindow.h
+++ b/src/Library/Platform/Null/NullWindow.h
@@ -14,6 +14,7 @@ class NullWindow : public PlatformWindow {
 
     virtual void setTitle(const std::string &title) override;
     virtual std::string title() const override;
+    virtual void setIcon(const std::string &fileName) override;
     virtual void resize(const Sizei &size) override;
     virtual Sizei size() const override;
     virtual void setPosition(const Pointi &pos) override;

--- a/src/Library/Platform/Proxy/ProxyWindow.cpp
+++ b/src/Library/Platform/Proxy/ProxyWindow.cpp
@@ -15,6 +15,10 @@ std::string ProxyWindow::title() const {
     return nonNullBase()->title();
 }
 
+void ProxyWindow::setIcon(const std::string &fileName) {
+    nonNullBase()->setIcon(fileName);
+}
+
 void ProxyWindow::resize(const Sizei &size) {
     nonNullBase()->resize(size);
 }

--- a/src/Library/Platform/Proxy/ProxyWindow.h
+++ b/src/Library/Platform/Proxy/ProxyWindow.h
@@ -14,6 +14,7 @@ class ProxyWindow : public ProxyBase<PlatformWindow> {
 
     virtual void setTitle(const std::string &title) override;
     virtual std::string title() const override;
+    virtual void setIcon(const std::string &fileName) override;
     virtual void resize(const Sizei &size) override;
     virtual Sizei size() const override;
     virtual void setPosition(const Pointi &pos) override;

--- a/src/Library/Platform/Sdl/CMakeLists.txt
+++ b/src/Library/Platform/Sdl/CMakeLists.txt
@@ -30,9 +30,11 @@ add_library(library_platform_main OBJECT ${PLATFORM_SDL_MAIN_SOURCES} ${PLATFORM
 target_check_style(library_platform_main)
 target_link_libraries(library_platform_main PRIVATE SDL2::SDL2OE)
 
+find_package(SDL2_image REQUIRED)
+
 add_library(library_platform_sdl STATIC ${PLATFORM_SDL_SOURCES} ${PLATFORM_SDL_HEADERS})
 target_check_style(library_platform_sdl)
-target_link_libraries(library_platform_sdl PUBLIC utility library_logger PRIVATE SDL2::SDL2OE)
+target_link_libraries(library_platform_sdl PUBLIC utility library_logger PRIVATE SDL2::SDL2OE SDL2_image::SDL2_image)
 
 # Currently we have only one implementation library defining Platform::createStandardPlatform function, but we used
 # to have two. So we're keeping the old mechanism with an additional library_platform_implementation library.

--- a/src/Library/Platform/Sdl/SdlWindow.cpp
+++ b/src/Library/Platform/Sdl/SdlWindow.cpp
@@ -5,6 +5,9 @@
 #include <memory>
 
 #include <SDL_syswm.h>
+#include <SDL_video.h>
+#include <SDL_image.h>
+
 #ifdef None
 #undef None
 #endif
@@ -32,6 +35,19 @@ void SdlWindow::setTitle(const std::string &title) {
 
 std::string SdlWindow::title() const {
     return SDL_GetWindowTitle(_window);
+}
+
+void SdlWindow::setIcon(const std::string &fileName) {
+    if (fileName.empty())
+        return;
+    SDL_Surface *surface = IMG_Load(fileName.c_str());
+    if (!surface) {
+        _state->logSdlError("IMG_Load");
+        return;
+    }
+    SDL_SetWindowIcon(_window, surface);
+    // Can't because only the SDL3 version returns a success bool: _state->logSdlError("SDL_SetWindowIcon");
+    SDL_FreeSurface(surface); //TODO: SDL doesn't say who is responsible in the SDL_SetWindowIcon usage
 }
 
 void SdlWindow::resize(const Sizei &size) {

--- a/src/Library/Platform/Sdl/SdlWindow.h
+++ b/src/Library/Platform/Sdl/SdlWindow.h
@@ -18,6 +18,8 @@ class SdlWindow : public PlatformWindow {
     virtual void setTitle(const std::string &title) override;
     virtual std::string title() const override;
 
+    virtual void setIcon(const std::string &fileName) override;
+
     virtual void resize(const Sizei &size) override;
     virtual Sizei size() const override;
 


### PR DESCRIPTION
My approach to solve #2005, screen capture over there. Works on Linux but has no reason not to on other platforms.

See TODO in this diff - near bottom: Couldn't find docs on whether `SDL_SetWindowIcon` takes ownership of the passed surface, but freeing it right after doesn't crash, so I'm more confident than not this is correct.

Also doesn't include more detailed user documentation except for the one-liner in the config: Where to put the instructions on how to get that art from the original media?

Also: I'm doubting the prerequisites in README.md: If someone is only going to run a release zip as the following paragraph suggests, they won't need the header files, no? So those *-dev packages aren't needed at _that_ point, only later when running cmake??? I've just followed the precedents here.

Also: How to get the linker to pull SDL2_image was just trial and error, I had no idea about what I was doing. You'll likely do it more elegantly. I'm more used to .kts build scripts run by Gradle...