### PR TITLE
Don't swap buffers from inside Renderer::Reinitialize

### DIFF
--- a/src/Bin/OpenEnroth/OpenEnroth.cpp
+++ b/src/Bin/OpenEnroth/OpenEnroth.cpp
@@ -64,6 +64,7 @@ static void printTraceDiff(std::string_view current, std::string_view canonical)
 }
 
 void migrateTrace(OpenEnrothOptions::Migration migration, EventTrace *trace) {
+    std::unordered_set<PlatformKey> keys;
     switch (migration) {
     default: assert(false); [[fallthrough]];
     case OpenEnrothOptions::MIGRATION_NONE:
@@ -71,11 +72,12 @@ void migrateTrace(OpenEnrothOptions::Migration migration, EventTrace *trace) {
     case OpenEnrothOptions::MIGRATION_DROP_REDUNDANT_KEY_EVENTS:
         return EventTrace::migrateDropRedundantKeyEvents(trace);
     case OpenEnrothOptions::MIGRATION_COLLAPSE_KEY_EVENTS:
-        std::unordered_set<PlatformKey> keys;
         for (InputAction inputAction : allInputActions())
             if (toggleTypeForInputAction(inputAction) != TOGGLE_ONCE)
                 keys.insert(keyboardActionMapping->keyFor(inputAction));
         return EventTrace::migrateCollapseKeyEvents(keys, trace);
+    case OpenEnrothOptions::MIGRATION_DROP_PAINT_AFTER_ACTIVATE:
+        return EventTrace::migrateDropPaintAfterActivate(trace);
     }
 }
 

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -18,7 +18,8 @@
 MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(OpenEnrothOptions::Migration, CASE_INSENSITIVE, {
     {OpenEnrothOptions::MIGRATION_NONE, "none"},
     {OpenEnrothOptions::MIGRATION_DROP_REDUNDANT_KEY_EVENTS, "drop_redundant_key_events"},
-    {OpenEnrothOptions::MIGRATION_COLLAPSE_KEY_EVENTS, "collapse_key_events"}
+    {OpenEnrothOptions::MIGRATION_COLLAPSE_KEY_EVENTS, "collapse_key_events"},
+    {OpenEnrothOptions::MIGRATION_DROP_PAINT_AFTER_ACTIVATE, "drop_paint_after_activate"}
 })
 
 OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.h
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.h
@@ -20,6 +20,7 @@ struct OpenEnrothOptions : public GameStarterOptions {
         MIGRATION_NONE,
         MIGRATION_DROP_REDUNDANT_KEY_EVENTS,
         MIGRATION_COLLAPSE_KEY_EVENTS,
+        MIGRATION_DROP_PAINT_AFTER_ACTIVATE,
     };
     using enum Migration;
 

--- a/src/Engine/Graphics/Renderer/NullRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/NullRenderer.cpp
@@ -13,7 +13,6 @@ bool NullRenderer::Initialize() {
 }
 
 bool NullRenderer::Reinitialize(bool firstInit) {
-    openGLContext->swapBuffers();
     return BaseRenderer::Reinitialize(firstInit);
 }
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -4711,9 +4711,6 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
     glScissor(0, 0, outputRender.w, outputRender.h);
     glEnable(GL_SCISSOR_TEST);
 
-    // Swap Buffers (Double Buffering)
-    openGLContext->swapBuffers();
-
     this->clipRect = Recti(Pointi(0, 0), outputRender);
 
     // PostInitialization();

--- a/src/Library/Trace/EventTrace.h
+++ b/src/Library/Trace/EventTrace.h
@@ -81,6 +81,8 @@ struct EventTrace {
      */
     static void migrateCollapseKeyEvents(const std::unordered_set<PlatformKey> &keys, EventTrace *trace);
 
+    static void migrateDropPaintAfterActivate(EventTrace *trace);
+
     EventTraceHeader header;
     std::vector<std::unique_ptr<PlatformEvent>> events;
 };

--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 64e38c4ecce72828e64755ac54a82c708f8862f1
+        GIT_TAG 3cfe4d20c60af9c4c6156d8f8274917c765cc21d
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -384,8 +384,7 @@ GAME_TEST(Issues, Issue1724) {
     auto tbState = tapes.turnBasedMode();
     auto zombieActor = tapes.custom([]() {return std::ranges::count_if(pActors, [](const Actor &act) { return (act.currentHP < 1) && act.CanAct(); }); } );
     test.playTraceFromTestData("issue_1724.mm7", "issue_1724.json");
-
-     EXPECT_GT(statusBar.filter([](const auto &s) { return s.starts_with("Immolation deals"); }).size(), 0);// test for immolation message
+    EXPECT_GT(statusBar.filter([](const auto &s) { return s.starts_with("Immolation deals"); }).size(), 0); // test for immolation message.
     EXPECT_GT(partyXP.back(), partyXP.front());
     EXPECT_EQ(tbState.back(), true);
     EXPECT_EQ(zombieActor.max(), 0);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -358,13 +358,13 @@ GAME_TEST(Issues, Issue2116) {
 }
 
 GAME_TEST(Issues, Issue2117) {
-    // Jumping down from Celeste crashes the game
+    // Jumping down from Celeste crashes the game.
     auto mapTape = tapes.map();
     auto posTape = tapes.custom([] { return pParty->pos; });
     test.playTraceFromTestData("issue_2117.mm7", "issue_2117.json");
     EXPECT_EQ(mapTape.front(), MAP_CELESTE);
     EXPECT_EQ(mapTape.back(), MAP_BRACADA_DESERT); // Jumped down to the desert.
-    EXPECT_TRUE(posTape.contains(Vec3f(8146, 4379, 3700))); // Via the dodgy teleport step
+    EXPECT_TRUE(posTape.contains(Vec3f(8146, 4379, 3700))); // Via the dodgy teleport step.
 }
 
 GAME_TEST(Issues, Issue2118) {


### PR DESCRIPTION
We have tripped on this a couple times in the past. There really should be one event loop & a single `swapBuffers()` call there.