### PR TITLE
Fix for 2116

### DIFF
--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -320,7 +320,7 @@ void stru262_TurnBased::StartTurn() {
     for (player_num = 0; player_num < 4; ++player_num) {
         for (j = 0; j < this->pQueue.size(); ++j) {
             if (pQueue[j].uPackedID.type() == OBJECT_Character) {
-                if (pParty->pCharacters[pQueue[j].uPackedID.id()].CanAct() && (player_num != pQueue[j].uPackedID.id()))
+                if (pParty->pCharacters[pQueue[j].uPackedID.id()].CanAct() && (player_num == pQueue[j].uPackedID.id()))
                     break;
             }
         }


### PR DESCRIPTION
The old code that tries to make sure that all the characters that can act is in the actor queue is silly - it only adds a missing character if there's no _other_ character that can act. 

I want to push a more aggressive fix for this problem - I think all the other code that handles players in TurnBased ignores players that are unable to act, so TurnBased::Start() should just always shove all the characters into the queue regardless of if they can act or not. But for now this code fixes the actual problem from #2116 