### PR TITLE
Game option: Show extended monster info

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -613,7 +613,7 @@ class GameConfig : public Config {
         // TODO(captainurist): move to [audio]?
         Bool WalkSound = {this, "walk_sound", true, "Enable footsteps sound when walking."};
 
-        Bool ExtendedMonsterInfo = {this, "extended_monster_info", false, "Display second and special attack in the Monster Info popup."};
+        Bool ExtendedMonsterInfo = {this, "extended_monster_info", true, "Display second and special attack in the Monster Info popup."};
 
      private:
         static int ValidateLevel(int level) {

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -613,6 +613,8 @@ class GameConfig : public Config {
         // TODO(captainurist): move to [audio]?
         Bool WalkSound = {this, "walk_sound", true, "Enable footsteps sound when walking."};
 
+        Bool ExtendedMonsterInfo = {this, "extended_monster_info", false, "Display second and special attack in the Monster Info popup."};
+
      private:
         static int ValidateLevel(int level) {
             return std::clamp(level, 0, 9);

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -75,6 +75,34 @@ bool Localization::Initialize() {
     this->localization_strings[LSTR_REMAINING_POWER] = "Remaining power: %d";
     this->localization_strings[LSTR_PLAYER_IS_NOT_ACTIVE] = "That player is not active";
 
+    this->special_attack_names[SPECIAL_ATTACK_CURSE] = "Curse";
+    this->special_attack_names[SPECIAL_ATTACK_WEAK] = "Weaken";
+    this->special_attack_names[SPECIAL_ATTACK_SLEEP] = "Sleep";
+    this->special_attack_names[SPECIAL_ATTACK_DRUNK] = "Drunk"; // "Inebriate"?
+    this->special_attack_names[SPECIAL_ATTACK_INSANE] = "Insanity";
+    this->special_attack_names[SPECIAL_ATTACK_POISON_WEAK] = "Poison";
+    this->special_attack_names[SPECIAL_ATTACK_POISON_MEDIUM] = "Poison";
+    this->special_attack_names[SPECIAL_ATTACK_POISON_SEVERE] = "Poison";
+    this->special_attack_names[SPECIAL_ATTACK_DISEASE_WEAK] = "Disease";
+    this->special_attack_names[SPECIAL_ATTACK_DISEASE_MEDIUM] = "Disease";
+    this->special_attack_names[SPECIAL_ATTACK_DISEASE_SEVERE] = "Disease";
+    this->special_attack_names[SPECIAL_ATTACK_PARALYZED] = "Paralyze";
+    this->special_attack_names[SPECIAL_ATTACK_UNCONSCIOUS] = "Knockout";
+    this->special_attack_names[SPECIAL_ATTACK_DEAD] = "Death";
+    this->special_attack_names[SPECIAL_ATTACK_PETRIFIED] = "Petrify";
+    this->special_attack_names[SPECIAL_ATTACK_ERADICATED] = "Eradicate";
+    this->special_attack_names[SPECIAL_ATTACK_BREAK_ANY] = "Break Item";
+    this->special_attack_names[SPECIAL_ATTACK_BREAK_ARMOR] = "Break Armor";
+    this->special_attack_names[SPECIAL_ATTACK_BREAK_WEAPON] = "Break Weapon";
+    this->special_attack_names[SPECIAL_ATTACK_STEAL] = "Steal";
+    this->special_attack_names[SPECIAL_ATTACK_AGING] = "Aging";
+    this->special_attack_names[SPECIAL_ATTACK_MANA_DRAIN] = "SP Drain";
+    this->special_attack_names[SPECIAL_ATTACK_FEAR] = "Fear";
+
+    this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_SHOT] = "Multi-shot";
+    this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_SUMMON] = "Summoner";
+    this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_EXPLODE] = "Explodes";
+
     InitializeMm6ItemCategories();
 
     InitializeMonthNames();

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -17,6 +17,13 @@ const std::string &Localization::GetString(LstrId index) const {
     return this->localization_strings[index];
 }
 
+std::string Localization::SkillValueShortString(CombinedSkillValue skillValue) const {
+    if (skillValue.mastery() == CHARACTER_SKILL_MASTERY_NONE)
+        return {};
+
+    return fmt::sprintf(this->skill_value_short_templates[skillValue.mastery()], skillValue.level()); // NOLINT: not std::sprintf.
+}
+
 //----- (00452C49) --------------------------------------------------------
 bool Localization::Initialize() {
     char *tmp_pos;     // eax@3
@@ -102,6 +109,11 @@ bool Localization::Initialize() {
     this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_SHOT] = "Multi-shot";
     this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_SUMMON] = "Summoner";
     this->monster_special_ability_names[MONSTER_SPECIAL_ABILITY_EXPLODE] = "Explodes";
+
+    this->skill_value_short_templates[CHARACTER_SKILL_MASTERY_NOVICE] = "%d";
+    this->skill_value_short_templates[CHARACTER_SKILL_MASTERY_EXPERT] = "%dE";
+    this->skill_value_short_templates[CHARACTER_SKILL_MASTERY_MASTER] = "%dM";
+    this->skill_value_short_templates[CHARACTER_SKILL_MASTERY_GRANDMASTER] = "%dG";
 
     InitializeMm6ItemCategories();
 

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -140,6 +140,28 @@ void Localization::InitializeSpellNames() {
     this->character_buff_names[CHARACTER_BUFF_SPEED]            = this->localization_strings[LSTR_TEMP_SPEED];
     this->character_buff_names[CHARACTER_BUFF_RESIST_WATER]     = this->localization_strings[LSTR_WATER_RES];
     this->character_buff_names[CHARACTER_BUFF_WATER_WALK]       = this->localization_strings[LSTR_WATER_BREATHING];
+
+    this->actor_buff_names[ACTOR_BUFF_CHARM]                    = this->localization_strings[LSTR_CHARMED];
+    this->actor_buff_names[ACTOR_BUFF_SUMMONED]                 = this->localization_strings[LSTR_SUMMONED];
+    this->actor_buff_names[ACTOR_BUFF_SHRINK]                   = this->localization_strings[LSTR_SHRUNK];
+    this->actor_buff_names[ACTOR_BUFF_AFRAID]                   = this->localization_strings[LSTR_AFRAID];
+    this->actor_buff_names[ACTOR_BUFF_STONED]                   = this->localization_strings[LSTR_STONED];
+    this->actor_buff_names[ACTOR_BUFF_PARALYZED]                = this->localization_strings[LSTR_PARALYZED];
+    this->actor_buff_names[ACTOR_BUFF_SLOWED]                   = this->localization_strings[LSTR_SLOWED];
+    this->actor_buff_names[ACTOR_BUFF_BERSERK]                  = this->localization_strings[LSTR_BERSERK];
+    this->actor_buff_names[ACTOR_BUFF_SOMETHING_THAT_HALVES_AC] = {};
+    this->actor_buff_names[ACTOR_BUFF_MASS_DISTORTION]          = {};
+    this->actor_buff_names[ACTOR_BUFF_FATE]                     = this->localization_strings[LSTR_FATE];
+    this->actor_buff_names[ACTOR_BUFF_ENSLAVED]                 = this->localization_strings[LSTR_ENSLAVED];
+    this->actor_buff_names[ACTOR_BUFF_DAY_OF_PROTECTION]        = this->localization_strings[LSTR_DAY_OF_PROTECTION];
+    this->actor_buff_names[ACTOR_BUFF_HOUR_OF_POWER]            = this->localization_strings[LSTR_HOUR_OF_POWER];
+    this->actor_buff_names[ACTOR_BUFF_SHIELD]                   = this->localization_strings[LSTR_SHIELD];
+    this->actor_buff_names[ACTOR_BUFF_STONESKIN]                = this->localization_strings[LSTR_STONESKIN];
+    this->actor_buff_names[ACTOR_BUFF_BLESS]                    = this->localization_strings[LSTR_BLESS];
+    this->actor_buff_names[ACTOR_BUFF_HEROISM]                  = this->localization_strings[LSTR_HEROISM];
+    this->actor_buff_names[ACTOR_BUFF_HASTE]                    = this->localization_strings[LSTR_HASTE];
+    this->actor_buff_names[ACTOR_BUFF_PAIN_REFLECTION]          = this->localization_strings[LSTR_PAIN_REFLECTION];
+    this->actor_buff_names[ACTOR_BUFF_HAMMERHANDS]              = this->localization_strings[LSTR_HAMMERHANDS];
 }
 
 void Localization::InitializeNpcProfessionNames() {

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -10,6 +10,7 @@
 #include "Engine/Objects/CharacterEnums.h"
 #include "Engine/Spells/SpellEnums.h"
 #include "Engine/PartyEnums.h"
+#include "Objects/ActorEnums.h"
 
 #include "Utility/IndexedArray.h"
 #include "Utility/String/Format.h"
@@ -51,6 +52,10 @@ class Localization {
 
     const std::string &GetCharacterBuffName(CharacterBuff index) const {
         return this->character_buff_names[index];
+    }
+
+    const std::string &GetActorBuffName(ActorBuff index) const {
+        return this->actor_buff_names[index];
     }
 
     const std::string &GetClassName(CharacterClass index) const {
@@ -243,6 +248,7 @@ class Localization {
     IndexedArray<std::string, MAGIC_SCHOOL_FIRST, MAGIC_SCHOOL_LAST> spell_school_names;
     IndexedArray<std::string, PARTY_BUFF_FIRST, PARTY_BUFF_LAST> party_buff_names;
     IndexedArray<std::string, CHARACTER_BUFF_FIRST, CHARACTER_BUFF_LAST> character_buff_names;
+    IndexedArray<std::string, ACTOR_BUFF_FIRST, ACTOR_BUFF_LAST> actor_buff_names;
     IndexedArray<std::string, CLASS_FIRST, CLASS_LAST> class_names;
     IndexedArray<std::string, CLASS_FIRST, CLASS_LAST> class_desciptions;
     IndexedArray<std::string, ATTRIBUTE_FIRST_STAT, ATTRIBUTE_LAST_STAT> attribute_names;

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -16,6 +16,7 @@
 #include "Utility/String/Format.h"
 
 #include "LocalizationEnums.h"
+#include "Objects/MonsterEnums.h"
 
 class Localization {
  public:
@@ -136,6 +137,14 @@ class Localization {
 
     const std::string &GetNpcProfessionName(NpcProfession prof) const {
         return this->npc_profession_names[prof];
+    }
+
+    const std::string &GetSpecialAttackName(SpecialAttackType index) const {
+        return this->special_attack_names[index];
+    }
+
+    const std::string &GetMonsterSpecialAbilityName(MonsterSpecialAbility index) const {
+        return this->monster_special_ability_names[index];
     }
 
     const std::string &getHPDescription() const {
@@ -261,6 +270,8 @@ class Localization {
     IndexedArray<std::string, CHARACTER_SKILL_INVALID, CHARACTER_SKILL_LAST_VISIBLE> skill_descriptions_grand;
     IndexedArray<std::string, CONDITION_FIRST, CONDITION_LAST> character_conditions;
     IndexedArray<std::string, NPC_PROFESSION_FIRST, NPC_PROFESSION_LAST> npc_profession_names;
+    IndexedArray<std::string, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> special_attack_names;
+    IndexedArray<std::string, MONSTER_SPECIAL_ABILITY_FIRST, MONSTER_SPECIAL_ABILITY_LAST> monster_special_ability_names;
     std::string hp_description;
     std::string sp_description;
     std::string armour_class_description;

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <cstdio>
 #include <array>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "Engine/Objects/NPCEnums.h"
 #include "Engine/Objects/CharacterEnums.h"
@@ -16,6 +14,7 @@
 #include "Utility/String/Format.h"
 
 #include "LocalizationEnums.h"
+#include "Objects/CombinedSkillValue.h"
 #include "Objects/MonsterEnums.h"
 
 class Localization {
@@ -27,7 +26,7 @@ class Localization {
     template<class... Args>
     std::string FormatString(LstrId index, Args &&... args) const {
         // TODO(captainurist): what if fmt throws?
-        return fmt::sprintf(GetString(index), std::forward<Args>(args)...);
+        return fmt::sprintf(GetString(index), std::forward<Args>(args)...); // NOLINT: not std::sprintf.
         // TODO(captainurist): there was also a call to sprintfex_internal after a call to vsprintf.
     }
 
@@ -78,6 +77,8 @@ class Localization {
     const std::string &GetSkillName(CharacterSkillType index) const {
         return this->skill_names[index];
     }
+
+    std::string SkillValueShortString(CombinedSkillValue skillValue) const;
 
     const std::string &MasteryName(CharacterSkillMastery mastery) const {
         switch (mastery) {
@@ -272,6 +273,7 @@ class Localization {
     IndexedArray<std::string, NPC_PROFESSION_FIRST, NPC_PROFESSION_LAST> npc_profession_names;
     IndexedArray<std::string, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> special_attack_names;
     IndexedArray<std::string, MONSTER_SPECIAL_ABILITY_FIRST, MONSTER_SPECIAL_ABILITY_LAST> monster_special_ability_names;
+    IndexedArray<std::string, CHARACTER_SKILL_MASTERY_FIRST, CHARACTER_SKILL_MASTERY_LAST> skill_value_short_templates;
     std::string hp_description;
     std::string sp_description;
     std::string armour_class_description;

--- a/src/Engine/Objects/ActorEnumFunctions.h
+++ b/src/Engine/Objects/ActorEnumFunctions.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cassert>
+
+#include "ActorEnums.h"
+#include "Engine/Spells/SpellEnums.h"
+
+inline SpellId spellForActorBuff(ActorBuff buff) {
+    switch (buff) {
+    default:
+        assert(false);
+        [[fallthrough]];
+    case ACTOR_BUFF_NONE:                       return SPELL_NONE;
+    case ACTOR_BUFF_CHARM:                      return SPELL_MIND_CHARM;
+    case ACTOR_BUFF_SUMMONED:                   return SPELL_LIGHT_SUMMON_ELEMENTAL;
+    case ACTOR_BUFF_SHRINK:                     return SPELL_DARK_SHRINKING_RAY;
+    case ACTOR_BUFF_AFRAID:                     return SPELL_MIND_MASS_FEAR;
+    case ACTOR_BUFF_STONED:                     return SPELL_LIGHT_PARALYZE;
+    case ACTOR_BUFF_PARALYZED:                  return SPELL_LIGHT_PARALYZE;
+    case ACTOR_BUFF_SLOWED:                     return SPELL_EARTH_SLOW;
+    case ACTOR_BUFF_BERSERK:                    return SPELL_MIND_BERSERK;
+    case ACTOR_BUFF_SOMETHING_THAT_HALVES_AC:   return SPELL_NONE;
+    case ACTOR_BUFF_MASS_DISTORTION:            return SPELL_EARTH_MASS_DISTORTION;
+    case ACTOR_BUFF_FATE:                       return SPELL_SPIRIT_FATE;
+    case ACTOR_BUFF_ENSLAVED:                   return SPELL_MIND_ENSLAVE;
+    case ACTOR_BUFF_DAY_OF_PROTECTION:          return SPELL_LIGHT_DAY_OF_PROTECTION;
+    case ACTOR_BUFF_HOUR_OF_POWER:              return SPELL_LIGHT_HOUR_OF_POWER;
+    case ACTOR_BUFF_SHIELD:                     return SPELL_AIR_SHIELD;
+    case ACTOR_BUFF_STONESKIN:                  return SPELL_EARTH_STONESKIN;
+    case ACTOR_BUFF_BLESS:                      return SPELL_SPIRIT_BLESS;
+    case ACTOR_BUFF_HEROISM:                    return SPELL_SPIRIT_HEROISM;
+    case ACTOR_BUFF_HASTE:                      return SPELL_FIRE_HASTE;
+    case ACTOR_BUFF_PAIN_REFLECTION:            return SPELL_DARK_PAIN_REFLECTION;
+    case ACTOR_BUFF_HAMMERHANDS:                return SPELL_BODY_HAMMERHANDS;
+    }
+}

--- a/src/Engine/Objects/CMakeLists.txt
+++ b/src/Engine/Objects/CMakeLists.txt
@@ -19,6 +19,7 @@ set(ENGINE_OBJECTS_SOURCES
 set(ENGINE_OBJECTS_HEADERS
         Actor.h
         ActorEnums.h
+        ActorEnumFunctions.h
         Chest.h
         ChestEnums.h
         CombinedSkillValue.h

--- a/src/Engine/Objects/CombinedSkillValue.cpp
+++ b/src/Engine/Objects/CombinedSkillValue.cpp
@@ -85,13 +85,3 @@ int CombinedSkillValue::level() const {
 CharacterSkillMastery CombinedSkillValue::mastery() const {
     return _mastery;
 }
-
-std::string CombinedSkillValue::shortDescription() const {
-    static const IndexedArray<std::string, CHARACTER_SKILL_MASTERY_FIRST, CHARACTER_SKILL_MASTERY_LAST> masteryMarkers = {
-        {CHARACTER_SKILL_MASTERY_NOVICE, ""},
-        {CHARACTER_SKILL_MASTERY_EXPERT, "E"},
-        {CHARACTER_SKILL_MASTERY_MASTER, "M"},
-        {CHARACTER_SKILL_MASTERY_GRANDMASTER, "G"}
-    };
-    return fmt::format("{}{}", masteryMarkers[_mastery], _level);
-}

--- a/src/Engine/Objects/CombinedSkillValue.cpp
+++ b/src/Engine/Objects/CombinedSkillValue.cpp
@@ -1,7 +1,10 @@
 #include "CombinedSkillValue.h"
 
 #include <cassert>
+#include <string>
 #include <utility>
+#include "Utility/IndexedArray.h"
+#include "Utility/String/Format.h"
 
 CombinedSkillValue::CombinedSkillValue(int level, CharacterSkillMastery mastery) {
     assert(level >= 0 && level <= 63);
@@ -81,4 +84,14 @@ int CombinedSkillValue::level() const {
 
 CharacterSkillMastery CombinedSkillValue::mastery() const {
     return _mastery;
+}
+
+std::string CombinedSkillValue::shortDescription() const {
+    static const IndexedArray<std::string, CHARACTER_SKILL_MASTERY_FIRST, CHARACTER_SKILL_MASTERY_LAST> masteryMarkers = {
+        {CHARACTER_SKILL_MASTERY_NOVICE, ""},
+        {CHARACTER_SKILL_MASTERY_EXPERT, "E"},
+        {CHARACTER_SKILL_MASTERY_MASTER, "M"},
+        {CHARACTER_SKILL_MASTERY_GRANDMASTER, "G"}
+    };
+    return fmt::format("{}{}", masteryMarkers[_mastery], _level);
 }

--- a/src/Engine/Objects/CombinedSkillValue.h
+++ b/src/Engine/Objects/CombinedSkillValue.h
@@ -34,8 +34,6 @@ class CombinedSkillValue {
 
     friend bool operator==(const CombinedSkillValue &l, const CombinedSkillValue &r) = default;
 
-    std::string shortDescription() const;
-
  private:
     int _level = 0;
     CharacterSkillMastery _mastery = CHARACTER_SKILL_MASTERY_NONE;

--- a/src/Engine/Objects/CombinedSkillValue.h
+++ b/src/Engine/Objects/CombinedSkillValue.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <string>
 
 #include "Engine/Objects/CharacterEnums.h"
 
@@ -32,6 +33,8 @@ class CombinedSkillValue {
     explicit operator bool() const { return _level > 0; }
 
     friend bool operator==(const CombinedSkillValue &l, const CombinedSkillValue &r) = default;
+
+    std::string shortDescription() const;
 
  private:
     int _level = 0;

--- a/src/Engine/Objects/MonsterEnumFunctions.cpp
+++ b/src/Engine/Objects/MonsterEnumFunctions.cpp
@@ -1,8 +1,8 @@
 #include "MonsterEnumFunctions.h"
 
+#include <string>
+#include <utility>
 #include <vector>
-
-#include "Utility/IndexedArray.h"
 
 struct MonsterData {
     CharacterSex sex = SEX_MALE;
@@ -333,3 +333,36 @@ std::span<const MonsterAttackPreference> allMonsterAttackPreferences() {
 
     return result;
 }
+
+
+IndexedArray<std::pair<std::string, const Color *>, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> monsterSpecialAttackDisplay = {
+    {SPECIAL_ATTACK_CURSE, {"Curse", &colorTable.Cioccolato}},
+    {SPECIAL_ATTACK_WEAK, {"Weaken", &colorTable.Mimosa}},
+    {SPECIAL_ATTACK_SLEEP, {"Sleep", &colorTable.ScienceBlue}},
+    {SPECIAL_ATTACK_DRUNK, {"Drunk", &colorTable.NavyBlue}},
+    {SPECIAL_ATTACK_INSANE, {"Insanity", &colorTable.JazzberryJam}},
+    {SPECIAL_ATTACK_POISON_WEAK, {"Poison", &colorTable.Eucalyptus}},
+    {SPECIAL_ATTACK_POISON_MEDIUM, {"Poison", &colorTable.GreenTeal}},
+    {SPECIAL_ATTACK_POISON_SEVERE, {"Poison", &colorTable.VibrantGreen}},
+    {SPECIAL_ATTACK_DISEASE_WEAK, {"Disease", &colorTable.FlushOrange}},
+    {SPECIAL_ATTACK_DISEASE_MEDIUM, {"Disease", &colorTable.DarkOrange}},
+    {SPECIAL_ATTACK_DISEASE_SEVERE, {"Disease", &colorTable.OrangeyRed}},
+    {SPECIAL_ATTACK_PARALYZED, {"Paralyze", &colorTable.Primrose}},
+    {SPECIAL_ATTACK_UNCONSCIOUS, {"Knockout", &colorTable.StarkWhite}},
+    {SPECIAL_ATTACK_DEAD, {"Death", &colorTable.BloodRed}},
+    {SPECIAL_ATTACK_PETRIFIED, {"Petrify", &colorTable.MediumGrey}},
+    {SPECIAL_ATTACK_ERADICATED, {"Eradicate", &colorTable.MoonRaker}},
+    {SPECIAL_ATTACK_BREAK_ANY, {"Break Any", &colorTable.LaserLemon}},
+    {SPECIAL_ATTACK_BREAK_ARMOR, {"Break Armor", &colorTable.LaserLemon}},
+    {SPECIAL_ATTACK_BREAK_WEAPON, {"Break Weapon", &colorTable.LaserLemon}},
+    {SPECIAL_ATTACK_STEAL, {"Steal", &colorTable.DirtyYellow}},
+    {SPECIAL_ATTACK_AGING, {"Aging", &colorTable.White}},
+    {SPECIAL_ATTACK_MANA_DRAIN, {"SP Drain", &colorTable.BoltBlue}},
+    {SPECIAL_ATTACK_FEAR, {"Fear", &colorTable.CornFlowerBlue}}
+};
+
+IndexedArray<std::pair<std::string, const Color *>, MONSTER_SPECIAL_ABILITY_SHOT, MONSTER_SPECIAL_ABILITY_EXPLODE> monsterSpecialAbilityDisplay = {
+    {MONSTER_SPECIAL_ABILITY_SHOT, {"Multi-shot", &colorTable.Mercury}},
+    {MONSTER_SPECIAL_ABILITY_SUMMON, {"Summoner", &colorTable.EasternBlue}},
+    {MONSTER_SPECIAL_ABILITY_EXPLODE, {"Explodes", &colorTable.Sunflower}}
+};

--- a/src/Engine/Objects/MonsterEnumFunctions.cpp
+++ b/src/Engine/Objects/MonsterEnumFunctions.cpp
@@ -333,36 +333,3 @@ std::span<const MonsterAttackPreference> allMonsterAttackPreferences() {
 
     return result;
 }
-
-
-IndexedArray<std::pair<std::string, const Color *>, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> monsterSpecialAttackDisplay = {
-    {SPECIAL_ATTACK_CURSE, {"Curse", &colorTable.Cioccolato}},
-    {SPECIAL_ATTACK_WEAK, {"Weaken", &colorTable.Mimosa}},
-    {SPECIAL_ATTACK_SLEEP, {"Sleep", &colorTable.ScienceBlue}},
-    {SPECIAL_ATTACK_DRUNK, {"Drunk", &colorTable.NavyBlue}},
-    {SPECIAL_ATTACK_INSANE, {"Insanity", &colorTable.JazzberryJam}},
-    {SPECIAL_ATTACK_POISON_WEAK, {"Poison", &colorTable.Eucalyptus}},
-    {SPECIAL_ATTACK_POISON_MEDIUM, {"Poison", &colorTable.GreenTeal}},
-    {SPECIAL_ATTACK_POISON_SEVERE, {"Poison", &colorTable.VibrantGreen}},
-    {SPECIAL_ATTACK_DISEASE_WEAK, {"Disease", &colorTable.FlushOrange}},
-    {SPECIAL_ATTACK_DISEASE_MEDIUM, {"Disease", &colorTable.DarkOrange}},
-    {SPECIAL_ATTACK_DISEASE_SEVERE, {"Disease", &colorTable.OrangeyRed}},
-    {SPECIAL_ATTACK_PARALYZED, {"Paralyze", &colorTable.Primrose}},
-    {SPECIAL_ATTACK_UNCONSCIOUS, {"Knockout", &colorTable.StarkWhite}},
-    {SPECIAL_ATTACK_DEAD, {"Death", &colorTable.BloodRed}},
-    {SPECIAL_ATTACK_PETRIFIED, {"Petrify", &colorTable.MediumGrey}},
-    {SPECIAL_ATTACK_ERADICATED, {"Eradicate", &colorTable.MoonRaker}},
-    {SPECIAL_ATTACK_BREAK_ANY, {"Break Any", &colorTable.LaserLemon}},
-    {SPECIAL_ATTACK_BREAK_ARMOR, {"Break Armor", &colorTable.LaserLemon}},
-    {SPECIAL_ATTACK_BREAK_WEAPON, {"Break Weapon", &colorTable.LaserLemon}},
-    {SPECIAL_ATTACK_STEAL, {"Steal", &colorTable.DirtyYellow}},
-    {SPECIAL_ATTACK_AGING, {"Aging", &colorTable.White}},
-    {SPECIAL_ATTACK_MANA_DRAIN, {"SP Drain", &colorTable.BoltBlue}},
-    {SPECIAL_ATTACK_FEAR, {"Fear", &colorTable.CornFlowerBlue}}
-};
-
-IndexedArray<std::pair<std::string, const Color *>, MONSTER_SPECIAL_ABILITY_SHOT, MONSTER_SPECIAL_ABILITY_EXPLODE> monsterSpecialAbilityDisplay = {
-    {MONSTER_SPECIAL_ABILITY_SHOT, {"Multi-shot", &colorTable.Mercury}},
-    {MONSTER_SPECIAL_ABILITY_SUMMON, {"Summoner", &colorTable.EasternBlue}},
-    {MONSTER_SPECIAL_ABILITY_EXPLODE, {"Explodes", &colorTable.Sunflower}}
-};

--- a/src/Engine/Objects/MonsterEnumFunctions.h
+++ b/src/Engine/Objects/MonsterEnumFunctions.h
@@ -99,8 +99,3 @@ inline MonsterSupertype supertypeForMonsterId(MonsterId monsterId) {
 //
 
 std::span<const MonsterAttackPreference> allMonsterAttackPreferences();
-
-// Lookup table for label and color of a monster's special attack (`SpecialAttackType`), like petrify or insanity:
-extern IndexedArray<std::pair<std::string, const Color *>, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> monsterSpecialAttackDisplay;
-// Lookup table for label and color of a monster's special ability (`MonsterSpecialAbility`) - multi-shot, summoning or explode-on-death:
-extern IndexedArray<std::pair<std::string, const Color *>, MONSTER_SPECIAL_ABILITY_SHOT, MONSTER_SPECIAL_ABILITY_EXPLODE> monsterSpecialAbilityDisplay;

--- a/src/Engine/Objects/MonsterEnumFunctions.h
+++ b/src/Engine/Objects/MonsterEnumFunctions.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <span>
+#include <string>
 #include <utility>
 
 #include "Engine/Data/HouseEnums.h"
 
 #include "Utility/Segment.h"
+#include "Utility/IndexedArray.h"
+#include "Library/Color/ColorTable.h"
 
 #include "ItemEnums.h"
 #include "CharacterEnums.h"
@@ -96,3 +99,8 @@ inline MonsterSupertype supertypeForMonsterId(MonsterId monsterId) {
 //
 
 std::span<const MonsterAttackPreference> allMonsterAttackPreferences();
+
+// Lookup table for label and color of a monster's special attack (`SpecialAttackType`), like petrify or insanity:
+extern IndexedArray<std::pair<std::string, const Color *>, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> monsterSpecialAttackDisplay;
+// Lookup table for label and color of a monster's special ability (`MonsterSpecialAbility`) - multi-shot, summoning or explode-on-death:
+extern IndexedArray<std::pair<std::string, const Color *>, MONSTER_SPECIAL_ABILITY_SHOT, MONSTER_SPECIAL_ABILITY_EXPLODE> monsterSpecialAbilityDisplay;

--- a/src/Engine/Objects/MonsterEnums.h
+++ b/src/Engine/Objects/MonsterEnums.h
@@ -483,6 +483,9 @@ enum class SpecialAttackType : uint8_t {
     SPECIAL_ATTACK_AGING = 21,
     SPECIAL_ATTACK_MANA_DRAIN = 22,
     SPECIAL_ATTACK_FEAR = 23,
+
+    SPECIAL_ATTACK_FIRST = SPECIAL_ATTACK_CURSE,
+    SPECIAL_ATTACK_LAST = SPECIAL_ATTACK_FEAR
 };
 using enum SpecialAttackType;
 

--- a/src/Engine/Objects/MonsterEnums.h
+++ b/src/Engine/Objects/MonsterEnums.h
@@ -432,6 +432,9 @@ enum class MonsterSpecialAbility {
     MONSTER_SPECIAL_ABILITY_SHOT = 0x1,
     MONSTER_SPECIAL_ABILITY_SUMMON = 0x2,
     MONSTER_SPECIAL_ABILITY_EXPLODE = 0x3,
+
+    MONSTER_SPECIAL_ABILITY_FIRST = MONSTER_SPECIAL_ABILITY_SHOT,
+    MONSTER_SPECIAL_ABILITY_LAST = MONSTER_SPECIAL_ABILITY_EXPLODE,
 };
 using enum MonsterSpecialAbility;
 
@@ -458,6 +461,7 @@ enum class MonsterSupertype {
 };
 using enum MonsterSupertype;
 
+// TODO(captainurist): MonsterSpecialAttack
 enum class SpecialAttackType : uint8_t {
     SPECIAL_ATTACK_NONE = 0,
     SPECIAL_ATTACK_CURSE = 1,

--- a/src/Engine/Spells/SpellEnumFunctions.h
+++ b/src/Engine/Spells/SpellEnumFunctions.h
@@ -18,7 +18,7 @@ inline Segment<SpellId> allRegularSpells() {
 }
 
 /**
- * Is spell target is item in inventory?
+ * @returns                             Whether the spell is targeting an inventory item.
  */
 inline bool isSpellTargetsItem(SpellId uSpellID) {
     return uSpellID == SPELL_WATER_ENCHANT_ITEM ||

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -971,13 +971,13 @@ std::pair<int, int> MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow)
         }
         if (monsterInfo.spell1Id != SPELL_NONE) {
             if (extended)
-                spell2Str = fmt::format("{} {}", pSpellStats->pInfos[monsterInfo.spell1Id].pShortName, monsterInfo.spell1SkillMastery.shortDescription());
+                spell2Str = fmt::format("{} {}", pSpellStats->pInfos[monsterInfo.spell1Id].pShortName, localization->SkillValueShortString(monsterInfo.spell1SkillMastery));
             else
                 spell1Str = pSpellStats->pInfos[monsterInfo.spell1Id].pShortName;
         }
         if (monsterInfo.spell2Id != SPELL_NONE) {
             if (extended)
-                spell3Str = fmt::format("{} {}", pSpellStats->pInfos[monsterInfo.spell2Id].pShortName, monsterInfo.spell2SkillMastery.shortDescription());
+                spell3Str = fmt::format("{} {}", pSpellStats->pInfos[monsterInfo.spell2Id].pShortName, localization->SkillValueShortString(monsterInfo.spell2SkillMastery));
             else
                 spell2Str = pSpellStats->pInfos[monsterInfo.spell2Id].pShortName;
         }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -185,6 +185,40 @@ IndexedArray<int, MONSTER_TYPE_FIRST, MONSTER_TYPE_LAST> monster_popup_y_offsets
     {MONSTER_TYPE_UNUSED_RAT,               0},
 };
 
+// OE addition - colors for monster special attack text.
+static constexpr IndexedArray<Color, SPECIAL_ATTACK_FIRST, SPECIAL_ATTACK_LAST> monsterSpecialAttackColors = {
+    {SPECIAL_ATTACK_CURSE,          colorTable.Cioccolato},
+    {SPECIAL_ATTACK_WEAK,           colorTable.Mimosa},
+    {SPECIAL_ATTACK_SLEEP,          colorTable.ScienceBlue},
+    {SPECIAL_ATTACK_DRUNK,          colorTable.NavyBlue},
+    {SPECIAL_ATTACK_INSANE,         colorTable.JazzberryJam},
+    {SPECIAL_ATTACK_POISON_WEAK,    colorTable.Eucalyptus},
+    {SPECIAL_ATTACK_POISON_MEDIUM,  colorTable.GreenTeal},
+    {SPECIAL_ATTACK_POISON_SEVERE,  colorTable.VibrantGreen},
+    {SPECIAL_ATTACK_DISEASE_WEAK,   colorTable.FlushOrange},
+    {SPECIAL_ATTACK_DISEASE_MEDIUM, colorTable.DarkOrange},
+    {SPECIAL_ATTACK_DISEASE_SEVERE, colorTable.OrangeyRed},
+    {SPECIAL_ATTACK_PARALYZED,      colorTable.Primrose},
+    {SPECIAL_ATTACK_UNCONSCIOUS,    colorTable.StarkWhite},
+    {SPECIAL_ATTACK_DEAD,           colorTable.BloodRed},
+    {SPECIAL_ATTACK_PETRIFIED,      colorTable.MediumGrey},
+    {SPECIAL_ATTACK_ERADICATED,     colorTable.MoonRaker},
+    {SPECIAL_ATTACK_BREAK_ANY,      colorTable.LaserLemon},
+    {SPECIAL_ATTACK_BREAK_ARMOR,    colorTable.LaserLemon},
+    {SPECIAL_ATTACK_BREAK_WEAPON,   colorTable.LaserLemon},
+    {SPECIAL_ATTACK_STEAL,          colorTable.DirtyYellow},
+    {SPECIAL_ATTACK_AGING,          colorTable.White},
+    {SPECIAL_ATTACK_MANA_DRAIN,     colorTable.BoltBlue},
+    {SPECIAL_ATTACK_FEAR,           colorTable.CornFlowerBlue}
+};
+
+// OE addition - colors for monster special ability text.
+static constexpr IndexedArray<Color, MONSTER_SPECIAL_ABILITY_FIRST, MONSTER_SPECIAL_ABILITY_LAST> monsterSpecialAbilityColors = {
+    {MONSTER_SPECIAL_ABILITY_SHOT, colorTable.Mercury},
+    {MONSTER_SPECIAL_ABILITY_SUMMON, colorTable.EasternBlue},
+    {MONSTER_SPECIAL_ABILITY_EXPLODE, colorTable.Sunflower}
+};
+
 void Inventory_ItemPopupAndAlchemy();
 Color GetSpellColor(SpellId spellId);
 uint64_t GetExperienceRequiredForLevel(int level);
@@ -856,10 +890,13 @@ std::pair<int, int> MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow)
     }
     pTextHeight += 2 * lineAdvance;
 
+
+    // TODO(captainurist): Display ranged attack as "Ranged attack". This currently doesn't fit in the table, we used to
+    //                     just do attackStr + " R" but that's cryptic. Redo properly with dynamic alignment.
+
     std::string attackStr, damageStr;
     if (expert_level) {
         attackStr = displayNameForDamageType(monsterInfo.attack1Type, localization);
-        if (extended && monsterInfo.attack1MissileType) attackStr += " R";
         if (monsterInfo.attack1DamageBonus) {
             damageStr = fmt::format("{}d{}+{}", monsterInfo.attack1DamageDiceRolls, monsterInfo.attack1DamageDiceSides, monsterInfo.attack1DamageBonus);
         } else {
@@ -883,7 +920,6 @@ std::pair<int, int> MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow)
     }
     if (expert_level && extended && monsterInfo.attack2Chance > 0 && (monsterInfo.attack2DamageDiceRolls > 0 || monsterInfo.attack2DamageBonus > 0)) {
         attackStr = displayNameForDamageType(monsterInfo.attack2Type, localization);
-        if (monsterInfo.attack2MissileType) attackStr += " R";
         if (monsterInfo.attack2DamageBonus) {
             damageStr = fmt::format("{}d{}+{}", monsterInfo.attack2DamageDiceRolls, monsterInfo.attack2DamageDiceSides, monsterInfo.attack2DamageBonus);
         } else {
@@ -907,15 +943,17 @@ std::pair<int, int> MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow)
     if (master_level && extended && monsterInfo.specialAttackType != SPECIAL_ATTACK_NONE) {
         pTextHeight += lineAdvance;
         if (pWindow) {
-            auto [str, color] = monsterSpecialAttackDisplay[monsterInfo.specialAttackType];
-            pWindow->DrawText(font, {X_RIGHT_INDENTED, pTextHeight}, *color, str);
+            pWindow->DrawText(font, {X_RIGHT_INDENTED, pTextHeight},
+                              monsterSpecialAttackColors[monsterInfo.specialAttackType],
+                              localization->GetSpecialAttackName(monsterInfo.specialAttackType));
         }
     }
     if (master_level && extended && monsterInfo.specialAbilityType != MONSTER_SPECIAL_ABILITY_NONE) {
         pTextHeight += lineAdvance;
         if (pWindow) {
-            auto [str, color] = monsterSpecialAbilityDisplay[monsterInfo.specialAbilityType];
-            pWindow->DrawText(font, {X_RIGHT_INDENTED, pTextHeight}, *color, str);
+            pWindow->DrawText(font, {X_RIGHT_INDENTED, pTextHeight},
+                              monsterSpecialAbilityColors[monsterInfo.specialAbilityType],
+                              localization->GetMonsterSpecialAbilityName(monsterInfo.specialAbilityType));
         }
     }
     pTextHeight += 2 * lineAdvance;


### PR DESCRIPTION
Fixes #2042 as side effect.

Adds an option, settable via console or ini file edit, to give the player more info in the monster popup (still with enough skill of course):
- Second attack
- Ranged indicator
- Spell level and mastery
- Specials (disease, item breaking, SP drain...)
- Reverts resistance display to the numeric one I see in grayface-patched mm7 ('None' or 'Immune' unchanged)

All that is available though web sites like [rpgclassic](https://shrines.rpgclassics.com/pc/mm7/monsterlist2.shtml), so it just saves one trip to the browser, not really a balance issue... I refrained from adding exp gained and more, though.