### PR TITLE
Update documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1001,6 +1001,7 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = */android/*
 EXCLUDE_PATTERNS      += */thirdparty/*
+EXCLUDE_PATTERNS      += cmake-*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ The Flatpak package is somewhat easier to use:
   * Includes all the necessary dependencies to run OpenEnroth; this is useful if your system does not have the
     required libraries available or the available versions are incompatible with the loose executable bundle
   * Requires the game data to be in a specific location
-  * Can be used e.g. on a Steam Deck or on "immutable"/"atomic" Linux distributions#
+  * Can be used e.g. on a Steam Deck or on "immutable"/"atomic" Linux distributions
     like [Bazzite](https://bazzite.gg/) or [Universal Blue](https://universal-blue.org/).
 
 The loose executable bundle is more flexible:
   * May require you to install some libraries to your operating system
   * Both the game executable and data can be installed anywhere on your computer
+
+The loose executables are built on Ubuntu 24.04 and may not work on other distributions - e.g. Fedora does not
+have a matching version of `libdwarf` available at all, so the loose executable will not run here.
 
 #### Flatpak
 
@@ -123,10 +126,10 @@ The loose executable bundle is more flexible:
 
 #### Loose executables
 
-1. Install the required libraries SDL2, `libdwarf` and `libelf`:
-   * `sudo apt-get install libsdl2 libdwarf libelf` (Ubuntu/Debian)
-   * `sudo dnf install SDL2 libdwarf elfutils-libelf` (RedHat/Fedora)
-   * For other distributions, check your distribution's user guides
+1. Install the required libraries (SDL2, `libdwarf` and `libelf`):
+   * `sudo apt-get install libsdl2-2* libdwarf1 libelf++* libgl1` (Ubuntu 24.04)
+   * For other distributions, check your distribution's user guides and package management tools to find
+     the correct package names for these libraries.
 2. Install OpenEnroth:
    * Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip
      the files

--- a/README.md
+++ b/README.md
@@ -1,93 +1,159 @@
 # Might and Magic Trilogy
 
-[![Windows](https://github.com/OpenEnroth/OpenEnroth/workflows/Windows/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/windows.yml) [![Linux](https://github.com/OpenEnroth/OpenEnroth/workflows/Linux/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/linux.yml) [![MacOS](https://github.com/OpenEnroth/OpenEnroth/workflows/MacOS/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/macos.yml) [![Doxygen](https://github.com/OpenEnroth/OpenEnroth/workflows/Doxygen/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/doxygen.yml) [![Style Checker](https://github.com/OpenEnroth/OpenEnroth/workflows/Style/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/style.yml)
+[![Windows](https://github.com/OpenEnroth/OpenEnroth/workflows/Windows/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/windows.yml) 
+[![Linux](https://github.com/OpenEnroth/OpenEnroth/workflows/Linux/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/linux.yml) 
+[![MacOS](https://github.com/OpenEnroth/OpenEnroth/workflows/MacOS/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/macos.yml) 
+[![Doxygen](https://github.com/OpenEnroth/OpenEnroth/workflows/Doxygen/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/doxygen.yml) 
+[![Style Checker](https://github.com/OpenEnroth/OpenEnroth/workflows/Style/badge.svg)](https://github.com/OpenEnroth/OpenEnroth/actions/workflows/style.yml)
 
-We are creating an extensible engine & modding environment that would make it possible to play original Might&Magic VI-VIII games on modern platforms with improved graphics and quality-of-life features expected of modern titles, and make modding and installing & playing the mods a pleasurable experience.
+We are creating an extensible engine & modding environment that would make it possible to play original Might & Magic VI-VIII
+games on modern platforms with improved graphics and quality-of-life features expected of modern titles, and make modding and
+installing & playing the mods a pleasurable experience.
 
-Currently only MM7 is playable. You can check out the [milestones](https://github.com/OpenEnroth/OpenEnroth/milestones) to see where we're at.
+Currently only MM7 is playable. You can check out the [milestones](https://github.com/OpenEnroth/OpenEnroth/milestones) to
+see where we're at.
 
 ![screenshot_main](https://user-images.githubusercontent.com/24377109/79051217-491a7800-7c2f-11ea-85c7-f9120b7d79dd.png)
 
-Download
--------
+# Download
 
-To download the code without having to compile it we have our releases at [https://github.com/OpenEnroth/OpenEnroth/releases](https://github.com/OpenEnroth/OpenEnroth/releases) 
+To download the code without having to compile it we have our releases at
+[https://github.com/OpenEnroth/OpenEnroth/releases](https://github.com/OpenEnroth/OpenEnroth/releases) 
 
 Currently there are only the nightly builds which may have bugs.
 
-Discord
--------
+# Discord
 
 Join our discord channel to discuss, track progress or get involved in the development of this project.
 
 [![Discord channel invite](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq) 
 
 
-Getting Started on Windows
---------------------------
+# Getting Started
 
-1. You will need a GoG or any other version of Might and Magic VII. Run the installer as usual.
+Regardless of what system you want to play OpenEnroth on, you will need a copy of OpenEnroth and the Might and Magic VII
+game data. Where and how you install these on your computer depends on your operating system.
 
-2. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
+## Getting the game data
 
-3. From the `dist` folder inside the zip file copy `OpenEnroth.exe` and `OpenEnroth.pdb` to the folder where the game is installed.
+You can buy Might and Magic VII from [gog.com](https://www.gog.com/en/game/might_and_magic_7_for_blood_and_honor) and
+download the installer from there; if you have a copy from another source (eg. an original retail disc) this should
+also work with OpenEnroth.
 
-4. Run `OpenEnroth.exe`.
+At the very least, OpenEnroth requires the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories from the game data.
+
+### Non-GOG versions
+
+Install or extract your copy of the game as normal.
+
+### GOG Version
+
+#### Windows
+
+On Windows, you can simply run the installer to extract the game data to your computer.
+
+#### Linux and macOS
+
+The installer cannot be run directly on Linux and macOS but you can use `innoextract` to extract its contents.
+
+* On macOS, install [Homebrew](https://brew.sh/) if you don't have it already (run `brew --version` in a Terminal
+  window to see if you do) and install `innoextract` using `brew install innoextract`
+* On Linux, the exact command depends on your distribution.
+  * For Ubuntu or Debian-based systems (including eg. Linux Mint, Pop!OS, etc): `sudo apt install -y innoextract`
+  * For Fedora or other RedHat-based systems (*except* for "immutable" distributions like Bazzite):
+    `sudo dnf install -y innoextract`
+  * For other systems, please check the distribution's user guide. [Repology](https://repology.org/project/innoextract/versions)
+    has an extensive list of Linux distributions and the name of the package for innoextract on each.
+
+Once you have innoextract, create a new directory for the game data, then open a terminal window and run:
+
+`innoextract -e -d <new game data directory> <path to GOG installer .exe>`
+
+This will extract the game data to the new directory.
+
+## Installing OpenEnroth
+
+### Windows
+
+1. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
+2. Copy `OpenEnroth.exe` and `OpenEnroth.pdb` to the directory containing the game data.
+3. Run `OpenEnroth.exe`.
 
 
-Getting Started on Ubuntu Linux
--------------------------------
+### macOS
 
-1. You will need a GoG or any other version of Might and Magic VII. If you have an offline GoG installer, then follow these steps:
-   * Install `innoextract` with `sudo apt-get install innoextract`.
-   * Run `innoextract -e -d <target-folder> <mm7-gog-folder>/setup_mm_7.exe`, where `<target-folder>` is the folder where you want to have game data extracted from the mm7 installer.
-   * Check the files in `<target-folder>`, it should now contain the `app` subfolder. This is where game assets were extracted into.
-
-2. Install OpenEnroth dependencies with `sudo apt-get install libsdl2-dev libdwarf-dev libelf-dev`.
-
-3. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
-
-4. From the `dist` folder inside the zip file copy the `OpenEnroth` binary to `<target-folder>/app`.
-
-5. Run `OpenEnroth` binary.
+1. Move the game data to `~/Library/Application Support/OpenEnroth`, creating this directory if needed.
+2. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip
+   the files.
+3. Run `xattr -rc <extracted-path>/dist/OpenEnroth.app`. This is needed because OpenEnroth binaries are
+   unsigned, without this step the app bundle won't start.
+4. Run `OpenEnroth.app`.
 
 
-Getting Started on MacOS
-------------------------
+### Linux
 
-1. You will need a GoG or any other version of Might and Magic VII. If you have an offline GoG installer, then follow these steps:
-   * Install `innoextract` with `brew install innoextract`.
-   * Run `innoextract -e -d <target-folder> <mm7-gog-folder>/setup_mm_7.exe`, where `<target-folder>` is the folder where you want to have game data extracted from the mm7 installer.
-   * Check the files in `<target-folder>`, it should now contain the `app` subfolder. This is where game assets were extracted into.
+There are two options on Linux - loose executables to install wherever you like and a Flatpak package for ease of
+use. The key differences are:
 
-2. Move extracted game assets to `~/Library/Application Support/OpenEnroth`. This is where `OpenEnroth` will look for game data.
+The Flatpak package is somewhat easier to use:
+  * Includes all the necessary dependencies to run OpenEnroth; this is useful if your system does not have the
+    required libraries available or the available versions are incompatible with the loose executable bundle
+  * Requires the game data to be in a specific location
+  * Can be used e.g. on a Steam Deck or on "immutable"/"atomic" Linux distributions#
+    like [Bazzite](https://bazzite.gg/) or [Universal Blue](https://universal-blue.org/).
 
-3. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
-   
-4. Run `xattr -rc <extracted-path>/dist/OpenEnroth.app`. This is needed because OpenEnroth binaries are unsigned, without this step the app bundle won't start.
+The loose executable bundle is more flexible:
+  * May require you to install some libraries to your operating system
+  * Both the game executable and data can be installed anywhere on your computer
 
-5. Start `OpenEnroth.app`.
+#### Flatpak
 
+1. Check for Flatpak support:
+   * Run `flatpak --version`.
+   * If you receive a message listing a version number, you're ready to go; otherwise please visit
+     [https://flatpak.org/setup/](https://flatpak.org/setup/) and follow instructions there to set up.
+2. Install OpenEnroth:
+   * Download the `io.github.openenroth.openenroth_*.flatpak` package from one of the
+     prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases).
+   * Run `flatpak install --user /path/to/io.github.openenroth.openenroth_*.flatpak` to install the OpenEnroth
+     package.
+   * Create `~/.var/app/io.github.openenroth/openenroth/data/mm7`
+   * Move the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) to this new directory
+3. Run OpenEnroth from your desktop's application menu or using `flatpak run io.github.openenroth.openenroth`
 
-Game Assets Path Override
--------------------------
+#### Loose executables
 
-You can set `OPENENROTH_MM7_PATH` env variable to point to the location of the game assets. If this variable is set, OpenEnroth will look for game assets only in the location it's pointing to. You might also want to add the following line to your bash profile (e.g. `~/.profile` on Ubuntu):
+1. Install the required libraries SDL2, `libdwarf` and `libelf`:
+   * `sudo apt-get install libsdl2 libdwarf libelf` (Ubuntu/Debian)
+   * `sudo dnf install SDL2 libdwarf elfutils-libelf` (RedHat/Fedora)
+   * For other distributions, check your distribution's user guides
+2. Install OpenEnroth:
+   * Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip
+     the files
+   * Create a new directory for your OpenEnroth installation and copy the `dist/OpenEnroth` executable from the
+     zip there
+   * Copy the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) to your OpenEnroth
+     directory
+4. Run the `OpenEnroth` executable (you may need to run `chmod a+x OpenEnroth` first).
+
+# Game Assets Path Override
+
+You can set `OPENENROTH_MM7_PATH` env variable to point to the location of the game assets. If this variable
+is set, OpenEnroth will look for game assets only in the location it's pointing to. You might also want to
+add the following line to your shell profile (e.g. `~/.profile` on Linux or `~/.zshrc` on Mac):
 
 ```
 export OPENENROTH_MM7_PATH="<path-to-mm7-game-assets>"
 ```
 
 
-Development
------------
+# Development
 
 See the [HACKING](HACKING.md) document for information on how to compile or if you intend to contribute.
 
 See the code [DOCUMENTATION](https://openenroth.github.io/OpenEnroth/index.html).
 
-Screenshots
------------
+# Screenshots
 
 ![screenshot_1](https://user-images.githubusercontent.com/24377109/79051879-f04cde80-7c32-11ea-939d-1dcc97b46f5d.png)
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ an "atomic"/"immutable" Linux distribution such as Bazzite or SteamOS.
 ### Linux (Loose executable)
 
 The loose executable bundle is the easier option if:
-  * You want easy access to the OpenEnroth executable for development or debugging
-  * You absolutely need specific control over the installation location for OpenEnroth and the game data
-  * You can install system packages (specifically, SDL2, `libdwarf`, `libelf` and `libgl1`)
-  * You're using Ubuntu 24.04 - other distributions may not have the required libraries available
-    or not in compatible versions
+* You want easy access to the OpenEnroth executable for development or debugging
+* You absolutely need specific control over the installation location for OpenEnroth and the game data
+* You can install system packages (specifically, SDL2, `libdwarf`, `libelf` and `libgl1`)
+* You're using Ubuntu 24.04 - other distributions may not have the required libraries available
+  or not in compatible versions
 
 1. Install the required libraries (SDL2, `libdwarf` and `libelf`):
    * `sudo apt-get install libsdl2-2* libdwarf1 libelf++* libgl1` (Ubuntu 24.04)

--- a/README.md
+++ b/README.md
@@ -93,23 +93,15 @@ This will extract the game data to the new directory.
 ### Linux
 
 There are two options on Linux - loose executables to install wherever you like and a Flatpak package for ease of
-use. The key differences are:
-
-The Flatpak package is somewhat easier to use:
-  * Includes all the necessary dependencies to run OpenEnroth; this is useful if your system does not have the
-    required libraries available or the available versions are incompatible with the loose executable bundle
-  * Requires the game data to be in a specific location
-  * Can be used e.g. on a Steam Deck or on "immutable"/"atomic" Linux distributions
-    like [Bazzite](https://bazzite.gg/) or [Universal Blue](https://universal-blue.org/).
-
-The loose executable bundle is more flexible:
-  * May require you to install some libraries to your operating system
-  * Both the game executable and data can be installed anywhere on your computer
-
-The loose executables are built on Ubuntu 24.04 and may not work on other distributions - e.g. Fedora does not
-have a matching version of `libdwarf` available at all, so the loose executable will not run here.
+use.
 
 #### Flatpak
+
+The Flatpak package is the easiest choice if:
+  * You aren't using Ubuntu 24.04, or
+  * You cannot install system packages on your computer for any reason  (as long as Flatpak is
+    available), e.g. because you're using an "atomic"/"immutable" Linux distribution such as
+    Bazzite or SteamOS
 
 1. Check for Flatpak support:
    * Run `flatpak --version`.
@@ -120,11 +112,18 @@ have a matching version of `libdwarf` available at all, so the loose executable 
      prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases).
    * Run `flatpak install --user /path/to/io.github.openenroth.openenroth_*.flatpak` to install the OpenEnroth
      package.
-   * Create `~/.var/app/io.github.openenroth/openenroth/data/mm7`
-   * Move the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) to this new directory
+   * Create `~/.var/app/io.github.openenroth/openenroth/data/mm7/data/`
+   * Move the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) into this new directory
 3. Run OpenEnroth from your desktop's application menu or using `flatpak run io.github.openenroth.openenroth`
 
 #### Loose executables
+
+The loose executable bundle is the easier option if:
+  * You want easy access to the OpenEnroth executable for development or debugging
+  * You absolutely need specific control over the installation location for OpenEnroth and the game data
+  * You can install system packages (specifically, SDL2, `libdwarf`, `libelf` and `libgl1`)
+  * You're using Ubuntu 24.04 - other distributions may not have the required libraries available
+    or not in compatible versions
 
 1. Install the required libraries (SDL2, `libdwarf` and `libelf`):
    * `sudo apt-get install libsdl2-2* libdwarf1 libelf++* libgl1` (Ubuntu 24.04)
@@ -133,11 +132,10 @@ have a matching version of `libdwarf` available at all, so the loose executable 
 2. Install OpenEnroth:
    * Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip
      the files
-   * Create a new directory for your OpenEnroth installation and copy the `dist/OpenEnroth` executable from the
-     zip there
-   * Copy the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) to your OpenEnroth
-     directory
-4. Run the `OpenEnroth` executable (you may need to run `chmod a+x OpenEnroth` first).
+   * Copy the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) to the directory
+     you unzipped the release to, next to the `OpenEnroth` executable
+4. Run the `OpenEnroth` executable (you may need to run `chmod a+x OpenEnroth` first) from a terminal
+   or by double-clicking it in a file browser.
 
 # Game Assets Path Override
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Once you have innoextract, create a new directory for the game data, then open a
 
 This will extract the game data to the new directory.
 
+### Game Assets Path Override
+
+You can set an environment variable called `OPENENROTH_MM7_PATH` to point to the location of the game data.
+If this variable is set, OpenEnroth will look for game assets only in the location it's pointing to. You
+might also want to add the following line to your shell profile (e.g. `~/.profile` on Linux or `~/.zshrc` on Mac):
+
+```
+export OPENENROTH_MM7_PATH="<path-to-mm7-game-assets>"
+```
+
 ## Installing OpenEnroth
 
 ### Windows
@@ -78,7 +88,6 @@ This will extract the game data to the new directory.
 1. Download one of the prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip the files.
 2. Copy `OpenEnroth.exe` and `OpenEnroth.pdb` to the directory containing the game data.
 3. Run `OpenEnroth.exe`.
-
 
 ### macOS
 
@@ -89,24 +98,16 @@ This will extract the game data to the new directory.
    unsigned, without this step the app bundle won't start.
 4. Run `OpenEnroth.app`.
 
+### Linux (Flatpak)
 
-### Linux
-
-There are two options on Linux - loose executables to install wherever you like and a Flatpak package for ease of
-use.
-
-#### Flatpak
-
-The Flatpak package is the easiest choice if:
-  * You aren't using Ubuntu 24.04, or
-  * You cannot install system packages on your computer for any reason  (as long as Flatpak is
-    available), e.g. because you're using an "atomic"/"immutable" Linux distribution such as
-    Bazzite or SteamOS
+The Flatpak package is the easiest choice if you aren't using Ubuntu 24.04, or you cannot install system
+packages on your computer for any reason (as long as Flatpak is available), e.g. because you're using
+an "atomic"/"immutable" Linux distribution such as Bazzite or SteamOS.
 
 1. Check for Flatpak support:
    * Run `flatpak --version`.
    * If you receive a message listing a version number, you're ready to go; otherwise please visit
-     [https://flatpak.org/setup/](https://flatpak.org/setup/) and follow instructions there to set up.
+    [https://flatpak.org/setup/](https://flatpak.org/setup/) and follow instructions there to set up.
 2. Install OpenEnroth:
    * Download the `io.github.openenroth.openenroth_*.flatpak` package from one of the
      prebuilt [releases](https://github.com/OpenEnroth/OpenEnroth/releases).
@@ -116,7 +117,7 @@ The Flatpak package is the easiest choice if:
    * Move the game data (at least the `ANIMS`, `DATA`, `MUSIC` and `SOUNDS` directories) into this new directory
 3. Run OpenEnroth from your desktop's application menu or using `flatpak run io.github.openenroth.openenroth`
 
-#### Loose executables
+### Linux (Loose executable)
 
 The loose executable bundle is the easier option if:
   * You want easy access to the OpenEnroth executable for development or debugging
@@ -136,16 +137,6 @@ The loose executable bundle is the easier option if:
      you unzipped the release to, next to the `OpenEnroth` executable
 4. Run the `OpenEnroth` executable (you may need to run `chmod a+x OpenEnroth` first) from a terminal
    or by double-clicking it in a file browser.
-
-# Game Assets Path Override
-
-You can set `OPENENROTH_MM7_PATH` env variable to point to the location of the game assets. If this variable
-is set, OpenEnroth will look for game assets only in the location it's pointing to. You might also want to
-add the following line to your shell profile (e.g. `~/.profile` on Linux or `~/.zshrc` on Mac):
-
-```
-export OPENENROTH_MM7_PATH="<path-to-mm7-game-assets>"
-```
 
 
 # Development


### PR DESCRIPTION
Sorry this took such a long time!

This rewrites the "Getting started" section of the readme to reduce repetition and segment the installation process into two parts (game data and OpenEnroth itself), and adds documentation for how to install the Flatpak package and what situations it is intended for.

I've also added some linebreaks throughout the markdown to make it a bit more readable in text editors and standardised the headline styles.