### PR TITLE
Fix #2225

### DIFF
--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 9cb444dc16288b879b68ef77c76004898c8570f0
+        GIT_TAG 5b5e5788babaccfaac76b55e61ed22834ecd1900
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Will fix retraces not being canonical.

Might need to leave this open until we can find why ninja is swallowing the errors.