### PR TITLE
match ndk version to dependencies repo

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,7 +34,7 @@ on:
 env:
   # This version is referenced in android/openenroth/build.gradle.
   # When updating the version here you should also update it in the Dependencies repo!
-  NDK_VERSION: 26.3.11579264
+  NDK_VERSION: 28.1.13356709
 
 jobs:
   build_android:


### PR DESCRIPTION
https://github.com/OpenEnroth/OpenEnroth_Dependencies/releases/download/deps_r6_master/android_Debug_arm64.zip uses NDK 28.1.13356709 this repo should match