### PR TITLE
Build only libmain.so on Android

### DIFF
--- a/android/openenroth/build.gradle
+++ b/android/openenroth/build.gradle
@@ -70,12 +70,14 @@ android {
                 cmake {
                     arguments "-DANDROID_STL=c++_static", "-DOE_BUILD_TESTS=OFF"
                     abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86'
+                    targets "main"
                     version "3.24.0+"
                 }
             } else {
                 cmake {
                     arguments "-DANDROID_STL=c++_static", "-DOE_BUILD_TESTS=OFF"
                     abiFilters System.env['GITHUBARCH']
+                    targets "main"
                     version "3.24.0+"
                 }
             }


### PR DESCRIPTION
Apparently we were building everything else too, even if libmain didn't need it.