### PR TITLE
Viewport simplification

### DIFF
--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -176,7 +176,7 @@ bool GameWindowHandler::OnChar(PlatformKey key, int c) {
         textInputHandled |= keyboardInputHandler->ProcessTextInput(PlatformKey::KEY_CHAR, c);
     }
 
-    if (!textInputHandled && !viewparams->field_4C) {
+    if (!textInputHandled) {
         return GUI_HandleHotkey(key);  // try other hotkeys
     }
     return false;
@@ -323,8 +323,7 @@ void GameWindowHandler::OnKey(PlatformKey key) {
     } else {
         pMediaPlayer->StopMovie();
         if (keyboardActionMapping->IsKeyMatchAction(InputAction::Return, key)) {
-            if (!viewparams->field_4C)
-                UI_OnKeyDown(key);
+            UI_OnKeyDown(key);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::Escape, key)) {
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, window_SpeakInHouse != 0, 0);
         } else if (keyboardActionMapping->IsKeyMatchAction(InputAction::ToggleFullscreen, key) && !pMovie_Track) {
@@ -342,9 +341,7 @@ void GameWindowHandler::OnKey(PlatformKey key) {
             || keyboardActionMapping->IsKeyMatchAction(InputAction::DialogSelect, key)) {
             if (current_screen_type != SCREEN_GAME &&
                 current_screen_type != SCREEN_GAMEOVER_WINDOW) {
-                if (!viewparams->field_4C) {
-                    UI_OnKeyDown(key);
-                }
+                UI_OnKeyDown(key);
             }
         }
     }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -808,13 +808,10 @@ void Engine::Initialize() {
 void MM6_Initialize() {
     viewparams = new ViewingParams;
     Sizei wsize = window->size();
-    game_viewport_x = viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
-    game_viewport_y = viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
-    game_viewport_z = viewparams->uScreen_BttmR_X = wsize.w - engine->config->graphics.ViewPortX2.value(); //468;
-    game_viewport_w = viewparams->uScreen_BttmR_Y = wsize.h - engine->config->graphics.ViewPortY2.value(); //352;
-
-    game_viewport_width = game_viewport_z - game_viewport_x;
-    game_viewport_height = game_viewport_w - game_viewport_y;
+    viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
+    viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
+    viewparams->uScreen_BttmR_X = wsize.w - engine->config->graphics.ViewPortX2.value(); //468;
+    viewparams->uScreen_BttmR_Y = wsize.h - engine->config->graphics.ViewPortY2.value(); //352;
 
     pAudioPlayer = std::make_unique<AudioPlayer>();
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -450,10 +450,10 @@ void Engine::LogEngineBuildInfo() {
 //----- (0044EA5E) --------------------------------------------------------
 Vis_PIDAndDepth Engine::PickMouse(float fPickDepth, int uMouseX, int uMouseY,
                                   Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter) {
-    if (uMouseX >= pViewport->uScreen_TL_X &&
-        uMouseX <= pViewport->uScreen_BR_X &&
-        uMouseY >= pViewport->uScreen_TL_Y &&
-        uMouseY <= pViewport->uScreen_BR_Y) {
+    if (uMouseX >= pViewport->uViewportTL_X &&
+        uMouseX <= pViewport->uViewportBR_X &&
+        uMouseY >= pViewport->uViewportTL_Y &&
+        uMouseY <= pViewport->uViewportBR_Y) {
         return vis->PickMouse(fPickDepth, uMouseX, uMouseY, sprite_filter, face_filter);
     } else {
         return Vis_PIDAndDepth();
@@ -609,13 +609,10 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
 //----- (004647AB) --------------------------------------------------------
 void FinalInitialization() {
-    pViewport->SetScreen(
-        viewparams->uSomeX,
-        viewparams->uSomeY,
-        viewparams->uSomeZ,
-        viewparams->uSomeW
-    );
-    pViewport->ResetScreen();
+    pViewport->SetViewport(viewparams->uScreen_topL_X,
+                           viewparams->uScreen_topL_Y,
+                           viewparams->uScreen_BttmR_X,
+                           viewparams->uScreen_BttmR_Y);
 
     InitializeTurnBasedAnimations(&stru_50C198);
     pBitmaps_LOD->reserveLoadedTextures();
@@ -846,14 +843,10 @@ void MM7Initialization() {
         viewparams->field_20 &= 0xFFFFFF00;
     }
 
-    viewparams->uSomeY = viewparams->uScreen_topL_Y;
-    viewparams->uSomeX = viewparams->uScreen_topL_X;
-    viewparams->uSomeZ = viewparams->uScreen_BttmR_X;
-    viewparams->uSomeW = viewparams->uScreen_BttmR_Y;
-
-    pViewport->SetScreen(viewparams->uScreen_topL_X, viewparams->uScreen_topL_Y,
-                         viewparams->uScreen_BttmR_X,
-                         viewparams->uScreen_BttmR_Y);
+    pViewport->SetViewport(viewparams->uScreen_topL_X, 
+                           viewparams->uScreen_topL_Y,
+                           viewparams->uScreen_BttmR_X,
+                           viewparams->uScreen_BttmR_Y);
 }
 
 //----- (00464479) --------------------------------------------------------

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -450,10 +450,10 @@ void Engine::LogEngineBuildInfo() {
 //----- (0044EA5E) --------------------------------------------------------
 Vis_PIDAndDepth Engine::PickMouse(float fPickDepth, int uMouseX, int uMouseY,
                                   Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter) {
-    if (uMouseX >= pViewport->uViewportTL_X &&
-        uMouseX <= pViewport->uViewportBR_X &&
-        uMouseY >= pViewport->uViewportTL_Y &&
-        uMouseY <= pViewport->uViewportBR_Y) {
+    if (uMouseX >= pViewport->viewportTL_X &&
+        uMouseX <= pViewport->viewportBR_X &&
+        uMouseY >= pViewport->viewportTL_Y &&
+        uMouseY <= pViewport->viewportBR_Y) {
         return vis->PickMouse(fPickDepth, uMouseX, uMouseY, sprite_filter, face_filter);
     } else {
         return Vis_PIDAndDepth();
@@ -831,8 +831,6 @@ void MM7Initialization() {
         pODMRenderParams->building_gamme = 0;
         pODMRenderParams->shading_dist_shademist = 4096;
         pODMRenderParams->outdoor_no_wavy_water = 0;
-    } else {
-        viewparams->field_20 &= 0xFFFFFF00;
     }
 
     // @TODO(Baste) this is initialized to the same value in three spots!

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -609,10 +609,11 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
 //----- (004647AB) --------------------------------------------------------
 void FinalInitialization() {
-    pViewport->SetViewport(viewparams->uScreen_topL_X,
-                           viewparams->uScreen_topL_Y,
-                           viewparams->uScreen_BttmR_X,
-                           viewparams->uScreen_BttmR_Y);
+    // @TODO(Baste) this is initialized to the same value in three spots!
+    pViewport->SetViewport(engine->config->graphics.ViewPortX1.value(),
+                           engine->config->graphics.ViewPortY1.value(),
+                           render->GetRenderDimensions().w - engine->config->graphics.ViewPortX2.value(),
+                           render->GetRenderDimensions().h - engine->config->graphics.ViewPortY2.value());
 
     InitializeTurnBasedAnimations(&stru_50C198);
     pBitmaps_LOD->reserveLoadedTextures();
@@ -807,12 +808,6 @@ void Engine::Initialize() {
 //----- (00466082) --------------------------------------------------------
 void MM6_Initialize() {
     viewparams = new ViewingParams;
-    Sizei wsize = window->size();
-    viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
-    viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
-    viewparams->uScreen_BttmR_X = wsize.w - engine->config->graphics.ViewPortX2.value(); //468;
-    viewparams->uScreen_BttmR_Y = wsize.h - engine->config->graphics.ViewPortY2.value(); //352;
-
     pAudioPlayer = std::make_unique<AudioPlayer>();
 
     pODMRenderParams = new ODMRenderParams;
@@ -840,10 +835,11 @@ void MM7Initialization() {
         viewparams->field_20 &= 0xFFFFFF00;
     }
 
-    pViewport->SetViewport(viewparams->uScreen_topL_X, 
-                           viewparams->uScreen_topL_Y,
-                           viewparams->uScreen_BttmR_X,
-                           viewparams->uScreen_BttmR_Y);
+    // @TODO(Baste) this is initialized to the same value in three spots!
+    pViewport->SetViewport(engine->config->graphics.ViewPortX1.value(),
+                           engine->config->graphics.ViewPortY1.value(),
+                           render->GetRenderDimensions().w - engine->config->graphics.ViewPortX2.value(),
+                           render->GetRenderDimensions().h - engine->config->graphics.ViewPortY2.value());
 }
 
 //----- (00464479) --------------------------------------------------------

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -263,7 +263,7 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     fov_y_deg = (180.0 / pi) * 2.0 * std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
     screenCenterX = (double)pViewport->uScreenCenterX;
-    screenCenterY = (double)pViewport->uScreenCenterY - pViewport->uScreen_TL_Y;
+    screenCenterY = (double)pViewport->uScreenCenterY - pViewport->uViewportTL_Y;
 
     aspect = float(game_viewport_width / float(game_viewport_height));
 }

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -257,21 +257,21 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
         halfFovTan = std::tan(blv_fov_rad / 2.0);
 
-    ViewPlaneDistPixels = (double)pViewport->uScreenWidth * 0.5 / halfFovTan;
+    ViewPlaneDistPixels = (double)pViewport->uViewportWidth * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDistPixels);
+    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((pViewport->uViewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
-    screenCenterX = (double)pViewport->uScreenCenterX;
-    screenCenterY = (double)pViewport->uScreenCenterY - pViewport->uViewportTL_Y;
+    screenCenterX = (double)pViewport->uViewportCenterX;
+    screenCenterY = (double)pViewport->uViewportCenterY - pViewport->uViewportTL_Y;
 
-    aspect = float(game_viewport_width / float(game_viewport_height));
+    aspect = float(pViewport->uViewportWidth / float(pViewport->uViewportHeight));
 }
 
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
     float HalfAngleX = (pi / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (pi / 2.0) - (std::atan((game_viewport_height / 2.0) / pCamera3D->ViewPlaneDistPixels));
+    float HalfAngleY = (pi / 2.0) - (std::atan((pViewport->uViewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
         HalfAngleX = (pi / 2.0) - (blv_fov_rad / 2.0);
@@ -456,9 +456,9 @@ void Camera3D::Project(RenderVertexSoft *pVertices, unsigned int uNumVertices, b
         v->_rhw = RHW;
         viewscalefactor = RHW * ViewPlaneDistPixels;
 
-        v->vWorldViewProjX = (double)pViewport->uScreenCenterX -
+        v->vWorldViewProjX = (double)pViewport->uViewportCenterX -
                              viewscalefactor * (double)v->vWorldViewPosition.y;
-        v->vWorldViewProjY = (double)pViewport->uScreenCenterY -
+        v->vWorldViewProjY = (double)pViewport->uViewportCenterY -
                              viewscalefactor * (double)v->vWorldViewPosition.z;
 
         if (fit_into_viewport) {

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -257,21 +257,21 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR)
         halfFovTan = std::tan(blv_fov_rad / 2.0);
 
-    ViewPlaneDistPixels = (double)pViewport->uViewportWidth * 0.5 / halfFovTan;
+    ViewPlaneDistPixels = (double)pViewport->viewportWidth * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((pViewport->uViewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels);
+    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((pViewport->viewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
-    screenCenterX = (double)pViewport->uViewportCenterX;
-    screenCenterY = (double)pViewport->uViewportCenterY - pViewport->uViewportTL_Y;
+    screenCenterX = (double)pViewport->viewportCenterX;
+    screenCenterY = (double)pViewport->viewportCenterY - pViewport->viewportTL_Y;
 
-    aspect = float(pViewport->uViewportWidth / float(pViewport->uViewportHeight));
+    aspect = float(pViewport->viewportWidth / float(pViewport->viewportHeight));
 }
 
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
     float HalfAngleX = (pi / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (pi / 2.0) - (std::atan((pViewport->uViewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels));
+    float HalfAngleY = (pi / 2.0) - (std::atan((pViewport->viewportHeight / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
         HalfAngleX = (pi / 2.0) - (blv_fov_rad / 2.0);
@@ -456,18 +456,18 @@ void Camera3D::Project(RenderVertexSoft *pVertices, unsigned int uNumVertices, b
         v->_rhw = RHW;
         viewscalefactor = RHW * ViewPlaneDistPixels;
 
-        v->vWorldViewProjX = (double)pViewport->uViewportCenterX -
+        v->vWorldViewProjX = (double)pViewport->viewportCenterX -
                              viewscalefactor * (double)v->vWorldViewPosition.y;
-        v->vWorldViewProjY = (double)pViewport->uViewportCenterY -
+        v->vWorldViewProjY = (double)pViewport->viewportCenterY -
                              viewscalefactor * (double)v->vWorldViewPosition.z;
 
         if (fit_into_viewport) {
-            fitted_x = (double)(signed int)pViewport->uViewportBR_X;
+            fitted_x = (double)(signed int)pViewport->viewportBR_X;
             if (fitted_x >= pVertices[i].vWorldViewProjX)
                 temp_r = pVertices[i].vWorldViewProjX;
             else
                 temp_r = fitted_x;
-            temp_l = (double)(signed int)pViewport->uViewportTL_X;
+            temp_l = (double)(signed int)pViewport->viewportTL_X;
             if (temp_l <= temp_r) {
                 if (fitted_x >= pVertices[i].vWorldViewProjX)
                     fitted_x = pVertices[i].vWorldViewProjX;
@@ -476,12 +476,12 @@ void Camera3D::Project(RenderVertexSoft *pVertices, unsigned int uNumVertices, b
             }
             pVertices[i].vWorldViewProjX = fitted_x;
 
-            fitted_y = (double)(signed int)pViewport->uViewportBR_Y;
+            fitted_y = (double)(signed int)pViewport->viewportBR_Y;
             if (fitted_y >= pVertices[i].vWorldViewProjY)
                 temp_b = pVertices[i].vWorldViewProjY;
             else
                 temp_b = fitted_y;
-            temp_t = (double)(signed int)pViewport->uViewportTL_Y;
+            temp_t = (double)(signed int)pViewport->viewportTL_Y;
             if (temp_t <= temp_b) {
                 if (fitted_y >= pVertices[i].vWorldViewProjY)
                     fitted_y = pVertices[i].vWorldViewProjY;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -177,10 +177,10 @@ void BLVRenderParams::Reset() {
 
 
     {
-        this->uViewportX = pViewport->uScreen_TL_X;
-        this->uViewportY = pViewport->uScreen_TL_Y;
-        this->uViewportZ = pViewport->uScreen_BR_X;
-        this->uViewportW = pViewport->uScreen_BR_Y;
+        this->uViewportX = pViewport->uViewportTL_X;
+        this->uViewportY = pViewport->uViewportTL_Y;
+        this->uViewportZ = pViewport->uViewportBR_X;
+        this->uViewportW = pViewport->uViewportBR_Y;
 
         this->uViewportWidth = uViewportZ - uViewportX + 1;
         this->uViewportHeight = uViewportW - uViewportY + 1;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -177,10 +177,10 @@ void BLVRenderParams::Reset() {
 
 
     {
-        this->uViewportX = pViewport->uViewportTL_X;
-        this->uViewportY = pViewport->uViewportTL_Y;
-        this->uViewportZ = pViewport->uViewportBR_X;
-        this->uViewportW = pViewport->uViewportBR_Y;
+        this->uViewportX = pViewport->viewportTL_X;
+        this->uViewportY = pViewport->viewportTL_Y;
+        this->uViewportZ = pViewport->viewportBR_X;
+        this->uViewportW = pViewport->viewportBR_Y;
 
         this->uViewportWidth = uViewportZ - uViewportX + 1;
         this->uViewportHeight = uViewportW - uViewportY + 1;
@@ -1292,9 +1292,9 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
             int screen_space_half_width = static_cast<int>(billb_scale * v11->hw_sprites[(int64_t)v9]->uWidth / 2.0f);
             int screen_space_height = static_cast<int>(billb_scale * v11->hw_sprites[(int64_t)v9]->uHeight);
 
-            if (projected_x + screen_space_half_width >= (signed int)pViewport->uViewportTL_X &&
-                projected_x - screen_space_half_width <= (signed int)pViewport->uViewportBR_X) {
-                if (projected_y >= pViewport->uViewportTL_Y && (projected_y - screen_space_height) <= pViewport->uViewportBR_Y) {
+            if (projected_x + screen_space_half_width >= (signed int)pViewport->viewportTL_X &&
+                projected_x - screen_space_half_width <= (signed int)pViewport->viewportBR_X) {
+                if (projected_y >= pViewport->viewportTL_Y && (projected_y - screen_space_height) <= pViewport->viewportBR_Y) {
                     assert(uNumBillboardsToDraw < 500);
                     ++uNumBillboardsToDraw;
                     ++uNumDecorationsDrawnThisFrame;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -809,9 +809,9 @@ void OutdoorLocation::PrepareActorsDrawList() {
                 int screen_space_half_width = static_cast<int>(proj_scale * frame->hw_sprites[Sprite_Octant]->uWidth / 2.0f);
                 int screen_space_height = static_cast<int>(proj_scale * frame->hw_sprites[Sprite_Octant]->uHeight);
 
-                if (projected_x + screen_space_half_width >= (signed int)pViewport->uViewportTL_X &&
-                    projected_x - screen_space_half_width <= (signed int)pViewport->uViewportBR_X) {
-                    if (projected_y >= pViewport->uViewportTL_Y && (projected_y - screen_space_height) <= pViewport->uViewportBR_Y) { // test
+                if (projected_x + screen_space_half_width >= (signed int)pViewport->viewportTL_X &&
+                    projected_x - screen_space_half_width <= (signed int)pViewport->viewportBR_X) {
+                    if (projected_y >= pViewport->viewportTL_Y && (projected_y - screen_space_height) <= pViewport->viewportBR_Y) { // test
                         ++uNumBillboardsToDraw;
                         ++uNumSpritesDrawnThisFrame;
 

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -185,9 +185,9 @@ void BaseRenderer::DrawSpriteObjects() {
                     int screen_space_half_width = static_cast<int>(billb_scale * frame->hw_sprites[octant]->uWidth / 2.0f);
                     int screen_space_height = static_cast<int>(billb_scale * frame->hw_sprites[octant]->uHeight);
 
-                    if (projected_x + screen_space_half_width >= (signed int)pViewport->uViewportTL_X &&
-                        projected_x - screen_space_half_width <= (signed int)pViewport->uViewportBR_X) {
-                        if (projected_y >= pViewport->uViewportTL_Y && (projected_y - screen_space_height) <= pViewport->uViewportBR_Y) {
+                    if (projected_x + screen_space_half_width >= (signed int)pViewport->viewportTL_X &&
+                        projected_x - screen_space_half_width <= (signed int)pViewport->viewportBR_X) {
+                        if (projected_y >= pViewport->viewportTL_Y && (projected_y - screen_space_height) <= pViewport->viewportBR_Y) {
                             object->uAttributes |= SPRITE_VISIBLE;
                             pBillboardRenderList[::uNumBillboardsToDraw].uPaletteIndex = frame->GetPaletteIndex();
                             pBillboardRenderList[::uNumBillboardsToDraw].uIndoorSectorID = object->uSectorID;
@@ -323,9 +323,9 @@ void BaseRenderer::PrepareDecorationsRenderList_ODM() {
                             int screen_space_half_width = static_cast<int>(_v41 * frame->hw_sprites[(int64_t)v37]->uWidth / 2.0f);
                             int screen_space_height = static_cast<int>(_v41 * frame->hw_sprites[(int64_t)v37]->uHeight);
 
-                            if (projected_x + screen_space_half_width >= (signed int)pViewport->uViewportTL_X &&
-                                projected_x - screen_space_half_width <= (signed int)pViewport->uViewportBR_X) {
-                                if (projected_y >= pViewport->uViewportTL_Y && (projected_y - screen_space_height) <= pViewport->uViewportBR_Y) {
+                            if (projected_x + screen_space_half_width >= (signed int)pViewport->viewportTL_X &&
+                                projected_x - screen_space_half_width <= (signed int)pViewport->viewportBR_X) {
+                                if (projected_y >= pViewport->viewportTL_Y && (projected_y - screen_space_height) <= pViewport->viewportBR_Y) {
                                     ::uNumBillboardsToDraw++;
                                     ++uNumDecorationsDrawnThisFrame;
 
@@ -375,10 +375,10 @@ void BaseRenderer::TransformBillboardsAndSetPalettesODM() {
     billboard.sParentBillboardID = -1;
     //  billboard.pTarget = render->pTargetSurface;
     //  billboard.uTargetPitch = render->uTargetSurfacePitch;
-    billboard.uViewportX = pViewport->uViewportTL_X;
-    billboard.uViewportY = pViewport->uViewportTL_Y;
-    billboard.uViewportZ = pViewport->uViewportBR_X - 1;
-    billboard.uViewportW = pViewport->uViewportBR_Y;
+    billboard.uViewportX = pViewport->viewportTL_X;
+    billboard.uViewportY = pViewport->viewportTL_Y;
+    billboard.uViewportZ = pViewport->viewportBR_X - 1;
+    billboard.uViewportW = pViewport->viewportBR_Y;
     pODMRenderParams->uNumBillboards = ::uNumBillboardsToDraw;
 
     for (unsigned int i = 0; i < ::uNumBillboardsToDraw; ++i) {
@@ -682,10 +682,10 @@ void BaseRenderer::DrawMonsterPortrait(const Recti &rc, SpriteFrame *Portrait, i
 
 void BaseRenderer::DrawSpecialEffectsQuad(GraphicsImage *texture, int palette) {
     Recti targetrect{};
-    targetrect.x = pViewport->uViewportTL_X;
-    targetrect.y = pViewport->uViewportTL_Y;
-    targetrect.w = pViewport->uViewportBR_X - pViewport->uViewportTL_X;
-    targetrect.h = pViewport->uViewportBR_Y - pViewport->uViewportTL_Y;
+    targetrect.x = pViewport->viewportTL_X;
+    targetrect.y = pViewport->viewportTL_Y;
+    targetrect.w = pViewport->viewportBR_X - pViewport->viewportTL_X;
+    targetrect.h = pViewport->viewportBR_Y - pViewport->viewportTL_Y;
 
     DrawImage(texture, targetrect, palette, colorTable.MediumGrey);
 }

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -4712,14 +4712,10 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
         game_viewport_width = game_viewport_z - game_viewport_x;
         game_viewport_height = game_viewport_w - game_viewport_y;
 
-        viewparams->uSomeY = viewparams->uScreen_topL_Y;
-        viewparams->uSomeX = viewparams->uScreen_topL_X;
-        viewparams->uSomeZ = viewparams->uScreen_BttmR_X;
-        viewparams->uSomeW = viewparams->uScreen_BttmR_Y;
-
-        pViewport->SetScreen(viewparams->uScreen_topL_X, viewparams->uScreen_topL_Y,
-                            viewparams->uScreen_BttmR_X,
-                            viewparams->uScreen_BttmR_Y);
+        pViewport->SetViewport(viewparams->uScreen_topL_X, 
+                               viewparams->uScreen_topL_Y,
+                               viewparams->uScreen_BttmR_X,
+                               viewparams->uScreen_BttmR_Y);
     }
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);       // Black Background

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -4704,15 +4704,11 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
     BaseRenderer::Reinitialize(firstInit);
 
     if (!firstInit) {
-        viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
-        viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
-        viewparams->uScreen_BttmR_X = outputRender.w - engine->config->graphics.ViewPortX2.value(); //468;
-        viewparams->uScreen_BttmR_Y = outputRender.h - engine->config->graphics.ViewPortY2.value(); //352;
-
-        pViewport->SetViewport(viewparams->uScreen_topL_X, 
-                               viewparams->uScreen_topL_Y,
-                               viewparams->uScreen_BttmR_X,
-                               viewparams->uScreen_BttmR_Y);
+        // @TODO(Baste) this is initialized to the same value in three spots!
+        pViewport->SetViewport(engine->config->graphics.ViewPortX1.value(), //8
+                               engine->config->graphics.ViewPortY1.value(), //8
+                               outputRender.w - engine->config->graphics.ViewPortX2.value(), //468;
+                               outputRender.h - engine->config->graphics.ViewPortY2.value()); //352;
     }
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);       // Black Background

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -1001,8 +1001,8 @@ RgbaImage OpenGLRenderer::MakeViewportScreenshot(const int width, const int heig
 
     // TODO(captainurist): subImage().scale()
     RgbaImage sPixels = ReadScreenPixels();
-    float interval_x = static_cast<float>(game_viewport_width) / width;
-    float interval_y = static_cast<float>(game_viewport_height) / height;
+    float interval_x = static_cast<float>(pViewport->uViewportWidth) / width;
+    float interval_y = static_cast<float>(pViewport->uViewportHeight) / height;
 
     RgbaImage pPixels = RgbaImage::solid(width, height, Color());
 
@@ -1401,8 +1401,8 @@ void OpenGLRenderer::_set_ortho_projection(bool gameviewport) {
         glViewport(0, 0, outputRender.w, outputRender.h);
         projmat = glm::ortho(float(0), float(outputRender.w), float(outputRender.h), float(0), float(-1), float(1));
     } else {  // project to game viewport
-        glViewport(game_viewport_x, outputRender.h-game_viewport_w-1, game_viewport_width, game_viewport_height);
-        projmat = glm::ortho(float(game_viewport_x), float(game_viewport_z), float(game_viewport_w), float(game_viewport_y), float(1), float(-1));
+        glViewport(pViewport->uViewportTL_X, outputRender.h- pViewport->uViewportBR_Y -1, pViewport->uViewportWidth, pViewport->uViewportHeight);
+        projmat = glm::ortho(float(pViewport->uViewportTL_X), float(pViewport->uViewportBR_X), float(pViewport->uViewportBR_Y), float(pViewport->uViewportTL_Y), float(1), float(-1));
     }
 }
 
@@ -1977,12 +1977,12 @@ void OpenGLRenderer::DrawOutdoorSky() {
     // lowers clouds as party goes up
     float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
         / ((double)pCamera3D->ViewPlaneDistPixels + pCamera3D->GetFarClip())
-        + (double)(pViewport->uScreenCenterY));
+        + (double)(pViewport->uViewportCenterY));
 
     float depth_to_far_clip = std::cos((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
     float height_to_far_clip = std::sin((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
 
-    float bot_y_proj = ((double)(pViewport->uScreenCenterY) -
+    float bot_y_proj = ((double)(pViewport->uViewportCenterY) -
         (double)pCamera3D->ViewPlaneDistPixels /
         (depth_to_far_clip + 0.0000001) *
         (height_to_far_clip - (double)pCamera3D->vCameraPos.z));
@@ -2035,7 +2035,7 @@ void OpenGLRenderer::DrawOutdoorSky() {
 
         for (unsigned i = 0; i < uNumVertices; ++i) {
             // outbound screen X dist
-            float x_dist = widthperpixel * (pViewport->uScreenCenterX - VertexRenderList[i].vWorldViewProjX);
+            float x_dist = widthperpixel * (pViewport->uViewportCenterX - VertexRenderList[i].vWorldViewProjX);
             // outbound screen y dist
             float y_dist = widthperpixel * (horizon_height_offset - VertexRenderList[i].vWorldViewProjY);
 
@@ -4704,13 +4704,10 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
     BaseRenderer::Reinitialize(firstInit);
 
     if (!firstInit) {
-        game_viewport_x = viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
-        game_viewport_y = viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
-        game_viewport_z = viewparams->uScreen_BttmR_X = outputRender.w - engine->config->graphics.ViewPortX2.value(); //468;
-        game_viewport_w = viewparams->uScreen_BttmR_Y = outputRender.h - engine->config->graphics.ViewPortY2.value(); //352;
-
-        game_viewport_width = game_viewport_z - game_viewport_x;
-        game_viewport_height = game_viewport_w - game_viewport_y;
+        viewparams->uScreen_topL_X = engine->config->graphics.ViewPortX1.value(); //8
+        viewparams->uScreen_topL_Y = engine->config->graphics.ViewPortY1.value(); //8
+        viewparams->uScreen_BttmR_X = outputRender.w - engine->config->graphics.ViewPortX2.value(); //468;
+        viewparams->uScreen_BttmR_Y = outputRender.h - engine->config->graphics.ViewPortY2.value(); //352;
 
         pViewport->SetViewport(viewparams->uScreen_topL_X, 
                                viewparams->uScreen_topL_Y,

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -530,10 +530,10 @@ void OpenGLRenderer::ScreenFade(Color color, float t) {
     Colorf cf = color.toColorf();
     cf.a = std::clamp(t, 0.0f, 1.0f);
 
-    float drawx = static_cast<float>(pViewport->uViewportTL_X);
-    float drawy = static_cast<float>(pViewport->uViewportTL_Y);
-    float drawz = static_cast<float>(pViewport->uViewportBR_X);
-    float draww = static_cast<float>(pViewport->uViewportBR_Y);
+    float drawx = static_cast<float>(pViewport->viewportTL_X);
+    float drawy = static_cast<float>(pViewport->viewportTL_Y);
+    float drawz = static_cast<float>(pViewport->viewportBR_X);
+    float draww = static_cast<float>(pViewport->viewportBR_Y);
 
     static GraphicsImage *effpar03 = assets->getBitmap("effpar03");
     float gltexid = static_cast<float>(effpar03->renderId().value());
@@ -1001,15 +1001,15 @@ RgbaImage OpenGLRenderer::MakeViewportScreenshot(const int width, const int heig
 
     // TODO(captainurist): subImage().scale()
     RgbaImage sPixels = ReadScreenPixels();
-    float interval_x = static_cast<float>(pViewport->uViewportWidth) / width;
-    float interval_y = static_cast<float>(pViewport->uViewportHeight) / height;
+    float interval_x = static_cast<float>(pViewport->viewportWidth) / width;
+    float interval_y = static_cast<float>(pViewport->viewportHeight) / height;
 
     RgbaImage pPixels = RgbaImage::solid(width, height, Color());
 
     if (uCurrentlyLoadedLevelType != LEVEL_NULL) {
         for (int y = 0; y < height; ++y) {
             for (int x = 0; x < width; ++x) {
-                pPixels[y][x] = sPixels[outputRender.h - (y + 1) * interval_y - pViewport->uViewportTL_Y][x * interval_x + pViewport->uViewportTL_X];
+                pPixels[y][x] = sPixels[outputRender.h - (y + 1) * interval_y - pViewport->viewportTL_Y][x * interval_x + pViewport->viewportTL_X];
             }
         }
     }
@@ -1401,8 +1401,8 @@ void OpenGLRenderer::_set_ortho_projection(bool gameviewport) {
         glViewport(0, 0, outputRender.w, outputRender.h);
         projmat = glm::ortho(float(0), float(outputRender.w), float(outputRender.h), float(0), float(-1), float(1));
     } else {  // project to game viewport
-        glViewport(pViewport->uViewportTL_X, outputRender.h- pViewport->uViewportBR_Y -1, pViewport->uViewportWidth, pViewport->uViewportHeight);
-        projmat = glm::ortho(float(pViewport->uViewportTL_X), float(pViewport->uViewportBR_X), float(pViewport->uViewportBR_Y), float(pViewport->uViewportTL_Y), float(1), float(-1));
+        glViewport(pViewport->viewportTL_X, outputRender.h- pViewport->viewportBR_Y -1, pViewport->viewportWidth, pViewport->viewportHeight);
+        projmat = glm::ortho(float(pViewport->viewportTL_X), float(pViewport->viewportBR_X), float(pViewport->viewportBR_Y), float(pViewport->viewportTL_Y), float(1), float(-1));
     }
 }
 
@@ -1977,12 +1977,12 @@ void OpenGLRenderer::DrawOutdoorSky() {
     // lowers clouds as party goes up
     float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
         / ((double)pCamera3D->ViewPlaneDistPixels + pCamera3D->GetFarClip())
-        + (double)(pViewport->uViewportCenterY));
+        + (double)(pViewport->viewportCenterY));
 
     float depth_to_far_clip = std::cos((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
     float height_to_far_clip = std::sin((double)pCamera3D->_viewPitch * rot_to_rads) * pCamera3D->GetFarClip();
 
-    float bot_y_proj = ((double)(pViewport->uViewportCenterY) -
+    float bot_y_proj = ((double)(pViewport->viewportCenterY) -
         (double)pCamera3D->ViewPlaneDistPixels /
         (depth_to_far_clip + 0.0000001) *
         (height_to_far_clip - (double)pCamera3D->vCameraPos.z));
@@ -2019,23 +2019,23 @@ void OpenGLRenderer::DrawOutdoorSky() {
         //  |8,351                468,351 |
         // 1._____________________________.2
         //
-        VertexRenderList[0].vWorldViewProjX = (double)(signed int)pViewport->uViewportTL_X;  // 8
-        VertexRenderList[0].vWorldViewProjY = (double)(signed int)pViewport->uViewportTL_Y;  // 8
+        VertexRenderList[0].vWorldViewProjX = (double)(signed int)pViewport->viewportTL_X;  // 8
+        VertexRenderList[0].vWorldViewProjY = (double)(signed int)pViewport->viewportTL_Y;  // 8
 
-        VertexRenderList[1].vWorldViewProjX = (double)(signed int)pViewport->uViewportTL_X;   // 8
+        VertexRenderList[1].vWorldViewProjX = (double)(signed int)pViewport->viewportTL_X;   // 8
         VertexRenderList[1].vWorldViewProjY = (double)bot_y_proj + 1;  // 247
 
-        VertexRenderList[2].vWorldViewProjX = (double)(signed int)pViewport->uViewportBR_X;   // 468
+        VertexRenderList[2].vWorldViewProjX = (double)(signed int)pViewport->viewportBR_X;   // 468
         VertexRenderList[2].vWorldViewProjY = (double)bot_y_proj + 1;  // 247
 
-        VertexRenderList[3].vWorldViewProjX = (double)(signed int)pViewport->uViewportBR_X;  // 468
-        VertexRenderList[3].vWorldViewProjY = (double)(signed int)pViewport->uViewportTL_Y;  // 8
+        VertexRenderList[3].vWorldViewProjX = (double)(signed int)pViewport->viewportBR_X;  // 468
+        VertexRenderList[3].vWorldViewProjY = (double)(signed int)pViewport->viewportTL_Y;  // 8
 
         float widthperpixel = 1 / pCamera3D->ViewPlaneDistPixels;
 
         for (unsigned i = 0; i < uNumVertices; ++i) {
             // outbound screen X dist
-            float x_dist = widthperpixel * (pViewport->uViewportCenterX - VertexRenderList[i].vWorldViewProjX);
+            float x_dist = widthperpixel * (pViewport->viewportCenterX - VertexRenderList[i].vWorldViewProjX);
             // outbound screen y dist
             float y_dist = widthperpixel * (horizon_height_offset - VertexRenderList[i].vWorldViewProjY);
 
@@ -2064,23 +2064,23 @@ void OpenGLRenderer::DrawOutdoorSky() {
 
         if (engine->config->graphics.Fog.value()) {
             // fade sky
-            VertexRenderList[4].vWorldViewProjX = (double)pViewport->uViewportTL_X;
-            VertexRenderList[4].vWorldViewProjY = (double)pViewport->uViewportTL_Y;
-            VertexRenderList[5].vWorldViewProjX = (double)pViewport->uViewportTL_X;
+            VertexRenderList[4].vWorldViewProjX = (double)pViewport->viewportTL_X;
+            VertexRenderList[4].vWorldViewProjY = (double)pViewport->viewportTL_Y;
+            VertexRenderList[5].vWorldViewProjX = (double)pViewport->viewportTL_X;
             VertexRenderList[5].vWorldViewProjY = (double)bot_y_proj - engine->config->graphics.FogHorizon.value();
-            VertexRenderList[6].vWorldViewProjX = (double)pViewport->uViewportBR_X;
+            VertexRenderList[6].vWorldViewProjX = (double)pViewport->viewportBR_X;
             VertexRenderList[6].vWorldViewProjY = (double)bot_y_proj - engine->config->graphics.FogHorizon.value();
-            VertexRenderList[7].vWorldViewProjX = (double)pViewport->uViewportBR_X;
-            VertexRenderList[7].vWorldViewProjY = (double)pViewport->uViewportTL_Y;
+            VertexRenderList[7].vWorldViewProjX = (double)pViewport->viewportBR_X;
+            VertexRenderList[7].vWorldViewProjY = (double)pViewport->viewportTL_Y;
 
             // sub sky
-            VertexRenderList[8].vWorldViewProjX = (double)pViewport->uViewportTL_X;
+            VertexRenderList[8].vWorldViewProjX = (double)pViewport->viewportTL_X;
             VertexRenderList[8].vWorldViewProjY = (double)bot_y_proj - engine->config->graphics.FogHorizon.value();
-            VertexRenderList[9].vWorldViewProjX = (double)pViewport->uViewportTL_X;
-            VertexRenderList[9].vWorldViewProjY = (double)pViewport->uViewportBR_Y + 1;
-            VertexRenderList[10].vWorldViewProjX = (double)pViewport->uViewportBR_X;
-            VertexRenderList[10].vWorldViewProjY = (double)pViewport->uViewportBR_Y + 1;
-            VertexRenderList[11].vWorldViewProjX = (double)pViewport->uViewportBR_X;
+            VertexRenderList[9].vWorldViewProjX = (double)pViewport->viewportTL_X;
+            VertexRenderList[9].vWorldViewProjY = (double)pViewport->viewportBR_Y + 1;
+            VertexRenderList[10].vWorldViewProjX = (double)pViewport->viewportBR_X;
+            VertexRenderList[10].vWorldViewProjY = (double)pViewport->viewportBR_Y + 1;
+            VertexRenderList[11].vWorldViewProjX = (double)pViewport->viewportBR_X;
             VertexRenderList[11].vWorldViewProjY = (double)bot_y_proj - engine->config->graphics.FogHorizon.value();
         }
 

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -24,32 +24,27 @@
 #include "Media/Audio/AudioPlayer.h"
 
 //----- (004C0262) --------------------------------------------------------
-void Viewport::SetViewport(int sTL_X, int sTL_Y, int sBR_X, int sBR_Y) {
-    unsigned int tl_x;  // edx@1
-    unsigned int br_x;  // esi@1
-    unsigned int tl_y;  // edi@3
-    unsigned int br_y;  // eax@3
+void Viewport::SetViewport(int topLeft_X, int topLeft_Y, int bottomRight_X, int bottomRight_Y) {
+    unsigned int tl_x = std::min(topLeft_X, bottomRight_X);
+    unsigned int br_x = std::max(topLeft_X, bottomRight_X);
 
-    tl_x = std::min(sTL_X, sBR_X);
-    br_x = std::max(sTL_X, sBR_X);
+    unsigned int tl_y = std::min(topLeft_Y, bottomRight_Y);
+    unsigned int br_y = std::max(topLeft_Y, bottomRight_Y);
 
-    tl_y = std::min(sTL_Y, sBR_Y);
-    br_y = std::max(sTL_Y, sBR_Y);
+    this->viewportTL_Y = tl_y;
+    this->viewportTL_X = tl_x;
+    this->viewportBR_X = br_x;
+    this->viewportBR_Y = br_y;
 
-    this->uViewportTL_Y = tl_y;
-    this->uViewportTL_X = tl_x;
-    this->uViewportBR_X = br_x;
-    this->uViewportBR_Y = br_y;
-
-    this->uViewportWidth = br_x - tl_x + 1;
-    this->uViewportHeight = br_y - tl_y + 1;
-    this->uViewportCenterX = (signed int)(br_x + tl_x) / 2;
-    this->uViewportCenterY = (signed int)(br_y + tl_y) / 2;
+    this->viewportWidth = br_x - tl_x + 1;
+    this->viewportHeight = br_y - tl_y + 1;
+    this->viewportCenterX = (signed int)(br_x + tl_x) / 2;
+    this->viewportCenterY = (signed int)(br_y + tl_y) / 2;
 }
 
 bool Viewport::Contains(unsigned int x, unsigned int y) {
-    return ((int)x >= uViewportTL_X && (int)x <= uViewportBR_X &&
-            (int)y >= uViewportTL_Y && (int)y <= uViewportBR_Y);
+    return ((int)x >= viewportTL_X && (int)x <= viewportBR_X &&
+            (int)y >= viewportTL_Y && (int)y <= viewportBR_Y);
 }
 
 //----- (00443219) --------------------------------------------------------

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -1,4 +1,6 @@
-#include "Engine/Graphics/Viewport.h"
+#include "Viewport.h"
+
+#include <algorithm>
 
 #include "Engine/Engine.h"
 #include "Engine/Evt/Processor.h"

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -24,68 +24,32 @@
 #include "Media/Audio/AudioPlayer.h"
 
 //----- (004C0262) --------------------------------------------------------
-void Viewport::SetScreen(int sTL_X, int sTL_Y, int sBR_X, int sBR_Y) {
+void Viewport::SetViewport(int sTL_X, int sTL_Y, int sBR_X, int sBR_Y) {
     unsigned int tl_x;  // edx@1
     unsigned int br_x;  // esi@1
     unsigned int tl_y;  // edi@3
     unsigned int br_y;  // eax@3
 
-    tl_x = sTL_X;
-    br_x = sBR_X;
-    if (sTL_X > sBR_X) {
-        br_x = sTL_X;  // swap x's
-        tl_x = sBR_X;
-    }
-    tl_y = sTL_Y;
-    br_y = sBR_Y;
-    if (sTL_Y > sBR_Y) {
-        br_y = sTL_Y;  // swap y's
-        tl_y = sBR_Y;
-    }
-    this->uScreen_TL_X = tl_x;
-    this->uScreen_TL_Y = tl_y;
-    this->uScreen_BR_X = br_x;
-    this->uScreen_BR_Y = br_y;
+    tl_x = std::min(sTL_X, sBR_X);
+    br_x = std::max(sTL_X, sBR_X);
+
+    tl_y = std::min(sTL_Y, sBR_Y);
+    br_y = std::max(sTL_Y, sBR_Y);
+
+    this->uViewportTL_Y = tl_y;
+    this->uViewportTL_X = tl_x;
+    this->uViewportBR_X = br_x;
+    this->uViewportBR_Y = br_y;
+
     this->uScreenWidth = br_x - tl_x + 1;
     this->uScreenHeight = br_y - tl_y + 1;
     this->uScreenCenterX = (signed int)(br_x + tl_x) / 2;
-    // if ( render->pRenderD3D == 0 )
-    //    this->uScreenCenterY = this->uScreen_BR_Y - fixpoint_mul(field_30,
-    //    uScreenHeight);
-    // else
-    this->uScreenCenterY = (br_y + tl_y) / 2;
-    SetViewport(this->uScreen_TL_X, this->uScreen_TL_Y, this->uScreen_BR_X,
-                this->uScreen_BR_Y);
-}
-
-//----- (004C02F8) --------------------------------------------------------
-void Viewport::ResetScreen() {
-    SetScreen(uScreen_TL_X, uScreen_TL_Y, uScreen_BR_X, uScreen_BR_Y);
+    this->uScreenCenterY = (signed int)(br_y + tl_y) / 2;
 }
 
 bool Viewport::Contains(unsigned int x, unsigned int y) {
     return ((int)x >= uViewportTL_X && (int)x <= uViewportBR_X &&
             (int)y >= uViewportTL_Y && (int)y <= uViewportBR_Y);
-}
-
-void Viewport::SetViewport(int sTL_X, int sTL_Y, int sBR_X, int sBR_Y) {
-    int tl_x;
-    int tl_y;
-    int br_x;
-    int br_y;
-
-    tl_x = sTL_X;
-    if (sTL_X < this->uScreen_TL_X) tl_x = this->uScreen_TL_X;
-    tl_y = sTL_Y;
-    if (sTL_Y < this->uScreen_TL_Y) tl_y = this->uScreen_TL_Y;
-    br_x = sBR_X;
-    if (sBR_X > this->uScreen_BR_X) br_x = this->uScreen_BR_X;
-    br_y = sBR_Y;
-    if (sBR_Y > this->uScreen_BR_Y) br_y = this->uScreen_BR_Y;
-    this->uViewportTL_Y = tl_y;
-    this->uViewportTL_X = tl_x;
-    this->uViewportBR_X = br_x;
-    this->uViewportBR_Y = br_y;
 }
 
 //----- (00443219) --------------------------------------------------------

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -41,10 +41,10 @@ void Viewport::SetViewport(int sTL_X, int sTL_Y, int sBR_X, int sBR_Y) {
     this->uViewportBR_X = br_x;
     this->uViewportBR_Y = br_y;
 
-    this->uScreenWidth = br_x - tl_x + 1;
-    this->uScreenHeight = br_y - tl_y + 1;
-    this->uScreenCenterX = (signed int)(br_x + tl_x) / 2;
-    this->uScreenCenterY = (signed int)(br_y + tl_y) / 2;
+    this->uViewportWidth = br_x - tl_x + 1;
+    this->uViewportHeight = br_y - tl_y + 1;
+    this->uViewportCenterX = (signed int)(br_x + tl_x) / 2;
+    this->uViewportCenterY = (signed int)(br_y + tl_y) / 2;
 }
 
 bool Viewport::Contains(unsigned int x, unsigned int y) {

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -27,7 +27,6 @@ struct ViewingParams {
     inline ViewingParams() {
         draw_sw_outlines = false;
         draw_d3d_outlines = false;
-        field_4C = 0;
     }
 
     void CenterOnPartyZoomIn();
@@ -38,25 +37,17 @@ struct ViewingParams {
     void MapViewRight();
     void CenterOnPartyZoomOut();
     void AdjustPosition();
-    void _443365();
+    void _443365(); // Sets indoor_center and minimap zoom based on level type.
 
-    int field_20 = 0;
     unsigned int uMinimapZoom = 0;
     unsigned int uMapBookMapZoom = 0;
     int sViewCenterX = 0;
     int sViewCenterY = 0;
     int16_t indoor_center_x = 0;
     int16_t indoor_center_y = 0;
-    int field_3C = 0;
     GraphicsImage *location_minimap = nullptr;  // unsigned int uTextureID_LocationMap; ::40
-    int field_4C = 0;
     int draw_sw_outlines = 0;
     int draw_d3d_outlines = 0;
-    int field_58 = 0;
-    int field_5C = 0;
-    int field_60 = 0;
-    int field_64 = 0;
-    int field_68 = 0;
     Color pPalette[256] {};
 };
 

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -6,22 +6,19 @@
 
 class GraphicsImage;
 
-// TODO(pskelton): combined viewport and viewing params?? or at least not have multiple places
-// where screen coords and viewport coords are held
-
 struct Viewport {
-    void SetViewport(int uX, int uY, int uZ, int uW);
+    void SetViewport(int topLeft_X, int topLeft_Y, int bottomRight_X, int bottomRight_Y);
     bool Contains(unsigned int x, unsigned int y);
 
-    int uViewportTL_X;
-    int uViewportTL_Y;
-    int uViewportBR_X;
-    int uViewportBR_Y;
+    int viewportTL_X;
+    int viewportTL_Y;
+    int viewportBR_X;
+    int viewportBR_Y;
 
-    int uViewportWidth;
-    int uViewportHeight;
-    int uViewportCenterX;
-    int uViewportCenterY;
+    int viewportWidth;
+    int viewportHeight;
+    int viewportCenterX;
+    int viewportCenterY;
 };
 
 extern Viewport *pViewport;

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -43,12 +43,6 @@ struct ViewingParams {
     void AdjustPosition();
     void _443365();
 
-    // viewport coords
-    unsigned int uScreen_topL_X = 0; // 8
-    unsigned int uScreen_topL_Y = 0; // 8
-    unsigned int uScreen_BttmR_X = 0; // 468
-    unsigned int uScreen_BttmR_Y = 0;  // 352
-
     int field_20 = 0;
     unsigned int uMinimapZoom = 0;
     unsigned int uMapBookMapZoom = 0;

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -10,19 +10,8 @@ class GraphicsImage;
 // where screen coords and viewport coords are held
 
 struct Viewport {
-    inline Viewport() {
-        SetScreen(0, 0, 639, 479);
-    }
-
-    void ResetScreen();
-    void SetScreen(int uX, int uY, int uZ, int uW);
     void SetViewport(int uX, int uY, int uZ, int uW);
     bool Contains(unsigned int x, unsigned int y);
-
-    int uScreen_TL_X;  // 0
-    int uScreen_TL_Y;  // 0
-    int uScreen_BR_X;  // 639
-    int uScreen_BR_Y;  // 479
 
     int uViewportTL_X;
     int uViewportTL_Y;
@@ -53,11 +42,6 @@ struct ViewingParams {
     void CenterOnPartyZoomOut();
     void AdjustPosition();
     void _443365();
-
-    int uSomeX = 0;  // game screen co ords
-    int uSomeY = 0;
-    int uSomeZ = 0;
-    int uSomeW = 0;
 
     // viewport coords
     unsigned int uScreen_topL_X = 0; // 8

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -18,10 +18,10 @@ struct Viewport {
     int uViewportBR_X;
     int uViewportBR_Y;
 
-    int uScreenWidth;
-    int uScreenHeight;
-    int uScreenCenterX;
-    int uScreenCenterY;
+    int uViewportWidth;
+    int uViewportHeight;
+    int uViewportCenterX;
+    int uViewportCenterY;
 };
 
 extern Viewport *pViewport;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -558,12 +558,12 @@ bool Vis::CheckIntersectFace(BLVFace *pFace, Vec3f IntersectPoint, signed int sM
 
 //----- (0046A0A1) --------------------------------------------------------
 int UnprojectX(int x) {
-    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uViewportCenterX - x);
+    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->viewportCenterX - x);
 }
 
 //----- (0046A0F6) --------------------------------------------------------
 int UnprojectY(int y) {
-    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uViewportCenterY - y);
+    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->viewportCenterY - y);
 }
 
 //----- (004C248E) --------------------------------------------------------
@@ -840,10 +840,10 @@ bool Vis::DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx)
 
     // billboard will be visible somewhere on screen - clamp billboard corners to screen viewport
     auto& billboard = render->pBillboardRenderListD3D[uD3DBillboardIdx];
-    float bbVisibleLeft = std::clamp(billboard.pQuads[0].pos.x, (float)pViewport->uViewportTL_X, (float)pViewport->uViewportBR_X);
-    float bbVisibleRight = std::clamp(billboard.pQuads[3].pos.x, (float)pViewport->uViewportTL_X, (float)pViewport->uViewportBR_X);
-    float bbVisibleTop = std::clamp(billboard.pQuads[0].pos.y, (float)pViewport->uViewportTL_Y, (float)pViewport->uViewportBR_Y);
-    float bbVisibleBottom = std::clamp(billboard.pQuads[1].pos.y, (float)pViewport->uViewportTL_Y, (float)pViewport->uViewportBR_Y);
+    float bbVisibleLeft = std::clamp(billboard.pQuads[0].pos.x, (float)pViewport->viewportTL_X, (float)pViewport->viewportBR_X);
+    float bbVisibleRight = std::clamp(billboard.pQuads[3].pos.x, (float)pViewport->viewportTL_X, (float)pViewport->viewportBR_X);
+    float bbVisibleTop = std::clamp(billboard.pQuads[0].pos.y, (float)pViewport->viewportTL_Y, (float)pViewport->viewportBR_Y);
+    float bbVisibleBottom = std::clamp(billboard.pQuads[1].pos.y, (float)pViewport->viewportTL_Y, (float)pViewport->viewportBR_Y);
 
     // test visible polygon center first
     float test_x = (bbVisibleLeft + bbVisibleRight) * 0.5f;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -558,12 +558,12 @@ bool Vis::CheckIntersectFace(BLVFace *pFace, Vec3f IntersectPoint, signed int sM
 
 //----- (0046A0A1) --------------------------------------------------------
 int UnprojectX(int x) {
-    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uScreenCenterX - x);
+    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uViewportCenterX - x);
 }
 
 //----- (0046A0F6) --------------------------------------------------------
 int UnprojectY(int y) {
-    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uScreenCenterY - y);
+    return TrigLUT.atan2(pCamera3D->ViewPlaneDistPixels, pViewport->uViewportCenterY - y);
 }
 
 //----- (004C248E) --------------------------------------------------------

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -840,10 +840,10 @@ bool Vis::DoesRayIntersectBillboard(float fDepth, unsigned int uD3DBillboardIdx)
 
     // billboard will be visible somewhere on screen - clamp billboard corners to screen viewport
     auto& billboard = render->pBillboardRenderListD3D[uD3DBillboardIdx];
-    float bbVisibleLeft = std::clamp(billboard.pQuads[0].pos.x, (float)pViewport->uScreen_TL_X, (float)pViewport->uScreen_BR_X);
-    float bbVisibleRight = std::clamp(billboard.pQuads[3].pos.x, (float)pViewport->uScreen_TL_X, (float)pViewport->uScreen_BR_X);
-    float bbVisibleTop = std::clamp(billboard.pQuads[0].pos.y, (float)pViewport->uScreen_TL_Y, (float)pViewport->uScreen_BR_Y);
-    float bbVisibleBottom = std::clamp(billboard.pQuads[1].pos.y, (float)pViewport->uScreen_TL_Y, (float)pViewport->uScreen_BR_Y);
+    float bbVisibleLeft = std::clamp(billboard.pQuads[0].pos.x, (float)pViewport->uViewportTL_X, (float)pViewport->uViewportBR_X);
+    float bbVisibleRight = std::clamp(billboard.pQuads[3].pos.x, (float)pViewport->uViewportTL_X, (float)pViewport->uViewportBR_X);
+    float bbVisibleTop = std::clamp(billboard.pQuads[0].pos.y, (float)pViewport->uViewportTL_Y, (float)pViewport->uViewportBR_Y);
+    float bbVisibleBottom = std::clamp(billboard.pQuads[1].pos.y, (float)pViewport->uViewportTL_Y, (float)pViewport->uViewportBR_Y);
 
     // test visible polygon center first
     float test_x = (bbVisibleLeft + bbVisibleRight) * 0.5f;

--- a/src/Engine/Graphics/Weather.cpp
+++ b/src/Engine/Graphics/Weather.cpp
@@ -22,14 +22,14 @@ void Weather::DrawSnow() {
 
         Screen_Coord[i].x += vrng->random(base) - base / 2;
         Screen_Coord[i].y += vrng->random(size) + size;
-        if (Screen_Coord[i].x < pViewport->uViewportTL_X) {
-            Screen_Coord[i].x = pViewport->uViewportTL_X + vrng->random(base);
-        } else if (Screen_Coord[i].x >= (pViewport->uViewportBR_X - size)) {
-            Screen_Coord[i].x = pViewport->uViewportBR_X - vrng->random(base);
+        if (Screen_Coord[i].x < pViewport->viewportTL_X) {
+            Screen_Coord[i].x = pViewport->viewportTL_X + vrng->random(base);
+        } else if (Screen_Coord[i].x >= (pViewport->viewportBR_X - size)) {
+            Screen_Coord[i].x = pViewport->viewportBR_X - vrng->random(base);
         }
-        if (Screen_Coord[i].y >= (pViewport->uViewportBR_Y - size)) {
-            Screen_Coord[i].y = pViewport->uViewportTL_Y;
-            Screen_Coord[i].x = pViewport->uViewportTL_X + vrng->random(pViewport->uViewportBR_X - pViewport->uViewportTL_X - size);
+        if (Screen_Coord[i].y >= (pViewport->viewportBR_Y - size)) {
+            Screen_Coord[i].y = pViewport->viewportTL_Y;
+            Screen_Coord[i].x = pViewport->viewportTL_X + vrng->random(pViewport->viewportBR_X - pViewport->viewportTL_X - size);
         }
 
         render->FillRectFast(Screen_Coord[i].x, Screen_Coord[i].y, size, size, colorTable.White);
@@ -37,11 +37,11 @@ void Weather::DrawSnow() {
 }
 
 void Weather::Initialize() {
-    int width = pViewport->uViewportBR_X - pViewport->uViewportTL_X;
-    int height = pViewport->uViewportBR_Y - pViewport->uViewportTL_Y;
+    int width = pViewport->viewportBR_X - pViewport->viewportTL_X;
+    int height = pViewport->viewportBR_Y - pViewport->viewportTL_Y;
     for (Pointi &point : Screen_Coord) {
-        point.x = pViewport->uViewportTL_X + vrng->random(width);
-        point.y = pViewport->uViewportTL_Y + vrng->random(height);
+        point.x = pViewport->viewportTL_X + vrng->random(width);
+        point.y = pViewport->viewportTL_Y + vrng->random(height);
     }
 }
 
@@ -56,12 +56,12 @@ bool Weather::OnPlayerTurn(int dangle) {
         return false;
     }
 
-    unsigned int screen_width = pViewport->uViewportBR_X - pViewport->uViewportTL_X;
+    unsigned int screen_width = pViewport->viewportBR_X - pViewport->viewportTL_X;
 
     for (Pointi &point : Screen_Coord) {
         point.x += dangle;
-        if (point.x < pViewport->uViewportBR_X) {
-            if (point.x >= pViewport->uViewportTL_X) {
+        if (point.x < pViewport->viewportBR_X) {
+            if (point.x >= pViewport->viewportTL_X) {
                 continue;
             }
             point.x += screen_width;

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -147,13 +147,6 @@ std::array<int32_t, 128 * 3> sphereVertInd = {  // indicies for triangle in sphe
 //-------------------------------------------------------------------------
 // Data declarations
 
-int game_viewport_width;
-int game_viewport_height;
-int game_viewport_x;
-int game_viewport_y;
-int game_viewport_z;
-int game_viewport_w;
-
 char _4D864C_force_sw_render_rules;
 
 float flt_4D84E8 = 0.0f;

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -26,13 +26,6 @@ class GraphicsImage;
 //-------------------------------------------------------------------------
 // Data declarations
 
-extern int game_viewport_width;
-extern int game_viewport_height;
-extern int game_viewport_x;
-extern int game_viewport_y;
-extern int game_viewport_z;
-extern int game_viewport_w;
-
 extern float flt_4D84E8;
 
 extern unsigned int uGammaPos;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -213,10 +213,10 @@ void GUIWindow::DrawMessageBox(bool inside_game_viewport) {
     int y = 0;
     int z, w;
     if (inside_game_viewport) {
-        x = pViewport->uViewportTL_X;
-        z = pViewport->uViewportBR_X;
-        y = pViewport->uViewportTL_Y;
-        w = pViewport->uViewportBR_Y;
+        x = pViewport->viewportTL_X;
+        z = pViewport->viewportBR_X;
+        y = pViewport->viewportTL_Y;
+        w = pViewport->viewportBR_Y;
     } else {
         Sizei renDims = render->GetRenderDimensions();
         z = renDims.w;

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -83,10 +83,10 @@ class GUIWindow {
 
     static void InitializeGUI();
 
-    int uFrameX = 0;
-    int uFrameY = 0;
     int uFrameWidth = 0;
     int uFrameHeight = 0; // TODO(captainurist): frameRect
+    int uFrameX = 0;
+    int uFrameY = 0;
     int uFrameZ = 0;
     int uFrameW = 0;
     WindowType eWindowType = WINDOW_null;

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -57,21 +57,21 @@ GUIWindow_AutonotesBook::GUIWindow_AutonotesBook() : GUIWindow_Book() {
     ui_book_button7_off = assets->getImage_Alpha("tab-an-4a");
     ui_book_button8_off = assets->getImage_Alpha("tab-an-8a");
 
-    pBtn_Book_1 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 1}, {50, 34}, 1, 0,
+    pBtn_Book_1 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 1}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_PREV_PAGE), Io::InputAction::DialogLeft, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button1_on});
-    pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, {50, 34}, 1, 0,
+    pBtn_Book_2 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 38}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NEXT_PAGE), Io::InputAction::DialogRight, localization->GetString(LSTR_SCROLL_UP), {ui_book_button2_on});
-    pBtn_Book_3 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 113}, {50, 34}, 1, 0,
+    pBtn_Book_3 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 113}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_POTION), Io::InputAction::Invalid, localization->GetString(LSTR_POTION_NOTES), {ui_book_button3_on});
-    pBtn_Book_4 = CreateButton({pViewport->uViewportTL_X + 399, pViewport->uViewportTL_Y + 150}, {50, 34}, 1, 0,
+    pBtn_Book_4 = CreateButton({pViewport->viewportTL_X + 399, pViewport->viewportTL_Y + 150}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_FOUNTAIN), Io::InputAction::Invalid, localization->GetString(LSTR_FOUNTAIN_NOTES), {ui_book_button4_on});
-    pBtn_Book_5 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 188}, {50, 34}, 1, 0,
+    pBtn_Book_5 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 188}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_OBELISK), Io::InputAction::Invalid, localization->GetString(LSTR_OBELISK_NOTES), {ui_book_button5_on});
-    pBtn_Book_6 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 226}, {50, 34}, 1, 0,
+    pBtn_Book_6 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 226}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_SEER), Io::InputAction::Invalid, localization->GetString(LSTR_SEER_NOTES), {ui_book_button6_on});
-    pBtn_Autonotes_Misc = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 264}, {50, 34}, 1, 0,
+    pBtn_Autonotes_Misc = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 264}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_MISC), Io::InputAction::Invalid, localization->GetString(LSTR_MISCELLANEOUS_NOTES), {ui_book_button7_on});
-    pBtn_Autonotes_Instructors = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 302}, {50, 34}, 1, 0,
+    pBtn_Autonotes_Instructors = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 302}, {50, 34}, 1, 0,
         UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NOTES_INSTRUCTORS), Io::InputAction::Invalid, localization->GetString(LSTR_INSTRUCTORS), {ui_book_button8_on});
 
     recalculateCurrentNotesTypePages();
@@ -84,128 +84,128 @@ void GUIWindow_AutonotesBook::Update() {
     bool noteTypeChanged = false;
     GUIWindow autonotes_window;
 
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_autonotes_background);
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f, pViewport->viewportTL_Y / 480.0f, ui_book_autonotes_background);
     if ((_bookButtonClicked && _bookButtonAction == BOOK_PREV_PAGE) || !_startingNotesIdx) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 2) / 480.0f, ui_book_button1_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 2) / 480.0f, ui_book_button1_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 1) / 480.0f, ui_book_button1_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 1) / 480.0f, ui_book_button1_on);
     }
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_NEXT_PAGE) || (_startingNotesIdx + _currentPageNotes) >= _activeNotesIdx.size()) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_on);
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_POTION) {
         if (autonoteBookDisplayType == AUTONOTE_POTION_RECIPE) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_POTION_RECIPE;
             noteTypeChanged = true;
-            render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_POTION_RECIPE) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_on);
         } else {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_off);
+            render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_off);
         }
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_FOUNTAIN) {
         if (autonoteBookDisplayType == AUTONOTE_STAT_HINT) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 399) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 399) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_STAT_HINT;
             noteTypeChanged = true;
-            render->DrawTextureNew( (pViewport->uViewportTL_X + 399) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_on);
+            render->DrawTextureNew( (pViewport->viewportTL_X + 399) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_STAT_HINT) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 399) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 399) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_on);
         } else {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_off);
+            render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_off);
         }
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_OBELISK) {
         if (autonoteBookDisplayType == AUTONOTE_OBELISK) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_OBELISK;
             noteTypeChanged = true;
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_OBELISK) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_on);
         } else {
-            render->DrawTextureNew( (pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_off);
+            render->DrawTextureNew( (pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_off);
         }
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_SEER) {
         if (autonoteBookDisplayType == AUTONOTE_SEER) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_SEER;
             noteTypeChanged = true;
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_SEER) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_on);
         } else {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_off);
+            render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_off);
         }
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_MISC) {
         if (autonoteBookDisplayType == AUTONOTE_MISC) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 264) / 480.0f, ui_book_button7_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 264) / 480.0f, ui_book_button7_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_MISC;
             noteTypeChanged = true;
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 264) / 480.0f, ui_book_button7_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 264) / 480.0f, ui_book_button7_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_MISC) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 264) / 480.0f, ui_book_button7_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 264) / 480.0f, ui_book_button7_on);
         } else {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 263) / 480.0f, ui_book_button7_off);
+            render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 263) / 480.0f, ui_book_button7_off);
         }
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_NOTES_INSTRUCTORS) {
         if (autonoteBookDisplayType == AUTONOTE_TEACHER) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 302) / 480.0f, ui_book_button8_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 302) / 480.0f, ui_book_button8_on);
         } else {
             pAudioPlayer->playUISound(SOUND_StartMainChoice02);
             autonoteBookDisplayType = AUTONOTE_TEACHER;
             noteTypeChanged = true;
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 302) / 480.0f, ui_book_button8_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 302) / 480.0f, ui_book_button8_on);
         }
     } else {
         if (autonoteBookDisplayType == AUTONOTE_TEACHER) {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 302) / 480.0f, ui_book_button8_on);
+            render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 302) / 480.0f, ui_book_button8_on);
         } else {
-            render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 302) / 480.0f, ui_book_button8_off);
+            render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 302) / 480.0f, ui_book_button8_off);
         }
     }
 
     // for title
-    autonotes_window.uFrameWidth = pViewport->uViewportWidth;
-    autonotes_window.uFrameHeight = pViewport->uViewportHeight;
-    autonotes_window.uFrameX = pViewport->uViewportTL_X;
-    autonotes_window.uFrameY = pViewport->uViewportTL_Y;
-    autonotes_window.uFrameZ = pViewport->uViewportBR_X;
-    autonotes_window.uFrameW = pViewport->uViewportBR_Y;
+    autonotes_window.uFrameWidth = pViewport->viewportWidth;
+    autonotes_window.uFrameHeight = pViewport->viewportHeight;
+    autonotes_window.uFrameX = pViewport->viewportTL_X;
+    autonotes_window.uFrameY = pViewport->viewportTL_Y;
+    autonotes_window.uFrameZ = pViewport->viewportBR_X;
+    autonotes_window.uFrameW = pViewport->viewportBR_Y;
 
     autonotes_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_autonotes_title_color, localization->GetString(LSTR_AUTO_NOTES), 3);
 

--- a/src/GUI/UI/Books/AutonotesBook.cpp
+++ b/src/GUI/UI/Books/AutonotesBook.cpp
@@ -200,12 +200,13 @@ void GUIWindow_AutonotesBook::Update() {
     }
 
     // for title
-    autonotes_window.uFrameWidth = game_viewport_width;
-    autonotes_window.uFrameHeight = game_viewport_height;
-    autonotes_window.uFrameX = game_viewport_x;
-    autonotes_window.uFrameY = game_viewport_y;
-    autonotes_window.uFrameZ = game_viewport_z;
-    autonotes_window.uFrameW = game_viewport_w;
+    autonotes_window.uFrameWidth = pViewport->uViewportWidth;
+    autonotes_window.uFrameHeight = pViewport->uViewportHeight;
+    autonotes_window.uFrameX = pViewport->uViewportTL_X;
+    autonotes_window.uFrameY = pViewport->uViewportTL_Y;
+    autonotes_window.uFrameZ = pViewport->uViewportBR_X;
+    autonotes_window.uFrameW = pViewport->uViewportBR_Y;
+
     autonotes_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_autonotes_title_color, localization->GetString(LSTR_AUTO_NOTES), 3);
 
     // for other text

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -73,12 +73,12 @@ void GUIWindow_CalendarBook::Update() {
     render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_calendar_background);
     CivilTime time = pParty->GetPlayingTime().toCivilTime();
 
-    calendar_window.uFrameX = game_viewport_x;
-    calendar_window.uFrameY = game_viewport_y;
-    calendar_window.uFrameWidth = game_viewport_width;
-    calendar_window.uFrameHeight = game_viewport_height;
-    calendar_window.uFrameZ = game_viewport_z;
-    calendar_window.uFrameW = game_viewport_w;
+    calendar_window.uFrameWidth = pViewport->uViewportWidth;
+    calendar_window.uFrameHeight = pViewport->uViewportHeight;
+    calendar_window.uFrameX = pViewport->uViewportTL_X;
+    calendar_window.uFrameY = pViewport->uViewportTL_Y;
+    calendar_window.uFrameZ = pViewport->uViewportBR_X;
+    calendar_window.uFrameW = pViewport->uViewportBR_Y;
     calendar_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_calendar_title_color, localization->GetString(LSTR_TIME_IN_ERATHIA), 3);
 
     std::string str = fmt::format("{}\t100:\t110{}:{:02} {} - {}", localization->GetString(LSTR_TIME), time.hourAmPm,

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -70,15 +70,15 @@ void GUIWindow_CalendarBook::Update() {
 
     GUIWindow calendar_window;
 
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_calendar_background);
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f, pViewport->viewportTL_Y / 480.0f, ui_book_calendar_background);
     CivilTime time = pParty->GetPlayingTime().toCivilTime();
 
-    calendar_window.uFrameWidth = pViewport->uViewportWidth;
-    calendar_window.uFrameHeight = pViewport->uViewportHeight;
-    calendar_window.uFrameX = pViewport->uViewportTL_X;
-    calendar_window.uFrameY = pViewport->uViewportTL_Y;
-    calendar_window.uFrameZ = pViewport->uViewportBR_X;
-    calendar_window.uFrameW = pViewport->uViewportBR_Y;
+    calendar_window.uFrameWidth = pViewport->viewportWidth;
+    calendar_window.uFrameHeight = pViewport->viewportHeight;
+    calendar_window.uFrameX = pViewport->viewportTL_X;
+    calendar_window.uFrameY = pViewport->viewportTL_Y;
+    calendar_window.uFrameZ = pViewport->viewportBR_X;
+    calendar_window.uFrameW = pViewport->viewportBR_Y;
     calendar_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_calendar_title_color, localization->GetString(LSTR_TIME_IN_ERATHIA), 3);
 
     std::string str = fmt::format("{}\t100:\t110{}:{:02} {} - {}", localization->GetString(LSTR_TIME), time.hourAmPm,

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -33,9 +33,9 @@ GUIWindow_JournalBook::GUIWindow_JournalBook() {
     ui_book_button1_off = assets->getImage_Alpha("tab-an-6a");
     ui_book_button2_off = assets->getImage_Alpha("tab-an-7a");
 
-    pBtn_Book_1 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 1}, ui_book_button1_on->size(), 1, 0,
+    pBtn_Book_1 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 1}, ui_book_button1_on->size(), 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_PREV_PAGE), Io::InputAction::DialogLeft, localization->GetString(LSTR_SCROLL_UP), {ui_book_button1_on});
-    pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, ui_book_button2_on->size(), 1, 0,
+    pBtn_Book_2 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 38}, ui_book_button2_on->size(), 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NEXT_PAGE), Io::InputAction::DialogRight, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button2_on});
 
     journal_window.uFrameX = 48;
@@ -67,26 +67,26 @@ void GUIWindow_JournalBook::Update() {
 
     GUIWindow journal_window;
 
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_journal_background);
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f, pViewport->viewportTL_Y / 480.0f, ui_book_journal_background);
     if ((_bookButtonClicked && _bookButtonAction == BOOK_PREV_PAGE) || !_currentIdx) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 2) / 480.0f, ui_book_button1_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 2) / 480.0f, ui_book_button1_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 1) / 480.0f, ui_book_button1_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 1) / 480.0f, ui_book_button1_on);
     }
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_NEXT_PAGE) || (_currentIdx + 1) >= _journalIdx.size()) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_on);
     }
 
     if (_journalIdx.size() && !_journalEntryPage[_currentIdx]) {  // for title
-        journal_window.uFrameWidth = pViewport->uViewportWidth;
-        journal_window.uFrameHeight = pViewport->uViewportHeight;
-        journal_window.uFrameX = pViewport->uViewportTL_X;
-        journal_window.uFrameY = pViewport->uViewportTL_Y;
-        journal_window.uFrameZ = pViewport->uViewportBR_X;
-        journal_window.uFrameW = pViewport->uViewportBR_Y;
+        journal_window.uFrameWidth = pViewport->viewportWidth;
+        journal_window.uFrameHeight = pViewport->viewportHeight;
+        journal_window.uFrameX = pViewport->viewportTL_X;
+        journal_window.uFrameY = pViewport->viewportTL_Y;
+        journal_window.uFrameZ = pViewport->viewportBR_X;
+        journal_window.uFrameW = pViewport->viewportBR_Y;
 
         if (!pHistoryTable->historyLines[_journalIdx[_currentIdx]].pPageTitle.empty()) {
             journal_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_journal_title_color, pHistoryTable->historyLines[_journalIdx[_currentIdx]].pPageTitle, 3);

--- a/src/GUI/UI/Books/JournalBook.cpp
+++ b/src/GUI/UI/Books/JournalBook.cpp
@@ -81,12 +81,13 @@ void GUIWindow_JournalBook::Update() {
     }
 
     if (_journalIdx.size() && !_journalEntryPage[_currentIdx]) {  // for title
-        journal_window.uFrameWidth = game_viewport_width;
-        journal_window.uFrameX = game_viewport_x;
-        journal_window.uFrameY = game_viewport_y;
-        journal_window.uFrameHeight = game_viewport_height;
-        journal_window.uFrameZ = game_viewport_z;
-        journal_window.uFrameW = game_viewport_w;
+        journal_window.uFrameWidth = pViewport->uViewportWidth;
+        journal_window.uFrameHeight = pViewport->uViewportHeight;
+        journal_window.uFrameX = pViewport->uViewportTL_X;
+        journal_window.uFrameY = pViewport->uViewportTL_Y;
+        journal_window.uFrameZ = pViewport->uViewportBR_X;
+        journal_window.uFrameW = pViewport->uViewportBR_Y;
+
         if (!pHistoryTable->historyLines[_journalIdx[_currentIdx]].pPageTitle.empty()) {
             journal_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_journal_title_color, pHistoryTable->historyLines[_journalIdx[_currentIdx]].pPageTitle, 3);
         }

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -15,6 +15,8 @@
 #include "GUI/GUIFont.h"
 #include "GUI/GUIMessageQueue.h"
 #include "GUI/UI/Books/LloydsBook.h"
+
+#include "Engine/Graphics/Viewport.h"
 #include "GUI/UI/UIStatusBar.h"
 
 #include "Media/Audio/AudioPlayer.h"
@@ -85,12 +87,13 @@ void GUIWindow_LloydsBook::Update() {
     std::string pText = localization->GetString(LSTR_RECALL_BEACON);
 
     GUIWindow pWindow;
-    pWindow.uFrameX = game_viewport_x;
-    pWindow.uFrameY = game_viewport_y;
     pWindow.uFrameWidth = 428;
-    pWindow.uFrameHeight = game_viewport_height;
+    pWindow.uFrameHeight = pViewport->uViewportHeight;
+    pWindow.uFrameX = pViewport->uViewportTL_X;
+    pWindow.uFrameY = pViewport->uViewportTL_Y;
     pWindow.uFrameZ = 435;
-    pWindow.uFrameW = game_viewport_w;
+    pWindow.uFrameW = pViewport->uViewportBR_Y;
+
     if (!_recallingBeacon) {
         pText = localization->GetString(LSTR_SET_BEACON);
     }

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -88,11 +88,11 @@ void GUIWindow_LloydsBook::Update() {
 
     GUIWindow pWindow;
     pWindow.uFrameWidth = 428;
-    pWindow.uFrameHeight = pViewport->uViewportHeight;
-    pWindow.uFrameX = pViewport->uViewportTL_X;
-    pWindow.uFrameY = pViewport->uViewportTL_Y;
+    pWindow.uFrameHeight = pViewport->viewportHeight;
+    pWindow.uFrameX = pViewport->viewportTL_X;
+    pWindow.uFrameY = pViewport->viewportTL_Y;
     pWindow.uFrameZ = 435;
-    pWindow.uFrameW = pViewport->uViewportBR_Y;
+    pWindow.uFrameW = pViewport->viewportBR_Y;
 
     if (!_recallingBeacon) {
         pText = localization->GetString(LSTR_SET_BEACON);

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -124,12 +124,12 @@ void GUIWindow_MapBook::Update() {
     render->ResetUIClipRect();
 
     GUIWindow map_window;
-    map_window.uFrameWidth = game_viewport_width;
-    map_window.uFrameHeight = game_viewport_height;
-    map_window.uFrameX = game_viewport_x;
-    map_window.uFrameY = game_viewport_y;
-    map_window.uFrameZ = game_viewport_z;
-    map_window.uFrameW = game_viewport_w;
+    map_window.uFrameWidth = pViewport->uViewportWidth;
+    map_window.uFrameHeight = pViewport->uViewportHeight;
+    map_window.uFrameX = pViewport->uViewportTL_X;
+    map_window.uFrameY = pViewport->uViewportTL_Y;
+    map_window.uFrameZ = pViewport->uViewportBR_X;
+    map_window.uFrameW = pViewport->uViewportBR_Y;
 
     if (engine->_currentLoadedMapId != MAP_INVALID) {
         map_window.DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapStats->pInfos[engine->_currentLoadedMapId].name, 3);

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -47,62 +47,62 @@ GUIWindow_MapBook::GUIWindow_MapBook() {
     ui_book_button5_off = assets->getImage_Alpha("tabEoff");
     ui_book_button6_off = assets->getImage_Alpha("tabWoff");
 
-    pBtn_Book_1 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 1}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_1 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 1}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_ZOOM_IN), Io::InputAction::ZoomIn, localization->GetString(LSTR_ZOOM_IN), {ui_book_button1_on});
-    pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_2 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 38}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_ZOOM_OUT), Io::InputAction::ZoomOut, localization->GetString(LSTR_ZOOM_OUT), {ui_book_button2_on});
-    pBtn_Book_3 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 113}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_3 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 113}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_SCROLL_UP), Io::InputAction::DialogUp, localization->GetString(LSTR_SCROLL_UP), {ui_book_button3_on});
-    pBtn_Book_4 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 150}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_4 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 150}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_SCROLL_DOWN), Io::InputAction::DialogDown, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button4_on});
-    pBtn_Book_5 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 188}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_5 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 188}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_SCROLL_RIGHT), Io::InputAction::DialogRight, localization->GetString(LSTR_SCROLL_RIGHT), {ui_book_button5_on});
-    pBtn_Book_6 = CreateButton({pViewport->uViewportTL_X + 397, pViewport->uViewportTL_Y + 226}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
+    pBtn_Book_6 = CreateButton({pViewport->viewportTL_X + 397, pViewport->viewportTL_Y + 226}, {50, 34}, 1, 0, UIMSG_ClickBooksBtn,
          std::to_underlying(BOOK_SCROLL_LEFT), Io::InputAction::DialogLeft, localization->GetString(LSTR_SCROLL_LEFT), {ui_book_button6_on});
 }
 
 void GUIWindow_MapBook::Update() {
     render->DrawTextureNew(471 /  640.0f, 445 / 480.0f, ui_exit_cancel_button_background);
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_map_background);
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f, pViewport->viewportTL_Y / 480.0f, ui_book_map_background);
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_ZOOM_IN) || viewparams->uMapBookMapZoom / 128 >= 12) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 2) / 480.0f, ui_book_button1_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 2) / 480.0f, ui_book_button1_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 1) / 480.0f, ui_book_button1_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 1) / 480.0f, ui_book_button1_on);
     }
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_ZOOM_OUT) || viewparams->uMapBookMapZoom / 128 <= 3) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_on);
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_SCROLL_UP) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_off);
         viewparams->MapViewUp();
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 113) / 480.0f, ui_book_button3_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 113) / 480.0f, ui_book_button3_on);
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_SCROLL_DOWN) { // Button 4
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_off);
         viewparams->MapViewDown();
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 399) / 640.0f, (pViewport->uViewportTL_Y + 150) / 480.0f, ui_book_button4_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 399) / 640.0f, (pViewport->viewportTL_Y + 150) / 480.0f, ui_book_button4_on);
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_SCROLL_RIGHT) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_off);
         viewparams->MapViewRight();
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 188) / 480.0f, ui_book_button5_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 188) / 480.0f, ui_book_button5_on);
     }
 
     if (_bookButtonClicked && _bookButtonAction == BOOK_SCROLL_LEFT) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 408) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 408) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_off);
         viewparams->MapViewLeft();
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 397) / 640.0f, (pViewport->uViewportTL_Y + 226) / 480.0f, ui_book_button6_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 397) / 640.0f, (pViewport->viewportTL_Y + 226) / 480.0f, ui_book_button6_on);
     }
 
     if (_bookButtonClicked) {
@@ -124,12 +124,12 @@ void GUIWindow_MapBook::Update() {
     render->ResetUIClipRect();
 
     GUIWindow map_window;
-    map_window.uFrameWidth = pViewport->uViewportWidth;
-    map_window.uFrameHeight = pViewport->uViewportHeight;
-    map_window.uFrameX = pViewport->uViewportTL_X;
-    map_window.uFrameY = pViewport->uViewportTL_Y;
-    map_window.uFrameZ = pViewport->uViewportBR_X;
-    map_window.uFrameW = pViewport->uViewportBR_Y;
+    map_window.uFrameWidth = pViewport->viewportWidth;
+    map_window.uFrameHeight = pViewport->viewportHeight;
+    map_window.uFrameX = pViewport->viewportTL_X;
+    map_window.uFrameY = pViewport->viewportTL_Y;
+    map_window.uFrameZ = pViewport->viewportBR_X;
+    map_window.uFrameW = pViewport->viewportBR_Y;
 
     if (engine->_currentLoadedMapId != MAP_INVALID) {
         map_window.DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapStats->pInfos[engine->_currentLoadedMapId].name, 3);

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -64,12 +64,12 @@ void GUIWindow_QuestBook::Update() {
     }
 
     // for title
-    questbook_window.uFrameWidth = game_viewport_width;
-    questbook_window.uFrameHeight = game_viewport_height;
-    questbook_window.uFrameX = game_viewport_x;
-    questbook_window.uFrameY = game_viewport_y;
-    questbook_window.uFrameZ = game_viewport_z;
-    questbook_window.uFrameW = game_viewport_w;
+    questbook_window.uFrameWidth = pViewport->uViewportWidth;
+    questbook_window.uFrameHeight = pViewport->uViewportHeight;
+    questbook_window.uFrameX = pViewport->uViewportTL_X;
+    questbook_window.uFrameY = pViewport->uViewportTL_Y;
+    questbook_window.uFrameZ = pViewport->uViewportBR_X;
+    questbook_window.uFrameW = pViewport->uViewportBR_Y;
     questbook_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_quests_title_color, localization->GetString(LSTR_CURRENT_QUESTS), 3);
 
     // for other text

--- a/src/GUI/UI/Books/QuestBook.cpp
+++ b/src/GUI/UI/Books/QuestBook.cpp
@@ -31,9 +31,9 @@ GUIWindow_QuestBook::GUIWindow_QuestBook() {
     ui_book_button1_off = assets->getImage_Alpha("tab-an-6a");
     ui_book_button2_off = assets->getImage_Alpha("tab-an-7a");
 
-    pBtn_Book_1 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 1}, ui_book_button1_on->size(), 1, 0,
+    pBtn_Book_1 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 1}, ui_book_button1_on->size(), 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_PREV_PAGE), Io::InputAction::DialogLeft, localization->GetString(LSTR_SCROLL_UP), {ui_book_button1_on});
-    pBtn_Book_2 = CreateButton({pViewport->uViewportTL_X + 398, pViewport->uViewportTL_Y + 38}, ui_book_button2_on->size(), 1, 0,
+    pBtn_Book_2 = CreateButton({pViewport->viewportTL_X + 398, pViewport->viewportTL_Y + 38}, ui_book_button2_on->size(), 1, 0,
                                UIMSG_ClickBooksBtn, std::to_underlying(BOOK_NEXT_PAGE), Io::InputAction::DialogRight, localization->GetString(LSTR_SCROLL_DOWN), {ui_book_button2_on});
 
     for (auto i : pQuestTable.indices()) {
@@ -49,27 +49,27 @@ void GUIWindow_QuestBook::Update() {
     int pTextHeight;
     GUIWindow questbook_window;
 
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f, pViewport->uViewportTL_Y / 480.0f, ui_book_quests_background);
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f, pViewport->viewportTL_Y / 480.0f, ui_book_quests_background);
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_PREV_PAGE) || !_startingQuestIdx) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 2) / 480.0f, ui_book_button1_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 2) / 480.0f, ui_book_button1_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 1) / 480.0f, ui_book_button1_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 1) / 480.0f, ui_book_button1_on);
     }
 
     if ((_bookButtonClicked && _bookButtonAction == BOOK_NEXT_PAGE) || (_startingQuestIdx + _currentPageQuests) >= _activeQuestsIdx.size()) {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 407) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_off);
+        render->DrawTextureNew((pViewport->viewportTL_X + 407) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_off);
     } else {
-        render->DrawTextureNew((pViewport->uViewportTL_X + 398) / 640.0f, (pViewport->uViewportTL_Y + 38) / 480.0f, ui_book_button2_on);
+        render->DrawTextureNew((pViewport->viewportTL_X + 398) / 640.0f, (pViewport->viewportTL_Y + 38) / 480.0f, ui_book_button2_on);
     }
 
     // for title
-    questbook_window.uFrameWidth = pViewport->uViewportWidth;
-    questbook_window.uFrameHeight = pViewport->uViewportHeight;
-    questbook_window.uFrameX = pViewport->uViewportTL_X;
-    questbook_window.uFrameY = pViewport->uViewportTL_Y;
-    questbook_window.uFrameZ = pViewport->uViewportBR_X;
-    questbook_window.uFrameW = pViewport->uViewportBR_Y;
+    questbook_window.uFrameWidth = pViewport->viewportWidth;
+    questbook_window.uFrameHeight = pViewport->viewportHeight;
+    questbook_window.uFrameX = pViewport->viewportTL_X;
+    questbook_window.uFrameY = pViewport->viewportTL_Y;
+    questbook_window.uFrameZ = pViewport->viewportBR_X;
+    questbook_window.uFrameW = pViewport->viewportBR_Y;
     questbook_window.DrawTitleText(assets->pFontBookTitle.get(), 0, 22, ui_book_quests_title_color, localization->GetString(LSTR_CURRENT_QUESTS), 3);
 
     // for other text

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -129,12 +129,12 @@ void GUIWindow_TownPortalBook::Update() {
     render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, ui_book_townportal_background);
     render->DrawTextureNew(471 / 640.0f, 445 / 480.0f, ui_exit_cancel_button_background);
 
-    townPortalWindow.uFrameWidth = pViewport->uViewportWidth;
-    townPortalWindow.uFrameHeight = pViewport->uViewportHeight;
-    townPortalWindow.uFrameX = pViewport->uViewportTL_X;
-    townPortalWindow.uFrameY = pViewport->uViewportTL_Y;
-    townPortalWindow.uFrameZ = pViewport->uViewportBR_X;
-    townPortalWindow.uFrameW = pViewport->uViewportBR_Y;
+    townPortalWindow.uFrameWidth = pViewport->viewportWidth;
+    townPortalWindow.uFrameHeight = pViewport->viewportHeight;
+    townPortalWindow.uFrameX = pViewport->viewportTL_X;
+    townPortalWindow.uFrameY = pViewport->viewportTL_Y;
+    townPortalWindow.uFrameZ = pViewport->viewportBR_X;
+    townPortalWindow.uFrameW = pViewport->viewportBR_Y;
 
     if (townPortalCheats) {
         // draw grey icons for cheat locations

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Evt/Processor.h"
 #include "Engine/Spells/Spells.h"
 #include "Engine/MapInfo.h"
+#include "Engine/Graphics/Viewport.h"
 
 #include "GUI/GUIMessageQueue.h"
 #include "GUI/UI/UIStatusBar.h"
@@ -128,12 +129,12 @@ void GUIWindow_TownPortalBook::Update() {
     render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, ui_book_townportal_background);
     render->DrawTextureNew(471 / 640.0f, 445 / 480.0f, ui_exit_cancel_button_background);
 
-    townPortalWindow.uFrameX = game_viewport_x;
-    townPortalWindow.uFrameY = game_viewport_y;
-    townPortalWindow.uFrameWidth = game_viewport_width;
-    townPortalWindow.uFrameHeight = game_viewport_height;
-    townPortalWindow.uFrameZ = game_viewport_z;
-    townPortalWindow.uFrameW = game_viewport_w;
+    townPortalWindow.uFrameWidth = pViewport->uViewportWidth;
+    townPortalWindow.uFrameHeight = pViewport->uViewportHeight;
+    townPortalWindow.uFrameX = pViewport->uViewportTL_X;
+    townPortalWindow.uFrameY = pViewport->uViewportTL_Y;
+    townPortalWindow.uFrameZ = pViewport->uViewportBR_X;
+    townPortalWindow.uFrameW = pViewport->uViewportBR_Y;
 
     if (townPortalCheats) {
         // draw grey icons for cheat locations

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -18,6 +18,7 @@
 #include "Engine/Engine.h"
 
 #include "Arcomage/Arcomage.h"
+#include "Engine/Graphics/Viewport.h"
 
 #include "Media/MediaPlayer.h"
 
@@ -61,7 +62,7 @@ void GUIWindow_Tavern::arcomageRulesDialogue() {
 
     GUIFont *font;
     std::string str = pNPCTopics[354].pText;
-    dialog_window.uFrameWidth = game_viewport_width;
+    dialog_window.uFrameWidth = pViewport->uViewportWidth;
     dialog_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(str, dialog_window.uFrameWidth, 12) + 7;
     if (352 - pTextHeight < 8) {
@@ -82,7 +83,7 @@ void GUIWindow_Tavern::arcomageVictoryCondDialogue() {
     dialog_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
     std::string label = pNPCTopics[arcomageTopicForTavern(houseId())].pText;
-    dialog_window.uFrameWidth = game_viewport_width;
+    dialog_window.uFrameWidth = pViewport->uViewportWidth;
     dialog_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(label, dialog_window.uFrameWidth, 12) + 7;
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);

--- a/src/GUI/UI/Houses/Tavern.cpp
+++ b/src/GUI/UI/Houses/Tavern.cpp
@@ -62,7 +62,7 @@ void GUIWindow_Tavern::arcomageRulesDialogue() {
 
     GUIFont *font;
     std::string str = pNPCTopics[354].pText;
-    dialog_window.uFrameWidth = pViewport->uViewportWidth;
+    dialog_window.uFrameWidth = pViewport->viewportWidth;
     dialog_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(str, dialog_window.uFrameWidth, 12) + 7;
     if (352 - pTextHeight < 8) {
@@ -83,7 +83,7 @@ void GUIWindow_Tavern::arcomageVictoryCondDialogue() {
     dialog_window.uFrameZ = SIDE_TEXT_BOX_POS_Z;
 
     std::string label = pNPCTopics[arcomageTopicForTavern(houseId())].pText;
-    dialog_window.uFrameWidth = pViewport->uViewportWidth;
+    dialog_window.uFrameWidth = pViewport->viewportWidth;
     dialog_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(label, dialog_window.uFrameWidth, 12) + 7;
     render->DrawTextureCustomHeight(8 / 640.0f, (352 - pTextHeight) / 480.0f, ui_leather_mm7, pTextHeight);

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -269,7 +269,7 @@ void prepareArenaFight(ArenaLevel level) {
     pParty->arenaLevel = level;
 
     GUIWindow window = *pDialogueWindow;
-    window.uFrameWidth = game_viewport_width;
+    window.uFrameWidth = pViewport->uViewportWidth;
     window.uFrameZ = 452;
     int textHeight = assets->pFontArrus->CalcTextHeight(localization->GetString(LSTR_PLEASE_WAIT_WHILE_I_SUMMON_THE_MONSTERS), window.uFrameWidth, 13) + 7;
 

--- a/src/GUI/UI/NPCTopics.cpp
+++ b/src/GUI/UI/NPCTopics.cpp
@@ -269,7 +269,7 @@ void prepareArenaFight(ArenaLevel level) {
     pParty->arenaLevel = level;
 
     GUIWindow window = *pDialogueWindow;
-    window.uFrameWidth = pViewport->uViewportWidth;
+    window.uFrameWidth = pViewport->viewportWidth;
     window.uFrameZ = 452;
     int textHeight = assets->pFontArrus->CalcTextHeight(localization->GetString(LSTR_PLEASE_WAIT_WHILE_I_SUMMON_THE_MONSTERS), window.uFrameWidth, 13) + 7;
 

--- a/src/GUI/UI/UIBranchlessDialogue.cpp
+++ b/src/GUI/UI/UIBranchlessDialogue.cpp
@@ -6,6 +6,7 @@
 #include "Engine/Objects/Decoration.h"
 #include "Engine/Party.h"
 #include "Engine/mm7_data.h"
+#include "Engine/Graphics/Viewport.h"
 
 #include "GUI/GUIFont.h"
 #include "GUI/UI/UIHouses.h"
@@ -39,7 +40,7 @@ void GUIWindow_BranchlessDialogue::Update() {
         branchless_dialogue_str = current_npc_text;
 
     GUIWindow BranchlessDlg_window;
-    BranchlessDlg_window.uFrameWidth = game_viewport_width;
+    BranchlessDlg_window.uFrameWidth = pViewport->uViewportWidth;
     BranchlessDlg_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12) + 7;
     if (352 - pTextHeight < 8) {

--- a/src/GUI/UI/UIBranchlessDialogue.cpp
+++ b/src/GUI/UI/UIBranchlessDialogue.cpp
@@ -40,7 +40,7 @@ void GUIWindow_BranchlessDialogue::Update() {
         branchless_dialogue_str = current_npc_text;
 
     GUIWindow BranchlessDlg_window;
-    BranchlessDlg_window.uFrameWidth = pViewport->uViewportWidth;
+    BranchlessDlg_window.uFrameWidth = pViewport->viewportWidth;
     BranchlessDlg_window.uFrameZ = 452;
     int pTextHeight = assets->pFontArrus->CalcTextHeight(branchless_dialogue_str, BranchlessDlg_window.uFrameWidth, 12) + 7;
     if (352 - pTextHeight < 8) {

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -554,24 +554,24 @@ GUIWindow_CharacterRecord::GUIWindow_CharacterRecord(int uActiveCharacter, Scree
     CharacterUI_LoadPaperdollTextures();
     current_screen_type = screen;
 
-    pCharacterScreen_StatsBtn = CreateButton({pViewport->uViewportTL_X + 12, pViewport->uViewportTL_Y + 308},
+    pCharacterScreen_StatsBtn = CreateButton({pViewport->viewportTL_X + 12, pViewport->viewportTL_Y + 308},
                                              paperdoll_dbrds[9]->size(), 1, 0,
                                              UIMSG_ClickStatsBtn, 0, Io::InputAction::Stats, localization->GetString(LSTR_STATS),
                                              {{paperdoll_dbrds[10], paperdoll_dbrds[9]}});
-    pCharacterScreen_SkillsBtn = CreateButton({pViewport->uViewportTL_X + 102, pViewport->uViewportTL_Y + 308},
+    pCharacterScreen_SkillsBtn = CreateButton({pViewport->viewportTL_X + 102, pViewport->viewportTL_Y + 308},
                                               paperdoll_dbrds[7]->size(), 1, 0,
                                               UIMSG_ClickSkillsBtn, 0, Io::InputAction::Skills, localization->GetString(LSTR_SKILLS),
                                               {{paperdoll_dbrds[8], paperdoll_dbrds[7]}});
-    pCharacterScreen_InventoryBtn = CreateButton({pViewport->uViewportTL_X + 192, pViewport->uViewportTL_Y + 308},
+    pCharacterScreen_InventoryBtn = CreateButton({pViewport->viewportTL_X + 192, pViewport->viewportTL_Y + 308},
                                                  paperdoll_dbrds[5]->size(), 1, 0,
                                                  UIMSG_ClickInventoryBtn, 0, Io::InputAction::Inventory,
                                                  localization->GetString(LSTR_INVENTORY),
                                                  {{paperdoll_dbrds[6], paperdoll_dbrds[5]}});
-    pCharacterScreen_AwardsBtn = CreateButton({pViewport->uViewportTL_X + 282, pViewport->uViewportTL_Y + 308},
+    pCharacterScreen_AwardsBtn = CreateButton({pViewport->viewportTL_X + 282, pViewport->viewportTL_Y + 308},
                                               paperdoll_dbrds[3]->size(), 1, 0,
                                               UIMSG_ClickAwardsBtn, 0, Io::InputAction::Awards, localization->GetString(LSTR_AWARDS),
                                               {{paperdoll_dbrds[4], paperdoll_dbrds[3]}});
-    pCharacterScreen_ExitBtn = CreateButton({pViewport->uViewportTL_X + 371, pViewport->uViewportTL_Y + 308},
+    pCharacterScreen_ExitBtn = CreateButton({pViewport->viewportTL_X + 371, pViewport->viewportTL_Y + 308},
                                             paperdoll_dbrds[1]->size(), 1, 0,
                                             UIMSG_ClickExitCharacterWindowBtn, 0, Io::InputAction::Invalid,
                                             localization->GetString(LSTR_EXIT_DIALOGUE),

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -254,7 +254,7 @@ void GUIWindow_Dialogue::Update() {
 
     // Message window(Окно сообщения)----
     if (!dialogue_string.empty()) {
-        window.uFrameWidth = pViewport->uViewportWidth;
+        window.uFrameWidth = pViewport->viewportWidth;
         window.uFrameZ = 452;
         GUIFont *font = assets->pFontArrus.get();
         pTextHeight = assets->pFontArrus->CalcTextHeight(dialogue_string, window.uFrameWidth, 13) + 7;

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -14,6 +14,7 @@
 #include "Engine/mm7_data.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/Engine.h"
+#include "Engine/Graphics/Viewport.h"
 
 #include "GUI/GUIFont.h"
 #include "GUI/GUIButton.h"
@@ -253,7 +254,7 @@ void GUIWindow_Dialogue::Update() {
 
     // Message window(Окно сообщения)----
     if (!dialogue_string.empty()) {
-        window.uFrameWidth = game_viewport_width;
+        window.uFrameWidth = pViewport->uViewportWidth;
         window.uFrameZ = 452;
         GUIFont *font = assets->pFontArrus.get();
         pTextHeight = assets->pFontArrus->CalcTextHeight(dialogue_string, window.uFrameWidth, 13) + 7;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -202,8 +202,8 @@ GUIWindow_GameMenu::GUIWindow_GameMenu()
 void GUIWindow_GameMenu::Update() {
     // -----------------------------------
     // 004156F0 GUI_UpdateWindows --- part
-    render->DrawTextureNew(pViewport->uViewportTL_X / 640.0f,
-                                pViewport->uViewportTL_Y / 480.0f,
+    render->DrawTextureNew(pViewport->viewportTL_X / 640.0f,
+                                pViewport->viewportTL_Y / 480.0f,
                                 game_ui_menu_options);
 }
 
@@ -855,7 +855,7 @@ void GameUI_DrawLifeManaBars() {
 
 //----- (0041B3B6) --------------------------------------------------------
 void GameUI_DrawRightPanel() {
-    render->DrawTextureNew(pViewport->uViewportBR_X / 640.0f, 0,
+    render->DrawTextureNew(pViewport->viewportBR_X / 640.0f, 0,
                                 game_ui_right_panel_frame);
 }
 

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -18,6 +18,7 @@
 #include "Engine/MapInfo.h"
 #include "Engine/Party.h"
 #include "Engine/PriceCalculator.h"
+#include "Engine/Graphics/Viewport.h"
 #include "Engine/Tables/HouseTable.h"
 #include "Engine/Tables/TransitionTable.h"
 
@@ -743,7 +744,7 @@ void GUIWindow_House::drawNpcHouseGreetingMessage(NPCData *npcData) {
             if (npcData->greet) {
                 std::string greetString;
 
-                int uFrameWidth = game_viewport_width;
+                int uFrameWidth = pViewport->uViewportWidth;
                 int uFrameZ = 452;
                 if (npcData->uFlags & NPC_GREETED_SECOND) {
                     greetString = pNPCStats->pNPCGreetings[npcData->greet].pGreeting2;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -744,7 +744,7 @@ void GUIWindow_House::drawNpcHouseGreetingMessage(NPCData *npcData) {
             if (npcData->greet) {
                 std::string greetString;
 
-                int uFrameWidth = pViewport->uViewportWidth;
+                int uFrameWidth = pViewport->viewportWidth;
                 int uFrameZ = 452;
                 if (npcData->uFlags & NPC_GREETED_SECOND) {
                     greetString = pNPCStats->pNPCGreetings[npcData->greet].pGreeting2;

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1356,7 +1356,7 @@ void DrawSpellDescriptionPopup(SpellId spell_id) {
     );
     if ((signed int)spell_info_window.uFrameHeight < 150)
         spell_info_window.uFrameHeight = 150;
-    spell_info_window.uFrameWidth = pViewport->uViewportWidth;
+    spell_info_window.uFrameWidth = pViewport->viewportWidth;
     spell_info_window.DrawMessageBox(false);
     spell_info_window.uFrameWidth -= 12;
     spell_info_window.uFrameHeight -= 12;
@@ -1494,7 +1494,7 @@ void showSpellbookInfo(ItemId spellbook) {
     if (popup.uFrameHeight < 150) {
         popup.uFrameHeight = 150;
     }
-    popup.uFrameWidth = pViewport->uViewportWidth;
+    popup.uFrameWidth = pViewport->viewportWidth;
     popup.DrawMessageBox(false);
     popup.uFrameWidth -= 12;
     popup.uFrameHeight -= 12;
@@ -1920,7 +1920,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
             if (GetCurrentMenuID() > MENU_MAIN) break;
             mouse->DoMouseLook();
 
-            if ((signed int)pY > (signed int)pViewport->uViewportBR_Y) {
+            if ((signed int)pY > (signed int)pViewport->viewportBR_Y) {
                 int characterIndex = pX / 118;
                 if (characterIndex < 4) { // portaits zone
                     popup_window.sHint.clear();
@@ -1930,7 +1930,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                     popup_window.uFrameY = 60;
                     GameUI_CharacterQuickRecord_Draw(&popup_window, characterIndex);
                 }
-            } else if ((int)pX > pViewport->uViewportBR_X) {
+            } else if ((int)pX > pViewport->viewportBR_X) {
                 if (pY >= 130) {
                     if (pX >= 476 && pX <= 636 && pY >= 240 && pY <= 300) {  // buff_tooltip zone
                         drawBuffPopupWindow();
@@ -1981,10 +1981,10 @@ void UI_OnMouseRightClick(Pointi mousePos) {
         }
         case SCREEN_BOOKS: {
             if (pGUIWindow_CurrentMenu->eWindowType != WINDOW_MapsBook ||
-                (signed int)pX < (signed int)pViewport->uViewportTL_X ||
-                (signed int)pX > (signed int)pViewport->uViewportBR_X ||
-                (signed int)pY < (signed int)pViewport->uViewportTL_Y ||
-                (signed int)pY > (signed int)pViewport->uViewportBR_Y ||
+                (signed int)pX < (signed int)pViewport->viewportTL_X ||
+                (signed int)pX > (signed int)pViewport->viewportBR_X ||
+                (signed int)pY < (signed int)pViewport->viewportTL_Y ||
+                (signed int)pY > (signed int)pViewport->viewportBR_Y ||
                 ((popup_window.sHint = GetMapBookHintText(mousePos.x, mousePos.y)).empty())) {
                 break;
             }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1356,8 +1356,8 @@ void DrawSpellDescriptionPopup(SpellId spell_id) {
     );
     if ((signed int)spell_info_window.uFrameHeight < 150)
         spell_info_window.uFrameHeight = 150;
-    spell_info_window.uFrameWidth = game_viewport_width;
-    spell_info_window.DrawMessageBox(0);
+    spell_info_window.uFrameWidth = pViewport->uViewportWidth;
+    spell_info_window.DrawMessageBox(false);
     spell_info_window.uFrameWidth -= 12;
     spell_info_window.uFrameHeight -= 12;
     spell_info_window.uFrameZ = spell_info_window.uFrameX + spell_info_window.uFrameWidth - 1;
@@ -1494,8 +1494,8 @@ void showSpellbookInfo(ItemId spellbook) {
     if (popup.uFrameHeight < 150) {
         popup.uFrameHeight = 150;
     }
-    popup.uFrameWidth = game_viewport_width;
-    popup.DrawMessageBox(0);
+    popup.uFrameWidth = pViewport->uViewportWidth;
+    popup.DrawMessageBox(false);
     popup.uFrameWidth -= 12;
     popup.uFrameHeight -= 12;
     popup.uFrameZ = popup.uFrameX + popup.uFrameWidth - 1;

--- a/src/GUI/UI/UISpell.cpp
+++ b/src/GUI/UI/UISpell.cpp
@@ -8,6 +8,7 @@
 #include "Io/Mouse.h"
 
 #include "UIStatusBar.h"
+#include "Engine/Graphics/Viewport.h"
 
 TargetedSpellUI::TargetedSpellUI(WindowType windowType, Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
     : GUIWindow(windowType, position, dimensions, hint), _spellInfo(spellInfo) {
@@ -36,7 +37,7 @@ TargetedSpellUI_Character::TargetedSpellUI_Character(Pointi position, Sizei dime
 
 TargetedSpellUI_Actor::TargetedSpellUI_Actor(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
     : TargetedSpellUI(WINDOW_CastSpell, position, dimensions, spellInfo, hint) {
-    CreateButton({game_viewport_x, game_viewport_y}, {game_viewport_width, game_viewport_height}, 1, 0, UIMSG_CastSpell_TargetActor, 0);
+    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_TargetActor, 0);
 }
 
 TargetedSpellUI_ActorOrCharacter::TargetedSpellUI_ActorOrCharacter(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
@@ -45,10 +46,10 @@ TargetedSpellUI_ActorOrCharacter::TargetedSpellUI_ActorOrCharacter(Pointi positi
     CreateButton({165, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 1, Io::InputAction::SelectChar2);
     CreateButton({280, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 2, Io::InputAction::SelectChar3);
     CreateButton({390, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 3, Io::InputAction::SelectChar4);
-    CreateButton({8, 8}, {game_viewport_width, game_viewport_height}, 1, 0, UIMSG_CastSpell_TargetActorBuff, 0);
+    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_TargetActorBuff, 0);
 }
 
 TargetedSpellUI_Telekinesis::TargetedSpellUI_Telekinesis(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
     : TargetedSpellUI(WINDOW_CastSpell, position, dimensions, spellInfo, hint) {
-    CreateButton({game_viewport_x, game_viewport_y}, {game_viewport_width, game_viewport_height}, 1, 0, UIMSG_CastSpell_Telekinesis, 0);
+    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_Telekinesis, 0);
 }

--- a/src/GUI/UI/UISpell.cpp
+++ b/src/GUI/UI/UISpell.cpp
@@ -37,7 +37,7 @@ TargetedSpellUI_Character::TargetedSpellUI_Character(Pointi position, Sizei dime
 
 TargetedSpellUI_Actor::TargetedSpellUI_Actor(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
     : TargetedSpellUI(WINDOW_CastSpell, position, dimensions, spellInfo, hint) {
-    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_TargetActor, 0);
+    CreateButton({pViewport->viewportTL_X, pViewport->viewportTL_Y}, {pViewport->viewportWidth, pViewport->viewportHeight}, 1, 0, UIMSG_CastSpell_TargetActor, 0);
 }
 
 TargetedSpellUI_ActorOrCharacter::TargetedSpellUI_ActorOrCharacter(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
@@ -46,10 +46,10 @@ TargetedSpellUI_ActorOrCharacter::TargetedSpellUI_ActorOrCharacter(Pointi positi
     CreateButton({165, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 1, Io::InputAction::SelectChar2);
     CreateButton({280, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 2, Io::InputAction::SelectChar3);
     CreateButton({390, 422}, {35, 0}, 2, 0, UIMSG_CastSpell_TargetCharacter, 3, Io::InputAction::SelectChar4);
-    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_TargetActorBuff, 0);
+    CreateButton({pViewport->viewportTL_X, pViewport->viewportTL_Y}, {pViewport->viewportWidth, pViewport->viewportHeight}, 1, 0, UIMSG_CastSpell_TargetActorBuff, 0);
 }
 
 TargetedSpellUI_Telekinesis::TargetedSpellUI_Telekinesis(Pointi position, Sizei dimensions, CastSpellInfo *spellInfo, std::string_view hint)
     : TargetedSpellUI(WINDOW_CastSpell, position, dimensions, spellInfo, hint) {
-    CreateButton({pViewport->uViewportTL_X, pViewport->uViewportTL_Y}, {pViewport->uViewportWidth, pViewport->uViewportHeight}, 1, 0, UIMSG_CastSpell_Telekinesis, 0);
+    CreateButton({pViewport->viewportTL_X, pViewport->viewportTL_Y}, {pViewport->viewportWidth, pViewport->viewportHeight}, 1, 0, UIMSG_CastSpell_Telekinesis, 0);
 }

--- a/src/GUI/UI/UISpellbook.cpp
+++ b/src/GUI/UI/UISpellbook.cpp
@@ -114,8 +114,8 @@ void GUIWindow_Spellbook::openSpellbook() {
 
         int index = spellIndexInMagicSchool(spell);
         CreateButton(fmt::format("SpellBook_Spell{}", index),
-                     {pViewport->uViewportTL_X + pIconPos[chapter][pSpellbookSpellIndices[chapter][index + 1]].Xpos,
-                     pViewport->uViewportTL_Y + pIconPos[chapter][pSpellbookSpellIndices[chapter][index + 1]].Ypos},
+                     {pViewport->viewportTL_X + pIconPos[chapter][pSpellbookSpellIndices[chapter][index + 1]].Xpos,
+                     pViewport->viewportTL_Y + pIconPos[chapter][pSpellbookSpellIndices[chapter][index + 1]].Ypos},
                      SBPageSSpellsTextureList[index + 1]->size(), 1, UIMSG_Spellbook_ShowHightlightedSpellInfo,
                      UIMSG_SelectSpell, std::to_underlying(spell));
         pageSpells++;
@@ -183,8 +183,8 @@ void GUIWindow_Spellbook::Update() {
                         if (pTexture) {
                             SpellBookIconPos &iconPos = pIconPos[player.lastOpenedSpellbookPage][pSpellbookSpellIndices[player.lastOpenedSpellbookPage][index + 1]];
 
-                            pX_coord = pViewport->uViewportTL_X + iconPos.Xpos;
-                            pY_coord = pViewport->uViewportTL_Y + iconPos.Ypos;
+                            pX_coord = pViewport->viewportTL_X + iconPos.Xpos;
+                            pY_coord = pViewport->viewportTL_Y + iconPos.Ypos;
 
                             Recti iconRect = Recti(pX_coord, pY_coord, pTexture->width(), pTexture->height());
                             if (iconRect.contains(mousePos)) { // mouseover highlight

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -131,8 +131,8 @@ void Io::Mouse::DrawCursor() {
         } else if (_mouseLook) {
             platform->setCursorShown(false);
             auto pointer = assets->getImage_ColorKey("MICON2", colorTable.Black /*colorTable.TealMask*/);
-            int x = pViewport->uScreenCenterX - pointer->width() / 2;
-            int y = pViewport->uScreenCenterY - pointer->height() / 2;
+            int x = pViewport->uViewportCenterX - pointer->width() / 2;
+            int y = pViewport->uViewportCenterY - pointer->height() / 2;
             render->DrawTextureNew(x / 640., y / 480., pointer);
         } else {
             platform->setCursorShown(true);

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -131,8 +131,8 @@ void Io::Mouse::DrawCursor() {
         } else if (_mouseLook) {
             platform->setCursorShown(false);
             auto pointer = assets->getImage_ColorKey("MICON2", colorTable.Black /*colorTable.TealMask*/);
-            int x = pViewport->uViewportCenterX - pointer->width() / 2;
-            int y = pViewport->uViewportCenterY - pointer->height() / 2;
+            int x = pViewport->viewportCenterX - pointer->width() / 2;
+            int y = pViewport->viewportCenterY - pointer->height() / 2;
             render->DrawTextureNew(x / 640., y / 480., pointer);
         } else {
             platform->setCursorShown(true);


### PR DESCRIPTION
This is a simplification of Viewport.h and related files. I found most of these issues while working with adding support for arbitrary render scale, but a PR for that is far off, and I think this partial step is generally helpful when maintaining the code base. There was also an @todo from pskeleton about solving the problem this PR tries to solve, so I figured that I might as well make it.

The main thing that's happening in this PR is that I have reduced the number of duplicates of the viewport data from **5** to 1. We used to have:
Viewport::uScreen_TL_X / TL_Y / BR_X / BR_Y / Width / Height
Viewport::uViewportTL_X / TL_Y / BR_X / BR_Y
ViewingParams::uSomeX / Y / Z / W
ViewingParams::uScreen_topL_X / topL_Y / BttmR_X / BttmR_Y
mm7_data::game_viewport_x / y / z / w / width / height

All of these values were, after initialization had finished, different representations of the exact same values. This PR reduces all of them to a single set of values. They're in Viewport, and are named viewportXXX (which is the correct naming as far as I can tell from HACKING).

I have also removed quite a lot of code that pushed around, shuffled, and set the different viewport representations to different values and each other. They looked like they were doing a lot of important things, but after staring at them and following them in a circle, they turned out to just be a bunch of busywork that didn't actually make any difference. 

Finally, I did further cleaning up in Viewport by removing a bunch of fields that were either completely unused, or only written to, or only read from.

There's one remaining problem with viewports that I haven't fixed - SetViewport is still called in three different spots in the code base. It should probably only be called on startup and whenever the screen size changes. I have tried to only call it in OpenGLRenderer::Reinitialize, and that works _unless_ I run game tests in headless mode, in which case everything crashes. I assume that's because the renderer isn't used in headless mode (duh), but I haven't looked into that very deeply. I have left some @TODOs for later for that problem.