### PR TITLE
Better string splitting

### DIFF
--- a/src/Bin/CodeGen/CodeGen.cpp
+++ b/src/Bin/CodeGen/CodeGen.cpp
@@ -501,17 +501,14 @@ int runLstrCodegen(const CodeGenOptions &options, ResourceManager *resourceManag
 
     std::string txt = std::string(resourceManager->eventsData("global.txt").str());
 
-    std::vector<std::string_view> lines = split(txt, '\n');
-    for (std::string_view &line : lines)
-        if (line.ends_with('\r'))
-            line = line.substr(0, line.size() - 1);
+    std::vector<std::string_view> lines = split(txt).byCrLf();
 
     std::vector<std::string_view> chunks;
     for (std::string_view line : std::views::drop(lines, 1)) {
         if (line.empty())
             continue;
 
-        split(line, '\t', &chunks);
+        split(line).by('\t').to(&chunks);
         if (chunks.size() != 2)
             throw Exception("Invalid localization file");
 

--- a/src/Bin/CodeGen/CodeGen.cpp
+++ b/src/Bin/CodeGen/CodeGen.cpp
@@ -501,7 +501,7 @@ int runLstrCodegen(const CodeGenOptions &options, ResourceManager *resourceManag
 
     std::string txt = std::string(resourceManager->eventsData("global.txt").str());
 
-    std::vector<std::string_view> lines = split(txt).byCrLf();
+    std::vector<std::string_view> lines = split(txt).by("\r\n");
 
     std::vector<std::string_view> chunks;
     for (std::string_view line : std::views::drop(lines, 1)) {

--- a/src/Bin/OpenEnroth/OpenEnroth.cpp
+++ b/src/Bin/OpenEnroth/OpenEnroth.cpp
@@ -53,8 +53,8 @@ static void printLines(const std::vector<std::string_view> &lines, size_t line, 
 static void printTraceDiff(std::string_view current, std::string_view canonical) {
     assert(canonical != current);
 
-    std::vector<std::string_view> canonicalLines = split(canonical, '\n');
-    std::vector<std::string_view> currentLines = split(current, '\n');
+    std::vector<std::string_view> canonicalLines = split(canonical).by('\n');
+    std::vector<std::string_view> currentLines = split(current).by('\n');
 
     size_t line = std::ranges::mismatch(canonicalLines, currentLines).in1 - canonicalLines.begin() + 1; // Lines are 1-indexed.
 

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -340,7 +340,7 @@ void Localization::initializeSkillNames() {
         char *test_string = strtok(NULL, "\r") + 1;
 
         if (test_string != NULL && strlen(test_string) > 0) {
-            std::vector<std::string_view> tokens = split(test_string, '\t');
+            std::vector<std::string_view> tokens = split(test_string).by('\t');
             assert(tokens.size() >= 6 && "Invalid number of tokens");
 
             this->_skillDescriptions[i] = removeQuotes(tokens[1]);
@@ -402,7 +402,7 @@ void Localization::initializeClassNames() {
     strtok(this->_classDescRaw.data(), "\r");
     for (Class i : _classDescriptions.indices()) {
         char *test_string = strtok(NULL, "\r") + 1;
-        std::vector<std::string_view> tokens = split(test_string, '\t');
+        std::vector<std::string_view> tokens = split(test_string).by('\t');
         assert(tokens.size() == 3 && "Invalid number of tokens");
         _classDescriptions[i] = removeQuotes(tokens[1]);
     }
@@ -480,7 +480,7 @@ void Localization::initializeAttributeNames() {
     strtok(this->_attributeDescRaw.data(), "\r");
     for (int i = 0; i < 26; ++i) {
         char *test_string = strtok(NULL, "\r") + 1;
-        std::vector<std::string_view> tokens = split(test_string, '\t');
+        std::vector<std::string_view> tokens = split(test_string).by('\t');
         assert(tokens.size() == 2 && "Invalid number of tokens");
         switch (i) {
             case 0:

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -505,7 +505,7 @@ void SpellStats::Initialize(const Blob &spells) {
         }
         test_string = strtok(NULL, "\r") + 1;
 
-        std::vector<std::string_view> tokens = split(test_string, '\t');
+        std::vector<std::string_view> tokens = split(test_string).by('\t');
 
         pInfos[uSpellID].name = removeQuotes(tokens[2]);
         pInfos[uSpellID].damageType = valueOr(spellSchoolMaps, tokens[3], DAMAGE_PHYSICAL);

--- a/src/Engine/Tables/AwardTable.cpp
+++ b/src/Engine/Tables/AwardTable.cpp
@@ -14,7 +14,7 @@ IndexedArray<AwardData, AWARD_FIRST, AWARD_LAST> pAwards;
 
 void initializeAwards(const Blob &awards) {
     std::vector<std::string_view> chunks;
-    for (std::string_view line : split(awards.str()).byCrLf() | std::views::drop(1)) {
+    for (std::string_view line : split(awards.str()).by("\r\n") | std::views::drop(1)) {
         split(line).by('\t').to(&chunks);
         if (chunks.size() < 3)
             continue;

--- a/src/Engine/Tables/AwardTable.cpp
+++ b/src/Engine/Tables/AwardTable.cpp
@@ -14,11 +14,8 @@ IndexedArray<AwardData, AWARD_FIRST, AWARD_LAST> pAwards;
 
 void initializeAwards(const Blob &awards) {
     std::vector<std::string_view> chunks;
-    for (std::string_view line : split(awards.str(), '\n') | std::views::drop(1)) {
-        if (line.ends_with('\r'))
-            line = line.substr(0, line.size() - 1);
-
-        split(line, '\t', &chunks);
+    for (std::string_view line : split(awards.str()).byCrLf() | std::views::drop(1)) {
+        split(line).by('\t').to(&chunks);
         if (chunks.size() < 3)
             continue;
 

--- a/src/Engine/Tables/HistoryTable.cpp
+++ b/src/Engine/Tables/HistoryTable.cpp
@@ -22,7 +22,7 @@ void HistoryTable::Initialize(const Blob &history) {
 
     for (int i = 0; i < 28; ++i) {
         char *test_string = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(test_string, '\t');
+        std::vector<std::string_view> tokens = split(test_string).by('\t');
 
         historyLines[i + 1].pText = removeQuotes(tokens[1]);
         historyLines[i + 1].uTime = atoi(std::string(tokens[2]).c_str());  // TODO(captainurist): strange but in text here string not digit

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -104,7 +104,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     standardEnchantmentChanceSumByItemType.fill(0);
     for (Attribute i : allEnchantableAttributes()) {
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
         standardEnchantments[i].attributeName = removeQuotes(tokens[0]);
         standardEnchantments[i].itemSuffix = removeQuotes(tokens[1]);
 
@@ -119,7 +119,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     strtokSkipLines(5);
     for (ItemTreasureLevel i : standardEnchantmentRangeByTreasureLevel.indices()) {  // counted from 1
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
         assert(tokens.size() == 4 && "Invalid number of tokens");
         standardEnchantmentRangeByTreasureLevel[i] = Segment(svtoi(tokens[2]), svtoi(tokens[3]));
     }
@@ -129,7 +129,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     strtokSkipLines(3);
     for (ItemEnchantment i : specialEnchantments.indices()) {
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
         assert(tokens.size() >= 17 && "Invalid number of tokens");
         specialEnchantments[i].description = removeQuotes(tokens[0]);
         specialEnchantments[i].itemSuffixOrPrefix = removeQuotes(tokens[1]);
@@ -160,7 +160,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     strtokSkipLines(1);
     for (size_t line = 0; line < 799; line++) {
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
 
         ItemId item_counter = ItemId(svtoi(tokens[0]));
         items[item_counter].iconName = removeQuotes(tokens[1]);
@@ -168,7 +168,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
         items[item_counter].baseValue = svtoi(tokens[3]);
         items[item_counter].type = valueOr(equipStatMap, tokens[4], ITEM_TYPE_NONE);
         items[item_counter].skill = valueOr(equipSkillMap, tokens[5], SKILL_MISC);
-        std::vector<std::string_view> diceRollTokens = split(tokens[6], 'd');
+        std::vector<std::string_view> diceRollTokens = split(tokens[6]).by('d');
         if (diceRollTokens.size() == 2) {
             items[item_counter].damageDice = svtoi(diceRollTokens[0]);
             items[item_counter].damageRoll = svtoi(diceRollTokens[1]);
@@ -228,7 +228,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     strtokSkipLines(3);
     for(size_t line = 0; line < 618; line++) {
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
         assert(tokens.size() > 7 && "Invalid number of tokens");
 
         ItemId item_counter = ItemId(svtoi(tokens[0]));
@@ -249,7 +249,7 @@ void ItemTable::Initialize(ResourceManager *resourceManager) {
     strtokSkipLines(5);
     for (int i = 0; i < 3; ++i) {
         lineContent = strtok(nullptr, "\r") + 1;
-        std::vector<std::string_view> tokens = split(lineContent, '\t');
+        std::vector<std::string_view> tokens = split(lineContent).by('\t');
         assert(tokens.size() > 7 && "Invalid number of tokens");
         switch (i) {
             case 0:
@@ -296,7 +296,7 @@ void ItemTable::LoadPotions(const Blob &potions) {
     std::string txtRaw(potions.str());
     test_string = strtok(txtRaw.data(), "\r") + 1;
     while (test_string) {
-        tokens = split(test_string, '\t');
+        tokens = split(test_string).by('\t');
         if (tokens[0] == "222") break;
         test_string = strtok(nullptr, "\r") + 1;
     }
@@ -327,7 +327,7 @@ void ItemTable::LoadPotions(const Blob &potions) {
             logger->error("Error Parsing Potion Table at Row: {} Column: {}", std::to_underlying(row), 0);
             return;
         }
-        tokens = split(test_string, '\t');
+        tokens = split(test_string).by('\t');
     }
 }
 
@@ -339,7 +339,7 @@ void ItemTable::LoadPotionNotes(const Blob &potionNotes) {
     std::string txtRaw(potionNotes.str());
     test_string = strtok(txtRaw.data(), "\r") + 1;
     while (test_string) {
-        tokens = split(test_string, '\t');
+        tokens = split(test_string).by('\t');
         if (tokens[0] == "222") break;
         test_string = strtok(nullptr, "\r") + 1;
     }
@@ -363,7 +363,7 @@ void ItemTable::LoadPotionNotes(const Blob &potionNotes) {
             logger->error("Error Parsing Potion Table at Row: {} Column: {}", std::to_underlying(row) - std::to_underlying(ITEM_FIRST_REAL_POTION), 0);
             return;
         }
-        tokens = split(test_string, '\t');
+        tokens = split(test_string).by('\t');
     }
 }
 

--- a/src/Engine/Tables/QuestTable.cpp
+++ b/src/Engine/Tables/QuestTable.cpp
@@ -20,7 +20,7 @@ void initializeQuests(const Blob &quests) {
     std::vector<std::string_view> tokens;
     for (std::string_view line : split(quests.str()).by("\r\n").drop(1).skip("")) {
         split(line).by('\t').to(&tokens);
-        assert(tokens.size() >= 2 && "Invalid number of tokens");
+        assert(tokens.size() >= 2 && "Invalid number of tokens"); // TODO(captainurist): should not be an assert.
 
         QuestBit qbit = static_cast<QuestBit>(fromString<int>(tokens[0]));
         pQuestTable[qbit] = removeQuotes(tokens[1]);

--- a/src/Engine/Tables/QuestTable.cpp
+++ b/src/Engine/Tables/QuestTable.cpp
@@ -1,47 +1,28 @@
 #include "QuestTable.h"
 
-#include <cstring>
+#include <cassert>
 #include <string>
+#include <vector>
+
+#include "Library/Serialization/Serialization.h"
 
 #include "Utility/Memory/Blob.h"
+#include "Utility/String/Split.h"
 #include "Utility/String/Transformations.h"
 
 IndexedArray<std::string, QBIT_FIRST, QBIT_LAST> pQuestTable;
 
 void initializeQuests(const Blob &quests) {
-    char *test_string;
-    unsigned char c;
-    bool break_loop;
-    unsigned int temp_str_len;
-    char *tmp_pos;
-    int decode_step;
+    // quests.txt table structure: quest bit | text (localized) | dev notes (not used) |
+    //                             quest giver name (not localized, not used).
+    pQuestTable.fill({});
 
-    std::string txtRaw(quests.str());
-    strtok(txtRaw.data(), "\r");
-    memset(pQuestTable.data(), 0, sizeof(pQuestTable));
-    for (auto i : pQuestTable.indices()) {
-        test_string = strtok(NULL, "\r") + 1;
-        break_loop = false;
-        decode_step = 0;
-        do {
-            c = *(unsigned char *)test_string;
-            temp_str_len = 0;
-            while ((c != '\t') && (c > 0)) {
-                ++temp_str_len;
-                c = test_string[temp_str_len];
-            }
-            tmp_pos = test_string + temp_str_len;
-            if (*tmp_pos == 0) break_loop = true;
-            *tmp_pos = 0;
-            if (temp_str_len) {
-                if (decode_step == 1)
-                    pQuestTable[i] = removeQuotes(test_string);
-            } else {
-                break_loop = true;
-            }
-            ++decode_step;
-            test_string = tmp_pos + 1;
-        } while ((decode_step < 2) && !break_loop);
+    std::vector<std::string_view> tokens;
+    for (std::string_view line : split(quests.str()).by("\r\n").drop(1).skip("")) {
+        split(line).by('\t').to(&tokens);
+        assert(tokens.size() >= 2 && "Invalid number of tokens");
+
+        QuestBit qbit = static_cast<QuestBit>(fromString<int>(tokens[0]));
+        pQuestTable[qbit] = removeQuotes(tokens[1]);
     }
 }
-

--- a/src/Library/FileSystem/Interface/FileSystemPath.cpp
+++ b/src/Library/FileSystem/Interface/FileSystemPath.cpp
@@ -41,7 +41,7 @@ FileSystemPath &FileSystemPath::operator/=(std::string_view tail) {
     }
 
     gch::small_vector<std::string_view, 32> stack;
-    for (std::string_view chunk : ::split(tail, '/')) {
+    for (std::string_view chunk : ::split(tail).by('/')) {
         if (chunk.empty())
             continue;
 

--- a/src/Library/FileSystem/Interface/FileSystemPathSplit.h
+++ b/src/Library/FileSystem/Interface/FileSystemPathSplit.h
@@ -7,8 +7,8 @@
 
 class FileSystemPathView;
 
-class FileSystemPathSplit : public detail::SplitView {
-    using base_type = detail::SplitView;
+class FileSystemPathSplit : public detail::SplitView<detail::CharSplitter> {
+    using base_type = detail::SplitView<detail::CharSplitter>;
  public:
     FileSystemPathSplit() = default;
 
@@ -19,11 +19,9 @@ class FileSystemPathSplit : public detail::SplitView {
     [[nodiscard]] inline FileSystemPathView tailAt(std::same_as<std::string_view> auto chunk) const;
     [[nodiscard]] inline FileSystemPathView tailAfter(std::same_as<std::string_view> auto chunk) const;
 
-    [[nodiscard]] inline FileSystemPathView tailAt(detail::SplitViewIterator pos) const;
-
  private:
     friend class FileSystemPathView;
-    explicit FileSystemPathSplit(std::string_view s) : base_type(s.empty() ? base_type() : base_type(s, '/')) {}
+    explicit FileSystemPathSplit(std::string_view s) : base_type(s.empty() ? base_type() : base_type(s, detail::CharSplitter('/'))) {}
 };
 
 #ifndef __DOXYGEN__ // Doxygen chokes here...

--- a/src/Library/FileSystem/Interface/FileSystemPathView.h
+++ b/src/Library/FileSystem/Interface/FileSystemPathView.h
@@ -93,10 +93,6 @@ struct std::hash<FileSystemPathView> : std::hash<std::string_view> {
     }
 }
 
-[[nodiscard]] inline FileSystemPathView FileSystemPathSplit::tailAt(detail::SplitViewIterator pos) const {
-    return pos == detail::SplitViewSentinel() ? FileSystemPathView() : tailAt(*pos);
-}
-
 inline FileSystemPathView FileSystemPathComponents::prefix() const {
     return FileSystemPathView::fromNormalized(_path.substr(0, _prefixEnd));
 }

--- a/src/Library/FileSystem/Interface/FileSystemPathView.h
+++ b/src/Library/FileSystem/Interface/FileSystemPathView.h
@@ -71,14 +71,14 @@ struct std::hash<FileSystemPathView> : std::hash<std::string_view> {
 };
 
 [[nodiscard]] inline FileSystemPathView FileSystemPathSplit::tailAt(std::same_as<std::string_view> auto chunk) const {
-    std::string_view path = string();
+    std::string_view path = str();
     assert(chunk.data() >= path.data() && chunk.data() + chunk.size() <= path.data() + path.size());
     size_t offset = chunk.data() - path.data();
     return FileSystemPathView::fromNormalized(path.substr(offset));
 }
 
 [[nodiscard]] inline FileSystemPathView FileSystemPathSplit::tailAfter(std::same_as<std::string_view> auto chunk) const {
-    std::string_view path = string(); // NOLINT: not std::string.
+    std::string_view path = str(); // NOLINT: not std::string.
 
     if (chunk.empty())
         return FileSystemPathView::fromNormalized(path);

--- a/src/Library/FileSystem/Interface/Tests/FileSystemPath_ut.cpp
+++ b/src/Library/FileSystem/Interface/Tests/FileSystemPath_ut.cpp
@@ -176,25 +176,6 @@ UNIT_TEST(FileSystemPath, AppendedEscaping) {
     testOne("aa/bb/cc", "../../..", "");
 }
 
-UNIT_TEST(FileSystemPath, TailAtByIterator) {
-    FileSystemPath path("a/b");
-
-    auto split = path.split();
-    auto pos = split.begin();
-    auto end = split.end();
-
-    EXPECT_EQ(*pos, "a");
-    EXPECT_EQ(path.split().tailAt(pos).string(), "a/b");
-
-    pos++;
-    EXPECT_EQ(*pos, "b");
-    EXPECT_EQ(path.split().tailAt(pos).string(), "b");
-
-    pos++;
-    EXPECT_EQ(path.split().tailAt(pos).string(), "");
-    EXPECT_EQ(pos, end);
-}
-
 UNIT_TEST(FileSystemPath, Components) {
     auto testOne = [](std::string_view path, std::string_view prefix, std::string_view name, std::string_view stem, std::string_view ext) {
         FileSystemPath fsPath(path);

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -30,6 +30,7 @@ set(UTILITY_HEADERS
         Memory/Blob.h
         Memory/FreeDeleter.h
         Memory/MemSet.h
+        View.h
         ScopeGuard.h
         Segment.h
         Streams/BlobInputStream.h
@@ -78,6 +79,7 @@ if(OE_BUILD_TESTS)
             Streams/Tests/InputStream_ut.cpp
             Tests/IndexedArray_ut.cpp
             Tests/IndexedBitset_ut.cpp
+            Tests/View_ut.cpp
             Tests/Segment_ut.cpp
             Tests/UnicodeCrt_ut.cpp
             String/Tests/Transformations_ut.cpp

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -12,7 +12,6 @@ set(UTILITY_SOURCES
         Streams/OutputStream.cpp
         String/Ascii.cpp
         String/Encoding.cpp
-        String/Split.cpp
         String/Transformations.cpp
         UnicodeCrt.cpp
         String/Wrap.cpp)

--- a/src/Utility/String/Split.cpp
+++ b/src/Utility/String/Split.cpp
@@ -3,9 +3,4 @@
 #include <string_view>
 #include <vector>
 
-void split(std::string_view s, char sep, std::vector<std::string_view> *result) {
-    result->clear();
-    result->reserve(16);
-    for (std::string_view chunk : split(s, sep))
-        result->push_back(chunk);
-}
+// All split functionality is now in the header via templates.

--- a/src/Utility/String/Split.cpp
+++ b/src/Utility/String/Split.cpp
@@ -1,6 +1,0 @@
-#include "Split.h"
-
-#include <string_view>
-#include <vector>
-
-// All split functionality is now in the header via templates.

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -18,24 +18,81 @@ struct is_initializer_list<std::initializer_list<T>> : std::true_type {};
 template<class T>
 inline constexpr bool is_initializer_list_v = is_initializer_list<T>::value;
 
+class CharSplitter {
+ public:
+    using result_type = const char *;
+
+    CharSplitter() = default;
+
+    explicit CharSplitter(char sep) : _sep(sep) {}
+
+    result_type split(const char *begin, const char *end) const {
+        assert(begin <= end);
+        return std::find(begin, end, _sep);
+    }
+
+    const char *begin(result_type result) const {
+        return result;
+    }
+
+    const char *end(result_type result) const {
+        return result + 1;
+    }
+
+    friend bool operator==(const CharSplitter &l, const CharSplitter &r) = default;
+
+ private:
+    char _sep = '\0';
+};
+
+class CrLfSplitter {
+ public:
+    using result_type = std::pair<const char *, const char *>;
+
+    CrLfSplitter() = default;
+
+    result_type split(const char *begin, const char *end) const {
+        assert(begin <= end);
+        const char *l = std::find(begin, end, '\n');
+        const char *r = l + 1;
+        if (l > begin && *(l - 1) == '\r')
+            l--;
+        return {l, r};
+    }
+
+    const char *begin(result_type result) const {
+        return result.first;
+    }
+
+    const char *end(result_type result) const {
+        return result.second;
+    }
+
+    friend bool operator==(const CrLfSplitter &l, const CrLfSplitter &r) = default;
+};
+
 class SplitViewSentinel {};
 
+template<class Splitter>
 class SplitViewIterator {
  public:
     using difference_type = std::ptrdiff_t; // Required for std::input_or_output_iterator, even though we can't take iterator difference...
     using value_type = std::string_view; // Required for std::indirectly_readable.
 
     SplitViewIterator() {
-        _pos0++; // Construct an iterator that compares equal to `SplitViewSentinel`.
+        _pos = reinterpret_cast<const char *>(1); // Construct as done.
     }
 
-    SplitViewIterator(const char *begin, const char *end, char sep) : _pos0(begin), _end(end), _sep(sep) {
-        advance();
+    SplitViewIterator(const char *begin, const char *end, const Splitter &splitter) : _pos(begin), _end(end), _splitter(splitter) {
+        if (_pos <= _end)
+            _sep = _splitter.split(_pos, _end);
     }
 
     SplitViewIterator &operator++() {
-        _pos0 = _pos1 + 1; // Skip separator.
-        advance();
+        assert(_pos <= _end); // Don't increment past-end iterator.
+        _pos = _splitter.end(_sep);
+        if (_pos <= _end)
+            _sep = _splitter.split(_pos, _end);
         return *this;
     }
 
@@ -46,26 +103,23 @@ class SplitViewIterator {
     }
 
     std::string_view operator*() const {
-        return std::string_view(_pos0, _pos1);
+        assert(_pos <= _end); // Don't dereference past-end iterator.
+        return std::string_view(_pos, _splitter.begin(_sep));
     }
 
     friend bool operator==(const SplitViewIterator &l, const SplitViewSentinel &r) {
-        return l._pos0 == l._end + 1;
+        return l._pos == l._end + 1;
     }
 
-    friend bool operator==(const SplitViewIterator &l, const SplitViewIterator &r) = default;
-
- private:
-    void advance() {
-        if (_pos0 <= _end)
-            _pos1 = std::find(_pos0, _end, _sep);
+    friend bool operator==(const SplitViewIterator &l, const SplitViewIterator &r) {
+        return l._pos == r._pos;
     }
 
  private:
-    const char *_pos0 = nullptr;
-    const char *_pos1 = nullptr;
+    [[no_unique_address]] Splitter _splitter;
+    const char *_pos = nullptr;
     const char *_end = nullptr;
-    char _sep = '\0';
+    typename Splitter::result_type _sep;
 };
 
 /**
@@ -76,16 +130,18 @@ class SplitViewIterator {
  *
  * So here is our own implementation. More user-friendly, and more efficient.
  */
-class SplitView : public std::ranges::view_interface<SplitView> {
+template<class Splitter>
+class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
  public:
     SplitView() {
-        _begin++; // Construct an empty split view.
+        // Construct an empty SplitView. Note that a SplitView with _begin == _end is non-empty.
+        _begin = reinterpret_cast<const char *>(1);
     }
 
-    SplitView(std::string_view s, char sep) : _begin(s.data()), _end(s.data() + s.size()), _sep(sep) {}
+    SplitView(std::string_view s, Splitter splitter) : _splitter(splitter), _begin(s.data()), _end(s.data() + s.size()) {}
 
     [[nodiscard]] auto begin() const {
-        return SplitViewIterator(_begin, _end, _sep);
+        return SplitViewIterator<Splitter>(_begin, _end, _splitter);
     }
 
     [[nodiscard]] auto end() const {
@@ -96,8 +152,12 @@ class SplitView : public std::ranges::view_interface<SplitView> {
         return std::string_view(_begin, _end);
     }
 
-    [[nodiscard]] char separator() const {
-        return _sep;
+    // TODO(captainurist): #cpp23 this can go once we switch over to gcc-15, just use assign_range
+    template<class Container>
+    void to(Container *container) const {
+        container->clear();
+        for (std::string_view s : *this)
+            container->emplace_back(s);
     }
 
     /**
@@ -140,35 +200,58 @@ class SplitView : public std::ranges::view_interface<SplitView> {
     }
 
  private:
+    [[no_unique_address]] Splitter _splitter;
     const char *_begin = nullptr;
     const char *_end = nullptr;
-    char _sep = '\0';
+};
+
+class SplitProxy {
+ public:
+    explicit SplitProxy(std::string_view s) : _s(s) {}
+
+    [[nodiscard]] auto by(char sep) const {
+        return SplitView(_s, CharSplitter(sep));
+    }
+
+    [[nodiscard]] auto byCrLf() const {
+        return SplitView(_s, CrLfSplitter());
+    }
+
+ private:
+    std::string_view _s;
 };
 } // namespace detail
 
 #ifndef __DOXYGEN__ // Doxygen chokes here...
 // Enable taking detail::SplitView by value, we handle dangling at split() level.
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<detail::SplitView> = true;
+template<class Splitter>
+inline constexpr bool std::ranges::enable_borrowed_range<detail::SplitView<Splitter>> = true;
 #endif
 
 /**
- * Splits the provided string `s` using separator `sep`, returning a range of `std::string_view` chunks.
+ * Splits the provided string `s`, returning a proxy object with `.by(char)` and `.byCrLf()` methods.
  *
- * This function doesn't discard empty chunks, so the returned range will never be empty. Splitting an empty string
- * will produce a single empty chunk.
+ * Usage:
+ * - `split(s).by('c')` - split by character separator.
+ * - `split(s).byCrLf()` - split by line endings (`\\n` or `\\r\\n`).
+ *
+ * Splitting a string doesn't discard empty chunks, so the resulting range will never be empty. Splitting an empty
+ * string will produce a single empty chunk.
+ *
+ * If you need to store a result in a container there are two options:
+ * - `split(s).by(';').to(&vector)` - reuses preallocated vector.
+ * - `std::vector<std::string_view> v = split(s).by(';')` - allocates a new vector.
+ *
+ * Note that you can do the same with other container types, not just `std::vector`.
  *
  * @param s                             String to split.
- * @param sep                           Separator character.
  */
-inline auto split(std::string_view s, char sep) {
-    return detail::SplitView(s, sep);
+inline auto split(std::string_view s) {
+    return detail::SplitProxy(s);
 }
 
-inline auto split(const char *s, char sep) {
-    return split(std::string_view(s), sep);
+inline auto split(const char *s) {
+    return split(std::string_view(s));
 }
 
-void split(std::string &&s, char sep) = delete; // Don't dangle!
-
-void split(std::string_view s, char sep, std::vector<std::string_view> *result);
+void split(std::string &&s) = delete; // Don't dangle!

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstring> // For memchr, memcmp.
 #include <utility> // For std::forward.
 #include <string>
 #include <type_traits>
@@ -45,30 +46,50 @@ class CharSplitter {
     char _sep = '\0';
 };
 
-class CrLfSplitter {
+/**
+ * Splitter for multi-character separators, e.g. `"\r\n"`.
+ *
+ * Uses `memchr` for the first character followed by `memcmp` for the rest. We're not using `std::search` here because
+ * `memchr` is SIMD-optimized and ~2x faster on the data sizes we care about.
+ *
+ * String searching can be done way more efficiently (e.g. see Volnitsky algo as used in ClickHouse), but what we have
+ * here is already good enough.
+ */
+class StringSplitter {
  public:
-    using result_type = std::pair<const char *, const char *>;
+    using result_type = const char *;
 
-    CrLfSplitter() = default;
+    StringSplitter() = default;
+
+    explicit StringSplitter(std::string_view sep) : _sep(sep) {
+        assert(!sep.empty());
+    }
 
     result_type split(const char *begin, const char *end) const {
         assert(begin <= end);
-        const char *l = std::find(begin, end, '\n');
-        const char *r = l + 1;
-        if (l > begin && *(l - 1) == '\r')
-            l--;
-        return {l, r};
+        while (begin <= end - static_cast<std::ptrdiff_t>(_sep.size())) {
+            const char *p = static_cast<const char *>(memchr(begin, _sep[0], end - begin));
+            if (!p || p > end - static_cast<std::ptrdiff_t>(_sep.size()))
+                return end;
+            if (memcmp(p, _sep.data(), _sep.size()) == 0)
+                return p;
+            begin = p + 1;
+        }
+        return end;
     }
 
     const char *begin(result_type result) const {
-        return result.first;
+        return result;
     }
 
     const char *end(result_type result) const {
-        return result.second;
+        return result + _sep.size();
     }
 
-    friend bool operator==(const CrLfSplitter &l, const CrLfSplitter &r) = default;
+    friend bool operator==(const StringSplitter &l, const StringSplitter &r) = default;
+
+ private:
+    std::string_view _sep;
 };
 
 class SplitViewSentinel {};
@@ -108,7 +129,7 @@ class SplitViewIterator {
     }
 
     friend bool operator==(const SplitViewIterator &l, const SplitViewSentinel &r) {
-        return l._pos == l._end + 1;
+        return l._pos > l._end;
     }
 
     friend bool operator==(const SplitViewIterator &l, const SplitViewIterator &r) {
@@ -123,10 +144,9 @@ class SplitViewIterator {
 };
 
 /**
- * We use C++ and this is why we can't have nice things. It's 2024, we still can't split a string w/o jumping through
- * hoops. Just look at this: https://cplusplus.github.io/LWG/issue4017. One option is to use `std::views::drop` in a
- * hacky way to fix this. But then we run into the fact that `std::views::split` isn't even implemented in
- * AppleClang 14...
+ * We use C++ and this is why we can't have nice things. Just look at this: https://cplusplus.github.io/LWG/issue4017. 
+ * One option is to use `std::views::drop` in a hacky way to fix this. But then we run into the fact that 
+ * `std::views::split` isn't even implemented in AppleClang 14...
  *
  * So here is our own implementation. More user-friendly, and more efficient.
  */
@@ -213,8 +233,8 @@ class SplitProxy {
         return SplitView(_s, CharSplitter(sep));
     }
 
-    [[nodiscard]] auto byCrLf() const {
-        return SplitView(_s, CrLfSplitter());
+    [[nodiscard]] auto by(std::string_view sep) const {
+        return SplitView(_s, StringSplitter(sep));
     }
 
  private:
@@ -229,11 +249,11 @@ inline constexpr bool std::ranges::enable_borrowed_range<detail::SplitView<Split
 #endif
 
 /**
- * Splits the provided string `s`, returning a proxy object with `.by(char)` and `.byCrLf()` methods.
+ * Splits the provided string `s`, returning a proxy object with `.by(char)` and `.by(std::string_view)` methods.
  *
  * Usage:
- * - `split(s).by('c')` - split by character separator.
- * - `split(s).byCrLf()` - split by line endings (`\\n` or `\\r\\n`).
+ * - `split(s).by('c')` - split by a single character separator.
+ * - `split(s).by("\\r\\n")` - split by a multi-character separator.
  *
  * Splitting a string doesn't discard empty chunks, so the resulting range will never be empty. Splitting an empty
  * string will produce a single empty chunk.

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -168,7 +168,7 @@ class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
         return SplitViewSentinel();
     }
 
-    [[nodiscard]] std::string_view string() const {
+    [[nodiscard]] std::string_view str() const {
         return std::string_view(_begin, _end);
     }
 
@@ -200,7 +200,8 @@ class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
         (!is_initializer_list_v<Container>)
     operator Container() const {
         // Shamelessly stolen from std::ranges::to implementation. Our code works for std::set too, and
-        // std::ranges::to doesn't.
+        // std::ranges::to in gcc-14 doesn't (it routes through emplace(iterator, args) which doesn't exist
+        // for associative containers). This is fixed in gcc-15 via assign_range. See LWG4016.
         auto insert = []<class Element>(auto &container, Element &&element) {
             if constexpr (requires { container.emplace_back(std::forward<Element>(element)); }) {
                 container.emplace_back(std::forward<Element>(element));

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <cstring> // For memchr, memcmp.
-#include <utility> // For std::forward.
 #include <string>
 #include <type_traits>
 #include <algorithm> // For std::find.
@@ -172,12 +171,19 @@ class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
         return std::string_view(_begin, _end);
     }
 
-    // TODO(captainurist): #cpp23 this can go once we switch over to gcc-15, just use assign_range
     template<class Container>
     void to(Container *container) const {
+        // We can't use assign_range / insert_range / std::ranges::to here because:
+        // - assign_range / insert_range require implicit convertibility, and string_view -> string is explicit.
+        // - on top of that, std::ranges::to would enter infinite recursion through operator Container() below.
+        // So we use a manual loop with emplace_back / emplace.
         container->clear();
-        for (std::string_view s : *this)
-            container->emplace_back(s);
+        for (std::string_view chunk : *this) {
+            if constexpr (requires { container->emplace_back(chunk); })
+                container->emplace_back(chunk);
+            else
+                container->emplace(chunk);
+        }
     }
 
     /**
@@ -199,24 +205,8 @@ class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
         std::is_same_v<std::remove_cv_t<typename Container::value_type::value_type>, char> &&
         (!is_initializer_list_v<Container>)
     operator Container() const {
-        // Shamelessly stolen from std::ranges::to implementation. Our code works for std::set too, and
-        // std::ranges::to in gcc-14 doesn't (it routes through emplace(iterator, args) which doesn't exist
-        // for associative containers). This is fixed in gcc-15 via assign_range. See LWG4016.
-        auto insert = []<class Element>(auto &container, Element &&element) {
-            if constexpr (requires { container.emplace_back(std::forward<Element>(element)); }) {
-                container.emplace_back(std::forward<Element>(element));
-            } else if constexpr (requires { container.push_back(std::forward<Element>(element)); }) {
-                container.push_back(std::forward<Element>(element));
-            } else if constexpr (requires { container.emplace(std::forward<Element>(element)); }) {
-                container.emplace(std::forward<Element>(element));
-            } else {
-                container.insert(std::forward<Element>(element));
-            }
-        }; // NOLINT
-
         Container result;
-        for (std::string_view chunk : *this)
-            insert(result, chunk);
+        to(&result);
         return result;
     }
 

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -9,7 +9,7 @@
 namespace detail {
 
 /**
- * Splitter for single-character separators, e.g. `'\t'`. Uses SIMD-optimized `memchr`.
+ * Splitter for single-character separators, e.g. `'\\t'`. Uses SIMD-optimized `memchr`.
  */
 class CharSplitter {
  public:
@@ -40,7 +40,7 @@ class CharSplitter {
 };
 
 /**
- * Splitter for multi-character separators, e.g. `"\r\n"`.
+ * Splitter for multi-character separators, e.g. `"\\r\\n"`.
  *
  * Uses `memchr` for the first character followed by `memcmp` for the rest. We're not using `std::search` here because
  * `memchr` is SIMD-optimized and ~2x faster on the data sizes we care about.

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -2,21 +2,12 @@
 
 #include <cassert>
 #include <cstring> // For memchr, memcmp.
-#include <string>
-#include <type_traits>
 #include <algorithm> // For std::find.
-#include <vector>
-#include <ranges>
+#include <string>
+
+#include "Utility/View.h"
 
 namespace detail {
-template<class T>
-struct is_initializer_list : std::false_type {};
-
-template<class T>
-struct is_initializer_list<std::initializer_list<T>> : std::true_type {};
-
-template<class T>
-inline constexpr bool is_initializer_list_v = is_initializer_list<T>::value;
 
 class CharSplitter {
  public:
@@ -150,7 +141,7 @@ class SplitViewIterator {
  * So here is our own implementation. More user-friendly, and more efficient.
  */
 template<class Splitter>
-class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
+class SplitView : public ViewInterface<SplitView<Splitter>> {
  public:
     SplitView() {
         // Construct an empty SplitView. Note that a SplitView with _begin == _end is non-empty.
@@ -159,55 +150,16 @@ class SplitView : public std::ranges::view_interface<SplitView<Splitter>> {
 
     SplitView(std::string_view s, Splitter splitter) : _splitter(splitter), _begin(s.data()), _end(s.data() + s.size()) {}
 
-    [[nodiscard]] auto begin() const {
+    [[nodiscard]] auto begin() {
         return SplitViewIterator<Splitter>(_begin, _end, _splitter);
     }
 
-    [[nodiscard]] auto end() const {
+    [[nodiscard]] auto end() {
         return SplitViewSentinel();
     }
 
     [[nodiscard]] std::string_view str() const {
         return std::string_view(_begin, _end);
-    }
-
-    template<class Container>
-    void to(Container *container) const {
-        // We can't use assign_range / insert_range / std::ranges::to here because:
-        // - assign_range / insert_range require implicit convertibility, and string_view -> string is explicit.
-        // - on top of that, std::ranges::to would enter infinite recursion through operator Container() below.
-        // So we use a manual loop with emplace_back / emplace.
-        container->clear();
-        for (std::string_view chunk : *this) {
-            if constexpr (requires { container->emplace_back(chunk); })
-                container->emplace_back(chunk);
-            else
-                container->emplace(chunk);
-        }
-    }
-
-    /**
-     * Converts this view to a container of string-like elements.
-     *
-     * This operator enables implicit conversion to various container types (e.g., `std::vector<std::string>`,
-     * `std::set<std::string_view>`) for convenient use in initialization and assignment contexts.
-     *
-     * The `initializer_list` exclusion in the requires clause is necessary to prevent ambiguous overload resolution
-     * when assigning to containers. Without it, `v = split(...)` would be ambiguous because `std::vector::operator=`
-     * has overloads for both `const vector&` and `initializer_list<value_type>`. Since `initializer_list<string_view>`
-     * technically satisfies the `Container::value_type::value_type == char` constraint, the compiler would consider
-     * both conversion paths and fail with an ambiguity error.
-     *
-     * @tparam Container                    Target container type. Must hold string-like elements.
-     * @return                              Container populated with the string chunks from this view.
-     */
-    template<class Container> requires
-        std::is_same_v<std::remove_cv_t<typename Container::value_type::value_type>, char> &&
-        (!is_initializer_list_v<Container>)
-    operator Container() const {
-        Container result;
-        to(&result);
-        return result;
     }
 
  private:
@@ -247,7 +199,7 @@ inline constexpr bool std::ranges::enable_borrowed_range<detail::SplitView<Split
  * - `split(s).by("\\r\\n")` - split by a multi-character separator.
  *
  * Splitting a string doesn't discard empty chunks, so the resulting range will never be empty. Splitting an empty
- * string will produce a single empty chunk.
+ * string will produce a single empty chunk. Use `skip("")` to filter out empty chunks.
  *
  * If you need to store a result in a container there are two options:
  * - `split(s).by(';').to(&vector)` - reuses preallocated vector.

--- a/src/Utility/String/Split.h
+++ b/src/Utility/String/Split.h
@@ -2,13 +2,15 @@
 
 #include <cassert>
 #include <cstring> // For memchr, memcmp.
-#include <algorithm> // For std::find.
 #include <string>
 
 #include "Utility/View.h"
 
 namespace detail {
 
+/**
+ * Splitter for single-character separators, e.g. `'\t'`. Uses SIMD-optimized `memchr`.
+ */
 class CharSplitter {
  public:
     using result_type = const char *;
@@ -19,7 +21,8 @@ class CharSplitter {
 
     result_type split(const char *begin, const char *end) const {
         assert(begin <= end);
-        return std::find(begin, end, _sep);
+        const char *p = static_cast<const char *>(memchr(begin, static_cast<unsigned char>(_sep), end - begin));
+        return p ? p : end;
     }
 
     const char *begin(result_type result) const {
@@ -168,6 +171,9 @@ class SplitView : public ViewInterface<SplitView<Splitter>> {
     const char *_end = nullptr;
 };
 
+/**
+ * Intermediate object returned by `split(s)` that exposes the `.by(...)` separator-selection step.
+ */
 class SplitProxy {
  public:
     explicit SplitProxy(std::string_view s) : _s(s) {}

--- a/src/Utility/String/Tests/Split_ut.cpp
+++ b/src/Utility/String/Tests/Split_ut.cpp
@@ -12,9 +12,9 @@
 static_assert(std::ranges::view<detail::SplitView<detail::CharSplitter>>);
 static_assert(std::ranges::viewable_range<detail::SplitView<detail::CharSplitter>>);
 static_assert(std::ranges::forward_range<detail::SplitView<detail::CharSplitter>>);
-static_assert(std::ranges::view<detail::SplitView<detail::CrLfSplitter>>);
-static_assert(std::ranges::viewable_range<detail::SplitView<detail::CrLfSplitter>>);
-static_assert(std::ranges::forward_range<detail::SplitView<detail::CrLfSplitter>>);
+static_assert(std::ranges::view<detail::SplitView<detail::StringSplitter>>);
+static_assert(std::ranges::viewable_range<detail::SplitView<detail::StringSplitter>>);
+static_assert(std::ranges::forward_range<detail::SplitView<detail::StringSplitter>>);
 
 UNIT_TEST(StringSplit, SplitToVector) {
     std::vector<std::string_view> v;
@@ -124,54 +124,54 @@ UNIT_TEST(StringSplit, AssignToVector) {
     EXPECT_EQ(v, std::vector<std::string_view>({"x", "y"}));
 }
 
-UNIT_TEST(StringSplit, CrLf) {
+UNIT_TEST(StringSplit, StringSeparator) {
     std::vector<std::string_view> v;
 
-    // Unix line endings (\n only)
-    split("line1\nline2\nline3").byCrLf().to(&v);
+    // Basic \r\n splitting.
+    split("line1\r\nline2\r\nline3").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
 
-    // Windows line endings (\r\n)
-    split("line1\r\nline2\r\nline3").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
+    // Lone \n is NOT a separator.
+    split("line1\nline2\r\nline3").by("\r\n").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1\nline2", "line3"}));
 
-    // Mixed line endings
-    split("line1\nline2\r\nline3").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
+    // Lone \r is NOT a separator.
+    split("line1\rline2\r\nline3").by("\r\n").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1\rline2", "line3"}));
 
-    // Empty string
-    split("").byCrLf().to(&v);
+    // Empty string.
+    split("").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({""}));
 
-    // Single newline
-    split("\n").byCrLf().to(&v);
+    // Single \r\n.
+    split("\r\n").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"", ""}));
 
-    // Single CRLF
-    split("\r\n").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"", ""}));
-
-    // Trailing newline
-    split("line1\nline2\n").byCrLf().to(&v);
+    // Trailing \r\n.
+    split("line1\r\nline2\r\n").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", ""}));
 
-    // Trailing CRLF
-    split("line1\r\nline2\r\n").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", ""}));
-
-    // Multiple consecutive newlines
-    split("line1\n\nline2").byCrLf().to(&v);
+    // Multiple consecutive \r\n.
+    split("line1\r\n\r\nline2").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"line1", "", "line2"}));
 
-    // Multiple consecutive CRLFs
-    split("line1\r\n\r\nline2").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "", "line2"}));
-
-    // String with no newlines
-    split("single line").byCrLf().to(&v);
+    // No separator found.
+    split("single line").by("\r\n").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"single line"}));
 
-    // Lone \r characters (should not be treated as line ending)
-    split("line1\rline2\nline3").byCrLf().to(&v);
-    EXPECT_EQ(v, std::vector<std::string_view>({"line1\rline2", "line3"}));
+    // Multi-char separator other than \r\n.
+    split("a::b::c").by("::").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"a", "b", "c"}));
+
+    // Separator at start.
+    split("::a::b").by("::").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"", "a", "b"}));
+
+    // Separator longer than 2 chars.
+    split("a<=>b<=>c").by("<=>").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"a", "b", "c"}));
+
+    // Partial match of separator.
+    split("a<=b<=>c").by("<=>").to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"a<=b", "c"}));
 }

--- a/src/Utility/String/Tests/Split_ut.cpp
+++ b/src/Utility/String/Tests/Split_ut.cpp
@@ -124,6 +124,20 @@ UNIT_TEST(StringSplit, AssignToVector) {
     EXPECT_EQ(v, std::vector<std::string_view>({"x", "y"}));
 }
 
+UNIT_TEST(StringSplit, SplitToStringVector) {
+    // Test that to() works with std::vector<std::string> (explicit string_view -> string conversion).
+    std::vector<std::string> v;
+
+    split("aa;bb;cc").by(';').to(&v);
+    EXPECT_EQ(v, std::vector<std::string>({"aa", "bb", "cc"}));
+
+    split("ABC").by(';').to(&v);
+    EXPECT_EQ(v, std::vector<std::string>({"ABC"}));
+
+    split("").by(';').to(&v);
+    EXPECT_EQ(v, std::vector<std::string>({""}));
+}
+
 UNIT_TEST(StringSplit, StringSeparator) {
     std::vector<std::string_view> v;
 

--- a/src/Utility/String/Tests/Split_ut.cpp
+++ b/src/Utility/String/Tests/Split_ut.cpp
@@ -189,3 +189,9 @@ UNIT_TEST(StringSplit, StringSeparator) {
     split("a<=b<=>c").by("<=>").to(&v);
     EXPECT_EQ(v, std::vector<std::string_view>({"a<=b", "c"}));
 }
+
+UNIT_TEST(StringSplit, ViewInterfaceMethods) {
+    std::vector<std::string_view> r;
+    split("header;a;b;c").by(';').drop(1).to(&r);
+    EXPECT_EQ(r, std::vector<std::string_view>({"a", "b", "c"}));
+}

--- a/src/Utility/String/Tests/Split_ut.cpp
+++ b/src/Utility/String/Tests/Split_ut.cpp
@@ -9,30 +9,33 @@
 
 #include "Utility/String/Split.h"
 
-static_assert(std::ranges::view<detail::SplitView>);
-static_assert(std::ranges::viewable_range<detail::SplitView>);
-static_assert(std::ranges::forward_range<detail::SplitView>);
+static_assert(std::ranges::view<detail::SplitView<detail::CharSplitter>>);
+static_assert(std::ranges::viewable_range<detail::SplitView<detail::CharSplitter>>);
+static_assert(std::ranges::forward_range<detail::SplitView<detail::CharSplitter>>);
+static_assert(std::ranges::view<detail::SplitView<detail::CrLfSplitter>>);
+static_assert(std::ranges::viewable_range<detail::SplitView<detail::CrLfSplitter>>);
+static_assert(std::ranges::forward_range<detail::SplitView<detail::CrLfSplitter>>);
 
 UNIT_TEST(StringSplit, SplitToVector) {
     std::vector<std::string_view> v;
 
-    split("aa;bb;cc", ';', &v);
+    split("aa;bb;cc").by(';').to(&v);
     std::vector<std::string_view> r0 = {"aa", "bb", "cc"};
     EXPECT_EQ(v, r0);
 
-    split("ABC", ';', &v);
+    split("ABC").by(';').to(&v);
     std::vector<std::string_view> r1 = {"ABC"};
     EXPECT_EQ(v, r1);
 
-    split("AB", 'B', &v);
+    split("AB").by('B').to(&v);
     std::vector<std::string_view> r2 = {"A", ""};
     EXPECT_EQ(v, r2);
 
-    split(";", ';', &v);
+    split(";").by(';').to(&v);
     std::vector<std::string_view> r3 = {"", ""};
     EXPECT_EQ(v, r3);
 
-    split("", ';', &v);
+    split("").by(';').to(&v);
     std::vector<std::string_view> r4 = {""};
     EXPECT_EQ(v, r4);
 }
@@ -40,22 +43,22 @@ UNIT_TEST(StringSplit, SplitToVector) {
 UNIT_TEST(StringSplit, ConverToContainer) {
     const char *s = "1;2;3";
 
-    std::vector<std::string_view> v1 = split(s, ';');
+    std::vector<std::string_view> v1 = split(s).by(';');
     EXPECT_EQ(v1, std::vector<std::string_view>({"1", "2", "3"}));
 
-    std::vector<std::string> v2 = split(s, ';');
+    std::vector<std::string> v2 = split(s).by(';');
     EXPECT_EQ(v2, std::vector<std::string>({"1", "2", "3"}));
 
-    std::set<std::string_view> v3 = split(s, ';');
+    std::set<std::string_view> v3 = split(s).by(';');
     EXPECT_EQ(v3, std::set<std::string_view>({"1", "2", "3"}));
 
-    std::set<std::string> v4 = split(s, ';');
+    std::set<std::string> v4 = split(s).by(';');
     EXPECT_EQ(v4, std::set<std::string>({"1", "2", "3"}));
 
-    std::unordered_set<std::string_view> v5 = split(s, ';');
+    std::unordered_set<std::string_view> v5 = split(s).by(';');
     EXPECT_EQ(v5, std::unordered_set<std::string_view>({"1", "2", "3"}));
 
-    std::unordered_set<std::string> v6 = split(s, ';');
+    std::unordered_set<std::string> v6 = split(s).by(';');
     EXPECT_EQ(v6, std::unordered_set<std::string>({"1", "2", "3"}));
 }
 
@@ -63,29 +66,29 @@ UNIT_TEST(StringSplit, NonNullTerminated) {
     const char *s = "1,2,3,4,5,6,7,8,9,10";
     std::string_view sv(s, s+9);
 
-    std::vector<std::string_view> v1 = split(sv, ',');
+    std::vector<std::string_view> v1 = split(sv).by(',');
     EXPECT_EQ(v1, std::vector<std::string_view>({"1", "2", "3", "4", "5"}));
 }
 
 UNIT_TEST(StringSplit, DefaultConstructed) {
-    detail::SplitView view;
+    detail::SplitView<detail::CharSplitter> view;
     EXPECT_EQ(view.begin(), view.end());
     EXPECT_TRUE(view.empty());
 
-    detail::SplitViewIterator end;
+    detail::SplitViewIterator<detail::CharSplitter> end;
     EXPECT_EQ(end, detail::SplitViewSentinel());
     EXPECT_EQ(end, end);
 
     EXPECT_NO_THROW((
         [] {
-            for (std::string_view chunk : detail::SplitView())
+            for (std::string_view chunk : detail::SplitView<detail::CharSplitter>())
                 throw 0; // Shouldn't get here.
         } ()
     ));
 }
 
 UNIT_TEST(StringSplit, ForwardRange) {
-    auto ss = split("1.2.3", '.');
+    auto ss = split("1.2.3").by('.');
 
     auto pos = ss.begin();
     EXPECT_EQ(*pos, "1");
@@ -106,7 +109,7 @@ UNIT_TEST(StringSplit, ForwardRange) {
 }
 
 UNIT_TEST(StringSplit, BorrowedRange) {
-    auto mismatch = std::ranges::mismatch(split("a/b/c", '/'), split("a.b.z", '.'));
+    auto mismatch = std::ranges::mismatch(split("a/b/c").by('/'), split("a.b.z").by('.'));
     EXPECT_EQ(*mismatch.in1, "c");
     EXPECT_EQ(*mismatch.in2, "z");
 }
@@ -114,9 +117,61 @@ UNIT_TEST(StringSplit, BorrowedRange) {
 UNIT_TEST(StringSplit, AssignToVector) {
     // Test that assignment to vector works (not just initialization).
     std::vector<std::string_view> v;
-    v = split("a,b,c", ',');
+    v = split("a,b,c").by(',');
     EXPECT_EQ(v, std::vector<std::string_view>({"a", "b", "c"}));
 
-    v = split("x.y", '.');
+    v = split("x.y").by('.');
     EXPECT_EQ(v, std::vector<std::string_view>({"x", "y"}));
+}
+
+UNIT_TEST(StringSplit, CrLf) {
+    std::vector<std::string_view> v;
+
+    // Unix line endings (\n only)
+    split("line1\nline2\nline3").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
+
+    // Windows line endings (\r\n)
+    split("line1\r\nline2\r\nline3").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
+
+    // Mixed line endings
+    split("line1\nline2\r\nline3").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", "line3"}));
+
+    // Empty string
+    split("").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({""}));
+
+    // Single newline
+    split("\n").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"", ""}));
+
+    // Single CRLF
+    split("\r\n").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"", ""}));
+
+    // Trailing newline
+    split("line1\nline2\n").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", ""}));
+
+    // Trailing CRLF
+    split("line1\r\nline2\r\n").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "line2", ""}));
+
+    // Multiple consecutive newlines
+    split("line1\n\nline2").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "", "line2"}));
+
+    // Multiple consecutive CRLFs
+    split("line1\r\n\r\nline2").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1", "", "line2"}));
+
+    // String with no newlines
+    split("single line").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"single line"}));
+
+    // Lone \r characters (should not be treated as line ending)
+    split("line1\rline2\nline3").byCrLf().to(&v);
+    EXPECT_EQ(v, std::vector<std::string_view>({"line1\rline2", "line3"}));
 }

--- a/src/Utility/Tests/View_ut.cpp
+++ b/src/Utility/Tests/View_ut.cpp
@@ -1,0 +1,154 @@
+#include <string>
+#include <string_view>
+#include <vector>
+#include <set>
+#include <tuple>
+
+#include "Testing/Unit/UnitTest.h"
+
+#include "Utility/View.h"
+#include "Utility/Segment.h"
+#include "Utility/String/Split.h"
+
+static_assert(std::ranges::view<detail::ViewWrapper<std::ranges::ref_view<std::vector<int>>>>);
+static_assert(std::ranges::random_access_range<detail::ViewWrapper<std::ranges::ref_view<std::vector<int>>>>);
+
+UNIT_TEST(View, Drop) {
+    std::vector<int> v = {1, 2, 3, 4, 5};
+
+    std::vector<int> r1 = view(v).drop(2);
+    EXPECT_EQ(r1, std::vector<int>({3, 4, 5}));
+
+    std::vector<int> r2 = view(v).drop(0);
+    EXPECT_EQ(r2, std::vector<int>({1, 2, 3, 4, 5}));
+
+    std::vector<int> r3 = view(v).drop(5);
+    EXPECT_EQ(r3, std::vector<int>({}));
+
+    std::vector<int> r4 = view(v).drop(100);
+    EXPECT_EQ(r4, std::vector<int>({}));
+}
+
+UNIT_TEST(View, Skip) {
+    std::vector<std::string_view> v = {"hello", "", "world", "", "", "!"};
+
+    std::vector<std::string_view> r;
+    view(v).skip("").to(&r);
+    EXPECT_EQ(r, std::vector<std::string_view>({"hello", "world", "!"}));
+}
+
+UNIT_TEST(View, Resize) {
+    std::vector<int> v = {1, 2, 3};
+
+    std::vector<int> r1 = view(v).resize(5, 0);
+    EXPECT_EQ(r1, std::vector<int>({1, 2, 3, 0, 0}));
+
+    // Already long enough — no padding.
+    std::vector<int> r2 = view(v).resize(3, 0);
+    EXPECT_EQ(r2, std::vector<int>({1, 2, 3}));
+
+    // Shorter — truncated.
+    std::vector<int> r3 = view(v).resize(2, 0);
+    EXPECT_EQ(r3, std::vector<int>({1, 2}));
+
+    // Empty range.
+    std::vector<int> empty;
+    std::vector<int> r4 = view(empty).resize(3, 42);
+    EXPECT_EQ(r4, std::vector<int>({42, 42, 42}));
+
+    // Returns reference when inner iterator returns reference (e.g. vector).
+    auto resizedRef = view(empty).resize(5, 0);
+    static_assert(std::is_reference_v<decltype(*resizedRef.begin())>);
+
+    // Returns by value when inner iterator returns by value (e.g. transform_view).
+    auto resizedVal = view(empty).replace(0, 1).resize(5, 0);
+    static_assert(!std::is_reference_v<decltype(*resizedVal.begin())>);
+}
+
+UNIT_TEST(View, Zip) {
+    std::vector<std::string_view> v = {"a", "b", "c"};
+
+    std::vector<std::tuple<std::string_view, int>> r;
+    view(v).zip(Segment(1, 3)).to(&r);
+
+    using T = std::tuple<std::string_view, int>;
+    std::vector<T> expected = {T{"a", 1}, T{"b", 2}, T{"c", 3}};
+    EXPECT_EQ(r, expected);
+}
+
+UNIT_TEST(View, To) {
+    std::vector<int> v = {1, 2, 3};
+
+    std::vector<int> r;
+    view(v).to(&r);
+    EXPECT_EQ(r, std::vector<int>({1, 2, 3}));
+}
+
+UNIT_TEST(View, ConvertToContainer) {
+    std::vector<int> v = {1, 2, 3};
+
+    std::vector<int> r = view(v);
+    EXPECT_EQ(r, std::vector<int>({1, 2, 3}));
+}
+
+UNIT_TEST(View, AssignToContainer) {
+    std::vector<int> v = {1, 2, 3};
+
+    std::vector<int> r;
+    r = view(v);
+    EXPECT_EQ(r, std::vector<int>({1, 2, 3}));
+}
+
+UNIT_TEST(View, Chaining) {
+    std::vector<std::string_view> v = {"header", "", "a", "", "b", "c"};
+
+    std::vector<std::string_view> r;
+    view(v).drop(1).skip("").to(&r);
+    EXPECT_EQ(r, std::vector<std::string_view>({"a", "b", "c"}));
+}
+
+UNIT_TEST(View, FullChain) {
+    std::vector<std::string_view> v = {"header", "a", "b", "c"};
+
+    std::vector<std::tuple<std::string_view, int>> r;
+    view(v).drop(1).zip(Segment(1, 3)).to(&r);
+
+    using T = std::tuple<std::string_view, int>;
+    std::vector<T> expected = {T{"a", 1}, T{"b", 2}, T{"c", 3}};
+    EXPECT_EQ(r, expected);
+}
+
+UNIT_TEST(View, SizeAndEmpty) {
+    std::vector<int> v = {1, 2, 3};
+
+    auto wrapped = view(v);
+    EXPECT_EQ(wrapped.size(), 3u);
+    EXPECT_FALSE(wrapped.empty());
+
+    auto dropped = view(v).drop(3);
+    EXPECT_TRUE(dropped.empty());
+}
+
+UNIT_TEST(View, Replace) {
+    std::vector<std::string_view> v = {"a", "", "b", "", "c"};
+
+    std::vector<std::string_view> r;
+    view(v).replace("", "0").to(&r);
+    EXPECT_EQ(r, std::vector<std::string_view>({"a", "0", "b", "0", "c"}));
+}
+
+UNIT_TEST(View, ReplaceInt) {
+    std::vector<int> v = {1, 0, 2, 0, 3};
+
+    std::vector<int> r = view(v).replace(0, -1);
+    EXPECT_EQ(r, std::vector<int>({1, -1, 2, -1, 3}));
+}
+
+UNIT_TEST(View, ExplicitConversion) {
+    // string_view -> string is explicit, should still work via emplace.
+    std::vector<std::string_view> v = {"a", "b", "c"};
+
+    std::vector<std::string> r;
+    view(v).to(&r);
+    EXPECT_EQ(r, std::vector<std::string>({"a", "b", "c"}));
+}

--- a/src/Utility/Tests/View_ut.cpp
+++ b/src/Utility/Tests/View_ut.cpp
@@ -29,6 +29,22 @@ UNIT_TEST(View, Drop) {
     EXPECT_EQ(r4, std::vector<int>({}));
 }
 
+UNIT_TEST(View, Take) {
+    std::vector<int> v = {1, 2, 3, 4, 5};
+
+    std::vector<int> r1 = view(v).take(2);
+    EXPECT_EQ(r1, std::vector<int>({1, 2}));
+
+    std::vector<int> r2 = view(v).take(0);
+    EXPECT_EQ(r2, std::vector<int>({}));
+
+    std::vector<int> r3 = view(v).take(5);
+    EXPECT_EQ(r3, std::vector<int>({1, 2, 3, 4, 5}));
+
+    std::vector<int> r4 = view(v).take(100);
+    EXPECT_EQ(r4, std::vector<int>({1, 2, 3, 4, 5}));
+}
+
 UNIT_TEST(View, Skip) {
     std::vector<std::string_view> v = {"hello", "", "world", "", "", "!"};
 

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -176,10 +176,6 @@ class ViewWrapper : public ViewInterface<ViewWrapper<Range>> {
     Range _range;
 };
 
-// CTAD.
-template<class Range>
-ViewWrapper(Range) -> ViewWrapper<Range>;
-
 } // namespace detail
 
 #ifndef __DOXYGEN__ // Doxygen chokes here...
@@ -189,7 +185,8 @@ inline constexpr bool std::ranges::enable_borrowed_range<detail::ViewWrapper<Ran
 #endif
 
 /**
- * Wraps a range into a `ViewWrapper` with fluent view methods (`drop`, `skip`, `zip`, `to`).
+ * Wraps a range into a `ViewWrapper` with fluent view methods (`drop`, `take`, `skip`, `replace`, `resize`,
+ * `zip`, `to`, plus implicit conversion to a container).
  *
  * @param range                          Range to wrap.
  */

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -87,7 +87,7 @@ class ResizeView {
  * CRTP mixin that provides a fluent range API on top of `std::ranges::view_interface`.
  *
  * Any class that inherits `ViewInterface<Derived>` and provides `begin()`/`end()` gets:
- * - `drop(n)`, `skip(value)`, `replace(from, to)`, `resize(n, value)`, `zip(other)` — chainable range transformations.
+ * - `drop(n)`, `take(n)`, `skip(value)`, `replace(from, to)`, `resize(n, value)`, `zip(other)` — chainable range transformations.
  * - `to(&container)` — populate an existing container.
  * - `operator Container()` — implicit conversion to a container.
  * - `empty()`, `size()`, `operator bool` — from `view_interface`.
@@ -104,6 +104,10 @@ class ViewInterface : public std::ranges::view_interface<Derived> {
  public:
     [[nodiscard]] auto drop(size_t n) {
         return detail::ViewWrapper(std::views::drop(derived(), n));
+    }
+
+    [[nodiscard]] auto take(size_t n) {
+        return detail::ViewWrapper(std::views::take(derived(), n));
     }
 
     [[nodiscard]] auto skip(auto value) {

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <ranges>
+#include <string>
+#include <type_traits>
+#include <utility> // For std::forward.
+#include <vector>
+
+namespace detail {
+
+template<class T>
+struct is_initializer_list : std::false_type {};
+
+template<class T>
+struct is_initializer_list<std::initializer_list<T>> : std::true_type {};
+
+template<class T>
+inline constexpr bool is_initializer_list_v = is_initializer_list<T>::value;
+
+template<class Range>
+class ViewWrapper;
+
+class ResizeViewSentinel {};
+
+template<class InnerIterator, class InnerSentinel>
+class ResizeViewIterator {
+ public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::iter_value_t<InnerIterator>;
+
+    ResizeViewIterator() = default;
+    ResizeViewIterator(InnerIterator pos, InnerSentinel end, size_t size, value_type fill)
+        : _pos(std::move(pos)), _end(std::move(end)), _size(size), _fill(std::move(fill)) {}
+
+    decltype(auto) operator*() const {
+        // Using decltype(auto) to preserve the value category of the inner iterator's operator*.
+        // If *_pos returns a reference, the ternary yields an lvalue and we return by reference.
+        // If *_pos returns by value, the ternary yields a prvalue and we return by value.
+        return _pos == _end ? _fill : *_pos;
+    }
+
+    ResizeViewIterator &operator++() {
+        ++_index;
+        if (_pos != _end)
+            ++_pos;
+        return *this;
+    }
+
+    ResizeViewIterator operator++(int) {
+        ResizeViewIterator tmp = *this;
+        ++*this;
+        return tmp;
+    }
+
+    friend bool operator==(const ResizeViewIterator &l, const ResizeViewSentinel &) {
+        return l._index >= l._size;
+    }
+
+ private:
+    InnerIterator _pos;
+    InnerSentinel _end;
+    size_t _index = 0;
+    size_t _size = 0;
+    value_type _fill;
+};
+
+template<class Range>
+class ResizeView {
+ public:
+    using value_type = std::ranges::range_value_t<Range>;
+
+    ResizeView() = default;
+    ResizeView(Range range, size_t size, value_type fill) : _range(std::move(range)), _size(size), _fill(std::move(fill)) {}
+
+    auto begin() { return ResizeViewIterator(std::ranges::begin(_range), std::ranges::end(_range), _size, _fill); }
+    auto end() { return ResizeViewSentinel(); }
+
+ private:
+    Range _range;
+    size_t _size = 0;
+    value_type _fill;
+};
+
+} // namespace detail
+
+/**
+ * CRTP mixin that provides a fluent range API on top of `std::ranges::view_interface`.
+ *
+ * Any class that inherits `ViewInterface<Derived>` and provides `begin()`/`end()` gets:
+ * - `drop(n)`, `skip(value)`, `replace(from, to)`, `resize(n, value)`, `zip(other)` — chainable range transformations.
+ * - `to(&container)` — populate an existing container.
+ * - `operator Container()` — implicit conversion to a container.
+ * - `empty()`, `size()`, `operator bool` — from `view_interface`.
+ *
+ * All methods are non-const, following the standard library convention for views. Standard view types like
+ * `filter_view` and `drop_view` have non-const `begin()` (they cache the result of the first call), so const
+ * iteration is generally not supported for views. The const/non-const distinction on the underlying range is
+ * captured in the view's type parameter (e.g. `ref_view<T>` vs `ref_view<const T>`), not in method qualifiers.
+ */
+template<class Derived>
+class ViewInterface : public std::ranges::view_interface<Derived> {
+    [[nodiscard]] Derived &derived() { return static_cast<Derived &>(*this); }
+
+ public:
+    [[nodiscard]] auto drop(size_t n) {
+        return detail::ViewWrapper(std::views::drop(derived(), n));
+    }
+
+    [[nodiscard]] auto skip(auto value) {
+        return detail::ViewWrapper(std::views::filter(derived(), [value] (const auto &e) { return e != value; }));
+    }
+
+    [[nodiscard]] auto replace(auto from, auto to) {
+        return detail::ViewWrapper(std::views::transform(derived(), [from, to] (const auto &e) { return e == from ? to : e; }));
+    }
+
+    [[nodiscard]] auto resize(size_t n, auto value) {
+        return detail::ViewWrapper(detail::ResizeView(derived(), n, value));
+    }
+
+    template<class R>
+    [[nodiscard]] auto zip(R &&other) {
+        return detail::ViewWrapper(std::views::zip(derived(), std::forward<R>(other)));
+    }
+
+    template<class Container>
+    void to(Container *container) {
+        // We can't use assign_range / insert_range / std::ranges::to here because:
+        // - assign_range / insert_range require implicit convertibility, and some conversions are explicit
+        //   (e.g., string_view -> string).
+        // - on top of that, std::ranges::to would enter infinite recursion through operator Container() below.
+        // So we use a manual loop with emplace_back / emplace.
+        container->clear();
+        for (auto &&element : derived()) {
+            if constexpr (requires { container->emplace_back(element); })
+                container->emplace_back(element);
+            else
+                container->emplace(element);
+        }
+    }
+
+    /**
+     * Implicit conversion to a container type.
+     *
+     * The `initializer_list` exclusion in the requires clause is necessary to prevent ambiguous overload resolution
+     * when assigning to containers. Without it, `v = range(...)` would be ambiguous because `std::vector::operator=`
+     * has overloads for both `const vector&` and `initializer_list<value_type>`.
+     */
+    template<class Container> requires
+        std::constructible_from<typename Container::value_type, std::ranges::range_reference_t<Derived>> &&
+        (!detail::is_initializer_list_v<Container>)
+    operator Container() {
+        Container result;
+        to(&result);
+        return result;
+    }
+};
+
+namespace detail {
+
+template<class Range>
+class ViewWrapper : public ViewInterface<ViewWrapper<Range>> {
+ public:
+    ViewWrapper() = default;
+
+    explicit ViewWrapper(Range range) : _range(std::move(range)) {}
+
+    auto begin() { return std::ranges::begin(_range); }
+    auto end() { return std::ranges::end(_range); }
+
+ private:
+    Range _range;
+};
+
+// CTAD.
+template<class Range>
+ViewWrapper(Range) -> ViewWrapper<Range>;
+
+} // namespace detail
+
+#ifndef __DOXYGEN__ // Doxygen chokes here...
+template<class Range>
+inline constexpr bool std::ranges::enable_borrowed_range<detail::ViewWrapper<Range>> =
+    std::ranges::enable_borrowed_range<Range>;
+#endif
+
+/**
+ * Wraps a range into a `ViewWrapper` with fluent view methods (`drop`, `skip`, `zip`, `to`).
+ *
+ * @param range                          Range to wrap.
+ */
+template<class Range>
+auto view(Range &&range) {
+    // std::views::all converts any range (including e.g. std::vector) into a ref view OR an owning view, depending on
+    // whether rvalue is passed in.
+    return detail::ViewWrapper(std::views::all(std::forward<Range>(range)));
+}


### PR DESCRIPTION
* Redid string splitting.
* Added sugary range wrapper, `view(container).drop(1).skip("")` etc.
* Using it for quest table. Will commit other tables separately.
