### PR TITLE
Fix enchantment spells failing on equipped items

### DIFF
--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -2123,7 +2123,7 @@ void OnPaperdollLeftClick() {
                 pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
                 pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
                 pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
-                pSpellInfo->targetInventoryIndex = v34 - 1;
+                pSpellInfo->targetInventoryIndex = entry.index();
 
                 ptr_50C9A4_ItemToEnchant = entry.get();
                 IsEnchantingInProgress = false;


### PR DESCRIPTION
Fixes #2451.

## Problem

`equipmentHitMap` stores 0-based inventory record indices (via `entry.index()`), but the paperdoll enchantment click handler at `UICharacter.cpp:2126` subtracted 1 — a leftover from legacy 1-based indexing (visible in the commented-out code on line 2104). This caused `targetInventoryIndex` to point to the wrong item, so the spell always failed on equipped items.

## Fix

Use `entry.index()` instead of `v34 - 1`, consistent with the other two enchantment click paths (inventory grid click in `UICharacter.cpp:2057` and `Character.cpp:6129`).

Affects all item-targeting enchantment spells on equipped items: Recharge Item, Fire Aura, Enchant Item, and Vampiric Weapon.

## Test plan
- [ ] Equip a wand, cast Recharge Item on it via paperdoll click — should succeed
- [ ] Cast Fire Aura on an equipped weapon via paperdoll click — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)