### PR TITLE
Fix and test #1494, #1495, #1496

### DIFF
--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -519,6 +519,7 @@ void SpellStats::Initialize(const Blob &spells) {
     }
 
     // Patch SPELL_SHIFT_CLICK_CASTABLE flags that are bogus in vanilla spells.txt. See issues #1494, #1495, #1496.
+    // TODO(captainurist): move these flag patches into the patched data tables instead of hardcoding them here.
     // These spells target a single actor and should be quick-castable on shift+click.
     for (SpellId spell : {SPELL_WATER_POISON_SPRAY, SPELL_LIGHT_LIGHT_BOLT, SPELL_LIGHT_DESTROY_UNDEAD, SPELL_LIGHT_PARALYZE}) {
         pSpellDatas[spell].flags |= SPELL_SHIFT_CLICK_CASTABLE;

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -517,6 +517,20 @@ void SpellStats::Initialize(const Blob &spells) {
         pSpellDatas[uSpellID].flags |= tokens[10].contains('c') || tokens[10].contains('C') ? SPELL_SHIFT_CLICK_CASTABLE : SpellFlag();
         pSpellDatas[uSpellID].flags |= tokens[10].contains('x') || tokens[10].contains('X') ? SPELL_FLAG_8 : SpellFlag();
     }
+
+    // Patch SPELL_SHIFT_CLICK_CASTABLE flags that are bogus in vanilla spells.txt. See issues #1494, #1495, #1496.
+    // These spells target a single actor and should be quick-castable on shift+click.
+    for (SpellId spell : {SPELL_WATER_POISON_SPRAY, SPELL_LIGHT_LIGHT_BOLT, SPELL_LIGHT_DESTROY_UNDEAD, SPELL_LIGHT_PARALYZE}) {
+        pSpellDatas[spell].flags |= SPELL_SHIFT_CLICK_CASTABLE;
+    }
+    // These spells target the casting party or a party member and should NOT be quick-castable on shift+click.
+    // For party-target spells the shift+click cast is also confusing because nothing visible happens at the
+    // clicked actor; for character-target spells (Cure Paralysis) the player gets a target-character prompt
+    // that doesn't relate to the clicked actor.
+    for (SpellId spell : {SPELL_MIND_CURE_PARALYSIS, SPELL_LIGHT_DAY_OF_PROTECTION, SPELL_LIGHT_HOUR_OF_POWER,
+                          SPELL_MIND_MASS_FEAR, SPELL_LIGHT_PRISMATIC_LIGHT, SPELL_DARK_ARMAGEDDON}) {
+        pSpellDatas[spell].flags &= ~SPELL_SHIFT_CLICK_CASTABLE;
+    }
 }
 
 void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3f from, Vec3f to) {

--- a/src/Engine/Spells/Tests/Spells_ut.cpp
+++ b/src/Engine/Spells/Tests/Spells_ut.cpp
@@ -59,3 +59,28 @@ GAME_TEST(Spells, PsychicShockDamageFormula) {
     }
     grng = savedGrng;
 }
+
+// Tests that SPELL_SHIFT_CLICK_CASTABLE is patched up in SpellStats::Initialize. Issues: #1494, #1495, #1496.
+GAME_TEST(Spells, ShiftClickCastableFlags) {
+    // #1494: these spells target a single actor and must be quick-castable on shift+click.
+    EXPECT_TRUE(IsSpellQuickCastableOnShiftClick(SPELL_WATER_POISON_SPRAY));
+    EXPECT_TRUE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_LIGHT_BOLT));
+    EXPECT_TRUE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_DESTROY_UNDEAD));
+    EXPECT_TRUE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_PARALYZE));
+
+    // #1495: these spells target the party or a party member; they must NOT be quick-castable on shift+click.
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_MIND_CURE_PARALYSIS));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_DAY_OF_PROTECTION));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_HOUR_OF_POWER));
+
+    // #1496: the all-in-sight AoE spells are inconsistent in vanilla; we standardize on
+    // "not castable" since the only way to indicate the target is by clicking an actor,
+    // and the spell ignores that target anyway.
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_MIND_MASS_FEAR));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_PRISMATIC_LIGHT));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_DARK_ARMAGEDDON));
+    // Spells in the same all-in-sight group that were already not quick-castable in vanilla:
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_SPIRIT_TURN_UNDEAD));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_DARK_SOULDRINKER));
+    EXPECT_FALSE(IsSpellQuickCastableOnShiftClick(SPELL_LIGHT_DISPEL_MAGIC));
+}


### PR DESCRIPTION
Patch `SPELL_SHIFT_CLICK_CASTABLE` flags loaded from vanilla spells.txt that don't match player expectations:

* #1494: add the quick-cast flag to Poison Spray, Light Bolt, Destroy Undead and Paralyze — they all target a single actor and should behave like Fire Bolt / Sparks on shift+click.
* #1495: remove the quick-cast flag from Cure Paralysis, Day of Protection and Hour of Power — they target the party or a party member, not an actor, so the shift+click cast is confusing or pops up a character picker unrelated to the clicked actor.
* #1496: standardize the all-in-sight AoE spells (Mass Fear, Prismatic Light, Armageddon) as not shift+click castable, matching the rest of that group (Turn Undead, Souldrinker, Dispel Magic).

The test locks in the flag state for all affected spells.

Fixes #1494. Fixes #1495. Fixes #1496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)