### PR TITLE
Fix Efreet lightning bolt dealing 0 damage (#2507)

### DIFF
--- a/src/Engine/Objects/Monsters.cpp
+++ b/src/Engine/Objects/Monsters.cpp
@@ -24,6 +24,7 @@ void ParseDamage(std::string_view damage_str, uint8_t *dice_rolls,
                  uint8_t *dice_sides, uint8_t *dmg_bonus);
 MonsterProjectile ParseMissleAttackType(std::string_view missle_attack_str);
 MonsterSpecialAttack ParseSpecialAttack(std::string_view spec_att_str);
+void parseSpellEntry(std::string_view cell, SpellId &outSpellId, CombinedSkillValue &outMastery);
 
 //----- (004548E2) --------------------------------------------------------
 SpellId ParseSpellType(std::string_view name) {
@@ -86,6 +87,32 @@ CombinedSkillValue ParseSkillValue(std::string_view skillString, std::string_vie
     }
 
     return CombinedSkillValue(skill, mastery);
+}
+
+// Parse one spell cell from monsters.txt. Canonical format: `"<spell name>,<mastery>,<skill>"`, e.g.
+// `"Lightning Bolt,M,10"`. A handful of vanilla cells drop the comma between the mastery letter and the
+// skill digits — Efreet's spell1 is `"Lightning Bolt,M10"`. When the third field is missing but the second
+// begins with a mastery letter, split it apart so the spell parses at the intended skill rather than
+// silently rolling 0d8 (issue #2507).
+void parseSpellEntry(std::string_view cell, SpellId &outSpellId, CombinedSkillValue &outMastery) {
+    outSpellId = SPELL_NONE;
+    outMastery = CombinedSkillValue::none();
+    if (cell.size() < 2)
+        return;
+    std::array<std::string_view, 3> parts = split(removeQuotes(cell)).by(',');
+    if (parts[0].empty())
+        return;
+    outSpellId = ParseSpellType(parts[0]);
+    std::string_view masteryString = parts[1];
+    std::string_view skillString = parts[2];
+    if (skillString.empty() && masteryString.size() > 1 &&
+            (masteryString[0] == 'N' || masteryString[0] == 'E' ||
+             masteryString[0] == 'M' || masteryString[0] == 'G')) {
+        skillString = masteryString.substr(1);
+        masteryString = masteryString.substr(0, 1);
+    }
+    if (!skillString.empty())
+        outMastery = ParseSkillValue(skillString, masteryString);
 }
 
 //----- (00454CB4) --------------------------------------------------------
@@ -367,25 +394,6 @@ void MonsterStats::Initialize(const Blob &monsters) {
             name = name.substr(0, x);
         }
         info.specialAttackType = ParseSpecialAttack(name);
-    };
-
-    // Spell cells. Format: `"<spell name>,<mastery>,<skill>"` — fields are comma-separated, surrounded by quotes.
-    // Spell names may contain spaces.
-    auto parseSpellEntry = [](std::string_view cell, SpellId &outSpellId, CombinedSkillValue &outMastery) {
-        outSpellId = SPELL_NONE;
-        outMastery = CombinedSkillValue::none();
-        if (cell.size() < 2)
-            return;
-        std::array<std::string_view, 3> parts = split(removeQuotes(cell)).by(',');
-        if (parts[0].empty())
-            return;
-        outSpellId = ParseSpellType(parts[0]);
-        // TODO(captainurist): Efreet's spell1 cell in monsters.txt is the malformed `"Lightning Bolt,M10"`
-        // (missing comma between mastery and skill), so parts[2] is empty. The original parser silently left
-        // mastery/skill at 0; we do the same. We can't edit the data file, so the proper fix is to teach this
-        // parser to split `M10` -> mastery `M`, skill `10` (will change Efreet behavior — needs retracing).
-        if (!parts[2].empty())
-            outMastery = ParseSkillValue(parts[2], parts[1]);
     };
 
     // Special-ability cell. Format is one of:

--- a/src/Engine/Objects/Tests/MonsterEnumFunctions_ut.cpp
+++ b/src/Engine/Objects/Tests/MonsterEnumFunctions_ut.cpp
@@ -1,6 +1,10 @@
 #include "Testing/Game/GameTest.h"
 
+#include "Engine/Objects/CombinedSkillValue.h"
 #include "Engine/Objects/MonsterEnumFunctions.h"
+#include "Engine/Spells/SpellEnums.h"
+
+void parseSpellEntry(std::string_view cell, SpellId &outSpellId, CombinedSkillValue &outMastery);
 
 GAME_TEST(MonsterEnumFunctions, MonsterTierForMonsterId) {
     // Angel A/B/C map to tiers A/B/C.
@@ -12,4 +16,44 @@ GAME_TEST(MonsterEnumFunctions, MonsterTierForMonsterId) {
     EXPECT_EQ(monsterTierForMonsterId(MONSTER_GHOST_A), MONSTER_TIER_A);
     EXPECT_EQ(monsterTierForMonsterId(MONSTER_GHOST_B), MONSTER_TIER_B);
     EXPECT_EQ(monsterTierForMonsterId(MONSTER_GHOST_C), MONSTER_TIER_C);
+}
+
+GAME_TEST(MonsterStats, ParseSpellEntry) {
+    SpellId spellId = SPELL_NONE;
+    CombinedSkillValue mastery = CombinedSkillValue::none();
+
+    // Canonical well-formed cell: spell name, mastery, skill split across three comma-separated fields.
+    parseSpellEntry("\"Fire Bolt,N,3\"", spellId, mastery);
+    EXPECT_EQ(spellId, SPELL_FIRE_FIRE_BOLT);
+    EXPECT_EQ(mastery.level(), 3);
+    EXPECT_EQ(mastery.mastery(), MASTERY_NOVICE);
+
+    // Issue #2507: Efreet's spell1 in monsters.txt is the malformed `"Lightning Bolt,M10"` — the comma
+    // between mastery and skill is missing. The parser must recover by splitting `M10` into mastery `M`
+    // and skill `10` so the lightning bolt deals its intended 10d8 instead of 0d8.
+    parseSpellEntry("\"Lightning Bolt,M10\"", spellId, mastery);
+    EXPECT_EQ(spellId, SPELL_AIR_LIGHTNING_BOLT);
+    EXPECT_EQ(mastery.level(), 10);
+    EXPECT_EQ(mastery.mastery(), MASTERY_MASTER);
+
+    // All four mastery letters survive the same recovery path.
+    parseSpellEntry("\"Fire Bolt,G7\"", spellId, mastery);
+    EXPECT_EQ(mastery.level(), 7);
+    EXPECT_EQ(mastery.mastery(), MASTERY_GRANDMASTER);
+    parseSpellEntry("\"Fire Bolt,E4\"", spellId, mastery);
+    EXPECT_EQ(mastery.level(), 4);
+    EXPECT_EQ(mastery.mastery(), MASTERY_EXPERT);
+    parseSpellEntry("\"Fire Bolt,N5\"", spellId, mastery);
+    EXPECT_EQ(mastery.level(), 5);
+    EXPECT_EQ(mastery.mastery(), MASTERY_NOVICE);
+
+    // Empty cell yields no spell and no mastery.
+    parseSpellEntry("", spellId, mastery);
+    EXPECT_EQ(spellId, SPELL_NONE);
+    EXPECT_EQ(mastery, CombinedSkillValue::none());
+
+    // A bare mastery letter with no skill digits leaves mastery unset (matches original behavior).
+    parseSpellEntry("\"Fire Bolt,M\"", spellId, mastery);
+    EXPECT_EQ(spellId, SPELL_FIRE_FIRE_BOLT);
+    EXPECT_EQ(mastery, CombinedSkillValue::none());
 }


### PR DESCRIPTION
## Summary

Closes #2507.

Efreet's spell1 cell in `monsters.txt` is the malformed `"Lightning Bolt,M10"` -- the comma between the mastery letter and the skill digits is missing. The cell parser was splitting on commas and reading the third field; finding it empty, it silently left `spell1SkillMastery` at 0, which made the spell roll 0d8 every cast.

The TODO comment captainurist left at `Monsters.cpp:383-386` predicted exactly this fix path.

## What changed

- Lifted `parseSpellEntry` from a lambda inside `MonsterStats::Initialize` to a file-scope function so it has a unit-testable surface.
- Added a recovery branch: when the third comma-separated field is missing but the second begins with a mastery letter (`N`/`E`/`M`/`G`), split it into the mastery letter and the trailing digits. `"Lightning Bolt,M10"` now parses identically to `"Lightning Bolt,M,10"`.
- Empty cells and bare-mastery-letter cells (`"Fire Bolt,M"`) still parse to `CombinedSkillValue::none()` -- only the canonical buggy pattern is recovered.
- Added `MonsterStats.ParseSpellEntry` covering the canonical format, the malformed-cell recovery for all four mastery letters, and the empty/degenerate inputs.

## Behavior change & trace impact

This is a deliberate behavior change. Efreets are the only `monsters.txt` row I can identify that hits this code path -- their Lightning Bolt damage rolls now diverge from the previous (0 damage) baseline.

`Run_GameTest_Headless_Parallel` passes locally (324 / 324, including the new `MonsterStats.ParseSpellEntry`), so no existing trace exercises an Efreet spell attack and no retracing is required.

## Test plan
- [x] `check_style_OpenEnroth`, `check_style_engine_objects`, `check_style_test_engine_objects` all clean.
- [x] `engine_objects`, `test_engine_objects`, `OpenEnroth_GameTest` build clean.
- [x] `OpenEnroth_UnitTest`: 378 / 378 pass.
- [x] `Run_GameTest_Headless_Parallel`: 324 / 324 pass against MM7 v1.1 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)