### PR TITLE
Drop a temporary cmake warning

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
 file(GLOB_RECURSE RESOURCE_SOURCES "scripts/*" "shaders/*" "images/*")
 
-message(WARNING ${RESOURCE_SOURCES})
-
 cmrc_add_resource_library(resources NAMESPACE openenroth ${RESOURCE_SOURCES})
 
 add_subdirectory(scripts)


### PR DESCRIPTION
I remember adding this for debug purposes and looks like I accidentally merged it in...