### PR TITLE
Dropped redundant key events from new traces

### DIFF
--- a/test/Bin/CMakeLists.txt
+++ b/test/Bin/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 ExternalProject_Add(OpenEnroth_TestData
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/test_data_tmp
         GIT_REPOSITORY https://github.com/OpenEnroth/OpenEnroth_TestData.git
-        GIT_TAG 3cfe4d20c60af9c4c6156d8f8274917c765cc21d
+        GIT_TAG 0e098bb8d8459ee06370201d857cb214e065e3d3
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Need this for the final migrations to enable keyrepeat for some of the actions that we have.

Not enabling this by default b/c I do want to have these events for future traces.