### PR TITLE
Fix and test #2502

### DIFF
--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -111,6 +111,40 @@ static tl::generator<Character &> iterateCharacters(EvtTargetCharacter who, Rand
     }
 }
 
+/**
+ * @return                              `true` if the supplied EVENT_Compare variable describes a transient
+ *                                      character status that should not be evaluated against dead, petrified
+ *                                      or eradicated party members (e.g. the Haste Pedestal on Emerald Island
+ *                                      asks whether every character is rested - a dead party member can never
+ *                                      be rested, so leaving them out of the check matches player expectations).
+ *                                      Returns `false` for VAR_Dead, VAR_Stoned and VAR_Eradicated, where a
+ *                                      script may legitimately want to query those very states.
+ *
+ *                                      See issue #2502.
+ */
+static bool isTransientConditionVariable(EvtVariable variable) {
+    switch (variable) {
+        case VAR_Cursed:
+        case VAR_Weak:
+        case VAR_Asleep:
+        case VAR_Afraid:
+        case VAR_Drunk:
+        case VAR_Insane:
+        case VAR_PoisonedGreen:
+        case VAR_DiseasedGreen:
+        case VAR_PoisonedYellow:
+        case VAR_DiseasedYellow:
+        case VAR_PoisonedRed:
+        case VAR_DiseasedRed:
+        case VAR_Paralyzed:
+        case VAR_Unconsious:
+        case VAR_MajorCondition:
+            return true;
+        default:
+            return false;
+    }
+}
+
 int EvtInterpreter::executeOneEvent(int step, bool isNpc) {
     EvtInstruction ir;
     bool stepFound = false;
@@ -296,11 +330,19 @@ int EvtInterpreter::executeOneEvent(int step, bool isNpc) {
         case EVENT_SetSprite:
             setDecorationSprite(ir.data.sprite_texture_descr.cog, ir.data.sprite_texture_descr.hide, ir.str);
             break;
-        case EVENT_Compare:
-            for (Character &character : iterateCharacters(_who, grng))
+        case EVENT_Compare: {
+            // For transient condition checks, exclude dead/petrified/eradicated party members - these characters
+            // cannot satisfy "all members rested" style triggers (e.g. the Haste Pedestal on Emerald Island)
+            // because resting does not clear conditions on dead members. See issue #2502.
+            bool skipNonAlive = isTransientConditionVariable(ir.data.variable_descr.type);
+            for (Character &character : iterateCharacters(_who, grng)) {
+                if (skipNonAlive && !character.isAlive())
+                    continue;
                 if (character.CompareVariable(ir.data.variable_descr.type, ir.data.variable_descr.value))
                     return ir.target_step;
+            }
             break;
+        }
         case EVENT_ChangeDoorState:
             switchDoorAnimation(ir.data.door_descr.door_id, ir.data.door_descr.door_action);
             break;

--- a/src/Engine/Objects/CMakeLists.txt
+++ b/src/Engine/Objects/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(engine_objects PUBLIC engine gui library_random library_co
 
 if(OE_BUILD_TESTS)
     set(TEST_ENGINE_OBJECTS_SOURCES
+            Tests/Character_ut.cpp
             Tests/Inventory_ut.cpp
             Tests/MonsterEnumFunctions_ut.cpp)
 

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6236,6 +6236,10 @@ bool Character::IsDrunk() const {
     return this->conditions.has(CONDITION_DRUNK);
 }
 
+bool Character::isAlive() const {
+    return !IsDead() && !IsPetrified() && !IsEradicated();
+}
+
 void Character::SetCondWeakWithBlockCheck(int blockable) {
     SetCondition(CONDITION_WEAK, blockable);
 }

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -252,6 +252,14 @@ class Character {
     bool IsParalyzed() const;
     bool IsDrunk() const;
 
+    /**
+     * @return                              `true` if the character is not dead, petrified, or eradicated.
+     *                                      Such characters cannot participate in event-driven party status checks
+     *                                      (e.g. the Haste Pedestal on Emerald Island only requires the "active"
+     *                                      party members to be rested).
+     */
+    bool isAlive() const;
+
     void SetCondWeakWithBlockCheck(int blockable);
     void SetCondInsaneWithBlockCheck(int blockable);
     void SetCondDeadWithBlockCheck(int blockable);

--- a/src/Engine/Objects/Tests/Character_ut.cpp
+++ b/src/Engine/Objects/Tests/Character_ut.cpp
@@ -1,0 +1,76 @@
+#include "Testing/Game/GameTest.h"
+
+#include "Engine/Objects/Character.h"
+
+// Regression test for issue #2502 - dead/petrified/eradicated party members should be excluded from
+// triggered status checks (e.g. the Haste Pedestal on Emerald Island).
+
+GAME_TEST(Character, IsAliveByDefault) {
+    // A freshly constructed character has no conditions and is considered alive.
+    Character character;
+    EXPECT_TRUE(character.isAlive());
+}
+
+GAME_TEST(Character, IsAliveWithMinorConditions) {
+    // Transient conditions like weakness, sleep or curse do not make the character "not alive".
+    Character character;
+
+    character.conditions.set(CONDITION_WEAK, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive());
+
+    character.conditions.set(CONDITION_CURSED, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive());
+
+    character.conditions.set(CONDITION_SLEEP, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive());
+
+    character.conditions.set(CONDITION_PARALYZED, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive());
+
+    character.conditions.set(CONDITION_UNCONSCIOUS, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive()); // Unconscious is recoverable, party members can still be revived by rest.
+}
+
+GAME_TEST(Character, IsAliveExcludesDead) {
+    // Dead characters are not alive, even if they also carry a stacked minor condition like weakness.
+    Character character;
+
+    character.conditions.set(CONDITION_DEAD, Time::fromTicks(1));
+    EXPECT_FALSE(character.isAlive());
+
+    // The bug from issue #2502: a character that became weak before dying still carries CONDITION_WEAK
+    // alongside CONDITION_DEAD because resting does not clear conditions on dead members.
+    character.conditions.set(CONDITION_WEAK, Time::fromTicks(1));
+    EXPECT_FALSE(character.isAlive());
+}
+
+GAME_TEST(Character, IsAliveExcludesPetrified) {
+    Character character;
+    character.conditions.set(CONDITION_PETRIFIED, Time::fromTicks(1));
+    EXPECT_FALSE(character.isAlive());
+}
+
+GAME_TEST(Character, IsAliveExcludesEradicated) {
+    Character character;
+    character.conditions.set(CONDITION_ERADICATED, Time::fromTicks(1));
+    EXPECT_FALSE(character.isAlive());
+}
+
+GAME_TEST(Character, IsAliveZombie) {
+    // Zombie characters are functional party members, they remain alive for the purposes of status checks.
+    Character character;
+    character.conditions.set(CONDITION_ZOMBIE, Time::fromTicks(1));
+    EXPECT_TRUE(character.isAlive());
+}
+
+GAME_TEST(Character, CompareWeakSkipsDeadCharacter) {
+    // Per-character predicate that the pedestal event loop relies on. A character carrying both
+    // CONDITION_DEAD and CONDITION_WEAK still reports as weak through CompareVariable - the bug fix
+    // skips such characters at the event-loop iteration level (see EvtInterpreter::EVENT_Compare).
+    Character character;
+    character.conditions.set(CONDITION_WEAK, Time::fromTicks(1));
+    character.conditions.set(CONDITION_DEAD, Time::fromTicks(1));
+
+    EXPECT_TRUE(character.CompareVariable(VAR_Weak, 0));
+    EXPECT_FALSE(character.isAlive());
+}


### PR DESCRIPTION
A character that became weak and then died still carries `CONDITION_WEAK` alongside `CONDITION_DEAD`, because `Party::restAndHeal` early-outs for dead, petrified and eradicated members and never clears their stacked transient conditions. The Haste Pedestal on Emerald Island (and any other event-driven "is the whole party rested?" trigger) iterates the party via `EVENT_Compare` and was treating such a dead member as still being weak, so the pedestal never fired.

This PR excludes dead/petrified/eradicated characters from `EVENT_Compare` iteration when the variable being tested is a transient condition (`VAR_Cursed` through `VAR_Unconsious` and `VAR_MajorCondition`). `VAR_Dead`, `VAR_Stoned` and `VAR_Eradicated` still see all party members, so scripts that legitimately query those states keep working.

Adds `Character::isAlive()` and unit tests covering the predicate plus the specific Weak+Dead stacking scenario from the bug report.

Fixes #2502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)