### PR TITLE
Game option: Show remaining power of Protection from Magic

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -267,6 +267,8 @@ class GameConfig : public Config {
         Bool DestroyDischargedWands = { this, "destroy_discharged_wands", false,
             "Destroy wands when they reach 0 charges." };
 
+        Bool ShowProtectionMagicPower = {this, "show_prot_magic_power", true, "Display the remaining power of Protection from Magic in the Party Buffs popup."};
+
      private:
         static int ValidateMaxFlightHeight(int max_flight_height) {
             if (max_flight_height <= 0 || max_flight_height > 16192)

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -83,6 +83,8 @@ bool Localization::Initialize() {
         this->localization_strings[LSTR_ENERGY] = "Energy";
     if (this->localization_strings[LSTR_IMMOLATION_DAMAGE].empty())
         this->localization_strings[LSTR_IMMOLATION_DAMAGE] = "Immolation deals %d damage to %d target(s)";
+    if (this->localization_strings[LSTR_REMAINING_POWER].empty())
+        this->localization_strings[LSTR_REMAINING_POWER] = "Remaining power: %d";
 
     InitializeMm6ItemCategories();
 

--- a/src/Engine/Localization.h
+++ b/src/Engine/Localization.h
@@ -439,8 +439,9 @@
 #define LSTR_WAND_ALREADY_CHARGED           683  // "Wand already charged!"
 #define LSTR_ENERGY                         684  // "Energy"
 #define LSTR_IMMOLATION_DAMAGE              685  // "Immolation deals %d damage to %d target(s)
+#define LSTR_REMAINING_POWER                686  // "Remaining power: %d"
 
-#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 9
+#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 10
 
 class Localization {
  public:

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -286,7 +286,7 @@ void GUIWindow::DrawMessageBox(bool inside_game_viewport) {
 std::string MakeDateTimeString(Duration time) {
     CivilDuration d = time.toCivilDuration();
 
-    std::string str = "";
+    std::string str;
     if (d.days) {
         auto day_str = localization->GetString(LSTR_DAYS);
         if (d.days <= 1) day_str = localization->GetString(LSTR_DAY_CAPITALIZED);
@@ -314,6 +314,9 @@ std::string MakeDateTimeString(Duration time) {
 
         str += fmt::format("{} {} ", d.seconds, seconds_str);
     }
+
+    if (!str.empty() && str.back() == ' ')
+        str.pop_back();
 
     return str;
 }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1376,6 +1376,11 @@ static void drawBuffPopupWindow() {
             popupWindow.DrawText(assets->pFontComic.get(), {52, yPos}, spellTooltipColors[i], localization->GetPartyBuffName(i));
             DrawBuff_remaining_time_string(yPos, &popupWindow, remaingTime, assets->pFontComic.get());
             stringCount++;
+            if (i == PARTY_BUFF_PROTECTION_FROM_MAGIC && engine->config->gameplay.ShowProtectionMagicPower.value()) {
+                yPos = stringCount * assets->pFontComic->GetHeight() + 40;
+                popupWindow.DrawText(assets->pFontComic.get(), {32, yPos}, colorTable.White, "\r020" + localization->FormatString(LSTR_REMAINING_POWER, pParty->pPartyBuffs[i].power));
+                stringCount++;
+            }
         }
     }
 }


### PR DESCRIPTION
Another small thing while we were in the UIPopup file:

Adds a game option that adds a second line for Protection from Magic in the party buffs popup, showing the remaining power (which works as "charges", very unlike all the rest of the buffs).

This is more of a balance issue, as you tend to not really count those charges in normal gameplay - though the _use_ of one charge is recognizable as sound effect IIRC - except at the wishing wells...

Screenshot:
<details>

![image](https://github.com/user-attachments/assets/00fada43-d3bb-45bc-b40c-b31560265c1c)

</details>

Text choices open to discussion - color, not re-showing the label...?