### PR TITLE
Fix spawn chance table incomplete for difficulty levels 4 and 5

### DIFF
--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -60,7 +60,7 @@ static constexpr IndexedArray<int, HOSTILITY_FIRST, HOSTILITY_LAST> _4DF380_host
     {HOSTILITY_LONG, 10240}
 };
 
-std::array<int16_t, 11> word_4E8152 = {{0, 0, 0, 90, 8, 2, 70, 20, 10, 50, 30}};  // level spawn monster levels ABC
+std::array<int16_t, 18> word_4E8152 = {{0, 0, 0, 90, 8, 2, 70, 20, 10, 50, 30, 20, 30, 40, 30, 10, 50, 40}};  // level spawn monster levels ABC
 
 //----- (0042FB5C) --------------------------------------------------------
 // True if monster should play attack animation when casting this spell.
@@ -4259,7 +4259,7 @@ void SpawnEncounter(MapInfo *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int
     if (baseInternalName[0] == '0') return;
 
     monsterCategoryOddsSet += monsterCatMod;
-    if (monsterCategoryOddsSet > 3) monsterCategoryOddsSet = 3;
+    if (monsterCategoryOddsSet > 5) monsterCategoryOddsSet = 5;
 
     if (countOverride) NumToSpawn = countOverride;
     if (NumToSpawn <= 0) return;


### PR DESCRIPTION
Fixes #99.

## Summary
- `word_4E8152` had 11 entries covering only Dif levels 0–3; `MapStats.txt` uses levels up to 5
- Extends the array to 18 entries adding levels 4 `{30, 40, 30}` and 5 `{10, 50, 40}`
- Fixes the clamp from `> 3` to `> 5`
- ~17 maps were affected, most notably Shoals (Dif=5 Sea Monsters) and Dragon Caves (Dif=5 Dragons) where 50% of spawns were the weakest A-tier variant instead of the intended ~10%

Values for levels 4 and 5 were verified by reading `word_4E8152` directly from the original `mm7.exe` binary at file offset `0xE8110` — they match exactly.

## Test plan
- [ ] Visit The Maze or Temple of the Dark (Dif=4 maps) and confirm monsters spawn normally
- [ ] Visit Shoals or Dragon Caves (Dif=5 maps) and confirm monsters spawn normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)