### PR TITLE
GUIFont doesn't need a palette

### DIFF
--- a/src/Application/GameOver.cpp
+++ b/src/Application/GameOver.cpp
@@ -51,7 +51,7 @@ void CreateWinnerCertificate() {
     pWindow.uFrameHeight = 338;
     pWindow.uFrameZ = 543;
     pWindow.uFrameW = 397;
-    std::unique_ptr<GUIFont> pFont = GUIFont::LoadFont("endgame.fnt", "FONTPAL");
+    std::unique_ptr<GUIFont> pFont = GUIFont::LoadFont("endgame.fnt");
 
     std::string pInString;
     if (pParty->isPartyGood())

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -547,6 +547,9 @@ int GUIFont::DrawTextInRect(GUIWindow *window, Pointi position, Color color, std
         return pLineWidth;
     }
 
+    assert(false);
+    return 0; // TODO(captainurist): The code below is never called, and it's messed up - \r is used for color tags, \f for right justification.
+
     render->BeginTextNew(fonttex, fontshadow);
 
     unsigned int text_width = 0;

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -13,6 +13,18 @@
 class GUIWindow;
 class GraphicsImage;
 
+/**
+ * Some notes on markup characters supported by `GUIFont` functions.
+ *
+ * - `\n` is a regular line feed.
+ * - `\tXXX`, where `XXX` is decimal offset in pixels. Moves the caret to a position offset by `XXX` to the right from
+ *   the start of the line. This is how aligned tables are implemented.
+ * - `\rXXX`, where `XXX` is a decimal offset in pixels. Moves the caret so that the rest of the line is
+ *   right-justified, with the given offset from the right window border. This is used e.g. in the create party screen.
+ * - `\fXXXXX`, where `XXXXX` is a decimal color code for 16-bit color to use for the text that follows.
+ *
+ * @see Color::fromC16
+ */
 class GUIFont {
  public:
     GUIFont();
@@ -41,7 +53,7 @@ class GUIFont {
      * @param text                          Input line of text.
      * @param color                         Color that the text should be started to be drawn at - this allows feeding
      *                                      in the color returned from the previous call to maintain correct color when
-     *                                      its split onto a new line.
+     *                                      it's split onto a new line.
      * @param defaultColor                  The color that the text should return to on hitting a default color tag.
      * @param position                      Position to draw the text line to.
      * @param max_len_pix                   The maximum allowed width for this line of text.

--- a/src/GUI/GUIFont.h
+++ b/src/GUI/GUIFont.h
@@ -18,7 +18,7 @@ class GUIFont {
     GUIFont();
     ~GUIFont();
 
-    static std::unique_ptr<GUIFont> LoadFont(std::string_view pFontFile, std::string_view pFontPalette);
+    static std::unique_ptr<GUIFont> LoadFont(std::string_view pFontFile);
 
     void CreateFontTex();
     void ReleaseFontTex();
@@ -59,7 +59,7 @@ class GUIFont {
     // TODO: these should take std::string_view
     void DrawCreditsEntry(GUIFont *pSecondFont, int uFrameX, int uFrameY,
                           unsigned int w, unsigned int h, Color firstColor,
-                          Color secondColor, std::string_view pString,
+                          Color secondColor, Color shadowColor, std::string_view pString,
                           GraphicsImage *image);
     int GetStringHeight2(GUIFont *secondFont, std::string_view text_str,
                          GUIWindow *pWindow, int startX, int a6);
@@ -71,12 +71,11 @@ class GUIFont {
     std::string FitTwoFontStringINWindow(std::string_view inString, GUIFont *pFontSecond,
                                     GUIWindow *pWindow, int startPixlOff,
                                     bool return_on_carriage = false);
-    void DrawTextLineToBuff(Color color, Color *uX_buff_pos,
+    void DrawTextLineToBuff(Color color, Color shadowColor, Color *uX_buff_pos,
                             std::string_view text, int line_width);
 
  private:
     LodFont _font;
-    Palette _palette;
 };
 
 void ReloadFonts();

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -1064,15 +1064,15 @@ void MainMenuUI_LoadFontsAndSomeStuff() {
     //     pSRZBufferLineOffsets[i] = 640 * i;  // must be 640 - needs sorting
     // }
     if (!assets->pFontArrus)
-        assets->pFontArrus = GUIFont::LoadFont("arrus.fnt", "FONTPAL");
+        assets->pFontArrus = GUIFont::LoadFont("arrus.fnt");
     if (!assets->pFontLucida)
-        assets->pFontLucida = GUIFont::LoadFont("lucida.fnt", "FONTPAL");
+        assets->pFontLucida = GUIFont::LoadFont("lucida.fnt");
     if (!assets->pFontCreate)
-        assets->pFontCreate = GUIFont::LoadFont("create.fnt", "FONTPAL");
+        assets->pFontCreate = GUIFont::LoadFont("create.fnt");
     if (!assets->pFontSmallnum)
-        assets->pFontSmallnum = GUIFont::LoadFont("smallnum.fnt", "FONTPAL");
+        assets->pFontSmallnum = GUIFont::LoadFont("smallnum.fnt");
     if (!assets->pFontComic)
-        assets->pFontComic = GUIFont::LoadFont("comic.fnt", "FONTPAL");
+        assets->pFontComic = GUIFont::LoadFont("comic.fnt");
 }
 
 static void LoadPartyBuffIcons() {

--- a/src/GUI/UI/UIBooks.cpp
+++ b/src/GUI/UI/UIBooks.cpp
@@ -90,13 +90,13 @@ void GUIWindow_Book::initializeFonts() {
     ui_book_map_frame = assets->getImage_Alpha("mapbordr");
 
     if (!assets->pFontBookCalendar)
-        assets->pFontBookCalendar = GUIFont::LoadFont("book.fnt", "FONTPAL");
+        assets->pFontBookCalendar = GUIFont::LoadFont("book.fnt");
     if (!assets->pFontBookTitle)
-        assets->pFontBookTitle = GUIFont::LoadFont("book2.fnt", "FONTPAL");
+        assets->pFontBookTitle = GUIFont::LoadFont("book2.fnt");
     if (!assets->pFontBookOnlyShadow)
-        assets->pFontBookOnlyShadow = GUIFont::LoadFont("autonote.fnt", "FONTPAL");
+        assets->pFontBookOnlyShadow = GUIFont::LoadFont("autonote.fnt");
     if (!assets->pFontBookLloyds)
-        assets->pFontBookLloyds = GUIFont::LoadFont("spell.fnt", "FONTPAL");
+        assets->pFontBookLloyds = GUIFont::LoadFont("spell.fnt");
 }
 
 void GUIWindow_Book::bookButtonClicked(BookButtonAction action) {

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -12,8 +12,8 @@
 #include "GUI/GUIMessageQueue.h"
 
 GUICredits::GUICredits() : GUIWindow(WINDOW_Credits, {0, 0}, render->GetRenderDimensions()) {
-    _fontQuick = GUIFont::LoadFont("quick.fnt", "FONTPAL");
-    _fontCChar = GUIFont::LoadFont("cchar.fnt", "FONTPAL");
+    _fontQuick = GUIFont::LoadFont("quick.fnt");
+    _fontCChar = GUIFont::LoadFont("cchar.fnt");
 
     _mm6TitleTexture = assets->getImage_PCXFromIconsLOD("mm6title.pcx");
 
@@ -29,7 +29,7 @@ GUICredits::GUICredits() : GUIWindow(WINDOW_Credits, {0, 0}, render->GetRenderDi
     int height = _fontQuick->GetStringHeight2(_fontCChar.get(), text, &credit_window, 0, 1) + 2 * credit_window.uFrameHeight;
     _creditsTexture = GraphicsImage::Create(width, height);
 
-    _fontQuick->DrawCreditsEntry(_fontCChar.get(), 0, credit_window.uFrameHeight, width, height, colorTable.CornFlowerBlue, colorTable.Primrose, text, _creditsTexture);
+    _fontQuick->DrawCreditsEntry(_fontCChar.get(), 0, credit_window.uFrameHeight, width, height, colorTable.CornFlowerBlue, colorTable.Primrose, colorTable.Black, text, _creditsTexture);
 
     render->Update_Texture(_creditsTexture);
 

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -700,7 +700,7 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     pPlayerCreationUI_BtnMinus = CreateButton({523, 393}, {20, 35}, 1, 0, UIMSG_PlayerCreationClickMinus, 0, Io::InputAction::Minus, "", {ui_partycreation_minus});
     pPlayerCreationUI_BtnPlus = CreateButton({613, 393}, {20, 35}, 1, 0, UIMSG_PlayerCreationClickPlus, 1, Io::InputAction::Plus, "", {ui_partycreation_plus});
 
-    ui_partycreation_font = GUIFont::LoadFont("cchar.fnt", "FONTPAL");
+    ui_partycreation_font = GUIFont::LoadFont("cchar.fnt");
 }
 
 GUIWindow_PartyCreation::~GUIWindow_PartyCreation() {


### PR DESCRIPTION
Preparing to break GUIFont up and split out text layout code – prerequisite for custom retained mode GUI.

Also added some docs.