### PR TITLE
Don't build release on every merge

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -10,9 +10,9 @@ on:
         required: false
         default: ''
         type: string
-  push:
-    branches:
-      - 'master'
+#  push:
+#    branches:
+#      - 'master'
 
 env:
   TAG_NAME: nightly


### PR DESCRIPTION
Right now we run all our workflows on merge twice – through the workflow, and again via build_release.

Disabling this for now.