### PR TITLE
Added struct SaveGame & SaveGameLite

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -164,7 +164,7 @@ bool Game::loop() {
 
             bFlashQuestBook = true;
             pMediaPlayer->PlayFullscreenMovie("Intro Post");
-            SaveNewGame();
+            saveNewGame();
             if (engine->config->debug.NoMargaret.value()) {
                 pParty->_questBits.set(QBIT_EMERALD_ISLAND_MARGARETH_OFF);
             }
@@ -759,7 +759,7 @@ void Game::processQueuedMessages() {
                     DialogueEnding();
                     pAudioPlayer->stopSounds();
                     pEventTimer->setPaused(true);
-                    AutoSave();
+                    autoSave();
                     uGameState = GAME_STATE_CHANGE_LOCATION;
                     engine->_transitionMapId = travelMapId;
                     // TODO(Nik-RE-dev): rest and heal uncoditionally even if party does not have food?
@@ -845,7 +845,7 @@ void Game::processQueuedMessages() {
                 assert(false);
                 playButtonSoundOnEscape = false;
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-                AutoSave();
+                autoSave();
                 engine->_transitionMapId = houseNpcs[currentHouseNpc].targetMapID;
                 dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;
                 uGameState = GAME_STATE_CHANGE_LOCATION;
@@ -898,7 +898,7 @@ void Game::processQueuedMessages() {
             }
             case UIMSG_OnGameOverWindowClose:
                 pAudioPlayer->stopSounds();
-                AutoSave();
+                autoSave();
 
                 pParty->pos = Vec3f(-17331, 12547, 465); // respawn point in Harmondale
                 pParty->velocity = Vec3f();
@@ -1541,11 +1541,11 @@ void Game::processQueuedMessages() {
                     engine->_statusBar->setEvent(LSTR_NO_SAVING_IN_THE_ARENA);
                     pAudioPlayer->playUISound(SOUND_error);
                 } else {
-                    QuickSaveGame();
+                    quickSaveGame();
                 }
                 continue;
             case UIMSG_QuickLoad:
-                QuickLoadGame();
+                quickLoadGame();
                 continue;
             default:
                 logger->warning("Game::processQueuedMessages - Unhandled message type: {}", static_cast<int>(uMessage));
@@ -1583,7 +1583,7 @@ void Game::gameLoop() {
     SetCurrentMenuID(MENU_NONE);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        LoadGame(pSavegameList->selectedSlot);
+        loadGame(pSavegameList->selectedSlot);
     }
 
     extern bool use_music_folder;

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -159,7 +159,7 @@ void Menu::EventLoop() {
                 continue;
             case UIMSG_LoadGame:
                 if (pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
-                    LoadGame(pSavegameList->selectedSlot);
+                    loadGame(pSavegameList->selectedSlot);
                     uGameState = GAME_STATE_LOADING_GAME;
                 }
                 continue;
@@ -169,7 +169,7 @@ void Menu::EventLoop() {
                     pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name = keyboardInputHandler->GetTextInput();
                     keyboardInputHandler->EndTextInput();
                 }
-                DoSavegame(pSavegameList->selectedSlot);
+                doSavegame(pSavegameList->selectedSlot);
                 continue;
             case UIMSG_Game_OpenSaveGameDialog: {
                 if (engine->_currentLoadedMapId == MAP_ARENA) {
@@ -436,7 +436,7 @@ void Menu::EventLoop() {
                 }
                 continue;
             case UIMSG_QuickLoad:
-                QuickLoadGame();
+                quickLoadGame();
                 break;
             default:
                 break;

--- a/src/Application/GameStates/MainMenuState.cpp
+++ b/src/Application/GameStates/MainMenuState.cpp
@@ -55,7 +55,7 @@ FsmAction MainMenuState::update() {
             transition = "exitGame";
             break;
         case UIMSG_QuickLoad: {
-            int slot = GetQuickSaveSlot();
+            int slot = getQuickSaveSlot();
             if (slot != -1) {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 pSavegameList->selectedSlot = slot;

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -223,7 +223,7 @@ Blob EngineController::saveGame() {
     // the control thread. One option is to unbind every time we switch to control thread, but this is slow, and not
     // needed 99% of the time. So we just call back into the game thread.
     Blob result;
-    runGameRoutine([&] { result = CreateSaveData(false, "").second; });
+    runGameRoutine([&] { result = createSaveData(false, "").second; });
     return result;
 }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -19,7 +19,6 @@
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/BspRenderer.h"
-#include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Overlays.h"
 #include "Engine/Graphics/PaletteManager.h"
 #include "Engine/Graphics/ParticleEngine.h"
@@ -64,6 +63,7 @@
 #include "Engine/Resources/ResourceManager.h"
 #include "Engine/MapInfo.h"
 #include "Engine/Resources/EngineFileSystem.h"
+#include "Engine/Resources/LOD.h"
 #include "Graphics/TileGenerator.h"
 
 #include "GUI/GUIProgressBar.h"
@@ -1469,7 +1469,7 @@ void Transition_StopSound_Autosave(std::string_view pMapName,
     // pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_None);
 
     if (engine->_currentLoadedMapId != pMapStats->GetMapInfo(pMapName)) {
-        AutoSave();
+        autoSave();
     }
 
     uGameState = GAME_STATE_CHANGE_LOCATION;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -36,6 +36,7 @@
 #include "Engine/Localization.h"
 #include "Engine/MapInfo.h"
 #include "Engine/Resources/LOD.h"
+#include "Engine/SaveLoad.h"
 
 #include "GUI/GUIProgressBar.h"
 #include "GUI/GUIWindow.h"
@@ -292,7 +293,7 @@ void IndoorLocation::Load(std::string_view filename, int num_days_played, int re
     bool respawnInitial = false; // Perform initial location respawn?
     bool respawnTimed = false; // Perform timed location respawn?
     IndoorDelta_MM7 delta;
-    if (Blob blob = lod::decodeMaybeCompressed(pSave_LOD->read(dlv_filename))) {
+    if (Blob blob = lod::decodeMaybeCompressed(pMapDeltas.at(dlv_filename))) {
         try {
             deserialize(blob, &delta, tags::context(location));
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -38,6 +38,7 @@
 #include "Engine/Graphics/BspRenderer.h"
 #include "Engine/MapInfo.h"
 #include "Engine/Resources/LOD.h"
+#include "Engine/SaveLoad.h"
 #include "Engine/Seasons.h"
 #include "Engine/Data/TileEnumFunctions.h"
 
@@ -480,7 +481,7 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
     bool respawnInitial = false; // Perform initial location respawn?
     bool respawnTimed = false; // Perform timed location respawn?
     OutdoorDelta_MM7 delta;
-    if (Blob blob = lod::decodeMaybeCompressed(pSave_LOD->read(ddm_filename))) {
+    if (Blob blob = lod::decodeMaybeCompressed(pMapDeltas.at(ddm_filename))) {
         try {
             deserialize(blob, &delta, tags::context(location));
 

--- a/src/Engine/Resources/LOD.cpp
+++ b/src/Engine/Resources/LOD.cpp
@@ -4,11 +4,9 @@
 
 #include "EngineFileSystem.h"
 
-std::unique_ptr<LodReader> pSave_LOD;
 std::unique_ptr<LodReader> pGames_LOD;
 
 bool Initialize_GamesLOD_NewLOD() {
     pGames_LOD = std::make_unique<LodReader>(dfs->read("data/games.lod"));
-    pSave_LOD = std::make_unique<LodReader>();
     return true;
 }

--- a/src/Engine/Resources/LOD.h
+++ b/src/Engine/Resources/LOD.h
@@ -8,9 +8,5 @@ class FileSystem;
 
 bool Initialize_GamesLOD_NewLOD();
 
-/** LOD reader for the current game being played. Used for accessing the per-map states, is updated on map change,
- * on save, and on load. */
-extern std::unique_ptr<LodReader> pSave_LOD;
-
 /** LOD reader for data/games.lod. */
 extern std::unique_ptr<LodReader> pGames_LOD;

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <unordered_map>
 #include <string>
 #include <utility>
 
@@ -22,14 +23,24 @@ struct SaveGameHeader {
     Time playingTime; // Game time of the save.
 };
 
-struct SaveGameState {
+struct SaveGame {
     SaveGameHeader header;
     Party party;
     Timer eventTimer;
     ActiveOverlayList overlays;
     std::array<NPCData, 501> npcData;
     std::array<uint16_t, 51> npcGroups;
+    std::unordered_map<std::string, Blob> mapDeltas;
+    Blob thumbnail;
 };
+
+struct SaveGameLite {
+    SaveGameHeader header;
+    Blob thumbnail;
+};
+
+/** Runtime storage for map deltas from the currently loaded save. */
+extern std::unordered_map<std::string, Blob> pMapDeltas;
 
 struct SavegameList {
     static void Initialize();
@@ -48,17 +59,16 @@ struct SavegameList {
     std::string lastLoadedSave{};
 };
 
-void LoadGame(int uSlot);
-std::pair<SaveGameHeader, Blob> CreateSaveData(bool resetWorld, std::string_view title);
-SaveGameHeader SaveGame(bool isAutoSave, bool resetWorld, std::string_view path, std::string_view title = {});
-void AutoSave();
-void DoSavegame(int uSlot);
-bool Initialize_GamesLOD_NewLOD();
-void SaveNewGame();
+void loadGame(int uSlot);
+std::pair<SaveGameHeader, Blob> createSaveData(bool resetWorld, std::string_view title);
+SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path, std::string_view title = {});
+void autoSave();
+void doSavegame(int uSlot);
+void saveNewGame();
 
-void QuickSaveGame();
-int GetQuickSaveSlot();
-void QuickLoadGame();
-std::string GetCurrentQuickSave();
+void quickSaveGame();
+int getQuickSaveSlot();
+void quickLoadGame();
+std::string getCurrentQuickSave();
 
 extern SavegameList *pSavegameList;

--- a/src/Engine/Snapshots/CompositeSnapshots.h
+++ b/src/Engine/Snapshots/CompositeSnapshots.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <string>
 #include <vector>
 #include <tuple>
+#include <unordered_map>
 
 #include "EntitySnapshots.h"
+
+#include "Utility/Memory/Blob.h"
+#include "Utility/Hash.h"
 
 /**
  * @file
@@ -18,10 +23,9 @@ class BSPModel;
 struct IndoorLocation;
 struct OutdoorLocation;
 class OutdoorTerrain;
-struct SaveGameState;
+struct SaveGame;
+struct SaveGameLite;
 struct SpriteFrameTable;
-class LodReader;
-class LodWriter;
 
 struct IndoorLocation_MM7 {
     BLVHeader_MM7 header;
@@ -124,19 +128,31 @@ void serialize(const OutdoorDelta_MM7 &src, OutputStream *dst);
 void deserialize(InputStream &src, OutdoorDelta_MM7 *dst, ContextTag<OutdoorLocation_MM7> ctx);
 
 
-struct SaveGameState_MM7 {
+struct SaveGame_MM7 {
     SaveGameHeader_MM7 header; // In header.bin.
     Party_MM7 party; // In party.bin.
     Timer_MM7 eventTimer; // In clock.bin.
     ActiveOverlayList_MM7 overlays; // In overlay.bin.
-    std::array<NPCData_MM7, 501> npcData; // in npcdata.bin.
-    std::array<uint16_t, 51> npcGroups; // in npcgroup.bin.
+    std::array<NPCData_MM7, 501> npcData; // In npcdata.bin.
+    std::array<uint16_t, 51> npcGroups; // In npcgroup.bin.
+    std::unordered_map<std::string, Blob> mapDeltas; // Map deltas by name (e.g. "out01.ddm", "d29.dlv").
+    std::unordered_map<std::pair<int, int>, Blob> lloydImages; // Lloyd's Beacon images as PCX blobs, by {playerIndex, beaconIndex}.
+    Blob thumbnail; // In image.pcx - save thumbnail.
 };
 
-void snapshot(const SaveGameState &src, SaveGameState_MM7 *dst);
-void reconstruct(const SaveGameState_MM7 &src, SaveGameState *dst);
-void serialize(const SaveGameState_MM7 &src, LodWriter *dst);
-void deserialize(const LodReader &src, SaveGameState_MM7 *dst);
+void snapshot(const SaveGame &src, SaveGame_MM7 *dst);
+void reconstruct(const SaveGame_MM7 &src, SaveGame *dst);
+void serialize(const SaveGame_MM7 &src, Blob *dst);
+void deserialize(const Blob &src, SaveGame_MM7 *dst);
+
+
+struct SaveGameLite_MM7 {
+    SaveGameHeader_MM7 header;
+    Blob thumbnail;
+};
+
+void reconstruct(const SaveGameLite_MM7 &src, SaveGameLite *dst);
+void deserialize(const Blob &src, SaveGameLite_MM7 *dst);
 
 
 struct SpriteFrameTable_MM7 {

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -192,7 +192,7 @@ void GUIWindow_LloydsBook::installOrRecallBeacon(int beaconId) {
         LloydBeacon &beacon = *character.vBeacons[beaconId];
         if (engine->_currentLoadedMapId != beacon.mapId) {
             // TODO(Nik-RE-dev): need separate function for teleportation to other maps
-            AutoSave();
+            autoSave();
             onMapLeave();
             engine->_transitionMapId = beacon.mapId;
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -155,7 +155,7 @@ void GUIWindow_TownPortalBook::clickTown(int townId) {
     }
 
     // begin TP
-    AutoSave();
+    autoSave();
     // if in current map
     // TODO(Nik-RE-dev): need separate function for teleportation to other maps
     if (engine->_currentLoadedMapId == townPortalList[townId].mapInfoID) {

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -158,7 +158,7 @@ void GUIWindow_Transport::transportDialogue() {
 
     if (pTravel->pSchedule[pParty->uCurrentDayOfMonth % 7]) {
         if (engine->_currentLoadedMapId != pTravel->uMapInfoID) {
-            AutoSave();
+            autoSave();
             engine->_transitionMapId = pTravel->uMapInfoID;
 
             dword_6BE364_game_settings_1 |= GAME_SETTINGS_SKIP_WORLD_UPDATE;

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -18,6 +18,7 @@
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
 #include "Engine/Resources/LOD.h"
+#include "Engine/SaveLoad.h"
 #include "Engine/PriceCalculator.h"
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/ParticleEngine.h"
@@ -516,7 +517,7 @@ GAME_TEST(Issues, Issue1340) {
     auto screenTape = tapes.screen();
     test.playTraceFromTestData("issue_1340.mm7", "issue_1340.json", [] {
         // Harmondale should not have been visited - check that the dlv data is the same as what's in games.lod.
-        Blob saveHarmondale = pSave_LOD->read("d29.dlv");
+        const Blob &saveHarmondale = pMapDeltas.at("d29.dlv");
         Blob origHarmondale = pGames_LOD->read("d29.dlv");
         EXPECT_EQ(saveHarmondale.string_view(), origHarmondale.string_view());
     });


### PR DESCRIPTION
What's going on here:
* All savegame state is now in a single struct, serialize / deserialize / reconstruct / snapshot do what they should do.
* Added a struct for partial savegame deserialization.
* `pSave_LOD` dropped.
* Some renamings in `SaveGame.h`.

I needed `struct SaveGame` b/c next step would be adding new OE-specific fields to it.