### PR TITLE
Inventory cleanup continued

### DIFF
--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -173,6 +173,20 @@ void EngineController::goToGame() {
         ticker.tick();
 }
 
+void EngineController::goToInventory(int characterIndex) {
+    goToGame();
+
+    if (GetCurrentMenuID() != MENU_NONE)
+        throw Exception("Can't go to inventory from the main menu");
+
+    pParty->setActiveCharacterIndex(characterIndex);
+    pressAndReleaseKey(PlatformKey::KEY_I);
+    tick(2); // Need two ticks for inventory to be shown.
+
+    if (current_screen_type != SCREEN_CHARACTERS || current_character_screen_window != WINDOW_CharacterWindow_Inventory)
+        throw Exception("Couldn't to go to inventory");
+}
+
 void EngineController::goToMainMenu() {
     ThrowingTicker ticker(this, "Couldn't return to main menu");
 

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -59,6 +59,8 @@ class EngineController {
 
     void goToGame();
 
+    void goToInventory(int characterIndex);
+
     /**
      * Opens main menu no matter the current game state.
      */

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6185,6 +6185,7 @@ void Character::OnInventoryLeftClick() {
                     // try to add anywhere
                     if (!inventory.tryAdd(pParty->pPickedItem)) {
                         // failed to add, put back the old item
+                        pAudioPlayer->playUISound(SOUND_error);
                         inventory.add(pos, tmp);
                         return;
                     }
@@ -6197,7 +6198,8 @@ void Character::OnInventoryLeftClick() {
                 // place picked item
                 if (inventory.tryAdd(inventoryPos, pParty->pPickedItem)) {
                     pParty->takeHoldingItem();
-                    return;
+                } else {
+                    pAudioPlayer->playUISound(SOUND_error); // Overlapping items or out of inventory space.
                 }
             }
         }

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -129,30 +129,6 @@ static constexpr IndexedArray<int, MASTERY_FIRST, MASTERY_LAST> goldStealingDieS
     {MASTERY_GRANDMASTER, 10}
 };
 
-static constexpr IndexedArray<ItemSlot, ITEM_TYPE_FIRST, ITEM_TYPE_LAST> pEquipTypeToBodyAnchor = {  // 4E8398
-    {ITEM_TYPE_SINGLE_HANDED,  ITEM_SLOT_MAIN_HAND},
-    {ITEM_TYPE_TWO_HANDED,     ITEM_SLOT_MAIN_HAND},
-    {ITEM_TYPE_BOW,            ITEM_SLOT_BOW},
-    {ITEM_TYPE_ARMOUR,         ITEM_SLOT_ARMOUR},
-    {ITEM_TYPE_SHIELD,         ITEM_SLOT_OFF_HAND},
-    {ITEM_TYPE_HELMET,         ITEM_SLOT_HELMET},
-    {ITEM_TYPE_BELT,           ITEM_SLOT_BELT},
-    {ITEM_TYPE_CLOAK,          ITEM_SLOT_CLOAK},
-    {ITEM_TYPE_GAUNTLETS,      ITEM_SLOT_GAUNTLETS},
-    {ITEM_TYPE_BOOTS,          ITEM_SLOT_BOOTS},
-    {ITEM_TYPE_RING,           ITEM_SLOT_RING1},
-    {ITEM_TYPE_AMULET,         ITEM_SLOT_AMULET},
-    {ITEM_TYPE_WAND,           ITEM_SLOT_MAIN_HAND},
-    {ITEM_TYPE_REAGENT,        ITEM_SLOT_INVALID},
-    {ITEM_TYPE_POTION,         ITEM_SLOT_INVALID},
-    {ITEM_TYPE_SPELL_SCROLL,   ITEM_SLOT_INVALID},
-    {ITEM_TYPE_BOOK,           ITEM_SLOT_INVALID},
-    {ITEM_TYPE_MESSAGE_SCROLL, ITEM_SLOT_INVALID},
-    {ITEM_TYPE_GOLD,           ITEM_SLOT_INVALID},
-    {ITEM_TYPE_GEM,            ITEM_SLOT_INVALID},
-    {ITEM_TYPE_NONE,           ITEM_SLOT_INVALID}
-};
-
 static constexpr unsigned char pBaseHealthByClass[12] = {40, 35, 35, 30, 30, 30,
                                         25, 20, 20, 0,  0,  0};
 static constexpr unsigned char pBaseManaByClass[12] = {0, 0, 0, 5, 5, 0, 10, 10, 15, 0, 0, 0};
@@ -1168,9 +1144,7 @@ bool Character::wearsEnchantedItem(ItemEnchantment enchantment) const {
 //----- (0048D709) --------------------------------------------------------
 bool Character::wearsItem(ItemId itemId) const {
     assert(itemId != ITEM_NULL);
-    // TODO(captainurist): deal away with this. Wetsuits should have type = armor.
-    Segment<ItemSlot> slots = itemId == ITEM_QUEST_WETSUIT ? Segment(ITEM_SLOT_ARMOUR, ITEM_SLOT_ARMOUR) : itemSlotsForItemType(pItemTable->items[itemId].type);
-    for (ItemSlot slot : slots)
+    for (ItemSlot slot : itemSlotsForItemType(pItemTable->items[itemId].type))
         if (InventoryConstEntry entry = inventory.functionalEntry(slot); entry && entry->itemId == itemId)
             return true;
     return false;
@@ -1412,6 +1386,7 @@ int Character::ReceiveSpecialAttackEffect(MonsterSpecialAttack attType, Actor *p
             break;
 
         case SPECIAL_ATTACK_BREAK_ANY:
+            // TODO(captainurist): can't break wands b/c they are not regular items. Makes little in-game sense IMO.
             for (InventoryEntry entry : inventory.entries())
                 if (isRegular(entry->itemId) && !entry->IsBroken())
                     itemstobreaklist.push_back(entry);
@@ -1426,9 +1401,10 @@ int Character::ReceiveSpecialAttackEffect(MonsterSpecialAttack attType, Actor *p
             break;
 
         case SPECIAL_ATTACK_BREAK_ARMOR:
-            // Have to check for ITEM_QUEST_WETSUIT explicitly b/c it's ITEM_TYPE_NONE.
+            // TODO(captainurist): This can break a wetsuit, and this looks like vanilla behavior. But the code in
+            //                     SPECIAL_ATTACK_BREAK_ANY can't break a wetsuit. Huh.
             for (InventoryEntry entry : inventory.equipment())
-                if (!entry->IsBroken() && (entry->type() == ITEM_TYPE_ARMOUR || entry->type() == ITEM_TYPE_SHIELD || entry->itemId == ITEM_QUEST_WETSUIT))
+                if (!entry->IsBroken() && (entry->type() == ITEM_TYPE_ARMOUR || entry->type() == ITEM_TYPE_SHIELD))
                     itemstobreaklist.push_back(entry);
 
             if (itemstobreaklist.empty()) return 0;
@@ -5720,19 +5696,6 @@ void Character::SubtractSkillByEvent(Skill skill, uint16_t subSkillValue) {
     pActiveSkills[skill] = CombinedSkillValue(newLevel, pActiveSkills[skill].mastery());
     // TODO(pskelton): check - should this be able to forget a skill '0' or min of '1'
     // TODO(pskelton): check - should this modify mastery as well
-}
-
-//----- (00467E7F) --------------------------------------------------------
-void Character::EquipBody(ItemType uEquipType) {
-    ItemSlot itemAnchor = pEquipTypeToBodyAnchor[uEquipType];
-    if (InventoryEntry entry = pParty->activeCharacter().inventory.entry(itemAnchor)) {
-        Item tmpItem = pParty->activeCharacter().inventory.take(entry);
-        pParty->activeCharacter().inventory.equip(itemAnchor, pParty->takeHoldingItem());
-        pParty->setHoldingItem(tmpItem);
-    } else {
-        if (pParty->activeCharacter().inventory.canEquip(itemAnchor))
-            pParty->activeCharacter().inventory.equip(itemAnchor, pParty->takeHoldingItem());
-    }
 }
 
 int cycleCharacter(bool backwards) {

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -215,7 +215,6 @@ class Character {
     bool CanCastSpell(unsigned int uRequiredMana);
     void SpendMana(unsigned int uRequiredMana);
     void PlayAwardSound();
-    void EquipBody(ItemType uEquipType);
 
     /**
      * @offset 0x43EE77

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -265,6 +265,9 @@ void ItemTable::Initialize(GameResourceManager *resourceManager) {
     Item::PopulateSpecialBonusMap();
     Item::PopulateArtifactBonusMap();
     LoadItemSizes();
+
+    // Patch up the data - we want wetsuits to be armor.
+    items[ITEM_QUEST_WETSUIT].type = ITEM_TYPE_ARMOUR;
 }
 
 //----- (00453B3C) --------------------------------------------------------

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -584,10 +584,7 @@ GAME_TEST(Issues, Issue1911) {
     EXPECT_EQ(pParty->pCharacters[0].GetActualAttack(true), 4);
 
     // Equip staff.
-    Item staff;
-    staff.itemId = ITEM_STAFF;
-    pParty->pPickedItem = staff;
-    pParty->pCharacters[0].EquipBody(ITEM_TYPE_TWO_HANDED);
+    pParty->pCharacters[0].inventory.equip(ITEM_SLOT_MAIN_HAND, Item(ITEM_STAFF));
     pParty->pCharacters[0].pActiveSkills[SKILL_STAFF] = CombinedSkillValue(1, MASTERY_NOVICE);
     EXPECT_EQ(pParty->pCharacters[0].GetActualAttack(true), 1); // +1 from staff skill.
 
@@ -628,8 +625,7 @@ GAME_TEST(Issues, Issue1925) {
         Item wand;
         wand.itemId = ITEM_WAND_OF_FIRE;
         wand.numCharges = wand.maxCharges = 1;
-        pParty->pPickedItem = wand;
-        pParty->pCharacters[0].EquipBody(ITEM_TYPE_WAND);
+        pParty->pCharacters[0].inventory.equip(ITEM_SLOT_MAIN_HAND, wand);
         game.tick();
 
         // Attack.
@@ -659,18 +655,14 @@ GAME_TEST(Issues, Issue1927) {
     game.tick();
 
     // Equip a bow
-    Item bow;
-    bow.itemId = ITEM_GRIFFIN_BOW;
-    pParty->pPickedItem = bow;
-    pParty->pCharacters[0].EquipBody(ITEM_TYPE_BOW);
+    pParty->pCharacters[0].inventory.equip(ITEM_SLOT_BOW, Item(ITEM_GRIFFIN_BOW));
     game.tick();
 
     // Equip wand.
     Item wand;
     wand.itemId = ITEM_ALACORN_WAND_OF_FIREBALLS;
     wand.numCharges = wand.maxCharges = 30;
-    pParty->pPickedItem = wand;
-    pParty->pCharacters[0].EquipBody(ITEM_TYPE_WAND);
+    pParty->pCharacters[0].inventory.equip(ITEM_SLOT_MAIN_HAND, wand);
     game.tick();
 
     EXPECT_EQ(rangeAttackTape.size(), 3); // nothing, bow, bow and wand

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -720,12 +720,7 @@ GAME_TEST(Prs, Pr1953) {
     char0.inventory.add(Item(ITEM_LEATHER_ARMOR));
     char0.inventory.equip(ITEM_SLOT_ARMOUR, Item(ITEM_ROYAL_LEATHER));
 
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_I); // Open inventory.
-    game.tick();
+    game.goToInventory(1);
     game.pressAndReleaseButton(BUTTON_LEFT, 20, 20); // Pick up leather armor.
     game.tick();
     EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_LEATHER_ARMOR);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -121,12 +121,7 @@ GAME_TEST(Issues, Issue2021_2022) {
 GAME_TEST(Issues, Issue2061) {
     // Game Crashes if you click the border of the inventory screen.
     game.startNewGame();
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_I);
-    game.tick();
+    game.goToInventory(1);
     game.pressAndReleaseButton(BUTTON_LEFT, 3, 20); // This used to assert.
     game.tick();
     EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_NULL); // Shouldn't pick anything.
@@ -141,12 +136,7 @@ GAME_TEST(Issues, Issue2066) {
     pParty->pCharacters[0].inventory.clear();
     pParty->pCharacters[0].inventory.add(Pointi(0, 0), Item(ITEM_LEATHER_ARMOR)); // Add leather armor at (0, 0).
 
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-    game.tick();
-    game.pressAndReleaseKey(PlatformKey::KEY_I);
-    game.tick();
+    game.goToInventory(1);
     game.pressAndReleaseButton(BUTTON_LEFT, 30, 30); // Pick up leather armor.
     game.tick();
     game.pressAndReleaseButton(BUTTON_LEFT, 30, 0); // Try to place outside inventory boundaries.


### PR DESCRIPTION
Use new API in old tests.

Added `EngineController::goToInventory`, using it in test code.

Changed wetsuit item type to armor so that the wetsuit handling code could be simplified.

Added a test that we properly handle trying to equip an item when inventory is full (as in, all 126 slots are occupied even though we still have free equipment slots).