### PR TITLE
Add regression test for #987: grandmaster teacher promotions

### DIFF
--- a/src/Engine/Objects/CMakeLists.txt
+++ b/src/Engine/Objects/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(engine_objects PUBLIC engine gui library_random library_co
 
 if(OE_BUILD_TESTS)
     set(TEST_ENGINE_OBJECTS_SOURCES
+            Tests/Character_ut.cpp
             Tests/Inventory_ut.cpp
             Tests/MonsterEnumFunctions_ut.cpp)
 

--- a/src/Engine/Objects/Tests/Character_ut.cpp
+++ b/src/Engine/Objects/Tests/Character_ut.cpp
@@ -1,0 +1,36 @@
+#include "Testing/Game/GameTest.h"
+
+#include "Engine/Party.h"
+#include "GUI/UI/NPCTopics.h"
+
+namespace {
+
+void expectGrandmasterTrainingAvailable(Class classType, Skill skill) {
+    Character &character = pParty->activeCharacter();
+    character.classType = classType;
+    character.setSkillValue(skill, CombinedSkillValue(10, MASTERY_MASTER));
+    pParty->SetGold(100000);
+
+    NPCData teacher;
+    teacher.dialogue_1_evt_id = 200 + 3 * std::to_underlying(skill) + 2;
+    ASSERT_EQ(handleScriptedNPCTopicSelection(DIALOGUE_SCRIPTED_LINE_1, &teacher),
+              DIALOGUE_MASTERY_TEACHER_OFFER);
+
+    npcDialogueOptionString(DIALOGUE_MASTERY_TEACHER_LEARN, &teacher);
+    selectSpecialNPCTopicSelection(DIALOGUE_MASTERY_TEACHER_LEARN, &teacher);
+
+    EXPECT_EQ(character.getSkillValue(skill).mastery(), MASTERY_GRANDMASTER);
+}
+
+}  // namespace
+
+GAME_TEST(Issues, Issue987) {
+    // Light and Dark grandmaster teachers should accept either corresponding final promotion.
+    game.startNewGame();
+    game.tick(2);
+
+    expectGrandmasterTrainingAvailable(CLASS_ARCHAMGE, SKILL_LIGHT);
+    expectGrandmasterTrainingAvailable(CLASS_PRIEST_OF_SUN, SKILL_LIGHT);
+    expectGrandmasterTrainingAvailable(CLASS_LICH, SKILL_DARK);
+    expectGrandmasterTrainingAvailable(CLASS_PRIEST_OF_MOON, SKILL_DARK);
+}


### PR DESCRIPTION
## Summary

Adds a regression game test for Light and Dark grandmaster teacher eligibility. The test exercises the production NPC dialogue and training flow for each valid final promotion—Archmage, Priest of the Sun, Lich, and Priest of the Moon—and verifies that training upgrades the corresponding skill to grandmaster.

This specifically locks in the `either promotion` behavior fixed for #987, and would fail if either production predicate regressed from `||` to `&&`.

Fixes #987.

## Validation

- `check_style`
- `Run_UnitTest` — 378/378 passed
- `Run_GameTest_Headless_Parallel` — passed

🤖 AI-assisted with [Codex](https://openai.com/codex/)