### PR TITLE
Fix and test #2144

### DIFF
--- a/src/Engine/Objects/CMakeLists.txt
+++ b/src/Engine/Objects/CMakeLists.txt
@@ -57,7 +57,8 @@ target_link_libraries(engine_objects PUBLIC engine gui library_random library_co
 if(OE_BUILD_TESTS)
     set(TEST_ENGINE_OBJECTS_SOURCES
             Tests/Inventory_ut.cpp
-            Tests/MonsterEnumFunctions_ut.cpp)
+            Tests/MonsterEnumFunctions_ut.cpp
+            Tests/Monsters_ut.cpp)
 
     add_library(test_engine_objects OBJECT ${TEST_ENGINE_OBJECTS_SOURCES})
     target_link_libraries(test_engine_objects PUBLIC testing_unit engine_objects)

--- a/src/Engine/Objects/Monsters.cpp
+++ b/src/Engine/Objects/Monsters.cpp
@@ -143,11 +143,14 @@ void ParseDamage(std::string_view damage_str, uint8_t *dice_rolls,
 
 //----- (00454E3A) --------------------------------------------------------
 MonsterProjectile ParseMissleAttackType(std::string_view missle_attack_str) {
-    // TODO(captainurist): this is broken, we get "FireAr" for flaming arrow here.
+    // monsters.txt stores the flaming-arrow cell value as the 6-character abbreviation "FireAr"
+    // (e.g. for Elite Archer / Bowman). The original engine compared against this exact spelling,
+    // but earlier OE ports mistakenly checked "ARROWF", which never matches the real data, so
+    // fire-arrow archers were silently falling back to MONSTER_PROJECTILE_NONE. See issue #2144.
 
     if (ascii::noCaseEquals(missle_attack_str, "ARROW"))
         return MONSTER_PROJECTILE_ARROW;
-    else if (ascii::noCaseEquals(missle_attack_str, "ARROWF"))
+    else if (ascii::noCaseEquals(missle_attack_str, "FireAr"))
         return MONSTER_PROJECTILE_FLAMING_ARROW;
     else if (ascii::noCaseEquals(missle_attack_str, "FIRE"))
         return MONSTER_PROJECTILE_FIRE_BOLT;

--- a/src/Engine/Objects/Tests/Monsters_ut.cpp
+++ b/src/Engine/Objects/Tests/Monsters_ut.cpp
@@ -1,0 +1,36 @@
+#include <string_view>
+
+#include "Testing/Game/GameTest.h"
+
+#include "Engine/Objects/MonsterEnums.h"
+
+// Forward declaration. `ParseMissleAttackType` is defined in Monsters.cpp without
+// being exposed through Monsters.h, but it has external linkage, so we can pull
+// it in for the unit test.
+MonsterProjectile ParseMissleAttackType(std::string_view missle_attack_str);
+
+GAME_TEST(Monsters, ParseMissleAttackTypeFlamingArrow) {
+    // Regression test for issue #2144.
+    // monsters.txt stores the flaming-arrow projectile column as the 6-char abbreviation
+    // "FireAr" (this is the actual cell value for e.g. Elite Archer and Bowman). The parser
+    // used to compare against "ARROWF", which never matched, so fire-arrow archers silently
+    // fell back to MONSTER_PROJECTILE_NONE.
+    EXPECT_EQ(ParseMissleAttackType("FireAr"), MONSTER_PROJECTILE_FLAMING_ARROW);
+    // The comparison is case-insensitive, matching the original engine's behavior.
+    EXPECT_EQ(ParseMissleAttackType("firear"), MONSTER_PROJECTILE_FLAMING_ARROW);
+    EXPECT_EQ(ParseMissleAttackType("FIREAR"), MONSTER_PROJECTILE_FLAMING_ARROW);
+
+    // Spot-check the other archer cell so we don't regress the happy path.
+    EXPECT_EQ(ParseMissleAttackType("Arrow"), MONSTER_PROJECTILE_ARROW);
+    EXPECT_EQ(ParseMissleAttackType("ARROW"), MONSTER_PROJECTILE_ARROW);
+
+    // And a few elemental bolts to make sure we didn't break anything else.
+    EXPECT_EQ(ParseMissleAttackType("Fire"), MONSTER_PROJECTILE_FIRE_BOLT);
+    EXPECT_EQ(ParseMissleAttackType("Water"), MONSTER_PROJECTILE_WATER_BOLT);
+    EXPECT_EQ(ParseMissleAttackType("Ener"), MONSTER_PROJECTILE_ENERGY_BOLT);
+
+    // Unknown / empty inputs should fall back to NONE.
+    EXPECT_EQ(ParseMissleAttackType(""), MONSTER_PROJECTILE_NONE);
+    EXPECT_EQ(ParseMissleAttackType("ARROWF"), MONSTER_PROJECTILE_NONE);
+    EXPECT_EQ(ParseMissleAttackType("nonsense"), MONSTER_PROJECTILE_NONE);
+}


### PR DESCRIPTION
Elite Archers and Bowmen never fired fire arrows because the monsters.txt projectile cell for that case is the 6-character abbreviation `"FireAr"`, while `ParseMissleAttackType` was comparing against `"ARROWF"`, which never matched. The parser silently fell back to `MONSTER_PROJECTILE_NONE`, so all fire-arrow archer attacks were dropped before `SpriteForMonsterProjectile` could route them.

Match `"FireAr"` instead, replace the stale TODO with a note pointing at the bug history, and add a unit test that locks in the matched and unmatched cases.

Fixes #2144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)