### PR TITLE
Dump character inventory in traces

### DIFF
--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -15,6 +15,51 @@
 
 #include "Utility/String/Ascii.h"
 
+// TODO(captainurist): doesn't belong here
+static std::string makeValidUtf8(const std::string& input) {
+    std::string output;
+    size_t i = 0;
+    const size_t len = input.size();
+
+    while (i < len) {
+        unsigned char c = input[i];
+
+        // Single-byte (ASCII)
+        if (c <= 0x7F) {
+            output += c;
+            ++i;
+        } else if ((c >> 5) == 0x6 && i + 1 < len &&          // 110xxxxx (2 bytes)
+                 (input[i + 1] & 0xC0) == 0x80) {
+            output += c;
+            output += input[i + 1];
+            i += 2;
+
+        } else if ((c >> 4) == 0xE && i + 2 < len &&          // 1110xxxx (3 bytes)
+                 (input[i + 1] & 0xC0) == 0x80 &&
+                 (input[i + 2] & 0xC0) == 0x80) {
+            output += c;
+            output += input[i + 1];
+            output += input[i + 2];
+            i += 3;
+        } else if ((c >> 3) == 0x1E && i + 3 < len &&         // 11110xxx (4 bytes)
+                 (input[i + 1] & 0xC0) == 0x80 &&
+                 (input[i + 2] & 0xC0) == 0x80 &&
+                 (input[i + 3] & 0xC0) == 0x80) {
+            output += c;
+            output += input[i + 1];
+            output += input[i + 2];
+            output += input[i + 3];
+            i += 4;
+        } else {
+            // Invalid UTF-8 byte sequence
+            output += '?';
+            ++i;
+        }
+    }
+
+    return output;
+}
+
 static bool shouldSkip(const GameConfig *config, const ConfigSection *section, const AnyConfigEntry *entry) {
     return
         (section == &config->window && entry != &config->window.Width && entry != &config->window.Height) ||
@@ -71,6 +116,35 @@ void EngineTraceStateAccessor::prepareForPlayback(GameConfig *config, const Conf
 }
 
 EventTraceGameState EngineTraceStateAccessor::makeGameState() {
+    auto toDebugString = [](const Item &item) {
+        std::string result;
+        if (item.isWand()) {
+            result = fmt::format("{} [{}/{}]", item.GetIdentifiedName(), item.numCharges, item.maxCharges);
+        } else if (item.isPotion() && item.itemId != ITEM_POTION_BOTTLE) {
+            std::string name = item.GetIdentifiedName();
+            if (name.ends_with("Potion")) {
+                result = fmt::format("{} [{}]", name, item.potionPower);
+            } else {
+                result = fmt::format("{} Potion [{}]", name, item.potionPower);
+            }
+        } else if (item.isSpellScroll()) {
+            result = fmt::format("Scroll of {}", item.GetIdentifiedName());
+        } else if (item.standardEnchantment) {
+            result = fmt::format("{} [+{}]", item.GetIdentifiedName(), item.standardEnchantmentStrength);
+        } else if (item.itemId == ITEM_QUEST_LICH_JAR_FULL) {
+            result = fmt::format("{} [{}]", item.GetIdentifiedName(), item.lichJarCharacterIndex);
+        } else {
+            result = item.GetIdentifiedName();
+        }
+
+        if (!item.IsIdentified())
+            result += " [UNID]";
+        if (item.IsBroken())
+            result += " [BROKEN]";
+
+        return makeValidUtf8(result);
+    };
+
     EventTraceGameState result;
     result.locationName = ascii::toLower(pMapStats->pInfos[engine->_currentLoadedMapId].fileName);
     result.partyPosition = pParty->pos.toInt();
@@ -85,6 +159,13 @@ EventTraceGameState EngineTraceStateAccessor::makeGameState() {
         traceCharacter.accuracy = character.GetActualAccuracy();
         traceCharacter.speed = character.GetActualSpeed();
         traceCharacter.luck = character.GetActualLuck();
+
+        for (int index : character.pEquipment)
+            if (index > 0)
+                traceCharacter.equipment.emplace_back(toDebugString(character.pInventoryItemList[index - 1]));
+        for (int index : character.pInventoryMatrix)
+            if (index > 0)
+                traceCharacter.backpack.emplace_back(toDebugString(character.pInventoryItemList[index - 1]));
     }
     return result;
 }

--- a/src/Library/Trace/EventTrace.cpp
+++ b/src/Library/Trace/EventTrace.cpp
@@ -193,7 +193,9 @@ MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(EventTraceCharacterState, (
     (endurance, "endurance"),
     (accuracy, "accuracy"),
     (speed, "speed"),
-    (luck, "luck")
+    (luck, "luck"),
+    (equipment, "equipment"),
+    (backpack, "backpack")
 ))
 
 MM_DEFINE_JSON_STRUCT_SERIALIZATION_FUNCTIONS(EventTraceGameState, (

--- a/src/Library/Trace/EventTrace.h
+++ b/src/Library/Trace/EventTrace.h
@@ -23,6 +23,8 @@ struct EventTraceCharacterState {
     int accuracy = 0;
     int speed = 0;
     int luck = 0;
+    std::vector<std::string> equipment;
+    std::vector<std::string> backpack;
 };
 
 struct EventTraceGameState {

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 7af440753835abb946c4c33941f3387feec2f978
+        GIT_TAG 38c30147704eb66b5e171b44c9e01d84af3d1c09
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Depends on #2091. Prerequisite for #1953.

We need proper UTF functions in Utility, but I'm not adding them yet. Mainly b/c we'll also need cp1251/cp1252 handling, and I'll need to do some library research first.