### PR TITLE
Small turn engine fixes

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -85,6 +85,7 @@
 #include "Tables/ChestTable.h"
 
 #include "Utility/String/Transformations.h"
+#include "TurnEngine/TurnEngine.h"
 
 /*
 
@@ -555,6 +556,8 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     // TODO(captainurist): need to zero this one out when loading a save, but is this a proper place to do that?
     attackList.clear();
+    // Clearing actors lists mean turn engine queue will have invalid actor ids
+    std::erase_if(pTurnEngine->pQueue, [](const auto& item) { return item.uPackedID.type() == OBJECT_Actor; });
     int configLimit = engine->config->gameplay.MaxActors.value();
     ai_near_actors_targets_pid.resize(configLimit, Pid());
     ai_near_actors_ids.resize(configLimit);

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -35,6 +35,7 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 #include "Library/Lod/LodWriter.h"
+#include "TurnEngine/TurnEngine.h"
 
 SavegameList *pSavegameList = new SavegameList;
 
@@ -57,6 +58,10 @@ void LoadGame(int uSlot) {
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
+    if (pParty->bTurnBasedModeOn) {
+        pTurnEngine->End(false);
+        pParty->bTurnBasedModeOn = false;
+    }
 
     std::string filename = fmt::format("saves/{}", pSavegameList->pFileList[uSlot]);
 

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 36709864eca080b94dc6f722bb18b8142663b44f
+        GIT_TAG 62685a20f13351f737876aa7c225fa5f4b050a9a
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -838,6 +838,22 @@ GAME_TEST(Issues, Issue1983) {
     EXPECT_CONTAINS(textsTape.flattened(), [] (std::string_view text) { return text.contains("Letter from Mr. Stantley") && text.contains("is beyond my meager knowledge"); });
 }
 
+GAME_TEST(Issues, Issue1989) {
+    // Crash entering Wormthrax' cave in turn mode
+    auto mapTape = tapes.map();
+    auto turnTape = tapes.turnBasedMode();
+
+    test.playTraceFromTestData("issue_1989.mm7", "issue_1989.json", [] { EXPECT_TRUE([] {
+        for (const auto& act : pActors)
+            if ((pParty->pos - act.pos).lengthSqr() < 400) // troll is nearby
+                return true;
+        return false; });
+    });
+    EXPECT_EQ(mapTape, tape(MAP_TATALIA, MAP_WROMTHRAXS_CAVE));
+    EXPECT_EQ(turnTape, tape(false, true)); // turn mode
+    EXPECT_EQ(pActors.size(), 1); // here be dragon
+}
+
 GAME_TEST(Issues, Issue1990) {
     // Test opening the Tularean Forest half-hidden chest, which generates a black potion.
     auto screenTape = tapes.screen();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -6,6 +6,45 @@
 
 // 2000
 
+GAME_TEST(Issues, Issue2002) {
+    // Character recovery is carried over when loading a saved game in turn based mode
+    // start game and enter turn based mode
+    game.startNewGame();
+    game.pressAndReleaseKey(PlatformKey::KEY_RETURN);
+    game.tick(15);
+    for (int i = 0; i < 3; ++i) {
+        game.pressKey(PlatformKey::KEY_A); // Attack with 3 chars
+        game.tick();
+        game.releaseKey(PlatformKey::KEY_A);
+        game.tick();
+    }
+
+    // check recovery
+    EXPECT_TRUE(pParty->bTurnBasedModeOn);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(pParty->pCharacters[i].timeToRecovery > 0_ticks);
+    }
+    EXPECT_FALSE(pParty->pCharacters[3].timeToRecovery > 0_ticks);
+
+    // now load a saved game
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_LoadGame");
+    game.tick(10);
+    game.pressGuiButton("LoadMenu_Slot0");
+    game.tick(2);
+    game.pressGuiButton("LoadMenu_Load");
+    game.tick(2);
+    game.skipLoadingScreen();
+    game.tick(2);
+
+    // check recovery again
+    for (int i = 0; i < 4; i++) {
+        EXPECT_FALSE(pParty->pCharacters[i].timeToRecovery > 0_ticks);
+    }
+    EXPECT_FALSE(pParty->bTurnBasedModeOn);
+}
+
 GAME_TEST(Issues, Issue2017) {
     // Bats move through closed doors in Barrow XII
     test.playTraceFromTestData("issue_2017.mm7", "issue_2017.json");


### PR DESCRIPTION
Fix #1989
Fix #2002 
Pretty hacky - but functional without having to make large changes. (Turn engine and its various tie-ins could do with a proper clean up - like lots of the code i guess X) )