### PR TITLE
Fix and test #1698

### DIFF
--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -532,6 +532,17 @@ void SpellStats::Initialize(const Blob &spells) {
                           SPELL_MIND_MASS_FEAR, SPELL_LIGHT_PRISMATIC_LIGHT, SPELL_DARK_ARMAGEDDON}) {
         pSpellDatas[spell].flags &= ~SPELL_SHIFT_CLICK_CASTABLE;
     }
+
+    // Vanilla bug fix: Control Undead is a Dark Magic spell, but its description in spells.txt
+    // states the duration scales with "Mind Magic". See issue #1698. The replacement is a no-op
+    // for localizations that don't contain the English wording.
+    // TODO(captainurist): these strings are translatable; move this fix into the patched data files.
+    SpellInfo &controlUndead = pInfos[SPELL_DARK_CONTROL_UNDEAD];
+    controlUndead.pDescription = replaceAll(controlUndead.pDescription, "Mind Magic", "Dark Magic");
+    controlUndead.pBasicSkillDesc = replaceAll(controlUndead.pBasicSkillDesc, "Mind Magic", "Dark Magic");
+    controlUndead.pExpertSkillDesc = replaceAll(controlUndead.pExpertSkillDesc, "Mind Magic", "Dark Magic");
+    controlUndead.pMasterSkillDesc = replaceAll(controlUndead.pMasterSkillDesc, "Mind Magic", "Dark Magic");
+    controlUndead.pGrandmasterSkillDesc = replaceAll(controlUndead.pGrandmasterSkillDesc, "Mind Magic", "Dark Magic");
 }
 
 void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3f from, Vec3f to) {

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -10,6 +10,7 @@
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Data/ItemData.h"
 #include "Engine/Spells/CastSpellInfo.h"
+#include "Engine/Spells/Spells.h"
 #include "Engine/Engine.h"
 #include "Engine/Random/Random.h"
 #include "Engine/Resources/EngineFileSystem.h"
@@ -331,6 +332,20 @@ GAME_TEST(Issues, Issue1685) {
 
     EXPECT_EQ(jar1.GetIdentifiedName(), "Kolya's Jar");
     EXPECT_EQ(jar2.GetIdentifiedName(), "Nicholas' Jar");
+}
+
+GAME_TEST(Issues, Issue1698) {
+    // Control Undead is a Dark Magic spell, but its vanilla description erroneously
+    // references Mind Magic (patched post-load in SpellStats::Initialize, issue #1698).
+    // The fix replaces those occurrences in every description string for
+    // SPELL_DARK_CONTROL_UNDEAD. For non-English locales the source text does not
+    // contain the English wording, so the assertions below pass vacuously.
+    const SpellInfo &controlUndead = pSpellStats->pInfos[SPELL_DARK_CONTROL_UNDEAD];
+    EXPECT_FALSE(controlUndead.pDescription.contains("Mind Magic"));
+    EXPECT_FALSE(controlUndead.pBasicSkillDesc.contains("Mind Magic"));
+    EXPECT_FALSE(controlUndead.pExpertSkillDesc.contains("Mind Magic"));
+    EXPECT_FALSE(controlUndead.pMasterSkillDesc.contains("Mind Magic"));
+    EXPECT_FALSE(controlUndead.pGrandmasterSkillDesc.contains("Mind Magic"));
 }
 
 GAME_TEST(Issues, Issue1721) {


### PR DESCRIPTION
Control Undead is a Dark Magic spell, but vanilla spells.txt describes its duration as scaling with "Mind Magic". Patch the loaded description text after parsing so the in-game spell book and right-click popup show the correct school. The string replace is locale-safe: it's a no-op for localizations that don't carry the English wording.

Adds a test verifying that no description string for `SPELL_DARK_CONTROL_UNDEAD` mentions "Mind Magic" after loading.

Fixes #1698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)