### PR TITLE
Refactored savegame list handling

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1528,8 +1528,8 @@ void Game::gameLoop() {
     SetCurrentMenuID(MENU_NONE);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        assert(engine->_pendingLoadSlot != -1);
-        loadGame(std::exchange(engine->_pendingLoadSlot, -1));
+        assert(!engine->_pendingLoadFileName.empty());
+        loadGame(std::exchange(engine->_pendingLoadFileName, {}));
     }
 
     extern bool use_music_folder;

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1526,8 +1526,8 @@ void Game::gameLoop() {
     SetCurrentMenuID(MENU_NONE);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        assert(engine->_pendingLoadSlot != -1);
-        loadGame(std::exchange(engine->_pendingLoadSlot, -1));
+        assert(!engine->_pendingLoadFileName.empty());
+        loadGame(std::exchange(engine->_pendingLoadFileName, {}));
     }
 
     extern bool use_music_folder;

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1526,7 +1526,8 @@ void Game::gameLoop() {
     SetCurrentMenuID(MENU_NONE);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        loadGame(pSavegameList->selectedSlot);
+        assert(engine->_pendingLoadSlot != -1);
+        loadGame(std::exchange(engine->_pendingLoadSlot, -1));
     }
 
     extern bool use_music_folder;

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1528,7 +1528,8 @@ void Game::gameLoop() {
     SetCurrentMenuID(MENU_NONE);
     if (bLoading) {
         uGameState = GAME_STATE_PLAYING;
-        loadGame(pSavegameList->selectedSlot);
+        assert(engine->_pendingLoadSlot != -1);
+        loadGame(std::exchange(engine->_pendingLoadSlot, -1));
     }
 
     extern bool use_music_folder;

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -253,9 +253,6 @@ class GameConfig : public Config {
             "Recovery time modifier when spell casting ended in failure for the reason where spell cannot be cast at all in current context. "
             "Context include situation where outdoor spell is casted indoor or targeted spell is casted with no characters on screen."};
 
-        String QuickSaveName = {this, "quick_saves_name", "quicksave",
-            "What name to use to store the quick saves as."};
-
         Int QuickSavesCount = {this, "quick_saves_count", 4, &ValidateQuickSaveCount,
             "How many quick saves have currently been used."
             "This will rotate back to 0 when 5 saves has been reached."};

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -250,9 +250,6 @@ class GameConfig : public Config {
             "Recovery time modifier when spell casting ended in failure for the reason where spell cannot be cast at all in current context. "
             "Context include situation where outdoor spell is casted indoor or targeted spell is casted with no characters on screen."};
 
-        String QuickSaveName = {this, "quick_saves_name", "quicksave",
-            "What name to use to store the quick saves as."};
-
         Int QuickSavesCount = {this, "quick_saves_count", 4, &ValidateQuickSaveCount,
             "How many quick saves have currently been used."
             "This will rotate back to 0 when 5 saves has been reached."};

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -137,17 +137,23 @@ void Menu::EventLoop() {
                     keyboardInputHandler->EndTextInput();
 
                 if (current_screen_type == SCREEN_SAVEGAME) {
-                    if (pSavegameList->selectedSlot != pSavegameList->saveListPosition + param) {
-                        pSavegameList->selectedSlot = pSavegameList->saveListPosition + param;
+                    int position = pSavegameList->saveListPosition + param;
+                    if (position >= pSavegameList->saveMenuSlotCount())
+                        continue; // Clicked below the last slot.
+                    int slot = pSavegameList->saveMenuSlot(position);
+                    if (pSavegameList->selectedSlot != slot) {
+                        pSavegameList->selectedSlot = slot;
                     } else {
                         keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
-                        if (pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name != localization->str(LSTR_EMPTY_SAVE)) {
-                            keyboardInputHandler->SetTextInput(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name);
-                        }
+                        if (pSavegameList->isSlotUsed(slot))
+                            keyboardInputHandler->SetTextInput(pSavegameList->slots[slot].header.name);
                     }
                 } else {
-                    if (!isLoadSlotClicked || pSavegameList->selectedSlot != pSavegameList->saveListPosition + param) {
-                        pSavegameList->selectedSlot = pSavegameList->saveListPosition + param;
+                    int slot = pSavegameList->saveListPosition + param;
+                    if (slot >= pSavegameList->numSavegameFiles)
+                        continue; // Clicked below the last save.
+                    if (!isLoadSlotClicked || pSavegameList->selectedSlot != slot) {
+                        pSavegameList->selectedSlot = slot;
                         isLoadSlotClicked = true;
                     } else {
                         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
@@ -155,7 +161,7 @@ void Menu::EventLoop() {
                 }
                 continue;
             case UIMSG_LoadGame:
-                if (pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
+                if (pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
                     loadGame(pSavegameList->selectedSlot);
                     uGameState = GAME_STATE_LOADING_GAME;
                 }
@@ -163,8 +169,15 @@ void Menu::EventLoop() {
             case UIMSG_SaveGame:
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
                 if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
-                    pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name = keyboardInputHandler->GetTextInput();
+                    if (keyboardInputHandler->GetTextInput().empty())
+                        continue; // Saves need a name, keep the input open.
+                    pSavegameList->slots[pSavegameList->selectedSlot].header.name = keyboardInputHandler->GetTextInput();
                     keyboardInputHandler->EndTextInput();
+                } else if (!pSavegameList->isSlotUsed(pSavegameList->selectedSlot) &&
+                           pSavegameList->slots[pSavegameList->selectedSlot].header.name.empty()) {
+                    // Don't just save into the new save slot, ask for the save name first.
+                    keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
+                    continue;
                 }
                 doSavegame(pSavegameList->selectedSlot);
                 continue;
@@ -413,6 +426,12 @@ void Menu::EventLoop() {
                 continue;
             case UIMSG_QuickLoad:
                 quickLoadGame();
+                if (current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME) {
+                    // Failed quickload has reinitialized the list under the open menu, reload the headers.
+                    loadSaveHeaders();
+                    if (current_screen_type == SCREEN_SAVEGAME)
+                        pSavegameList->selectedSlot = pSavegameList->numSavegameFiles;
+                }
                 break;
             default:
                 break;

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -84,11 +84,6 @@ void Game_OpenLoadGameDialog() {
     pGUIWindow_CurrentMenu = std::make_unique<GUIWindow_Load>(true);
 }
 
-static GUIWindow_SaveLoad *saveLoadMenu() {
-    assert(current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME);
-    return static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-}
-
 Menu::Menu() {
     mouse = EngineIocContainer::ResolveMouse();
 }

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -161,7 +161,7 @@ void Menu::EventLoop() {
                 continue;
             }
             case UIMSG_SaveLoadScroll:
-                saveLoadMenu()->scrollWithMouse();
+                saveLoadMenu()->scrollWithMouse(mouse->position());
                 continue;
             case UIMSG_Game_OpenOptionsDialog:  // Open
             {

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -133,25 +133,25 @@ void Menu::EventLoop() {
                 saveLoadMenu()->slotClicked(param);
                 continue;
             case UIMSG_LoadGame:
-                if (int slot = saveLoadMenu()->selectedSlot(); pSavegameList->isSlotUsed(slot)) {
-                    loadGame(slot);
+                if (saveLoadMenu()->hasSelectedSlot()) {
+                    loadGame(saveLoadMenu()->selectedSlot().fileName);
                     uGameState = GAME_STATE_LOADING_GAME;
                 }
                 continue;
             case UIMSG_SaveGame: {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-                int slot = saveLoadMenu()->selectedSlot();
+                GUIWindow_SaveLoad *menu = saveLoadMenu();
                 if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
                     if (keyboardInputHandler->GetTextInput().empty())
                         continue; // Saves need a name, keep the input open.
-                    pSavegameList->setSlotName(slot, keyboardInputHandler->GetTextInput());
+                    menu->setSelectedSlotName(keyboardInputHandler->GetTextInput());
                     keyboardInputHandler->EndTextInput();
-                } else if (!pSavegameList->isSlotUsed(slot) && pSavegameList->slots()[slot].header.name.empty()) {
+                } else if (menu->selectedSlot().fileName.empty() && menu->selectedSlot().header.name.empty()) {
                     // Don't just save into the new save slot, ask for the save name first.
                     keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
                     continue;
                 }
-                doSavegame(slot);
+                doSavegame(menu->selectedSlot().fileName, menu->selectedSlot().header.name);
                 continue;
             }
             case UIMSG_Game_OpenSaveGameDialog: {
@@ -384,12 +384,6 @@ void Menu::EventLoop() {
                 continue;
             case UIMSG_QuickLoad:
                 quickLoadGame();
-                if (current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME) {
-                    // Failed quickload has reinitialized the list under the open menu, reload the headers.
-                    pSavegameList->loadHeaders();
-                    if (current_screen_type == SCREEN_SAVEGAME)
-                        saveLoadMenu()->setSelectedSlot(pSavegameList->saveMenuSlots().front());
-                }
                 break;
             default:
                 break;

--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -40,9 +40,6 @@ enum class CurrentConfirmationState {
 };
 using enum CurrentConfirmationState;
 
-// TODO(Nik-RE-dev): drop variable and load game only on double click
-static bool isLoadSlotClicked = false;
-
 CurrentConfirmationState confirmationState = CONFIRM_NONE;
 
 InputAction currently_selected_action_for_binding = INPUT_ACTION_INVALID;  // 506E68
@@ -85,7 +82,11 @@ void Game_OpenLoadGameDialog() {
     // LoadUI_Load(1);
     current_screen_type = SCREEN_LOADGAME;
     pGUIWindow_CurrentMenu = std::make_unique<GUIWindow_Load>(true);
-    isLoadSlotClicked = false;
+}
+
+static GUIWindow_SaveLoad *saveLoadMenu() {
+    assert(current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME);
+    return static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
 }
 
 Menu::Menu() {
@@ -112,16 +113,12 @@ void Menu::EventLoop() {
                 continue;
 
             case UIMSG_ArrowUp:
-                --pSavegameList->saveListPosition;
-                if (pSavegameList->saveListPosition < 0)
-                    pSavegameList->saveListPosition = 0;
+                saveLoadMenu()->scrollUp();
                 new OnButtonClick({215, 199}, {17, 17}, pBtnArrowUp);
                 continue;
 
             case UIMSG_DownArrow:
-                if (pSavegameList->saveListPosition + 7 < param) {
-                    ++pSavegameList->saveListPosition;
-                }
+                saveLoadMenu()->scrollDown();
                 new OnButtonClick({215, 323}, {17, 17}, pBtnDownArrow);
                 continue;
 
@@ -133,54 +130,30 @@ void Menu::EventLoop() {
                 new OnSaveLoad({241, 302}, {106, 42}, pBtnLoadSlot);
                 continue;
             case UIMSG_SelectLoadSlot:
-                if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
-                    keyboardInputHandler->EndTextInput();
-
-                if (current_screen_type == SCREEN_SAVEGAME) {
-                    int position = pSavegameList->saveListPosition + param;
-                    if (position >= pSavegameList->saveMenuSlotCount())
-                        continue; // Clicked below the last slot.
-                    int slot = pSavegameList->saveMenuSlot(position);
-                    if (pSavegameList->selectedSlot != slot) {
-                        pSavegameList->selectedSlot = slot;
-                    } else {
-                        keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
-                        if (pSavegameList->isSlotUsed(slot))
-                            keyboardInputHandler->SetTextInput(pSavegameList->slots[slot].header.name);
-                    }
-                } else {
-                    int slot = pSavegameList->saveListPosition + param;
-                    if (slot >= pSavegameList->numSavegameFiles)
-                        continue; // Clicked below the last save.
-                    if (!isLoadSlotClicked || pSavegameList->selectedSlot != slot) {
-                        pSavegameList->selectedSlot = slot;
-                        isLoadSlotClicked = true;
-                    } else {
-                        engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
-                    }
-                }
+                saveLoadMenu()->slotClicked(param);
                 continue;
             case UIMSG_LoadGame:
-                if (pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
-                    loadGame(pSavegameList->selectedSlot);
+                if (int slot = saveLoadMenu()->selectedSlot(); pSavegameList->isSlotUsed(slot)) {
+                    loadGame(slot);
                     uGameState = GAME_STATE_LOADING_GAME;
                 }
                 continue;
-            case UIMSG_SaveGame:
+            case UIMSG_SaveGame: {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
+                int slot = saveLoadMenu()->selectedSlot();
                 if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS) {
                     if (keyboardInputHandler->GetTextInput().empty())
                         continue; // Saves need a name, keep the input open.
-                    pSavegameList->slots[pSavegameList->selectedSlot].header.name = keyboardInputHandler->GetTextInput();
+                    pSavegameList->setSlotName(slot, keyboardInputHandler->GetTextInput());
                     keyboardInputHandler->EndTextInput();
-                } else if (!pSavegameList->isSlotUsed(pSavegameList->selectedSlot) &&
-                           pSavegameList->slots[pSavegameList->selectedSlot].header.name.empty()) {
+                } else if (!pSavegameList->isSlotUsed(slot) && pSavegameList->slots()[slot].header.name.empty()) {
                     // Don't just save into the new save slot, ask for the save name first.
                     keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
                     continue;
                 }
-                doSavegame(pSavegameList->selectedSlot);
+                doSavegame(slot);
                 continue;
+            }
             case UIMSG_Game_OpenSaveGameDialog: {
                 if (engine->_currentLoadedMapId == MAP_ARENA) {
                     engine->_statusBar->setEvent(LSTR_NO_SAVING_IN_THE_ARENA);
@@ -192,24 +165,9 @@ void Menu::EventLoop() {
                 }
                 continue;
             }
-            case UIMSG_SaveLoadScroll: {
-                // pskelton add for scroll click
-                if (param < 7) {
-                    // Too few saves to scroll yet
-                    break;
-                }
-                Pointi mousePos = mouse->position();
-                int mx = mousePos.x, my = mousePos.y;
-                // 216 is offset down from top (216)
-                my -= 216;
-                // 107 is total height of bar
-                float fmy = static_cast<float>(my) / 107.0f;
-                int newlistpost = std::round((param - 7) * fmy);
-                newlistpost = std::clamp(newlistpost, 0, (param - 7));
-                pSavegameList->saveListPosition = newlistpost;
-                pAudioPlayer->playUISound(SOUND_StartMainChoice02);
+            case UIMSG_SaveLoadScroll:
+                saveLoadMenu()->scrollWithMouse();
                 continue;
-            }
             case UIMSG_Game_OpenOptionsDialog:  // Open
             {
                 engine->_messageQueue->clear();
@@ -428,9 +386,9 @@ void Menu::EventLoop() {
                 quickLoadGame();
                 if (current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME) {
                     // Failed quickload has reinitialized the list under the open menu, reload the headers.
-                    loadSaveHeaders();
+                    pSavegameList->loadHeaders();
                     if (current_screen_type == SCREEN_SAVEGAME)
-                        pSavegameList->selectedSlot = pSavegameList->numSavegameFiles;
+                        saveLoadMenu()->setSelectedSlot(pSavegameList->saveMenuSlots().front());
                 }
                 break;
             default:

--- a/src/Application/GameStates/LoadSlotState.cpp
+++ b/src/Application/GameStates/LoadSlotState.cpp
@@ -8,6 +8,7 @@
 #include "GUI/GUIMessageQueue.h"
 #include "GUI/GUIWindow.h"
 #include "GUI/UI/UISaveLoad.h"
+#include "Io/Mouse.h"
 
 LoadSlotState::LoadSlotState() = default;
 LoadSlotState::~LoadSlotState() = default;
@@ -61,7 +62,7 @@ FsmAction LoadSlotState::update() {
             return FsmAction::transition("back");
         }
         case UIMSG_SaveLoadScroll: {
-            _uiLoadSaveSlot->scrollWithMouse();
+            _uiLoadSaveSlot->scrollWithMouse(mouse->position());
             break;
         }
         case UIMSG_QuickLoad: {

--- a/src/Application/GameStates/LoadSlotState.cpp
+++ b/src/Application/GameStates/LoadSlotState.cpp
@@ -28,7 +28,7 @@ FsmAction LoadSlotState::update() {
         engine->_messageQueue->popMessage(&message, &param1, &param2);
         switch (message) {
         case UIMSG_LoadGame: {
-            if (!pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
+            if (!pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
                 break;
             }
             SetCurrentMenuID(MENU_LoadingProcInMainMenu);

--- a/src/Application/GameStates/LoadSlotState.cpp
+++ b/src/Application/GameStates/LoadSlotState.cpp
@@ -28,11 +28,9 @@ FsmAction LoadSlotState::update() {
         engine->_messageQueue->popMessage(&message, &param1, &param2);
         switch (message) {
         case UIMSG_LoadGame: {
-            int slot = _uiLoadSaveSlot->selectedSlot();
-            if (!pSavegameList->isSlotUsed(slot)) {
+            if (!_uiLoadSaveSlot->hasSelectedSlot())
                 break;
-            }
-            engine->_pendingLoadSlot = slot;
+            engine->_pendingLoadFileName = _uiLoadSaveSlot->selectedSlot().fileName;
             SetCurrentMenuID(MENU_LoadingProcInMainMenu);
             return FsmAction::transition("slotConfirmed");
         }

--- a/src/Application/GameStates/LoadSlotState.cpp
+++ b/src/Application/GameStates/LoadSlotState.cpp
@@ -28,14 +28,16 @@ FsmAction LoadSlotState::update() {
         engine->_messageQueue->popMessage(&message, &param1, &param2);
         switch (message) {
         case UIMSG_LoadGame: {
-            if (!pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
+            int slot = _uiLoadSaveSlot->selectedSlot();
+            if (!pSavegameList->isSlotUsed(slot)) {
                 break;
             }
+            engine->_pendingLoadSlot = slot;
             SetCurrentMenuID(MENU_LoadingProcInMainMenu);
             return FsmAction::transition("slotConfirmed");
         }
         case UIMSG_SelectLoadSlot: {
-            _uiLoadSaveSlot->slotSelected(param1);
+            _uiLoadSaveSlot->slotClicked(param1);
             break;
         }
         case UIMSG_SaveLoadBtn: {
@@ -43,7 +45,7 @@ FsmAction LoadSlotState::update() {
             break;
         }
         case UIMSG_DownArrow: {
-            _uiLoadSaveSlot->downArrowPressed(param1);
+            _uiLoadSaveSlot->downArrowPressed();
             break;
         }
         case UIMSG_ArrowUp: {
@@ -61,7 +63,7 @@ FsmAction LoadSlotState::update() {
             return FsmAction::transition("back");
         }
         case UIMSG_SaveLoadScroll: {
-            _uiLoadSaveSlot->scroll(param1);
+            _uiLoadSaveSlot->scrollWithMouse();
             break;
         }
         case UIMSG_QuickLoad: {

--- a/src/Application/GameStates/MainMenuState.cpp
+++ b/src/Application/GameStates/MainMenuState.cpp
@@ -59,7 +59,7 @@ FsmAction MainMenuState::update() {
             int slot = getQuickSaveSlot();
             if (slot != -1) {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-                pSavegameList->selectedSlot = slot;
+                engine->_pendingLoadSlot = slot;
                 SetCurrentMenuID(MENU_LoadingProcInMainMenu);
                 transition = "quickLoadGame";
             } else {

--- a/src/Application/GameStates/MainMenuState.cpp
+++ b/src/Application/GameStates/MainMenuState.cpp
@@ -3,6 +3,7 @@
 #include <Media/Audio/AudioPlayer.h>
 #include <Engine/Engine.h>
 #include <Engine/SaveLoad.h>
+#include <Engine/Resources/EngineFileSystem.h>
 #include <GUI/GUIMessageQueue.h>
 #include <GUI/GUIWindow.h>
 #include <GUI/UI/UIBranchlessDialogue.h>
@@ -10,6 +11,7 @@
 #include <Engine/Graphics/Renderer/Renderer.h>
 
 #include <memory>
+#include <string>
 
 MainMenuState::MainMenuState() {
 }
@@ -56,10 +58,10 @@ FsmAction MainMenuState::update() {
             transition = "exitGame";
             break;
         case UIMSG_QuickLoad: {
-            int slot = getQuickSaveSlot();
-            if (slot != -1) {
+            std::string fileName = getCurrentQuickSave();
+            if (ufs->exists(fmt::format("saves/{}", fileName))) {
                 pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-                engine->_pendingLoadSlot = slot;
+                engine->_pendingLoadFileName = fileName;
                 SetCurrentMenuID(MENU_LoadingProcInMainMenu);
                 transition = "quickLoadGame";
             } else {

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -237,10 +237,6 @@ void EngineController::loadGame(const Blob &savedGame) {
     goToMainMenu();
     pressGuiButton("MainMenu_LoadGame");
     tick(4);
-
-    assert(pSavegameList->slots()[0].isUsed);
-    assert(pSavegameList->slots()[0].fileName == "!!!save.mm7");
-
     pressGuiButton("LoadMenu_Slot0");
     tick(2);
     pressGuiButton("LoadMenu_Load");

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -239,12 +239,10 @@ void EngineController::loadGame(const Blob &savedGame) {
 
     goToMainMenu();
     pressGuiButton("MainMenu_LoadGame");
-    tick(3);
-    pSavegameList->saveListPosition = 0; // Make sure we start at the top of the list.
-    tick(1);
+    tick(4);
 
-    assert(pSavegameList->slots[0].isUsed);
-    assert(pSavegameList->slots[0].fileName == "!!!save.mm7");
+    assert(pSavegameList->slots()[0].isUsed);
+    assert(pSavegameList->slots()[0].fileName == "!!!save.mm7");
 
     pressGuiButton("LoadMenu_Slot0");
     tick(2);

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -236,12 +236,10 @@ void EngineController::loadGame(const Blob &savedGame) {
 
     goToMainMenu();
     pressGuiButton("MainMenu_LoadGame");
-    tick(3);
-    pSavegameList->saveListPosition = 0; // Make sure we start at the top of the list.
-    tick(1);
+    tick(4);
 
-    assert(pSavegameList->slots[0].isUsed);
-    assert(pSavegameList->slots[0].fileName == "!!!save.mm7");
+    assert(pSavegameList->slots()[0].isUsed);
+    assert(pSavegameList->slots()[0].fileName == "!!!save.mm7");
 
     pressGuiButton("LoadMenu_Slot0");
     tick(2);

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -240,8 +240,8 @@ void EngineController::loadGame(const Blob &savedGame) {
     pSavegameList->saveListPosition = 0; // Make sure we start at the top of the list.
     tick(1);
 
-    assert(pSavegameList->pSavegameUsedSlots[0]);
-    assert(pSavegameList->pFileList[0] == "!!!save.mm7");
+    assert(pSavegameList->slots[0].isUsed);
+    assert(pSavegameList->slots[0].fileName == "!!!save.mm7");
 
     pressGuiButton("LoadMenu_Slot0");
     tick(2);

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -243,8 +243,8 @@ void EngineController::loadGame(const Blob &savedGame) {
     pSavegameList->saveListPosition = 0; // Make sure we start at the top of the list.
     tick(1);
 
-    assert(pSavegameList->pSavegameUsedSlots[0]);
-    assert(pSavegameList->pFileList[0] == "!!!save.mm7");
+    assert(pSavegameList->slots[0].isUsed);
+    assert(pSavegameList->slots[0].fileName == "!!!save.mm7");
 
     pressGuiButton("LoadMenu_Slot0");
     tick(2);

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -240,10 +240,6 @@ void EngineController::loadGame(const Blob &savedGame) {
     goToMainMenu();
     pressGuiButton("MainMenu_LoadGame");
     tick(4);
-
-    assert(pSavegameList->slots()[0].isUsed);
-    assert(pSavegameList->slots()[0].fileName == "!!!save.mm7");
-
     pressGuiButton("LoadMenu_Slot0");
     tick(2);
     pressGuiButton("LoadMenu_Load");

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -133,6 +133,8 @@ class Engine {
     std::array<unsigned char, 50> _OE_transientVariables; // These are cleared on loading a new map
     MapId _currentLoadedMapId = MAP_INVALID;
     MapId _transitionMapId = MAP_INVALID;
+    std::string _lastLoadedSaveFileName; // File name of the last loaded savegame, pre-selected in the load menu.
+    int _pendingLoadSlot = -1; // Savegame slot to load when the main menu FSM exits into the game loop.
     TeleportPoint _teleportPoint;
     OverlaySystem &_overlaySystem;
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -133,7 +133,7 @@ class Engine {
     std::array<unsigned char, 50> _OE_transientVariables; // These are cleared on loading a new map
     MapId _currentLoadedMapId = MAP_INVALID;
     MapId _transitionMapId = MAP_INVALID;
-    std::string _lastLoadedSaveFileName; // File name of the last loaded savegame, pre-selected in the load menu.
+    std::string _lastLoadedSaveFileName; // File name of the last loaded savegame, pre-selected in the save & load menus.
     std::string _pendingLoadFileName; // Savegame to load when the main menu FSM exits into the game loop.
     TeleportPoint _teleportPoint;
     OverlaySystem &_overlaySystem;

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -134,7 +134,7 @@ class Engine {
     MapId _currentLoadedMapId = MAP_INVALID;
     MapId _transitionMapId = MAP_INVALID;
     std::string _lastLoadedSaveFileName; // File name of the last loaded savegame, pre-selected in the load menu.
-    int _pendingLoadSlot = -1; // Savegame slot to load when the main menu FSM exits into the game loop.
+    std::string _pendingLoadFileName; // Savegame to load when the main menu FSM exits into the game loop.
     TeleportPoint _teleportPoint;
     OverlaySystem &_overlaySystem;
 

--- a/src/Engine/Graphics/Image.h
+++ b/src/Engine/Graphics/Image.h
@@ -44,3 +44,11 @@ class GraphicsImage {
     RgbaImage _rgba;
     TextureRenderId _renderId;
 };
+
+struct GraphicsImageDeleter {
+    void operator()(GraphicsImage *image) const {
+        image->release();
+    }
+};
+
+using GraphicsImagePtr = std::unique_ptr<GraphicsImage, GraphicsImageDeleter>;

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -68,6 +68,7 @@ bool Localization::initialize() {
     this->_localizationStrings[LSTR_IMMOLATION_DAMAGE] = "Immolation deals %d damage to %d target(s)";
     this->_localizationStrings[LSTR_REMAINING_POWER] = "Remaining power: %d";
     this->_localizationStrings[LSTR_PLAYER_IS_NOT_ACTIVE] = "That player is not active";
+    this->_localizationStrings[LSTR_NEW_SAVE] = "[New Save]";
 
     this->_specialAttackNames[SPECIAL_ATTACK_CURSE] = "Curse";
     this->_specialAttackNames[SPECIAL_ATTACK_WEAK] = "Weaken";

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -69,6 +69,7 @@ bool Localization::initialize() {
     this->_localizationStrings[LSTR_REMAINING_POWER] = "Remaining power: %d";
     this->_localizationStrings[LSTR_PLAYER_IS_NOT_ACTIVE] = "That player is not active";
     this->_localizationStrings[LSTR_NEW_SAVE] = "[New Save]";
+    this->_localizationStrings[LSTR_QUICKSAVE] = "Quicksave";
 
     this->_specialAttackNames[SPECIAL_ATTACK_CURSE] = "Curse";
     this->_specialAttackNames[SPECIAL_ATTACK_WEAK] = "Weaken";

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -50,6 +50,7 @@ bool Localization::initialize() {
     this->_localizationStrings[LSTR_IMMOLATION_DAMAGE] = "Immolation deals %d damage to %d target(s)";
     this->_localizationStrings[LSTR_REMAINING_POWER] = "Remaining power: %d";
     this->_localizationStrings[LSTR_PLAYER_IS_NOT_ACTIVE] = "That player is not active";
+    this->_localizationStrings[LSTR_NEW_SAVE] = "[New Save]";
 
     this->_specialAttackNames[SPECIAL_ATTACK_CURSE] = "Curse";
     this->_specialAttackNames[SPECIAL_ATTACK_WEAK] = "Weaken";

--- a/src/Engine/Localization.cpp
+++ b/src/Engine/Localization.cpp
@@ -51,6 +51,7 @@ bool Localization::initialize() {
     this->_localizationStrings[LSTR_REMAINING_POWER] = "Remaining power: %d";
     this->_localizationStrings[LSTR_PLAYER_IS_NOT_ACTIVE] = "That player is not active";
     this->_localizationStrings[LSTR_NEW_SAVE] = "[New Save]";
+    this->_localizationStrings[LSTR_QUICKSAVE] = "Quicksave";
 
     this->_specialAttackNames[SPECIAL_ATTACK_CURSE] = "Curse";
     this->_specialAttackNames[SPECIAL_ATTACK_WEAK] = "Weaken";

--- a/src/Engine/LocalizationEnums.h
+++ b/src/Engine/LocalizationEnums.h
@@ -692,9 +692,10 @@ enum class LstrId {
     LSTR_REMAINING_POWER                = 686,  // "Remaining power: %d"
     LSTR_PLAYER_IS_NOT_ACTIVE           = 687,  // "That player is not active"
     LSTR_NEW_SAVE                       = 688,  // "[New Save]"
+    LSTR_QUICKSAVE                      = 689,  // "Quicksave"
 
     LSTR_FIRST = LSTR_AC,
-    LSTR_LAST = LSTR_NEW_SAVE,
+    LSTR_LAST = LSTR_QUICKSAVE,
 
     LSTR_FIRST_MM7 = LSTR_AC,
     LSTR_LAST_MM7 = LSTR_EVIL_ENDING,

--- a/src/Engine/LocalizationEnums.h
+++ b/src/Engine/LocalizationEnums.h
@@ -691,9 +691,10 @@ enum class LstrId {
     LSTR_IMMOLATION_DAMAGE              = 685,  // "Immolation deals %d damage to %d target(s)
     LSTR_REMAINING_POWER                = 686,  // "Remaining power: %d"
     LSTR_PLAYER_IS_NOT_ACTIVE           = 687,  // "That player is not active"
+    LSTR_NEW_SAVE                       = 688,  // "[New Save]"
 
     LSTR_FIRST = LSTR_AC,
-    LSTR_LAST = LSTR_PLAYER_IS_NOT_ACTIVE,
+    LSTR_LAST = LSTR_NEW_SAVE,
 
     LSTR_FIRST_MM7 = LSTR_AC,
     LSTR_LAST_MM7 = LSTR_EVIL_ENDING,

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -1,7 +1,7 @@
 #include "SaveLoad.h"
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <unordered_map>
 #include <string>
 #include <memory>
@@ -37,6 +37,9 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 
+#include "Utility/String/Ascii.h"
+#include "Utility/Exception.h"
+
 SavegameList *pSavegameList = new SavegameList;
 std::unordered_map<std::string, Blob> pMapDeltas;
 
@@ -46,8 +49,7 @@ void loadGame(int uSlot) {
         logger->warning("LoadGame: slot {} is empty", uSlot);
         return;
     }
-    pSavegameList->selectedSlot = uSlot;
-    pSavegameList->lastLoadedSave = pSavegameList->slots[uSlot].fileName;
+    engine->_lastLoadedSaveFileName = pSavegameList->slots()[uSlot].fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -56,7 +58,7 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->slots[uSlot].fileName);
+    std::string filename = fmt::format("saves/{}", pSavegameList->slots()[uSlot].fileName);
 
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
@@ -115,8 +117,6 @@ void loadGame(int uSlot) {
     engine->_transitionMapId = pMapStats->GetMapInfo(state.header.locationName);
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
-
-    pSavegameList->releaseThumbnails();
 
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
     // pAudioPlayer->SetMasterVolume(engine->config->sound_level);
@@ -192,20 +192,6 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
         return {};
     }
 
-    // saving - please wait
-
-    // if (current_screen_type == SCREEN_SAVEGAME) {
-    //    render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, saveload_ui_loadsave);
-    //    render->DrawTextureNew(18 / 640.0f, 141 / 480.0f, saveload_ui_loadsave);
-    //    int text_pos = pFontSmallnum->AlignText_Center(186, localization->str(190));
-    //    pGUIWindow_CurrentMenu->DrawText(pFontSmallnum, text_pos + 25, 219, 0, localization->str(190), 0, 0, 0);  // Сохранение
-    //    text_pos = pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName);
-    //    pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, text_pos + 25, 259, 0, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName, 185, 0);
-    //    text_pos = pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT));
-    //    pGUIWindow_CurrentMenu->DrawText(pFontSmallnum, text_pos + 25, 299, 0, localization->str(LSTR_PLEASE_WAIT), 0, 0, 0);  // Пожалуйста, подождите
-    //    render->Present();
-    //}
-
     auto [header, blob] = createSaveData(resetWorld, title);
 
     try {
@@ -228,69 +214,110 @@ void autoSave() {
 void doSavegame(int uSlot) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    std::string fileName;
-    if (uSlot < pSavegameList->numSavegameFiles) {
-        fileName = pSavegameList->slots[uSlot].fileName; // Overwrite an existing save.
-    } else {
+    std::string fileName = pSavegameList->slots()[uSlot].fileName; // Overwrite an existing save.
+    if (fileName.empty()) {
         for (int i = 0;; i++) { // New save, pick the first free numbered name.
             fileName = fmt::format("save{:03}.mm7", i);
             if (!ufs->exists(fmt::format("saves/{}", fileName)))
                 break;
         }
-        pSavegameList->slots[uSlot].fileName = fileName;
     }
 
-    pSavegameList->slots[uSlot].header = saveGame(false, false, fmt::format("saves/{}", fileName),
-                                                  pSavegameList->slots[uSlot].header.name);
-
-    pSavegameList->selectedSlot = uSlot;
+    saveGame(false, false, fmt::format("saves/{}", fileName), pSavegameList->slots()[uSlot].header.name);
 
     GUI_UpdateWindows();
     pGUIWindow_CurrentMenu = nullptr;
     current_screen_type = SCREEN_GAME;
 
-    pSavegameList->releaseThumbnails();
-
     gameTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
 }
 
-void SavegameList::Initialize() {
-    pSavegameList->Reset();
+SavegameList::SavegameList() {
+    _slots.assign(1, {}); // Just the new save slot.
+}
+
+void SavegameList::refresh() {
+    releaseThumbnails();
 
     std::vector<std::string> saves;
     if (ufs->exists("saves"))
         for (const auto &entry : ufs->ls("saves"))
             if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
                 saves.push_back(entry.name);
-    std::ranges::sort(saves);
 
-    pSavegameList->numSavegameFiles = static_cast<int>(saves.size());
-    pSavegameList->slots.resize(saves.size() + 1); // +1 for the new save slot.
-    for (size_t i = 0; i < saves.size(); i++)
-        pSavegameList->slots[i].fileName = saves[i];
+    _slots.assign(saves.size() + 1, {}); // +1 for the new save slot.
+    for (size_t i = 0; i < saves.size(); i++) {
+        _slots[i].fileName = saves[i];
+        _slots[i].isUsed = true; // The file exists, so the slot is loadable even before loadHeaders() is called.
+    }
+    _loadMenuSlots.clear();
+    _saveMenuSlots.clear();
 }
 
-SavegameList::SavegameList() { Reset(); }
+void SavegameList::loadHeaders() {
+    refresh();
+
+    for (int i = 0; i < saveFileCount(); ++i) {
+        SavegameSlot &slot = _slots[i];
+        std::string path = fmt::format("saves/{}", slot.fileName);
+        if (!ufs->exists(path)) {
+            slot.isUsed = false;
+            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
+            continue;
+        }
+
+        SaveGameLite save;
+        deserialize(ufs->read(path), &save, tags::via<SaveGameLite_MM7>);
+        slot.header = save.header;
+
+        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
+            slot.header.name = localization->str(LSTR_AUTOSAVE);
+
+        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
+            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
+
+        try {
+            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
+
+            if (slot.thumbnail->width() == 0) {
+                slot.thumbnail->release();
+                slot.thumbnail = nullptr;
+            }
+        } catch (const Exception &e) {
+            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
+            slot.thumbnail = nullptr;
+        }
+    }
+
+    // Sort saves by display name, with file name as a tie-breaker.
+    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
+        if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
+            return result < 0;
+        return l.fileName < r.fileName;
+    };
+    std::ranges::sort(_slots.begin(), _slots.begin() + saveFileCount(), slotLess);
+
+    // All saves are shown in the load menu. Autosave & quicksaves are loadable, but shouldn't be manually saved
+    // over, so they are not shown in the save menu, which shows the new save slot first instead.
+    _loadMenuSlots.clear();
+    _saveMenuSlots.clear();
+    _saveMenuSlots.push_back(saveFileCount()); // New save slot goes first.
+    for (int i = 0; i < saveFileCount(); i++) {
+        _loadMenuSlots.push_back(i);
+        const std::string &fileName = _slots[i].fileName;
+        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
+            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
+            _saveMenuSlots.push_back(i);
+    }
+}
 
 void SavegameList::releaseThumbnails() {
-    for (SavegameSlot &slot : slots)
+    for (SavegameSlot &slot : _slots)
         if (slot.thumbnail != nullptr) {
             slot.thumbnail->release();
             slot.thumbnail = nullptr;
         }
-}
-
-void SavegameList::Reset() {
-    releaseThumbnails();
-
-    slots.clear();
-    saveMenuSlots.clear();
-
-    numSavegameFiles = 0;
-    // Reset position in case that last loaded save will not be found
-    selectedSlot = 0;
-    saveListPosition = 0;
 }
 
 void saveNewGame() {
@@ -317,21 +344,11 @@ void quickSaveGame() {
 }
 
 int getQuickSaveSlot() {
-    pSavegameList->Initialize();
-    std::string quickSaveName = getCurrentQuickSave();
+    pSavegameList->refresh();
 
-    int uSlot = -1;
-    // find QuickSave slot
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        if (pSavegameList->slots[i].fileName == quickSaveName) {
-            uSlot = i;
-            // make sure this slot is activated for load
-            pSavegameList->slots[i].isUsed = true;
-            break;
-        }
-    }
-
-    return uSlot;
+    const std::vector<SavegameSlot> &slots = pSavegameList->slots();
+    auto pos = std::ranges::find(slots, getCurrentQuickSave(), &SavegameSlot::fileName);
+    return pos == slots.end() ? -1 : pos - slots.begin();
 }
 
 void quickLoadGame() {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -204,7 +204,7 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
 }
 
 void autoSave() {
-    saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
+    saveGame(true, false, fmt::format("saves/{}", autosaveFileName), localization->str(LSTR_AUTOSAVE));
 }
 
 void doSavegame(std::string fileName, std::string_view title) {
@@ -239,14 +239,14 @@ void saveNewGame() {
     pParty->_viewPitch = 0;
     pParty->_viewYaw = 512;
 
-    saveGame(true, true, fmt::format("saves/{}", autosaveFileName));
+    saveGame(true, true, fmt::format("saves/{}", autosaveFileName), localization->str(LSTR_AUTOSAVE));
 }
 
 void quickSaveGame() {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
     engine->config->gameplay.QuickSavesCount.cycleIncrement();
-    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), "Quicksave");
+    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), localization->str(LSTR_QUICKSAVE));
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
@@ -265,5 +265,5 @@ void quickLoadGame() {
 }
 
 std::string getCurrentQuickSave() {
-    return fmt::format("{}{}.mm7", engine->config->gameplay.QuickSaveName.value(), engine->config->gameplay.QuickSavesCount.value());
+    return fmt::format("{}{}.mm7", quickSaveFileNamePrefix, engine->config->gameplay.QuickSavesCount.value());
 }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "Engine/Engine.h"
 #include "Engine/Resources/EngineFileSystem.h"
@@ -41,13 +42,13 @@ SavegameList *pSavegameList = new SavegameList;
 std::unordered_map<std::string, Blob> pMapDeltas;
 
 void loadGame(int uSlot) {
-    if (!pSavegameList->pSavegameUsedSlots[uSlot]) {
+    if (!pSavegameList->isSlotUsed(uSlot)) {
         pAudioPlayer->playUISound(SOUND_error);
         logger->warning("LoadGame: slot {} is empty", uSlot);
         return;
     }
     pSavegameList->selectedSlot = uSlot;
-    pSavegameList->lastLoadedSave = pSavegameList->pFileList[uSlot];
+    pSavegameList->lastLoadedSave = pSavegameList->slots[uSlot].fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -56,7 +57,7 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->pFileList[uSlot]);
+    std::string filename = fmt::format("saves/{}", pSavegameList->slots[uSlot].fileName);
 
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
@@ -116,12 +117,7 @@ void loadGame(int uSlot) {
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
 
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
-            pSavegameList->pSavegameThumbnails[i]->release();
-            pSavegameList->pSavegameThumbnails[i] = nullptr;
-        }
-    }
+    pSavegameList->releaseThumbnails();
 
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
     // pAudioPlayer->SetMasterVolume(engine->config->sound_level);
@@ -227,14 +223,26 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
 }
 
 void autoSave() {
-    saveGame(true, false, "saves/autosave.mm7");
+    saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
 }
 
 void doSavegame(int uSlot) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    pSavegameList->pSavegameHeader[uSlot] = saveGame(false, false, fmt::format("saves/save{:03}.mm7", uSlot),
-                                                     pSavegameList->pSavegameHeader[uSlot].name);
+    std::string fileName;
+    if (uSlot < pSavegameList->numSavegameFiles) {
+        fileName = pSavegameList->slots[uSlot].fileName; // Overwrite an existing save.
+    } else {
+        for (int i = 0;; i++) { // New save, pick the first free numbered name.
+            fileName = fmt::format("save{:03}.mm7", i);
+            if (!ufs->exists(fmt::format("saves/{}", fileName)))
+                break;
+        }
+        pSavegameList->slots[uSlot].fileName = fileName;
+    }
+
+    pSavegameList->slots[uSlot].header = saveGame(false, false, fmt::format("saves/{}", fileName),
+                                                  pSavegameList->slots[uSlot].header.name);
 
     pSavegameList->selectedSlot = uSlot;
 
@@ -242,12 +250,7 @@ void doSavegame(int uSlot) {
     pGUIWindow_CurrentMenu = nullptr;
     current_screen_type = SCREEN_GAME;
 
-    for (int i = 0; i < MAX_SAVE_SLOTS; i++) {
-        if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
-            pSavegameList->pSavegameThumbnails[i]->release();
-            pSavegameList->pSavegameThumbnails[i] = nullptr;
-        }
-    }
+    pSavegameList->releaseThumbnails();
 
     pEventTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
@@ -256,31 +259,34 @@ void doSavegame(int uSlot) {
 void SavegameList::Initialize() {
     pSavegameList->Reset();
 
-    if (ufs->exists("saves")) {
-        for (const auto &entry : ufs->ls("saves")) {
-            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7")) {
-                pSavegameList->pFileList[pSavegameList->numSavegameFiles++] = entry.name;
-                if (pSavegameList->numSavegameFiles == MAX_SAVE_SLOTS) {
-                    break;
-                }
-            }
-        }
-    }
+    std::vector<std::string> saves;
+    if (ufs->exists("saves"))
+        for (const auto &entry : ufs->ls("saves"))
+            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
+                saves.push_back(entry.name);
+    std::ranges::sort(saves);
 
-    if (pSavegameList->numSavegameFiles) {
-        std::sort(pSavegameList->pFileList.begin(), pSavegameList->pFileList.begin() + pSavegameList->numSavegameFiles);
-    }
+    pSavegameList->numSavegameFiles = static_cast<int>(saves.size());
+    pSavegameList->slots.resize(saves.size() + 1); // +1 for the new save slot.
+    for (size_t i = 0; i < saves.size(); i++)
+        pSavegameList->slots[i].fileName = saves[i];
 }
 
 SavegameList::SavegameList() { Reset(); }
 
-void SavegameList::Reset() {
-    pSavegameUsedSlots.fill(false);
-    pSavegameThumbnails.fill(nullptr);
+void SavegameList::releaseThumbnails() {
+    for (SavegameSlot &slot : slots)
+        if (slot.thumbnail != nullptr) {
+            slot.thumbnail->release();
+            slot.thumbnail = nullptr;
+        }
+}
 
-    for (int j = 0; j < MAX_SAVE_SLOTS; j++) {
-        this->pFileList[j].clear();
-    }
+void SavegameList::Reset() {
+    releaseThumbnails();
+
+    slots.clear();
+    saveMenuSlots.clear();
 
     numSavegameFiles = 0;
     // Reset position in case that last loaded save will not be found
@@ -299,46 +305,14 @@ void saveNewGame() {
     pParty->_viewPitch = 0;
     pParty->_viewYaw = 512;
 
-    saveGame(true, true, "saves/autosave.mm7");
+    saveGame(true, true, fmt::format("saves/{}", autosaveFileName));
 }
 
 void quickSaveGame() {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
-    pSavegameList->Initialize();
 
     engine->config->gameplay.QuickSavesCount.cycleIncrement();
-    std::string quickSaveName = getCurrentQuickSave();
-
-    int uSlot = -1;
-    // find QuickSave slot
-    for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-        if (pSavegameList->pFileList[i] == quickSaveName) {
-            uSlot = i;
-            break;
-        }
-    }
-
-    // not found - find free slot
-    if (uSlot == -1) {
-        for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-            if (pSavegameList->pFileList[i] == "") {
-                uSlot = i;
-                break;
-            }
-        }
-    }
-
-    // if no free slot error
-    if (uSlot == -1) {
-        logger->error("QuickSaveGame:: No free save game slots!");
-        engine->config->gameplay.QuickSavesCount.cycleDecrement();
-        pAudioPlayer->playUISound(SOUND_error);
-        return;
-    }
-
-    pSavegameList->pSavegameHeader[uSlot].name = "Quicksave";
-    pSavegameList->pSavegameHeader[uSlot] = saveGame(false, false, fmt::format("saves/{}", quickSaveName),
-                                                     pSavegameList->pSavegameHeader[uSlot].name);
+    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), "Quicksave");
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
@@ -349,11 +323,11 @@ int getQuickSaveSlot() {
 
     int uSlot = -1;
     // find QuickSave slot
-    for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-        if (pSavegameList->pFileList[i] == quickSaveName) {
+    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
+        if (pSavegameList->slots[i].fileName == quickSaveName) {
             uSlot = i;
             // make sure this slot is activated for load
-            pSavegameList->pSavegameUsedSlots[i] = true;
+            pSavegameList->slots[i].isUsed = true;
             break;
         }
     }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -1,9 +1,9 @@
 #include "SaveLoad.h"
 
-#include <algorithm>
 #include <cassert>
 #include <unordered_map>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -36,21 +36,18 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 
-#include "Utility/String/Ascii.h"
-#include "Utility/Exception.h"
-
 #include "TurnEngine/TurnEngine.h"
 
-SavegameList *pSavegameList = new SavegameList;
 std::unordered_map<std::string, Blob> pMapDeltas;
 
-void loadGame(int uSlot) {
-    if (!pSavegameList->isSlotUsed(uSlot)) {
+void loadGame(std::string_view fileName) {
+    std::string path = fmt::format("saves/{}", fileName);
+    if (!ufs->exists(path)) {
         pAudioPlayer->playUISound(SOUND_error);
-        logger->warning("LoadGame: slot {} is empty", uSlot);
+        logger->warning("loadGame: '{}' doesn't exist", fileName);
         return;
     }
-    engine->_lastLoadedSaveFileName = pSavegameList->slots()[uSlot].fileName;
+    engine->_lastLoadedSaveFileName = fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -59,11 +56,9 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->slots()[uSlot].fileName);
-
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
-    deserialize(Blob::copy(ufs->read(filename)), &state, tags::via<SaveGame_MM7>);
+    deserialize(Blob::copy(ufs->read(path)), &state, tags::via<SaveGame_MM7>);
 
     // Move loaded state to global variables.
     *pParty = std::move(state.party);
@@ -212,10 +207,9 @@ void autoSave() {
     saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
 }
 
-void doSavegame(int uSlot) {
+void doSavegame(std::string fileName, std::string_view title) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    std::string fileName = pSavegameList->slots()[uSlot].fileName; // Overwrite an existing save.
     if (fileName.empty()) {
         for (int i = 0;; i++) { // New save, pick the first free numbered name.
             fileName = fmt::format("save{:03}.mm7", i);
@@ -224,7 +218,7 @@ void doSavegame(int uSlot) {
         }
     }
 
-    saveGame(false, false, fmt::format("saves/{}", fileName), pSavegameList->slots()[uSlot].header.name);
+    saveGame(false, false, fmt::format("saves/{}", fileName), title);
 
     GUI_UpdateWindows();
     pGUIWindow_CurrentMenu = nullptr;
@@ -232,93 +226,6 @@ void doSavegame(int uSlot) {
 
     pEventTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
-}
-
-SavegameList::SavegameList() {
-    _slots.assign(1, {}); // Just the new save slot.
-}
-
-void SavegameList::refresh() {
-    releaseThumbnails();
-
-    std::vector<std::string> saves;
-    if (ufs->exists("saves"))
-        for (const auto &entry : ufs->ls("saves"))
-            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
-                saves.push_back(entry.name);
-
-    _slots.assign(saves.size() + 1, {}); // +1 for the new save slot.
-    for (size_t i = 0; i < saves.size(); i++) {
-        _slots[i].fileName = saves[i];
-        _slots[i].isUsed = true; // The file exists, so the slot is loadable even before loadHeaders() is called.
-    }
-    _loadMenuSlots.clear();
-    _saveMenuSlots.clear();
-}
-
-void SavegameList::loadHeaders() {
-    refresh();
-
-    for (int i = 0; i < saveFileCount(); ++i) {
-        SavegameSlot &slot = _slots[i];
-        std::string path = fmt::format("saves/{}", slot.fileName);
-        if (!ufs->exists(path)) {
-            slot.isUsed = false;
-            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
-            continue;
-        }
-
-        SaveGameLite save;
-        deserialize(ufs->read(path), &save, tags::via<SaveGameLite_MM7>);
-        slot.header = save.header;
-
-        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
-            slot.header.name = localization->str(LSTR_AUTOSAVE);
-
-        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
-            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
-
-        try {
-            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
-
-            if (slot.thumbnail->width() == 0) {
-                slot.thumbnail->release();
-                slot.thumbnail = nullptr;
-            }
-        } catch (const Exception &e) {
-            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
-            slot.thumbnail = nullptr;
-        }
-    }
-
-    // Sort saves by display name, with file name as a tie-breaker.
-    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
-        if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
-            return result < 0;
-        return l.fileName < r.fileName;
-    };
-    std::ranges::sort(_slots.begin(), _slots.begin() + saveFileCount(), slotLess);
-
-    // All saves are shown in the load menu. Autosave & quicksaves are loadable, but shouldn't be manually saved
-    // over, so they are not shown in the save menu, which shows the new save slot first instead.
-    _loadMenuSlots.clear();
-    _saveMenuSlots.clear();
-    _saveMenuSlots.push_back(saveFileCount()); // New save slot goes first.
-    for (int i = 0; i < saveFileCount(); i++) {
-        _loadMenuSlots.push_back(i);
-        const std::string &fileName = _slots[i].fileName;
-        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
-            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
-            _saveMenuSlots.push_back(i);
-    }
-}
-
-void SavegameList::releaseThumbnails() {
-    for (SavegameSlot &slot : _slots)
-        if (slot.thumbnail != nullptr) {
-            slot.thumbnail->release();
-            slot.thumbnail = nullptr;
-        }
 }
 
 void saveNewGame() {
@@ -344,19 +251,11 @@ void quickSaveGame() {
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
 
-int getQuickSaveSlot() {
-    pSavegameList->refresh();
-
-    const std::vector<SavegameSlot> &slots = pSavegameList->slots();
-    auto pos = std::ranges::find(slots, getCurrentQuickSave(), &SavegameSlot::fileName);
-    return pos == slots.end() ? -1 : pos - slots.begin();
-}
-
 void quickLoadGame() {
-    int uSlot = getQuickSaveSlot();
+    std::string fileName = getCurrentQuickSave();
 
-    if (uSlot != -1) {
-        loadGame(uSlot);
+    if (ufs->exists(fmt::format("saves/{}", fileName))) {
+        loadGame(fileName);
         uGameState = GAME_STATE_LOADING_GAME;
         pAudioPlayer->playUISound(SOUND_StartMainChoice02);
     } else {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -1,9 +1,9 @@
 #include "SaveLoad.h"
 
-#include <algorithm>
 #include <cassert>
 #include <unordered_map>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -37,19 +37,16 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 
-#include "Utility/String/Ascii.h"
-#include "Utility/Exception.h"
-
-SavegameList *pSavegameList = new SavegameList;
 std::unordered_map<std::string, Blob> pMapDeltas;
 
-void loadGame(int uSlot) {
-    if (!pSavegameList->isSlotUsed(uSlot)) {
+void loadGame(std::string_view fileName) {
+    std::string path = fmt::format("saves/{}", fileName);
+    if (!ufs->exists(path)) {
         pAudioPlayer->playUISound(SOUND_error);
-        logger->warning("LoadGame: slot {} is empty", uSlot);
+        logger->warning("loadGame: '{}' doesn't exist", fileName);
         return;
     }
-    engine->_lastLoadedSaveFileName = pSavegameList->slots()[uSlot].fileName;
+    engine->_lastLoadedSaveFileName = fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -58,11 +55,9 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->slots()[uSlot].fileName);
-
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
-    deserialize(Blob::copy(ufs->read(filename)), &state, tags::via<SaveGame_MM7>);
+    deserialize(Blob::copy(ufs->read(path)), &state, tags::via<SaveGame_MM7>);
 
     // Move loaded state to global variables.
     *pParty = std::move(state.party);
@@ -211,10 +206,9 @@ void autoSave() {
     saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
 }
 
-void doSavegame(int uSlot) {
+void doSavegame(std::string fileName, std::string_view title) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    std::string fileName = pSavegameList->slots()[uSlot].fileName; // Overwrite an existing save.
     if (fileName.empty()) {
         for (int i = 0;; i++) { // New save, pick the first free numbered name.
             fileName = fmt::format("save{:03}.mm7", i);
@@ -223,7 +217,7 @@ void doSavegame(int uSlot) {
         }
     }
 
-    saveGame(false, false, fmt::format("saves/{}", fileName), pSavegameList->slots()[uSlot].header.name);
+    saveGame(false, false, fmt::format("saves/{}", fileName), title);
 
     GUI_UpdateWindows();
     pGUIWindow_CurrentMenu = nullptr;
@@ -231,93 +225,6 @@ void doSavegame(int uSlot) {
 
     gameTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
-}
-
-SavegameList::SavegameList() {
-    _slots.assign(1, {}); // Just the new save slot.
-}
-
-void SavegameList::refresh() {
-    releaseThumbnails();
-
-    std::vector<std::string> saves;
-    if (ufs->exists("saves"))
-        for (const auto &entry : ufs->ls("saves"))
-            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
-                saves.push_back(entry.name);
-
-    _slots.assign(saves.size() + 1, {}); // +1 for the new save slot.
-    for (size_t i = 0; i < saves.size(); i++) {
-        _slots[i].fileName = saves[i];
-        _slots[i].isUsed = true; // The file exists, so the slot is loadable even before loadHeaders() is called.
-    }
-    _loadMenuSlots.clear();
-    _saveMenuSlots.clear();
-}
-
-void SavegameList::loadHeaders() {
-    refresh();
-
-    for (int i = 0; i < saveFileCount(); ++i) {
-        SavegameSlot &slot = _slots[i];
-        std::string path = fmt::format("saves/{}", slot.fileName);
-        if (!ufs->exists(path)) {
-            slot.isUsed = false;
-            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
-            continue;
-        }
-
-        SaveGameLite save;
-        deserialize(ufs->read(path), &save, tags::via<SaveGameLite_MM7>);
-        slot.header = save.header;
-
-        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
-            slot.header.name = localization->str(LSTR_AUTOSAVE);
-
-        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
-            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
-
-        try {
-            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
-
-            if (slot.thumbnail->width() == 0) {
-                slot.thumbnail->release();
-                slot.thumbnail = nullptr;
-            }
-        } catch (const Exception &e) {
-            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
-            slot.thumbnail = nullptr;
-        }
-    }
-
-    // Sort saves by display name, with file name as a tie-breaker.
-    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
-        if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
-            return result < 0;
-        return l.fileName < r.fileName;
-    };
-    std::ranges::sort(_slots.begin(), _slots.begin() + saveFileCount(), slotLess);
-
-    // All saves are shown in the load menu. Autosave & quicksaves are loadable, but shouldn't be manually saved
-    // over, so they are not shown in the save menu, which shows the new save slot first instead.
-    _loadMenuSlots.clear();
-    _saveMenuSlots.clear();
-    _saveMenuSlots.push_back(saveFileCount()); // New save slot goes first.
-    for (int i = 0; i < saveFileCount(); i++) {
-        _loadMenuSlots.push_back(i);
-        const std::string &fileName = _slots[i].fileName;
-        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
-            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
-            _saveMenuSlots.push_back(i);
-    }
-}
-
-void SavegameList::releaseThumbnails() {
-    for (SavegameSlot &slot : _slots)
-        if (slot.thumbnail != nullptr) {
-            slot.thumbnail->release();
-            slot.thumbnail = nullptr;
-        }
 }
 
 void saveNewGame() {
@@ -343,19 +250,11 @@ void quickSaveGame() {
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
 
-int getQuickSaveSlot() {
-    pSavegameList->refresh();
-
-    const std::vector<SavegameSlot> &slots = pSavegameList->slots();
-    auto pos = std::ranges::find(slots, getCurrentQuickSave(), &SavegameSlot::fileName);
-    return pos == slots.end() ? -1 : pos - slots.begin();
-}
-
 void quickLoadGame() {
-    int uSlot = getQuickSaveSlot();
+    std::string fileName = getCurrentQuickSave();
 
-    if (uSlot != -1) {
-        loadGame(uSlot);
+    if (ufs->exists(fmt::format("saves/{}", fileName))) {
+        loadGame(fileName);
         uGameState = GAME_STATE_LOADING_GAME;
         pAudioPlayer->playUISound(SOUND_StartMainChoice02);
     } else {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "Engine/Engine.h"
 #include "Engine/Resources/EngineFileSystem.h"
@@ -40,13 +41,13 @@ SavegameList *pSavegameList = new SavegameList;
 std::unordered_map<std::string, Blob> pMapDeltas;
 
 void loadGame(int uSlot) {
-    if (!pSavegameList->pSavegameUsedSlots[uSlot]) {
+    if (!pSavegameList->isSlotUsed(uSlot)) {
         pAudioPlayer->playUISound(SOUND_error);
         logger->warning("LoadGame: slot {} is empty", uSlot);
         return;
     }
     pSavegameList->selectedSlot = uSlot;
-    pSavegameList->lastLoadedSave = pSavegameList->pFileList[uSlot];
+    pSavegameList->lastLoadedSave = pSavegameList->slots[uSlot].fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -55,7 +56,7 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->pFileList[uSlot]);
+    std::string filename = fmt::format("saves/{}", pSavegameList->slots[uSlot].fileName);
 
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
@@ -115,12 +116,7 @@ void loadGame(int uSlot) {
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
 
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
-            pSavegameList->pSavegameThumbnails[i]->release();
-            pSavegameList->pSavegameThumbnails[i] = nullptr;
-        }
-    }
+    pSavegameList->releaseThumbnails();
 
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
     // pAudioPlayer->SetMasterVolume(engine->config->sound_level);
@@ -226,14 +222,26 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
 }
 
 void autoSave() {
-    saveGame(true, false, "saves/autosave.mm7");
+    saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
 }
 
 void doSavegame(int uSlot) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    pSavegameList->pSavegameHeader[uSlot] = saveGame(false, false, fmt::format("saves/save{:03}.mm7", uSlot),
-                                                     pSavegameList->pSavegameHeader[uSlot].name);
+    std::string fileName;
+    if (uSlot < pSavegameList->numSavegameFiles) {
+        fileName = pSavegameList->slots[uSlot].fileName; // Overwrite an existing save.
+    } else {
+        for (int i = 0;; i++) { // New save, pick the first free numbered name.
+            fileName = fmt::format("save{:03}.mm7", i);
+            if (!ufs->exists(fmt::format("saves/{}", fileName)))
+                break;
+        }
+        pSavegameList->slots[uSlot].fileName = fileName;
+    }
+
+    pSavegameList->slots[uSlot].header = saveGame(false, false, fmt::format("saves/{}", fileName),
+                                                  pSavegameList->slots[uSlot].header.name);
 
     pSavegameList->selectedSlot = uSlot;
 
@@ -241,12 +249,7 @@ void doSavegame(int uSlot) {
     pGUIWindow_CurrentMenu = nullptr;
     current_screen_type = SCREEN_GAME;
 
-    for (int i = 0; i < MAX_SAVE_SLOTS; i++) {
-        if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
-            pSavegameList->pSavegameThumbnails[i]->release();
-            pSavegameList->pSavegameThumbnails[i] = nullptr;
-        }
-    }
+    pSavegameList->releaseThumbnails();
 
     gameTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
@@ -255,31 +258,34 @@ void doSavegame(int uSlot) {
 void SavegameList::Initialize() {
     pSavegameList->Reset();
 
-    if (ufs->exists("saves")) {
-        for (const auto &entry : ufs->ls("saves")) {
-            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7")) {
-                pSavegameList->pFileList[pSavegameList->numSavegameFiles++] = entry.name;
-                if (pSavegameList->numSavegameFiles == MAX_SAVE_SLOTS) {
-                    break;
-                }
-            }
-        }
-    }
+    std::vector<std::string> saves;
+    if (ufs->exists("saves"))
+        for (const auto &entry : ufs->ls("saves"))
+            if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
+                saves.push_back(entry.name);
+    std::ranges::sort(saves);
 
-    if (pSavegameList->numSavegameFiles) {
-        std::sort(pSavegameList->pFileList.begin(), pSavegameList->pFileList.begin() + pSavegameList->numSavegameFiles);
-    }
+    pSavegameList->numSavegameFiles = static_cast<int>(saves.size());
+    pSavegameList->slots.resize(saves.size() + 1); // +1 for the new save slot.
+    for (size_t i = 0; i < saves.size(); i++)
+        pSavegameList->slots[i].fileName = saves[i];
 }
 
 SavegameList::SavegameList() { Reset(); }
 
-void SavegameList::Reset() {
-    pSavegameUsedSlots.fill(false);
-    pSavegameThumbnails.fill(nullptr);
+void SavegameList::releaseThumbnails() {
+    for (SavegameSlot &slot : slots)
+        if (slot.thumbnail != nullptr) {
+            slot.thumbnail->release();
+            slot.thumbnail = nullptr;
+        }
+}
 
-    for (int j = 0; j < MAX_SAVE_SLOTS; j++) {
-        this->pFileList[j].clear();
-    }
+void SavegameList::Reset() {
+    releaseThumbnails();
+
+    slots.clear();
+    saveMenuSlots.clear();
 
     numSavegameFiles = 0;
     // Reset position in case that last loaded save will not be found
@@ -298,46 +304,14 @@ void saveNewGame() {
     pParty->_viewPitch = 0;
     pParty->_viewYaw = 512;
 
-    saveGame(true, true, "saves/autosave.mm7");
+    saveGame(true, true, fmt::format("saves/{}", autosaveFileName));
 }
 
 void quickSaveGame() {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
-    pSavegameList->Initialize();
 
     engine->config->gameplay.QuickSavesCount.cycleIncrement();
-    std::string quickSaveName = getCurrentQuickSave();
-
-    int uSlot = -1;
-    // find QuickSave slot
-    for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-        if (pSavegameList->pFileList[i] == quickSaveName) {
-            uSlot = i;
-            break;
-        }
-    }
-
-    // not found - find free slot
-    if (uSlot == -1) {
-        for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-            if (pSavegameList->pFileList[i] == "") {
-                uSlot = i;
-                break;
-            }
-        }
-    }
-
-    // if no free slot error
-    if (uSlot == -1) {
-        logger->error("QuickSaveGame:: No free save game slots!");
-        engine->config->gameplay.QuickSavesCount.cycleDecrement();
-        pAudioPlayer->playUISound(SOUND_error);
-        return;
-    }
-
-    pSavegameList->pSavegameHeader[uSlot].name = "Quicksave";
-    pSavegameList->pSavegameHeader[uSlot] = saveGame(false, false, fmt::format("saves/{}", quickSaveName),
-                                                     pSavegameList->pSavegameHeader[uSlot].name);
+    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), "Quicksave");
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
@@ -348,11 +322,11 @@ int getQuickSaveSlot() {
 
     int uSlot = -1;
     // find QuickSave slot
-    for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-        if (pSavegameList->pFileList[i] == quickSaveName) {
+    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
+        if (pSavegameList->slots[i].fileName == quickSaveName) {
             uSlot = i;
             // make sure this slot is activated for load
-            pSavegameList->pSavegameUsedSlots[i] = true;
+            pSavegameList->slots[i].isUsed = true;
             break;
         }
     }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -1,7 +1,7 @@
 #include "SaveLoad.h"
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <unordered_map>
 #include <string>
 #include <memory>
@@ -36,6 +36,9 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 
+#include "Utility/String/Ascii.h"
+#include "Utility/Exception.h"
+
 #include "TurnEngine/TurnEngine.h"
 
 SavegameList *pSavegameList = new SavegameList;
@@ -47,8 +50,7 @@ void loadGame(int uSlot) {
         logger->warning("LoadGame: slot {} is empty", uSlot);
         return;
     }
-    pSavegameList->selectedSlot = uSlot;
-    pSavegameList->lastLoadedSave = pSavegameList->slots[uSlot].fileName;
+    engine->_lastLoadedSaveFileName = pSavegameList->slots()[uSlot].fileName;
 
     // TODO(captainurist): remained from Party::Reset, doesn't really belong here (or in Party::Reset).
     current_character_screen_window = WINDOW_CharacterWindow_Stats;
@@ -57,7 +59,7 @@ void loadGame(int uSlot) {
         pParty->bTurnBasedModeOn = false;
     }
 
-    std::string filename = fmt::format("saves/{}", pSavegameList->slots[uSlot].fileName);
+    std::string filename = fmt::format("saves/{}", pSavegameList->slots()[uSlot].fileName);
 
     // Blob::copy below detaches from the underlying file so subsequent saves to the same path are not blocked.
     SaveGame state;
@@ -116,8 +118,6 @@ void loadGame(int uSlot) {
     engine->_transitionMapId = pMapStats->GetMapInfo(state.header.locationName);
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
-
-    pSavegameList->releaseThumbnails();
 
     // pAudioPlayer->SetMusicVolume(engine->config->music_level);
     // pAudioPlayer->SetMasterVolume(engine->config->sound_level);
@@ -193,20 +193,6 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
         return {};
     }
 
-    // saving - please wait
-
-    // if (current_screen_type == SCREEN_SAVEGAME) {
-    //    render->DrawTextureNew(8 / 640.0f, 8 / 480.0f, saveload_ui_loadsave);
-    //    render->DrawTextureNew(18 / 640.0f, 141 / 480.0f, saveload_ui_loadsave);
-    //    int text_pos = pFontSmallnum->AlignText_Center(186, localization->str(190));
-    //    pGUIWindow_CurrentMenu->DrawText(pFontSmallnum, text_pos + 25, 219, 0, localization->str(190), 0, 0, 0);  // Сохранение
-    //    text_pos = pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName);
-    //    pGUIWindow_CurrentMenu->DrawTextInRect(pFontSmallnum, text_pos + 25, 259, 0, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].pName, 185, 0);
-    //    text_pos = pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT));
-    //    pGUIWindow_CurrentMenu->DrawText(pFontSmallnum, text_pos + 25, 299, 0, localization->str(LSTR_PLEASE_WAIT), 0, 0, 0);  // Пожалуйста, подождите
-    //    render->Present();
-    //}
-
     auto [header, blob] = createSaveData(resetWorld, title);
 
     try {
@@ -229,69 +215,110 @@ void autoSave() {
 void doSavegame(int uSlot) {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
-    std::string fileName;
-    if (uSlot < pSavegameList->numSavegameFiles) {
-        fileName = pSavegameList->slots[uSlot].fileName; // Overwrite an existing save.
-    } else {
+    std::string fileName = pSavegameList->slots()[uSlot].fileName; // Overwrite an existing save.
+    if (fileName.empty()) {
         for (int i = 0;; i++) { // New save, pick the first free numbered name.
             fileName = fmt::format("save{:03}.mm7", i);
             if (!ufs->exists(fmt::format("saves/{}", fileName)))
                 break;
         }
-        pSavegameList->slots[uSlot].fileName = fileName;
     }
 
-    pSavegameList->slots[uSlot].header = saveGame(false, false, fmt::format("saves/{}", fileName),
-                                                  pSavegameList->slots[uSlot].header.name);
-
-    pSavegameList->selectedSlot = uSlot;
+    saveGame(false, false, fmt::format("saves/{}", fileName), pSavegameList->slots()[uSlot].header.name);
 
     GUI_UpdateWindows();
     pGUIWindow_CurrentMenu = nullptr;
     current_screen_type = SCREEN_GAME;
 
-    pSavegameList->releaseThumbnails();
-
     pEventTimer->setPaused(false);
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
 }
 
-void SavegameList::Initialize() {
-    pSavegameList->Reset();
+SavegameList::SavegameList() {
+    _slots.assign(1, {}); // Just the new save slot.
+}
+
+void SavegameList::refresh() {
+    releaseThumbnails();
 
     std::vector<std::string> saves;
     if (ufs->exists("saves"))
         for (const auto &entry : ufs->ls("saves"))
             if (entry.type == FILE_REGULAR && entry.name.ends_with(".mm7"))
                 saves.push_back(entry.name);
-    std::ranges::sort(saves);
 
-    pSavegameList->numSavegameFiles = static_cast<int>(saves.size());
-    pSavegameList->slots.resize(saves.size() + 1); // +1 for the new save slot.
-    for (size_t i = 0; i < saves.size(); i++)
-        pSavegameList->slots[i].fileName = saves[i];
+    _slots.assign(saves.size() + 1, {}); // +1 for the new save slot.
+    for (size_t i = 0; i < saves.size(); i++) {
+        _slots[i].fileName = saves[i];
+        _slots[i].isUsed = true; // The file exists, so the slot is loadable even before loadHeaders() is called.
+    }
+    _loadMenuSlots.clear();
+    _saveMenuSlots.clear();
 }
 
-SavegameList::SavegameList() { Reset(); }
+void SavegameList::loadHeaders() {
+    refresh();
+
+    for (int i = 0; i < saveFileCount(); ++i) {
+        SavegameSlot &slot = _slots[i];
+        std::string path = fmt::format("saves/{}", slot.fileName);
+        if (!ufs->exists(path)) {
+            slot.isUsed = false;
+            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
+            continue;
+        }
+
+        SaveGameLite save;
+        deserialize(ufs->read(path), &save, tags::via<SaveGameLite_MM7>);
+        slot.header = save.header;
+
+        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
+            slot.header.name = localization->str(LSTR_AUTOSAVE);
+
+        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
+            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
+
+        try {
+            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
+
+            if (slot.thumbnail->width() == 0) {
+                slot.thumbnail->release();
+                slot.thumbnail = nullptr;
+            }
+        } catch (const Exception &e) {
+            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
+            slot.thumbnail = nullptr;
+        }
+    }
+
+    // Sort saves by display name, with file name as a tie-breaker.
+    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
+        if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
+            return result < 0;
+        return l.fileName < r.fileName;
+    };
+    std::ranges::sort(_slots.begin(), _slots.begin() + saveFileCount(), slotLess);
+
+    // All saves are shown in the load menu. Autosave & quicksaves are loadable, but shouldn't be manually saved
+    // over, so they are not shown in the save menu, which shows the new save slot first instead.
+    _loadMenuSlots.clear();
+    _saveMenuSlots.clear();
+    _saveMenuSlots.push_back(saveFileCount()); // New save slot goes first.
+    for (int i = 0; i < saveFileCount(); i++) {
+        _loadMenuSlots.push_back(i);
+        const std::string &fileName = _slots[i].fileName;
+        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
+            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
+            _saveMenuSlots.push_back(i);
+    }
+}
 
 void SavegameList::releaseThumbnails() {
-    for (SavegameSlot &slot : slots)
+    for (SavegameSlot &slot : _slots)
         if (slot.thumbnail != nullptr) {
             slot.thumbnail->release();
             slot.thumbnail = nullptr;
         }
-}
-
-void SavegameList::Reset() {
-    releaseThumbnails();
-
-    slots.clear();
-    saveMenuSlots.clear();
-
-    numSavegameFiles = 0;
-    // Reset position in case that last loaded save will not be found
-    selectedSlot = 0;
-    saveListPosition = 0;
 }
 
 void saveNewGame() {
@@ -318,21 +345,11 @@ void quickSaveGame() {
 }
 
 int getQuickSaveSlot() {
-    pSavegameList->Initialize();
-    std::string quickSaveName = getCurrentQuickSave();
+    pSavegameList->refresh();
 
-    int uSlot = -1;
-    // find QuickSave slot
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        if (pSavegameList->slots[i].fileName == quickSaveName) {
-            uSlot = i;
-            // make sure this slot is activated for load
-            pSavegameList->slots[i].isUsed = true;
-            break;
-        }
-    }
-
-    return uSlot;
+    const std::vector<SavegameSlot> &slots = pSavegameList->slots();
+    auto pos = std::ranges::find(slots, getCurrentQuickSave(), &SavegameSlot::fileName);
+    return pos == slots.end() ? -1 : pos - slots.begin();
 }
 
 void quickLoadGame() {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -203,7 +203,7 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
 }
 
 void autoSave() {
-    saveGame(true, false, fmt::format("saves/{}", autosaveFileName));
+    saveGame(true, false, fmt::format("saves/{}", autosaveFileName), localization->str(LSTR_AUTOSAVE));
 }
 
 void doSavegame(std::string fileName, std::string_view title) {
@@ -238,14 +238,14 @@ void saveNewGame() {
     pParty->_viewPitch = 0;
     pParty->_viewYaw = 512;
 
-    saveGame(true, true, fmt::format("saves/{}", autosaveFileName));
+    saveGame(true, true, fmt::format("saves/{}", autosaveFileName), localization->str(LSTR_AUTOSAVE));
 }
 
 void quickSaveGame() {
     assert(engine->_currentLoadedMapId != MAP_ARENA); // Not Arena.
 
     engine->config->gameplay.QuickSavesCount.cycleIncrement();
-    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), "Quicksave");
+    saveGame(false, false, fmt::format("saves/{}", getCurrentQuickSave()), localization->str(LSTR_QUICKSAVE));
     engine->_statusBar->setEvent(LSTR_GAME_SAVED);
     pAudioPlayer->playUISound(SOUND_StartMainChoice02);
 }
@@ -264,5 +264,5 @@ void quickLoadGame() {
 }
 
 std::string getCurrentQuickSave() {
-    return fmt::format("{}{}.mm7", engine->config->gameplay.QuickSaveName.value(), engine->config->gameplay.QuickSavesCount.value());
+    return fmt::format("{}{}.mm7", quickSaveFileNamePrefix, engine->config->gameplay.QuickSavesCount.value());
 }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -229,6 +229,7 @@ void doSavegame(std::string fileName, std::string_view title) {
 
 void saveNewGame() {
     engine->_currentLoadedMapId = MAP_EMERALD_ISLAND;
+    engine->_lastLoadedSaveFileName.clear(); // Otherwise the save menu would pre-select a save from a previous playthrough.
     pParty->pos.x = 12552;
     pParty->pos.y = 800;
     pParty->pos.z = 193;

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -3,7 +3,9 @@
 #include <array>
 #include <unordered_map>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include "Engine/Graphics/Overlays.h"
 #include "Engine/Party.h"
@@ -15,7 +17,8 @@
 
 class GraphicsImage;
 
-constexpr int MAX_SAVE_SLOTS = 45;
+// Autosave file name. Note that it's not localized, unlike the autosave title displayed in-game.
+constexpr std::string_view autosaveFileName = "autosave.mm7";
 
 struct SaveGameHeader {
     std::string name; // Save name, as displayed in the save list in-game.
@@ -39,6 +42,13 @@ struct SaveGameLite {
     Blob thumbnail;
 };
 
+struct SavegameSlot {
+    std::string fileName;
+    SaveGameHeader header;
+    GraphicsImage *thumbnail = nullptr;
+    bool isUsed = false; // True for slots backed by an actual save file.
+};
+
 /** Runtime storage for map deltas from the currently loaded save. */
 extern std::unordered_map<std::string, Blob> pMapDeltas;
 
@@ -47,11 +57,30 @@ struct SavegameList {
     SavegameList();
 
     void Reset();
+    void releaseThumbnails();
 
-    std::array<std::string, MAX_SAVE_SLOTS> pFileList;
-    std::array<bool, MAX_SAVE_SLOTS> pSavegameUsedSlots;
-    std::array<SaveGameHeader, MAX_SAVE_SLOTS> pSavegameHeader;
-    std::array<GraphicsImage *, MAX_SAVE_SLOTS> pSavegameThumbnails;
+    bool isSlotUsed(int slot) const {
+        return slot >= 0 && slot < std::ssize(slots) && slots[slot].isUsed;
+    }
+
+    // Maps save menu positions to slot indices.
+    int saveMenuSlot(int position) const {
+        return saveMenuSlots[position];
+    }
+
+    // Number of positions in the save menu.
+    int saveMenuSlotCount() const {
+        return static_cast<int>(saveMenuSlots.size());
+    }
+
+    // Slots [0, numSavegameFiles) are the saves, slot numSavegameFiles is the always-present empty slot used by
+    // the save menu for creating a new save. This way reinitializing the list mid-menu can never shrink it below
+    // what menus index.
+    std::vector<SavegameSlot> slots;
+
+    // Slot indices shown in the save menu - the new save slot first, then the saves. Autosave & quicksaves are
+    // not shown in the save menu.
+    std::vector<int> saveMenuSlots;
 
     int numSavegameFiles = 0;
     int selectedSlot = 0;

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -52,40 +52,56 @@ struct SavegameSlot {
 /** Runtime storage for map deltas from the currently loaded save. */
 extern std::unordered_map<std::string, Blob> pMapDeltas;
 
-struct SavegameList {
-    static void Initialize();
+class SavegameList {
+ public:
     SavegameList();
 
-    void Reset();
+    /** Rescans the saves folder. Headers & thumbnails are not loaded because that means reading every save file,
+     *  which the quickload path doesn't need. Menus call `loadHeaders` for that. */
+    void refresh();
+
+    /** Rescans the saves folder, loads headers & thumbnails for all saves, sorts the slots by display name &
+     *  rebuilds the menu slot mappings. */
+    void loadHeaders();
+
     void releaseThumbnails();
 
-    bool isSlotUsed(int slot) const {
-        return slot >= 0 && slot < std::ssize(slots) && slots[slot].isUsed;
+    void setSlotName(int slot, std::string_view name) {
+        _slots[slot].header.name = name;
     }
 
-    // Maps save menu positions to slot indices.
-    int saveMenuSlot(int position) const {
-        return saveMenuSlots[position];
+    [[nodiscard]] const std::vector<SavegameSlot> &slots() const {
+        return _slots;
     }
 
-    // Number of positions in the save menu.
-    int saveMenuSlotCount() const {
-        return static_cast<int>(saveMenuSlots.size());
+    [[nodiscard]] bool isSlotUsed(int slot) const {
+        return slot >= 0 && slot < std::ssize(_slots) && _slots[slot].isUsed;
     }
 
-    // Slots [0, numSavegameFiles) are the saves, slot numSavegameFiles is the always-present empty slot used by
-    // the save menu for creating a new save. This way reinitializing the list mid-menu can never shrink it below
-    // what menus index.
-    std::vector<SavegameSlot> slots;
+    // Slot indices shown in the load menu - all save files.
+    [[nodiscard]] const std::vector<int> &loadMenuSlots() const {
+        return _loadMenuSlots;
+    }
 
     // Slot indices shown in the save menu - the new save slot first, then the saves. Autosave & quicksaves are
     // not shown in the save menu.
-    std::vector<int> saveMenuSlots;
+    [[nodiscard]] const std::vector<int> &saveMenuSlots() const {
+        return _saveMenuSlots;
+    }
 
-    int numSavegameFiles = 0;
-    int selectedSlot = 0;
-    int saveListPosition = 0;
-    std::string lastLoadedSave{};
+ private:
+    // Number of save files, slots [0, saveFileCount()) are backed by them.
+    [[nodiscard]] int saveFileCount() const {
+        return std::ssize(_slots) - 1;
+    }
+
+ private:
+    // Slots for the save files, plus an always-present trailing empty slot used by the save menu for creating a
+    // new save. This way reinitializing the list mid-menu can never shrink it below what menus index.
+    std::vector<SavegameSlot> _slots;
+
+    std::vector<int> _loadMenuSlots;
+    std::vector<int> _saveMenuSlots;
 };
 
 void loadGame(int uSlot);

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -17,6 +17,9 @@
 // Autosave file name. Note that it's not localized, unlike the autosave title displayed in-game.
 constexpr std::string_view autosaveFileName = "autosave.mm7";
 
+// Quicksave file name prefix. Full quicksave file names also contain a number, e.g. "quicksave1.mm7".
+constexpr std::string_view quickSaveFileNamePrefix = "quicksave";
+
 struct SaveGameHeader {
     std::string name; // Save name, as displayed in the save list in-game.
     std::string locationName; // Name of the map, e.g. "out01.odm".

--- a/src/Engine/SaveLoad.h
+++ b/src/Engine/SaveLoad.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #include "Engine/Graphics/Overlays.h"
 #include "Engine/Party.h"
@@ -14,8 +13,6 @@
 #include "Engine/Time/Timer.h"
 
 #include "Utility/Memory/Blob.h"
-
-class GraphicsImage;
 
 // Autosave file name. Note that it's not localized, unlike the autosave title displayed in-game.
 constexpr std::string_view autosaveFileName = "autosave.mm7";
@@ -42,78 +39,24 @@ struct SaveGameLite {
     Blob thumbnail;
 };
 
-struct SavegameSlot {
-    std::string fileName;
-    SaveGameHeader header;
-    GraphicsImage *thumbnail = nullptr;
-    bool isUsed = false; // True for slots backed by an actual save file.
-};
-
 /** Runtime storage for map deltas from the currently loaded save. */
 extern std::unordered_map<std::string, Blob> pMapDeltas;
 
-class SavegameList {
- public:
-    SavegameList();
-
-    /** Rescans the saves folder. Headers & thumbnails are not loaded because that means reading every save file,
-     *  which the quickload path doesn't need. Menus call `loadHeaders` for that. */
-    void refresh();
-
-    /** Rescans the saves folder, loads headers & thumbnails for all saves, sorts the slots by display name &
-     *  rebuilds the menu slot mappings. */
-    void loadHeaders();
-
-    void releaseThumbnails();
-
-    void setSlotName(int slot, std::string_view name) {
-        _slots[slot].header.name = name;
-    }
-
-    [[nodiscard]] const std::vector<SavegameSlot> &slots() const {
-        return _slots;
-    }
-
-    [[nodiscard]] bool isSlotUsed(int slot) const {
-        return slot >= 0 && slot < std::ssize(_slots) && _slots[slot].isUsed;
-    }
-
-    // Slot indices shown in the load menu - all save files.
-    [[nodiscard]] const std::vector<int> &loadMenuSlots() const {
-        return _loadMenuSlots;
-    }
-
-    // Slot indices shown in the save menu - the new save slot first, then the saves. Autosave & quicksaves are
-    // not shown in the save menu.
-    [[nodiscard]] const std::vector<int> &saveMenuSlots() const {
-        return _saveMenuSlots;
-    }
-
- private:
-    // Number of save files, slots [0, saveFileCount()) are backed by them.
-    [[nodiscard]] int saveFileCount() const {
-        return std::ssize(_slots) - 1;
-    }
-
- private:
-    // Slots for the save files, plus an always-present trailing empty slot used by the save menu for creating a
-    // new save. This way reinitializing the list mid-menu can never shrink it below what menus index.
-    std::vector<SavegameSlot> _slots;
-
-    std::vector<int> _loadMenuSlots;
-    std::vector<int> _saveMenuSlots;
-};
-
-void loadGame(int uSlot);
+void loadGame(std::string_view fileName);
 std::pair<SaveGameHeader, Blob> createSaveData(bool resetWorld, std::string_view title);
 SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path, std::string_view title = {});
 void autoSave();
-void doSavegame(int uSlot);
+
+/**
+ * Saves the game.
+ *
+ * @param fileName                  Name of the file to save into, e.g. "save000.mm7". Pass an empty string to save
+ *                                  into the first free `saveNNN.mm7`.
+ * @param title                     Save title to display in the save list in-game.
+ */
+void doSavegame(std::string fileName, std::string_view title);
 void saveNewGame();
 
 void quickSaveGame();
-int getQuickSaveSlot();
 void quickLoadGame();
 std::string getCurrentQuickSave();
-
-extern SavegameList *pSavegameList;

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -3,16 +3,17 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
-#include "Engine/Graphics/Image.h"
 #include "Engine/Localization.h"
 #include "Engine/MapInfo.h"
-#include "Engine/SaveLoad.h"
+#include "Engine/Resources/EngineFileSystem.h"
+#include "Engine/Snapshots/CompositeSnapshots.h"
 
 #include "Media/Audio/AudioPlayer.h"
 
@@ -23,7 +24,12 @@
 #include "GUI/GUIFont.h"
 #include "GUI/GUIMessageQueue.h"
 
+#include "Library/Image/Pcx.h"
 #include "Library/Logger/Logger.h"
+#include "Library/Snapshots/SnapshotSerialization.h"
+
+#include "Utility/String/Ascii.h"
+#include "Utility/Exception.h"
 
 using Io::TextInputType;
 
@@ -37,24 +43,89 @@ GraphicsImage *saveload_ui_x_d = nullptr;
 
 static GraphicsImage *scrollstop = nullptr;
 
+/**
+ * @return                          Slots to show in the load menu - all saves from the saves folder, sorted by
+ *                                  display name with file name as a tie-breaker.
+ */
+static std::vector<SavegameSlot> loadMenuSlots() {
+    std::vector<SavegameSlot> result;
+
+    if (!ufs->exists("saves"))
+        return result;
+
+    for (const auto &entry : ufs->ls("saves")) {
+        if (entry.type != FILE_REGULAR || !entry.name.ends_with(".mm7"))
+            continue;
+
+        SavegameSlot slot;
+        slot.fileName = entry.name;
+
+        SaveGameLite save;
+        try {
+            deserialize(ufs->read(fmt::format("saves/{}", entry.name)), &save, tags::via<SaveGameLite_MM7>);
+        } catch (const std::exception &e) {
+            logger->warning("Couldn't load savegame '{}': {}", entry.name, e.what()); // Don't list unreadable saves.
+            continue;
+        }
+        slot.header = save.header;
+
+        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
+            slot.header.name = localization->str(LSTR_AUTOSAVE);
+
+        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
+            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
+
+        try {
+            slot.thumbnail.reset(GraphicsImage::Create(pcx::decode(save.thumbnail))); // TODO(captainurist): lazy-load.
+
+            if (slot.thumbnail->width() == 0)
+                slot.thumbnail = nullptr;
+        } catch (const Exception &e) {
+            logger->debug("Savegame thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
+            slot.thumbnail = nullptr;
+        }
+
+        result.push_back(std::move(slot));
+    }
+
+    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
+        if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
+            return result < 0;
+        return l.fileName < r.fileName;
+    };
+    std::ranges::sort(result, slotLess);
+    return result;
+}
+
+/**
+ * @return                          Slots to show in the save menu - a new save slot first, then the saves. Autosave
+ *                                  & quicksaves are loadable, but shouldn't be manually saved over, so they are
+ *                                  not shown.
+ */
+static std::vector<SavegameSlot> saveMenuSlots() {
+    std::vector<SavegameSlot> result = loadMenuSlots();
+    std::erase_if(result, [](const SavegameSlot &slot) {
+        return ascii::noCaseEquals(slot.fileName, autosaveFileName) ||
+               ascii::noCaseStartsWith(slot.fileName, engine->config->gameplay.QuickSaveName.value());
+    });
+    result.insert(result.begin(), SavegameSlot()); // New save slot goes first.
+    return result;
+}
+
 GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions)
     : GUIWindow(type, position, dimensions) {}
-
-GUIWindow_SaveLoad::~GUIWindow_SaveLoad() {
-    pSavegameList->releaseThumbnails(); // Thumbnails are loaded when a save/load menu opens, released when it closes.
-}
 
 void GUIWindow_SaveLoad::scrollUp() {
     _scrollPosition = std::max(0, _scrollPosition - 1);
 }
 
 void GUIWindow_SaveLoad::scrollDown() {
-    if (_scrollPosition + 7 < std::ssize(menuSlots()))
+    if (_scrollPosition + 7 < std::ssize(_slots))
         ++_scrollPosition;
 }
 
 void GUIWindow_SaveLoad::scrollWithMouse() {
-    int slotCount = std::ssize(menuSlots());
+    int slotCount = std::ssize(_slots);
     if (slotCount < 7)
         return; // Too few saves to scroll yet.
     // 216 is the scroll bar offset from the top of the dialog, 107 is its total height.
@@ -66,12 +137,12 @@ void GUIWindow_SaveLoad::scrollWithMouse() {
 }
 
 void GUIWindow_SaveLoad::drawSaveLoad() {
-    if (pSavegameList->isSlotUsed(_selectedSlot)) {
-        const SavegameSlot &slot = pSavegameList->slots()[_selectedSlot];
+    if (hasSelectedSlot() && !selectedSlot().fileName.empty()) {
+        const SavegameSlot &slot = selectedSlot();
         Recti titleRect(frameRect.x + 240, (frameRect.y - assets->pFontSmallnum->GetHeight()) + 157,
                         220, assets->pFontSmallnum->GetHeight());
         if (slot.thumbnail)
-            render->DrawQuad2D(slot.thumbnail, {frameRect.x + 276, frameRect.y + 171});
+            render->DrawQuad2D(slot.thumbnail.get(), {frameRect.x + 276, frameRect.y + 171});
 
         // Draw map name
         GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
@@ -100,13 +171,13 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
             // Saves need a name, keep the input open.
             keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
         } else {
-            pSavegameList->setSlotName(_selectedSlot, keyboardInputHandler->GetTextInput());
+            setSelectedSlotName(keyboardInputHandler->GetTextInput());
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_SaveGame, 0, 0);
         }
     }
 
     if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
-        const std::string &name = pSavegameList->slots()[_selectedSlot].header.name;
+        const std::string &name = selectedSlot().header.name;
         GUIWindow::DrawText(assets->pFontSmallnum.get(),
             {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_LOADING)) + 25, 220}, colorTable.White,
             localization->str(LSTR_LOADING), frameRect);
@@ -116,7 +187,7 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
             {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT)) + 25, 304}, colorTable.White,
             localization->str(LSTR_PLEASE_WAIT), frameRect);
     } else {
-        int slotCount = std::ssize(menuSlots());
+        int slotCount = std::ssize(_slots);
         int stopPos = 0;
         if (slotCount > 7) {
             stopPos = (float(_scrollPosition) / (slotCount - 7)) * 89.0f;
@@ -129,11 +200,10 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
         for (int i = _scrollPosition; i < slotCount; ++i) {
             if (slot_Y >= 346)
                 break;
-            int slot = menuSlots()[i];
-            bool isNewSaveSlot = pSavegameList->slots()[slot].fileName.empty();
-            if (keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || slot != _selectedSlot) {
-                DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, slot == _selectedSlot ? colorTable.LaserLemon : colorTable.White,
-                               isNewSaveSlot ? localization->str(LSTR_NEW_SAVE) : pSavegameList->slots()[slot].header.name, 185, 0);
+            bool isNewSaveSlot = _slots[i].fileName.empty();
+            if (keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || i != _selectedSlot) {
+                DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, i == _selectedSlot ? colorTable.LaserLemon : colorTable.White,
+                               isNewSaveSlot ? localization->str(LSTR_NEW_SAVE) : _slots[i].header.name, 185, 0);
             } else {
                 GUIWindow::DrawFlashingInputCursor(DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y},
                     colorTable.LaserLemon, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, assets->pFontSmallnum.get(), frameRect);
@@ -149,10 +219,7 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow_SaveLoad(WINDOW_Save, {0, 0}, rende
     saveload_ui_saveu = assets->getImage_ColorKey("LS_saveU");
     saveload_ui_x_u = assets->getImage_ColorKey("x_u");
 
-    pSavegameList->loadHeaders();
-
-    // New save slot is shown first & selected by default.
-    _selectedSlot = pSavegameList->saveMenuSlots().front();
+    _slots = saveMenuSlots(); // New save slot is shown first & selected by default.
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
     saveload_ui_ls_saved = assets->getImage_ColorKey("LS_saveD");
@@ -190,21 +257,16 @@ void GUIWindow_Save::Update() {
 void GUIWindow_Save::slotClicked(int slotIndex) {
     if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
-    int position = _scrollPosition + slotIndex;
-    if (position >= std::ssize(menuSlots()))
+    int slot = _scrollPosition + slotIndex;
+    if (slot >= std::ssize(_slots))
         return; // Clicked below the last slot.
-    int slot = menuSlots()[position];
     if (_selectedSlot != slot) {
         _selectedSlot = slot;
     } else {
         keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
-        if (pSavegameList->isSlotUsed(slot))
-            keyboardInputHandler->SetTextInput(pSavegameList->slots()[slot].header.name);
+        if (!_slots[slot].fileName.empty())
+            keyboardInputHandler->SetTextInput(_slots[slot].header.name);
     }
-}
-
-const std::vector<int> &GUIWindow_Save::menuSlots() const {
-    return pSavegameList->saveMenuSlots();
 }
 
 GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow_SaveLoad(WINDOW_Load, {0, 0}, {0, 0}) {
@@ -232,14 +294,13 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow_SaveLoad(WINDOW_Load, {0
     DrawText(assets->pFontSmallnum.get(), {25, 199}, colorTable.White, localization->str(LSTR_READING), this->frameRect);
     render->Present();
 
-    pSavegameList->loadHeaders();
+    _slots = loadMenuSlots();
 
-    int slotCount = std::ssize(pSavegameList->loadMenuSlots());
-    for (int i : pSavegameList->loadMenuSlots()) {
-        if (pSavegameList->slots()[i].fileName == engine->_lastLoadedSaveFileName) {
-            _selectedSlot = i;
-            _scrollPosition = std::min(i, std::max(0, slotCount - 7));
-        }
+    // Pre-select the last loaded save.
+    auto pos = std::ranges::find(_slots, engine->_lastLoadedSaveFileName, &SavegameSlot::fileName);
+    if (pos != _slots.end()) {
+        _selectedSlot = pos - _slots.begin();
+        _scrollPosition = std::min(_selectedSlot, std::max<int>(0, std::ssize(_slots) - 7));
     }
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
@@ -281,20 +342,15 @@ void GUIWindow_Load::Update() {
 void GUIWindow_Load::slotClicked(int slotIndex) {
     if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
-    int position = _scrollPosition + slotIndex;
-    if (position >= std::ssize(menuSlots()))
+    int slot = _scrollPosition + slotIndex;
+    if (slot >= std::ssize(_slots))
         return; // Clicked below the last save.
-    int slot = menuSlots()[position];
     if (!_loadSlotClicked || _selectedSlot != slot) {
         _selectedSlot = slot;
         _loadSlotClicked = true;
     } else {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     }
-}
-
-const std::vector<int> &GUIWindow_Load::menuSlots() const {
-    return pSavegameList->loadMenuSlots();
 }
 
 void GUIWindow_Load::loadButtonPressed() {
@@ -316,14 +372,13 @@ void GUIWindow_Load::cancelButtonPressed() {
 }
 
 void GUIWindow_Load::quickLoad() {
-    int slot = getQuickSaveSlot();
-    if (slot != -1) {
+    auto pos = std::ranges::find(_slots, getCurrentQuickSave(), &SavegameSlot::fileName);
+    if (pos != _slots.end()) {
         pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-        _selectedSlot = slot;
+        _selectedSlot = pos - _slots.begin();
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     } else {
         logger->error("QuickLoadGame:: No quick save could be found!");
         pAudioPlayer->playUISound(SOUND_error);
-        pSavegameList->loadHeaders(); // Failed quickload has reinitialized the list under the open menu, reload the headers.
     }
 }

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "Engine/Engine.h"
 #include "Engine/Resources/EngineFileSystem.h"
@@ -28,7 +29,6 @@
 #include "GUI/GUIMessageQueue.h"
 #include "Library/Image/Pcx.h"
 
-#include "Library/Lod/LodReader.h"
 #include "Library/Logger/Logger.h"
 #include "Library/Snapshots/SnapshotSerialization.h"
 
@@ -49,6 +49,57 @@ GraphicsImage *saveload_ui_x_d = nullptr;
 
 static GraphicsImage *scrollstop = nullptr;
 
+void loadSaveHeaders() {
+    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
+        SavegameSlot &slot = pSavegameList->slots[i];
+        std::string str = fmt::format("saves/{}", slot.fileName);
+        if (!ufs->exists(str)) {
+            slot.isUsed = false;
+            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
+            continue;
+        }
+
+        SaveGameLite save;
+        deserialize(ufs->read(str), &save, tags::via<SaveGameLite_MM7>);
+        slot.header = save.header;
+
+        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
+            slot.header.name = localization->str(LSTR_AUTOSAVE);
+
+        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
+            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
+
+        try {
+            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
+
+            if (slot.thumbnail->width() == 0) {
+                slot.thumbnail->release();
+                slot.thumbnail = nullptr;
+            }
+        } catch (const Exception &e) {
+            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
+            slot.thumbnail = nullptr;
+        }
+
+        slot.isUsed = true;
+    }
+
+    // Sort saves by display name, with file name as a tie-breaker.
+    auto sortKey = [](const SavegameSlot &slot) { return std::pair(ascii::toLower(slot.header.name), std::string_view(slot.fileName)); };
+    std::ranges::sort(pSavegameList->slots.begin(), pSavegameList->slots.begin() + pSavegameList->numSavegameFiles, {}, sortKey);
+
+    // Autosave & quicksaves are loadable, but shouldn't be manually saved over, so they are not shown in the
+    // save menu.
+    pSavegameList->saveMenuSlots.clear();
+    pSavegameList->saveMenuSlots.push_back(pSavegameList->numSavegameFiles); // New save slot goes first.
+    for (int i = 0; i < pSavegameList->numSavegameFiles; i++) {
+        const std::string &fileName = pSavegameList->slots[i].fileName;
+        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
+            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
+            pSavegameList->saveMenuSlots.push_back(i);
+    }
+}
+
 GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRenderDimensions()) {
     saveload_ui_loadsave = assets->getImage_ColorKey("loadsave");
     saveload_ui_save_up = assets->getImage_ColorKey("save_up");
@@ -56,47 +107,11 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRen
     saveload_ui_x_u = assets->getImage_ColorKey("x_u");
 
     pSavegameList->Initialize();
+    loadSaveHeaders();
 
-    LodReader pLODFile;
-    for (int i = 0; i < MAX_SAVE_SLOTS; ++i) {
-        // std::string file_name = pSavegameList->pFileList[i];
-        std::string file_name = fmt::format("save{:03}.mm7", i);
-        if (file_name.empty()) {
-            file_name = "1.mm7";
-        }
-
-        std::string str = fmt::format("saves/{}", file_name);
-        if (!ufs->exists(str)) {
-            pSavegameList->pSavegameUsedSlots[i] = false;
-            pSavegameList->pSavegameHeader[i].name = localization->str(LSTR_EMPTY_SAVE);
-        } else {
-            SaveGameLite save;
-            deserialize(ufs->read(str), &save, tags::via<SaveGameLite_MM7>);
-            pSavegameList->pSavegameHeader[i] = save.header;
-
-            if (pSavegameList->pSavegameHeader[i].name.empty()) {
-                // blank so add something - suspect quicksaves
-                std::string newname = pSavegameList->pFileList[i];
-                std::string test = newname.substr(0, newname.size() - 4);
-                pSavegameList->pSavegameHeader[i].name = test;
-            }
-
-            try {
-                pSavegameList->pSavegameThumbnails[i] = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
-
-                if (pSavegameList->pSavegameThumbnails[i]->width() == 0) {
-                    pSavegameList->pSavegameThumbnails[i]->release();
-                    pSavegameList->pSavegameThumbnails[i] = nullptr;
-                }
-            }
-            catch (const Exception& e) {
-                logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
-                pSavegameList->pSavegameThumbnails[i] = nullptr;
-            }
-
-            pSavegameList->pSavegameUsedSlots[i] = (pSavegameList->pSavegameThumbnails[i] != nullptr);
-        }
-    }
+    // New save slot is shown first & selected by default.
+    pSavegameList->selectedSlot = pSavegameList->numSavegameFiles;
+    pSavegameList->saveListPosition = 0;
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
     saveload_ui_ls_saved = assets->getImage_ColorKey("LS_saveD");
@@ -117,9 +132,9 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRen
     pBtnLoadSlot = CreateButton("SaveMenu_Save", {241, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadBtn, 0, INPUT_ACTION_INVALID, "", {saveload_ui_ls_saved});
     pBtnCancel = CreateButton({350, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_Cancel, 0, INPUT_ACTION_INVALID, "", {saveload_ui_x_d});
     pBtnArrowUp = CreateButton({215, 199}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_ArrowUp, 0, INPUT_ACTION_INVALID, "", {ui_ar_up_dn});
-    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, MAX_SAVE_SLOTS, INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
+    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, pSavegameList->saveMenuSlotCount(), INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
 
-    CreateButton({215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, MAX_SAVE_SLOTS);
+    CreateButton({215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, pSavegameList->saveMenuSlotCount());
 }
 
 void GUIWindow_Save::Update() {
@@ -159,57 +174,13 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow(WINDOW_Load, {0, 0}, {0,
     render->Present();
 
     pSavegameList->Initialize();
+    loadSaveHeaders();
 
     for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        std::string str = fmt::format("saves/{}", pSavegameList->pFileList[i]);
-        if (!ufs->exists(str)) {
-            pSavegameList->pSavegameUsedSlots[i] = false;
-            pSavegameList->pSavegameHeader[i].name = localization->str(LSTR_EMPTY_SAVE);
-            continue;
-        }
-
-        if (pSavegameList->pFileList[i] == pSavegameList->lastLoadedSave) {
+        if (pSavegameList->slots[i].fileName == pSavegameList->lastLoadedSave) {
             pSavegameList->selectedSlot = i;
-            pSavegameList->saveListPosition = i;
-            if (pSavegameList->saveListPosition + 7 > pSavegameList->numSavegameFiles) {
-                pSavegameList->saveListPosition = std::max(0, pSavegameList->numSavegameFiles - 7);
-            }
+            pSavegameList->saveListPosition = std::min(i, std::max(0, pSavegameList->numSavegameFiles - 7));
         }
-
-        SaveGameLite save;
-        deserialize(ufs->read(str), &save, tags::via<SaveGameLite_MM7>);
-        pSavegameList->pSavegameHeader[i] = save.header;
-
-        if (ascii::noCaseEquals(pSavegameList->pFileList[i], localization->str(LSTR_AUTOSAVE_MM7))) { // TODO(captainurist): #unicode might not be ascii
-            pSavegameList->pSavegameHeader[i].name = localization->str(LSTR_AUTOSAVE);
-        }
-
-        if (pSavegameList->pSavegameHeader[i].name.empty()) {
-            // blank so add something - suspect quicksaves
-            std::string newname = pSavegameList->pFileList[i];
-            std::string test = newname.substr(0, newname.size() - 4);
-            pSavegameList->pSavegameHeader[i].name = test;
-        }
-
-        try {
-            pSavegameList->pSavegameThumbnails[i] = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
-
-            if (pSavegameList->pSavegameThumbnails[i]->width() == 0) {
-                pSavegameList->pSavegameThumbnails[i]->release();
-                pSavegameList->pSavegameThumbnails[i] = nullptr;
-            }
-        } catch (const Exception &e) {
-            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
-            pSavegameList->pSavegameThumbnails[i] = nullptr;
-        }
-
-        pSavegameList->pSavegameUsedSlots[i] = true;
-        //if (pSavegameList->pSavegameThumbnails[i] != nullptr) {
-        //    pSavegameUsedSlots[i] = 1;
-        //} else {
-        //    pSavegameUsedSlots[i] = 0;
-        //    pSavegameList->pFileList[i].clear();
-        //}
     }
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
@@ -249,21 +220,21 @@ void GUIWindow_Load::Update() {
 }
 
 static void UI_DrawSaveLoad(bool save) {
-    if (pSavegameList->pSavegameUsedSlots[pSavegameList->selectedSlot]) {
+    if (pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
         Recti frameRect(pGUIWindow_CurrentMenu->frameRect.x + 240,
                                            (pGUIWindow_CurrentMenu->frameRect.y - assets->pFontSmallnum->GetHeight()) + 157,
                                            220,
                                            assets->pFontSmallnum->GetHeight());
-        if (pSavegameList->pSavegameThumbnails[pSavegameList->selectedSlot]) {
-            render->DrawQuad2D(pSavegameList->pSavegameThumbnails[pSavegameList->selectedSlot],
+        if (pSavegameList->slots[pSavegameList->selectedSlot].thumbnail) {
+            render->DrawQuad2D(pSavegameList->slots[pSavegameList->selectedSlot].thumbnail,
                                {pGUIWindow_CurrentMenu->frameRect.x + 276, pGUIWindow_CurrentMenu->frameRect.y + 171});
         }
         // Draw map name
         GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
-                                       pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].locationName)].name, 3, frameRect);
+                                       pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameList->slots[pSavegameList->selectedSlot].header.locationName)].name, 3, frameRect);
 
         // Draw date
-        CivilTime time = pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].playingTime.toCivilTime();
+        CivilTime time = pSavegameList->slots[pSavegameList->selectedSlot].header.playingTime.toCivilTime();
 
         frameRect.y = pGUIWindow_CurrentMenu->frameRect.y + 261;
 
@@ -281,8 +252,13 @@ static void UI_DrawSaveLoad(bool save) {
 
     if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
         pGUIWindow_CurrentMenu->keyboard_input_status = WINDOW_INPUT_NONE;
-        pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name = keyboardInputHandler->GetTextInput();
-        engine->_messageQueue->addMessageCurrentFrame(UIMSG_SaveGame, 0, 0);
+        if (keyboardInputHandler->GetTextInput().empty()) {
+            // Saves need a name, keep the input open.
+            keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
+        } else {
+            pSavegameList->slots[pSavegameList->selectedSlot].header.name = keyboardInputHandler->GetTextInput();
+            engine->_messageQueue->addMessageCurrentFrame(UIMSG_SaveGame, 0, 0);
+        }
     }
 
     if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
@@ -290,27 +266,25 @@ static void UI_DrawSaveLoad(bool save) {
             {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_LOADING)) + 25, 220}, colorTable.White,
             localization->str(LSTR_LOADING), pGUIWindow_CurrentMenu->frameRect);
         pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(),
-                                               {assets->pFontSmallnum->AlignText_Center(186, pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name) + 25, 262}, colorTable.White,
-                                               pSavegameList->pSavegameHeader[pSavegameList->selectedSlot].name, 185, 0);
+                                               {assets->pFontSmallnum->AlignText_Center(186, pSavegameList->slots[pSavegameList->selectedSlot].header.name) + 25, 262}, colorTable.White,
+                                               pSavegameList->slots[pSavegameList->selectedSlot].header.name, 185, 0);
         GUIWindow::DrawText(assets->pFontSmallnum.get(),
             {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT)) + 25, 304}, colorTable.White,
             localization->str(LSTR_PLEASE_WAIT), pGUIWindow_CurrentMenu->frameRect);
     } else {
-        int maxSaveFiles = MAX_SAVE_SLOTS;
+        int maxSaveFiles = save ? pSavegameList->saveMenuSlotCount() : pSavegameList->numSavegameFiles;
         int framex = 0, framey = 0;
         int stopPos = 0;
 
         if (!save) {
-            maxSaveFiles = pSavegameList->numSavegameFiles;
             framex = pGUIWindow_CurrentMenu->frameRect.x;
             framey = pGUIWindow_CurrentMenu->frameRect.y;
         }
 
         if (maxSaveFiles > 7) {
             stopPos = (float(pSavegameList->saveListPosition) / (maxSaveFiles - 7)) * 89.0f;
-        }
-        if (pSavegameList->saveListPosition > maxSaveFiles - 7) {
-            stopPos = 89;
+            if (pSavegameList->saveListPosition > maxSaveFiles - 7)
+                stopPos = 89;
         }
         render->DrawQuad2D(scrollstop, {216 + framex, static_cast<int>(217 + framey + stopPos)});
 
@@ -319,12 +293,14 @@ static void UI_DrawSaveLoad(bool save) {
             if (slot_Y >= 346) {
                 break;
             }
-            if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || i != pSavegameList->selectedSlot) {
-                pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, i == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White,
-                                                       pSavegameList->pSavegameHeader[i].name, 185, 0);
+            int slot = save ? pSavegameList->saveMenuSlot(i) : i;
+            bool isNewSaveSlot = slot == pSavegameList->numSavegameFiles;
+            if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || slot != pSavegameList->selectedSlot) {
+                pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, slot == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White,
+                                                       isNewSaveSlot ? localization->str(LSTR_NEW_SAVE) : pSavegameList->slots[slot].header.name, 185, 0);
             } else {
                 GUIWindow::DrawFlashingInputCursor(pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y},
-                    i == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, assets->pFontSmallnum.get(), pGUIWindow_CurrentMenu->frameRect);
+                    colorTable.LaserLemon, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, assets->pFontSmallnum.get(), pGUIWindow_CurrentMenu->frameRect);
             }
             slot_Y += 21;
         }
@@ -336,6 +312,8 @@ void GUIWindow_Load::slotSelected(int slotIndex) {
     if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
     assert(current_screen_type != SCREEN_SAVEGAME); // No savegame in main menu
+    if (slotIndex + pSavegameList->saveListPosition >= pSavegameList->numSavegameFiles)
+        return; // Clicked below the last save.
     if (isLoadSlotClicked && pSavegameList->selectedSlot == slotIndex + pSavegameList->saveListPosition) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     } else {
@@ -393,5 +371,6 @@ void GUIWindow_Load::quickLoad() {
     } else {
         logger->error("QuickLoadGame:: No quick save could be found!");
         pAudioPlayer->playUISound(SOUND_error);
+        loadSaveHeaders(); // Failed quickload has reinitialized the list under the open menu, reload the headers.
     }
 }

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -123,6 +124,14 @@ GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei d
     : GUIWindow(type, position, dimensions)
 {}
 
+void GUIWindow_SaveLoad::preselectSlot(std::string_view fileName) {
+    auto pos = std::ranges::find(_slots, fileName, &SavegameSlot::fileName);
+    if (pos == _slots.end())
+        return;
+    _selectedSlot = pos - _slots.begin();
+    _scrollPosition = std::min(_selectedSlot, std::max<int>(0, std::ssize(_slots) - 7));
+}
+
 void GUIWindow_SaveLoad::scrollUp() {
     _scrollPosition = std::max(0, _scrollPosition - 1);
 }
@@ -225,7 +234,11 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow_SaveLoad(WINDOW_Save, {0, 0}, rende
     saveload_ui_saveu = assets->getImage_ColorKey("LS_saveU");
     saveload_ui_x_u = assets->getImage_ColorKey("x_u");
 
-    _slots = saveMenuSlots(); // New save slot is shown first & selected by default.
+    _slots = saveMenuSlots(); // New save slot is shown first.
+
+    // Pre-select the currently loaded save, so that just clicking the save button saves over it. There might be
+    // none, e.g. when playing a new game - then the new save slot stays selected.
+    preselectSlot(engine->_lastLoadedSaveFileName);
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
     saveload_ui_ls_saved = assets->getImage_ColorKey("LS_saveD");
@@ -303,11 +316,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow_SaveLoad(WINDOW_Load, {0
     _slots = loadMenuSlots();
 
     // Pre-select the last loaded save.
-    auto pos = std::ranges::find(_slots, engine->_lastLoadedSaveFileName, &SavegameSlot::fileName);
-    if (pos != _slots.end()) {
-        _selectedSlot = pos - _slots.begin();
-        _scrollPosition = std::min(_selectedSlot, std::max<int>(0, std::ssize(_slots) - 7));
-    }
+    preselectSlot(engine->_lastLoadedSaveFileName);
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
     saveload_ui_ls_saved = assets->getImage_ColorKey("LS_loadD");

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -18,7 +18,6 @@
 #include "Media/Audio/AudioPlayer.h"
 
 #include "Io/KeyboardInputHandler.h"
-#include "Io/Mouse.h"
 
 #include "GUI/GUIButton.h"
 #include "GUI/GUIFont.h"
@@ -69,10 +68,14 @@ static std::vector<SavegameSlot> loadMenuSlots() {
         }
         slot.header = save.header;
 
+        // Show autosave & quicksave titles in the current language - the stored titles are in whatever language
+        // was active when the save was made.
         if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
             slot.header.name = localization->str(LSTR_AUTOSAVE);
+        else if (ascii::noCaseStartsWith(slot.fileName, quickSaveFileNamePrefix))
+            slot.header.name = localization->str(LSTR_QUICKSAVE);
 
-        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
+        if (slot.header.name.empty()) // Foreign saves with blank titles - fall back to the file name.
             slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
 
         try {
@@ -88,12 +91,11 @@ static std::vector<SavegameSlot> loadMenuSlots() {
         result.push_back(std::move(slot));
     }
 
-    auto slotLess = [](const SavegameSlot &l, const SavegameSlot &r) {
+    std::ranges::sort(result, [](const SavegameSlot &l, const SavegameSlot &r) {
         if (int result = ascii::noCaseCompare(l.header.name, r.header.name))
             return result < 0;
         return l.fileName < r.fileName;
-    };
-    std::ranges::sort(result, slotLess);
+    });
     return result;
 }
 
@@ -106,7 +108,7 @@ static std::vector<SavegameSlot> saveMenuSlots() {
     std::vector<SavegameSlot> result = loadMenuSlots();
     std::erase_if(result, [](const SavegameSlot &slot) {
         return ascii::noCaseEquals(slot.fileName, autosaveFileName) ||
-               ascii::noCaseStartsWith(slot.fileName, engine->config->gameplay.QuickSaveName.value());
+               ascii::noCaseStartsWith(slot.fileName, quickSaveFileNamePrefix);
     });
     result.insert(result.begin(), SavegameSlot()); // New save slot goes first.
     return result;
@@ -118,7 +120,8 @@ GUIWindow_SaveLoad *saveLoadMenu() {
 }
 
 GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions)
-    : GUIWindow(type, position, dimensions) {}
+    : GUIWindow(type, position, dimensions)
+{}
 
 void GUIWindow_SaveLoad::scrollUp() {
     _scrollPosition = std::max(0, _scrollPosition - 1);
@@ -129,12 +132,12 @@ void GUIWindow_SaveLoad::scrollDown() {
         ++_scrollPosition;
 }
 
-void GUIWindow_SaveLoad::scrollWithMouse() {
+void GUIWindow_SaveLoad::scrollWithMouse(Pointi mousePos) {
     int slotCount = std::ssize(_slots);
     if (slotCount < 7)
         return; // Too few saves to scroll yet.
     // 216 is the scroll bar offset from the top of the dialog, 107 is its total height.
-    int my = mouse->position().y - frameRect.y - 216;
+    int my = mousePos.y - frameRect.y - 216;
     float fmy = static_cast<float>(my) / 107.0f;
     int newPosition = std::round((slotCount - 7) * fmy);
     _scrollPosition = std::clamp(newPosition, 0, slotCount - 7);
@@ -155,9 +158,7 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
 
         // Draw date
         CivilTime time = slot.header.playingTime.toCivilTime();
-
         titleRect.y = frameRect.y + 261;
-
         std::string str = fmt::format(
             "{} {}:{:02} {}\n{} {} {}",
             localization->dayName(time.dayOfWeek - 1),

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -1,23 +1,18 @@
 #include "GUI/UI/UISaveLoad.h"
 
-#include <string>
 #include <algorithm>
-#include <memory>
-#include <utility>
+#include <cmath>
+#include <string>
+#include <vector>
 
 #include "Engine/Engine.h"
-#include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/EngineGlobals.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
-#include "Engine/Graphics/ImageLoader.h"
-#include "Engine/Graphics/Viewport.h"
 #include "Engine/Graphics/Image.h"
-#include "Engine/Snapshots/EntitySnapshots.h"
 #include "Engine/Localization.h"
 #include "Engine/MapInfo.h"
 #include "Engine/SaveLoad.h"
-#include "Engine/Snapshots/CompositeSnapshots.h"
 
 #include "Media/Audio/AudioPlayer.h"
 
@@ -27,17 +22,10 @@
 #include "GUI/GUIButton.h"
 #include "GUI/GUIFont.h"
 #include "GUI/GUIMessageQueue.h"
-#include "Library/Image/Pcx.h"
 
 #include "Library/Logger/Logger.h"
-#include "Library/Snapshots/SnapshotSerialization.h"
-
-#include "Utility/String/Ascii.h"
-#include "Utility/Exception.h"
 
 using Io::TextInputType;
-
-static void UI_DrawSaveLoad(bool save);
 
 std::array<int, 2> saveload_dlg_xs = {{82, 0}};
 std::array<int, 2> saveload_dlg_ys = {{60, 0}};
@@ -49,69 +37,122 @@ GraphicsImage *saveload_ui_x_d = nullptr;
 
 static GraphicsImage *scrollstop = nullptr;
 
-void loadSaveHeaders() {
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        SavegameSlot &slot = pSavegameList->slots[i];
-        std::string str = fmt::format("saves/{}", slot.fileName);
-        if (!ufs->exists(str)) {
-            slot.isUsed = false;
-            slot.header.name = localization->str(LSTR_EMPTY_SAVE);
-            continue;
-        }
+GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions)
+    : GUIWindow(type, position, dimensions) {}
 
-        SaveGameLite save;
-        deserialize(ufs->read(str), &save, tags::via<SaveGameLite_MM7>);
-        slot.header = save.header;
+GUIWindow_SaveLoad::~GUIWindow_SaveLoad() {
+    pSavegameList->releaseThumbnails(); // Thumbnails are loaded when a save/load menu opens, released when it closes.
+}
 
-        if (ascii::noCaseEquals(slot.fileName, autosaveFileName))
-            slot.header.name = localization->str(LSTR_AUTOSAVE);
+void GUIWindow_SaveLoad::scrollUp() {
+    _scrollPosition = std::max(0, _scrollPosition - 1);
+}
 
-        if (slot.header.name.empty()) // blank so add something - suspect quicksaves
-            slot.header.name = slot.fileName.substr(0, slot.fileName.size() - 4);
+void GUIWindow_SaveLoad::scrollDown() {
+    if (_scrollPosition + 7 < std::ssize(menuSlots()))
+        ++_scrollPosition;
+}
 
-        try {
-            slot.thumbnail = GraphicsImage::Create(pcx::decode(save.thumbnail)); // TODO(captainurist): lazy-load.
+void GUIWindow_SaveLoad::scrollWithMouse() {
+    int slotCount = std::ssize(menuSlots());
+    if (slotCount < 7)
+        return; // Too few saves to scroll yet.
+    // 216 is the scroll bar offset from the top of the dialog, 107 is its total height.
+    int my = mouse->position().y - frameRect.y - 216;
+    float fmy = static_cast<float>(my) / 107.0f;
+    int newPosition = std::round((slotCount - 7) * fmy);
+    _scrollPosition = std::clamp(newPosition, 0, slotCount - 7);
+    pAudioPlayer->playUISound(SOUND_StartMainChoice02);
+}
 
-            if (slot.thumbnail->width() == 0) {
-                slot.thumbnail->release();
-                slot.thumbnail = nullptr;
-            }
-        } catch (const Exception &e) {
-            logger->debug("pSavegameList thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
-            slot.thumbnail = nullptr;
-        }
+void GUIWindow_SaveLoad::drawSaveLoad() {
+    if (pSavegameList->isSlotUsed(_selectedSlot)) {
+        const SavegameSlot &slot = pSavegameList->slots()[_selectedSlot];
+        Recti titleRect(frameRect.x + 240, (frameRect.y - assets->pFontSmallnum->GetHeight()) + 157,
+                        220, assets->pFontSmallnum->GetHeight());
+        if (slot.thumbnail)
+            render->DrawQuad2D(slot.thumbnail, {frameRect.x + 276, frameRect.y + 171});
 
-        slot.isUsed = true;
+        // Draw map name
+        GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
+                                 pMapStats->pInfos[pMapStats->GetMapInfo(slot.header.locationName)].name, 3, titleRect);
+
+        // Draw date
+        CivilTime time = slot.header.playingTime.toCivilTime();
+
+        titleRect.y = frameRect.y + 261;
+
+        std::string str = fmt::format(
+            "{} {}:{:02} {}\n{} {} {}",
+            localization->dayName(time.dayOfWeek - 1),
+            time.hourAmPm,
+            time.minute,
+            localization->amPm(time.isPm),
+            time.day,
+            localization->monthName(time.month - 1),
+            time.year);
+        GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White, str, 3, titleRect);
     }
 
-    // Sort saves by display name, with file name as a tie-breaker.
-    auto sortKey = [](const SavegameSlot &slot) { return std::pair(ascii::toLower(slot.header.name), std::string_view(slot.fileName)); };
-    std::ranges::sort(pSavegameList->slots.begin(), pSavegameList->slots.begin() + pSavegameList->numSavegameFiles, {}, sortKey);
+    if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
+        keyboard_input_status = WINDOW_INPUT_NONE;
+        if (keyboardInputHandler->GetTextInput().empty()) {
+            // Saves need a name, keep the input open.
+            keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
+        } else {
+            pSavegameList->setSlotName(_selectedSlot, keyboardInputHandler->GetTextInput());
+            engine->_messageQueue->addMessageCurrentFrame(UIMSG_SaveGame, 0, 0);
+        }
+    }
 
-    // Autosave & quicksaves are loadable, but shouldn't be manually saved over, so they are not shown in the
-    // save menu.
-    pSavegameList->saveMenuSlots.clear();
-    pSavegameList->saveMenuSlots.push_back(pSavegameList->numSavegameFiles); // New save slot goes first.
-    for (int i = 0; i < pSavegameList->numSavegameFiles; i++) {
-        const std::string &fileName = pSavegameList->slots[i].fileName;
-        if (!ascii::noCaseEquals(fileName, autosaveFileName) &&
-            !ascii::noCaseStartsWith(fileName, engine->config->gameplay.QuickSaveName.value()))
-            pSavegameList->saveMenuSlots.push_back(i);
+    if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
+        const std::string &name = pSavegameList->slots()[_selectedSlot].header.name;
+        GUIWindow::DrawText(assets->pFontSmallnum.get(),
+            {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_LOADING)) + 25, 220}, colorTable.White,
+            localization->str(LSTR_LOADING), frameRect);
+        DrawTextInRect(assets->pFontSmallnum.get(),
+                       {assets->pFontSmallnum->AlignText_Center(186, name) + 25, 262}, colorTable.White, name, 185, 0);
+        GUIWindow::DrawText(assets->pFontSmallnum.get(),
+            {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT)) + 25, 304}, colorTable.White,
+            localization->str(LSTR_PLEASE_WAIT), frameRect);
+    } else {
+        int slotCount = std::ssize(menuSlots());
+        int stopPos = 0;
+        if (slotCount > 7) {
+            stopPos = (float(_scrollPosition) / (slotCount - 7)) * 89.0f;
+            if (_scrollPosition > slotCount - 7)
+                stopPos = 89;
+        }
+        render->DrawQuad2D(scrollstop, {216 + frameRect.x, static_cast<int>(217 + frameRect.y + stopPos)});
+
+        int slot_Y = 199;
+        for (int i = _scrollPosition; i < slotCount; ++i) {
+            if (slot_Y >= 346)
+                break;
+            int slot = menuSlots()[i];
+            bool isNewSaveSlot = pSavegameList->slots()[slot].fileName.empty();
+            if (keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || slot != _selectedSlot) {
+                DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, slot == _selectedSlot ? colorTable.LaserLemon : colorTable.White,
+                               isNewSaveSlot ? localization->str(LSTR_NEW_SAVE) : pSavegameList->slots()[slot].header.name, 185, 0);
+            } else {
+                GUIWindow::DrawFlashingInputCursor(DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y},
+                    colorTable.LaserLemon, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, assets->pFontSmallnum.get(), frameRect);
+            }
+            slot_Y += 21;
+        }
     }
 }
 
-GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRenderDimensions()) {
+GUIWindow_Save::GUIWindow_Save() : GUIWindow_SaveLoad(WINDOW_Save, {0, 0}, render->GetRenderDimensions()) {
     saveload_ui_loadsave = assets->getImage_ColorKey("loadsave");
     saveload_ui_save_up = assets->getImage_ColorKey("save_up");
     saveload_ui_saveu = assets->getImage_ColorKey("LS_saveU");
     saveload_ui_x_u = assets->getImage_ColorKey("x_u");
 
-    pSavegameList->Initialize();
-    loadSaveHeaders();
+    pSavegameList->loadHeaders();
 
     // New save slot is shown first & selected by default.
-    pSavegameList->selectedSlot = pSavegameList->numSavegameFiles;
-    pSavegameList->saveListPosition = 0;
+    _selectedSlot = pSavegameList->saveMenuSlots().front();
 
     saveload_ui_x_d = assets->getImage_ColorKey("x_d");
     saveload_ui_ls_saved = assets->getImage_ColorKey("LS_saveD");
@@ -120,7 +161,6 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRen
 
     scrollstop = assets->getImage_ColorKey("con_x");
 
-    // GUIWindow_Save c-tor --- part
     CreateButton("SaveMenu_Slot0", {21, 198}, {191, 18}, BUTTON_TYPE_NORMAL, 0, UIMSG_SelectLoadSlot, 0);
     CreateButton("SaveMenu_Slot1", {21, 218}, {191, 18}, BUTTON_TYPE_NORMAL, 0, UIMSG_SelectLoadSlot, 1);
     CreateButton("SaveMenu_Slot2", {21, 238}, {191, 18}, BUTTON_TYPE_NORMAL, 0, UIMSG_SelectLoadSlot, 2);
@@ -132,9 +172,9 @@ GUIWindow_Save::GUIWindow_Save() : GUIWindow(WINDOW_Save, {0, 0}, render->GetRen
     pBtnLoadSlot = CreateButton("SaveMenu_Save", {241, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadBtn, 0, INPUT_ACTION_INVALID, "", {saveload_ui_ls_saved});
     pBtnCancel = CreateButton({350, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_Cancel, 0, INPUT_ACTION_INVALID, "", {saveload_ui_x_d});
     pBtnArrowUp = CreateButton({215, 199}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_ArrowUp, 0, INPUT_ACTION_INVALID, "", {ui_ar_up_dn});
-    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, pSavegameList->saveMenuSlotCount(), INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
+    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, 0, INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
 
-    CreateButton({215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, pSavegameList->saveMenuSlotCount());
+    CreateButton({215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, 0);
 }
 
 void GUIWindow_Save::Update() {
@@ -144,10 +184,30 @@ void GUIWindow_Save::Update() {
         render->DrawQuad2D(saveload_ui_save_up, {18, 139});
         render->DrawQuad2D(saveload_ui_x_u, {351, 302});
     }
-    UI_DrawSaveLoad(true);
+    drawSaveLoad();
 }
 
-GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow(WINDOW_Load, {0, 0}, {0, 0}) {
+void GUIWindow_Save::slotClicked(int slotIndex) {
+    if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
+        keyboardInputHandler->EndTextInput();
+    int position = _scrollPosition + slotIndex;
+    if (position >= std::ssize(menuSlots()))
+        return; // Clicked below the last slot.
+    int slot = menuSlots()[position];
+    if (_selectedSlot != slot) {
+        _selectedSlot = slot;
+    } else {
+        keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
+        if (pSavegameList->isSlotUsed(slot))
+            keyboardInputHandler->SetTextInput(pSavegameList->slots()[slot].header.name);
+    }
+}
+
+const std::vector<int> &GUIWindow_Save::menuSlots() const {
+    return pSavegameList->saveMenuSlots();
+}
+
+GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow_SaveLoad(WINDOW_Load, {0, 0}, {0, 0}) {
     current_screen_type = SCREEN_LOADGAME;
 
     saveload_ui_loadsave = assets->getImage_ColorKey("loadsave");
@@ -166,20 +226,19 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow(WINDOW_Load, {0, 0}, {0,
         render->DrawQuad2D(saveload_ui_x_u, {351, 302});
     }
 
-    // GUIWindow::GUIWindow
     this->frameRect = Recti(saveload_dlg_xs[ingame ? 1 : 0], saveload_dlg_ys[ingame ? 1 : 0],
                             saveload_dlg_zs[ingame ? 1 : 0], saveload_dlg_ws[ingame ? 1 : 0]);
 
     DrawText(assets->pFontSmallnum.get(), {25, 199}, colorTable.White, localization->str(LSTR_READING), this->frameRect);
     render->Present();
 
-    pSavegameList->Initialize();
-    loadSaveHeaders();
+    pSavegameList->loadHeaders();
 
-    for (int i = 0; i < pSavegameList->numSavegameFiles; ++i) {
-        if (pSavegameList->slots[i].fileName == pSavegameList->lastLoadedSave) {
-            pSavegameList->selectedSlot = i;
-            pSavegameList->saveListPosition = std::min(i, std::max(0, pSavegameList->numSavegameFiles - 7));
+    int slotCount = std::ssize(pSavegameList->loadMenuSlots());
+    for (int i : pSavegameList->loadMenuSlots()) {
+        if (pSavegameList->slots()[i].fileName == engine->_lastLoadedSaveFileName) {
+            _selectedSlot = i;
+            _scrollPosition = std::min(i, std::max(0, slotCount - 7));
         }
     }
 
@@ -201,9 +260,9 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) : GUIWindow(WINDOW_Load, {0, 0}, {0,
     pBtnLoadSlot = CreateButton("LoadMenu_Load", {241, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadBtn, 0, INPUT_ACTION_INVALID, "", {saveload_ui_ls_saved});
     pBtnCancel = CreateButton({350, 302}, {105, 40}, BUTTON_TYPE_NORMAL, 0, UIMSG_Cancel, 0, INPUT_ACTION_INVALID, "", {saveload_ui_x_d});
     pBtnArrowUp = CreateButton({215, 199}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_ArrowUp, 0, INPUT_ACTION_INVALID, "", {ui_ar_up_dn});
-    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, pSavegameList->numSavegameFiles, INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
+    pBtnDownArrow = CreateButton({215, 323}, {17, 17}, BUTTON_TYPE_NORMAL, 0, UIMSG_DownArrow, 0, INPUT_ACTION_INVALID, "", {ui_ar_dn_dn});
 
-    CreateButton("LoadMenu_Scroll", {215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, pSavegameList->numSavegameFiles);
+    CreateButton("LoadMenu_Scroll", {215, 216}, {17, 107}, BUTTON_TYPE_NORMAL, 0, UIMSG_SaveLoadScroll, 0);
 }
 
 void GUIWindow_Load::Update() {
@@ -216,161 +275,55 @@ void GUIWindow_Load::Update() {
         render->DrawQuad2D(saveload_ui_load_up, {18, 139});
         render->DrawQuad2D(saveload_ui_x_u, {351, 302});
     }
-    UI_DrawSaveLoad(false);
+    drawSaveLoad();
 }
 
-static void UI_DrawSaveLoad(bool save) {
-    if (pSavegameList->isSlotUsed(pSavegameList->selectedSlot)) {
-        Recti frameRect(pGUIWindow_CurrentMenu->frameRect.x + 240,
-                                           (pGUIWindow_CurrentMenu->frameRect.y - assets->pFontSmallnum->GetHeight()) + 157,
-                                           220,
-                                           assets->pFontSmallnum->GetHeight());
-        if (pSavegameList->slots[pSavegameList->selectedSlot].thumbnail) {
-            render->DrawQuad2D(pSavegameList->slots[pSavegameList->selectedSlot].thumbnail,
-                               {pGUIWindow_CurrentMenu->frameRect.x + 276, pGUIWindow_CurrentMenu->frameRect.y + 171});
-        }
-        // Draw map name
-        GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
-                                       pMapStats->pInfos[pMapStats->GetMapInfo(pSavegameList->slots[pSavegameList->selectedSlot].header.locationName)].name, 3, frameRect);
-
-        // Draw date
-        CivilTime time = pSavegameList->slots[pSavegameList->selectedSlot].header.playingTime.toCivilTime();
-
-        frameRect.y = pGUIWindow_CurrentMenu->frameRect.y + 261;
-
-        std::string str = fmt::format(
-            "{} {}:{:02} {}\n{} {} {}",
-            localization->dayName(time.dayOfWeek - 1),
-            time.hourAmPm,
-            time.minute,
-            localization->amPm(time.isPm),
-            time.day,
-            localization->monthName(time.month - 1),
-            time.year);
-        GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White, str, 3, frameRect);
-    }
-
-    if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-        pGUIWindow_CurrentMenu->keyboard_input_status = WINDOW_INPUT_NONE;
-        if (keyboardInputHandler->GetTextInput().empty()) {
-            // Saves need a name, keep the input open.
-            keyboardInputHandler->StartTextInput(TextInputType::Text, 19, pGUIWindow_CurrentMenu.get());
-        } else {
-            pSavegameList->slots[pSavegameList->selectedSlot].header.name = keyboardInputHandler->GetTextInput();
-            engine->_messageQueue->addMessageCurrentFrame(UIMSG_SaveGame, 0, 0);
-        }
-    }
-
-    if (GetCurrentMenuID() == MENU_LoadingProcInMainMenu) {
-        GUIWindow::DrawText(assets->pFontSmallnum.get(),
-            {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_LOADING)) + 25, 220}, colorTable.White,
-            localization->str(LSTR_LOADING), pGUIWindow_CurrentMenu->frameRect);
-        pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(),
-                                               {assets->pFontSmallnum->AlignText_Center(186, pSavegameList->slots[pSavegameList->selectedSlot].header.name) + 25, 262}, colorTable.White,
-                                               pSavegameList->slots[pSavegameList->selectedSlot].header.name, 185, 0);
-        GUIWindow::DrawText(assets->pFontSmallnum.get(),
-            {assets->pFontSmallnum->AlignText_Center(186, localization->str(LSTR_PLEASE_WAIT)) + 25, 304}, colorTable.White,
-            localization->str(LSTR_PLEASE_WAIT), pGUIWindow_CurrentMenu->frameRect);
-    } else {
-        int maxSaveFiles = save ? pSavegameList->saveMenuSlotCount() : pSavegameList->numSavegameFiles;
-        int framex = 0, framey = 0;
-        int stopPos = 0;
-
-        if (!save) {
-            framex = pGUIWindow_CurrentMenu->frameRect.x;
-            framey = pGUIWindow_CurrentMenu->frameRect.y;
-        }
-
-        if (maxSaveFiles > 7) {
-            stopPos = (float(pSavegameList->saveListPosition) / (maxSaveFiles - 7)) * 89.0f;
-            if (pSavegameList->saveListPosition > maxSaveFiles - 7)
-                stopPos = 89;
-        }
-        render->DrawQuad2D(scrollstop, {216 + framex, static_cast<int>(217 + framey + stopPos)});
-
-        int slot_Y = 199;
-        for (int i = pSavegameList->saveListPosition; i < maxSaveFiles; ++i) {
-            if (slot_Y >= 346) {
-                break;
-            }
-            int slot = save ? pSavegameList->saveMenuSlot(i) : i;
-            bool isNewSaveSlot = slot == pSavegameList->numSavegameFiles;
-            if (pGUIWindow_CurrentMenu->keyboard_input_status != WINDOW_INPUT_IN_PROGRESS || slot != pSavegameList->selectedSlot) {
-                pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y}, slot == pSavegameList->selectedSlot ? colorTable.LaserLemon : colorTable.White,
-                                                       isNewSaveSlot ? localization->str(LSTR_NEW_SAVE) : pSavegameList->slots[slot].header.name, 185, 0);
-            } else {
-                GUIWindow::DrawFlashingInputCursor(pGUIWindow_CurrentMenu->DrawTextInRect(assets->pFontSmallnum.get(), {27, slot_Y},
-                    colorTable.LaserLemon, keyboardInputHandler->GetTextInput(), 175, 1) + 27, slot_Y, assets->pFontSmallnum.get(), pGUIWindow_CurrentMenu->frameRect);
-            }
-            slot_Y += 21;
-        }
-    }
-}
-
-void GUIWindow_Load::slotSelected(int slotIndex) {
-    // main menu save/load wnd   clicking on savegame lines
-    if (pGUIWindow_CurrentMenu->keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
+void GUIWindow_Load::slotClicked(int slotIndex) {
+    if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
-    assert(current_screen_type != SCREEN_SAVEGAME); // No savegame in main menu
-    if (slotIndex + pSavegameList->saveListPosition >= pSavegameList->numSavegameFiles)
+    int position = _scrollPosition + slotIndex;
+    if (position >= std::ssize(menuSlots()))
         return; // Clicked below the last save.
-    if (isLoadSlotClicked && pSavegameList->selectedSlot == slotIndex + pSavegameList->saveListPosition) {
-        engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
+    int slot = menuSlots()[position];
+    if (!_loadSlotClicked || _selectedSlot != slot) {
+        _selectedSlot = slot;
+        _loadSlotClicked = true;
     } else {
-        pSavegameList->selectedSlot = slotIndex + pSavegameList->saveListPosition;
-        isLoadSlotClicked = true;
+        engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     }
+}
+
+const std::vector<int> &GUIWindow_Load::menuSlots() const {
+    return pSavegameList->loadMenuSlots();
 }
 
 void GUIWindow_Load::loadButtonPressed() {
-    new OnSaveLoad({ pGUIWindow_CurrentMenu->frameRect.x + 241, pGUIWindow_CurrentMenu->frameRect.y + 302 }, { 61, 28 }, pBtnLoadSlot);
+    new OnSaveLoad({ frameRect.x + 241, frameRect.y + 302 }, { 61, 28 }, pBtnLoadSlot);
 }
 
-void GUIWindow_Load::downArrowPressed(int maxSlots) {
-    if (pSavegameList->saveListPosition + 7 < maxSlots) {
-        ++pSavegameList->saveListPosition;
-    }
-    new OnButtonClick({ pGUIWindow_CurrentMenu->frameRect.x + 215, pGUIWindow_CurrentMenu->frameRect.y + 323 }, { 0, 0 }, pBtnDownArrow);
+void GUIWindow_Load::downArrowPressed() {
+    scrollDown();
+    new OnButtonClick({ frameRect.x + 215, frameRect.y + 323 }, { 0, 0 }, pBtnDownArrow);
 }
 
 void GUIWindow_Load::upArrowPressed() {
-    --pSavegameList->saveListPosition;
-    if (pSavegameList->saveListPosition < 0)
-        pSavegameList->saveListPosition = 0;
-    new OnButtonClick({ pGUIWindow_CurrentMenu->frameRect.x + 215, pGUIWindow_CurrentMenu->frameRect.y + 197 }, { 0, 0 }, pBtnArrowUp);
+    scrollUp();
+    new OnButtonClick({ frameRect.x + 215, frameRect.y + 197 }, { 0, 0 }, pBtnArrowUp);
 }
 
 void GUIWindow_Load::cancelButtonPressed() {
-    new OnCancel3({ pGUIWindow_CurrentMenu->frameRect.x + 350, pGUIWindow_CurrentMenu->frameRect.y + 302 }, { 61, 28 }, pBtnCancel);
-}
-
-void GUIWindow_Load::scroll(int maxSlots) {
-    // pskelton add for scroll click
-    if (maxSlots < 7) {
-        // Too few saves to scroll yet
-        return;
-    }
-    Pointi mousePos = mouse->position();
-    int mx = mousePos.x, my = mousePos.y;
-    // 276 is offset down from top (216 + 60 frame)
-    my -= 276;
-    // 107 is total height of bar
-    float fmy = static_cast<float>(my) / 107.0f;
-    int newlistpost = std::round((maxSlots - 7) * fmy);
-    newlistpost = std::clamp(newlistpost, 0, (maxSlots - 7));
-    pSavegameList->saveListPosition = newlistpost;
-    pAudioPlayer->playUISound(SOUND_StartMainChoice02);
+    new OnCancel3({ frameRect.x + 350, frameRect.y + 302 }, { 61, 28 }, pBtnCancel);
 }
 
 void GUIWindow_Load::quickLoad() {
     int slot = getQuickSaveSlot();
     if (slot != -1) {
         pAudioPlayer->playUISound(SOUND_StartMainChoice02);
-        pSavegameList->selectedSlot = slot;
+        _selectedSlot = slot;
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     } else {
         logger->error("QuickLoadGame:: No quick save could be found!");
         pAudioPlayer->playUISound(SOUND_error);
-        loadSaveHeaders(); // Failed quickload has reinitialized the list under the open menu, reload the headers.
+        pSavegameList->loadHeaders(); // Failed quickload has reinitialized the list under the open menu, reload the headers.
     }
 }

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -112,6 +112,11 @@ static std::vector<SavegameSlot> saveMenuSlots() {
     return result;
 }
 
+GUIWindow_SaveLoad *saveLoadMenu() {
+    assert(current_screen_type == SCREEN_SAVEGAME || current_screen_type == SCREEN_LOADGAME);
+    return static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+}
+
 GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions)
     : GUIWindow(type, position, dimensions) {}
 

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -1,27 +1,58 @@
 #pragma once
 
+#include <cassert>
+#include <string>
+#include <string_view>
 #include <vector>
 
+#include "Engine/SaveLoad.h"
+#include "Engine/Graphics/Image.h"
+
 #include "GUI/GUIWindow.h"
+
+struct SavegameSlot {
+    std::string fileName;
+    SaveGameHeader header;
+    GraphicsImagePtr thumbnail;
+};
 
 class GUIWindow_SaveLoad : public GUIWindow {
  public:
     GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions);
-    virtual ~GUIWindow_SaveLoad();
 
-    [[nodiscard]] int selectedSlot() const {
-        return _selectedSlot;
+    /**
+     * @return                      Slots shown in this menu, in display order.
+     */
+    [[nodiscard]] const std::vector<SavegameSlot> &slots() const {
+        return _slots;
     }
 
-    void setSelectedSlot(int slot) {
-        _selectedSlot = slot;
+    /**
+     * @return                      Whether a slot is selected. False only for a load menu with no saves to show.
+     */
+    [[nodiscard]] bool hasSelectedSlot() const {
+        return _selectedSlot < std::ssize(_slots);
+    }
+
+    [[nodiscard]] const SavegameSlot &selectedSlot() const {
+        assert(hasSelectedSlot());
+        return _slots[_selectedSlot];
+    }
+
+    void setSelectedSlotName(std::string_view name) {
+        assert(hasSelectedSlot());
+        _slots[_selectedSlot].header.name = name;
     }
 
     [[nodiscard]] int scrollPosition() const {
         return _scrollPosition;
     }
 
-    /** Handles a click on one of the visible slot rows. First click selects the slot, second click acts on it. */
+    /**
+     * Handles a click on one of the visible slot rows. First click selects the slot, second click acts on it.
+     *
+     * @param slotIndex             Index of the clicked row in the visible part of the list, in [0, 7).
+     */
     virtual void slotClicked(int slotIndex) = 0;
 
     void scrollUp();
@@ -29,12 +60,10 @@ class GUIWindow_SaveLoad : public GUIWindow {
     void scrollWithMouse();
 
  protected:
-    /** @return Savegame slot indices shown in this menu, in display order. */
-    [[nodiscard]] virtual const std::vector<int> &menuSlots() const = 0;
-
     void drawSaveLoad();
 
  protected:
+    std::vector<SavegameSlot> _slots;
     int _selectedSlot = 0;
     int _scrollPosition = 0;
 };
@@ -48,8 +77,6 @@ class GUIWindow_Save : public GUIWindow_SaveLoad {
     virtual void slotClicked(int slotIndex) override;
 
  protected:
-    [[nodiscard]] virtual const std::vector<int> &menuSlots() const override;
-
     GraphicsImage *saveload_ui_save_up = nullptr;
     GraphicsImage *saveload_ui_loadsave = nullptr;
     GraphicsImage *saveload_ui_saveu = nullptr;
@@ -70,8 +97,6 @@ class GUIWindow_Load : public GUIWindow_SaveLoad {
     void quickLoad();
 
  protected:
-    [[nodiscard]] virtual const std::vector<int> &menuSlots() const override;
-
     bool _loadSlotClicked = false;
     GraphicsImage *main_menu_background = nullptr;
 

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -56,6 +56,7 @@ class GUIWindow_SaveLoad : public GUIWindow {
     void scrollWithMouse(Pointi mousePos);
 
  protected:
+    void preselectSlot(std::string_view fileName); // Selects & scrolls to the slot for the given file. No-op if there's no such slot.
     void drawSaveLoad();
 
  protected:

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -53,7 +53,7 @@ class GUIWindow_SaveLoad : public GUIWindow {
 
     void scrollUp();
     void scrollDown();
-    void scrollWithMouse();
+    void scrollWithMouse(Pointi mousePos);
 
  protected:
     void drawSaveLoad();

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -1,19 +1,54 @@
 #pragma once
 
+#include <vector>
+
 #include "GUI/GUIWindow.h"
 
-/** Loads headers & thumbnails for all savegame slots and sorts them by display name. */
-void loadSaveHeaders();
+class GUIWindow_SaveLoad : public GUIWindow {
+ public:
+    GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions);
+    virtual ~GUIWindow_SaveLoad();
 
-class GUIWindow_Save : public GUIWindow {
+    [[nodiscard]] int selectedSlot() const {
+        return _selectedSlot;
+    }
+
+    void setSelectedSlot(int slot) {
+        _selectedSlot = slot;
+    }
+
+    [[nodiscard]] int scrollPosition() const {
+        return _scrollPosition;
+    }
+
+    /** Handles a click on one of the visible slot rows. First click selects the slot, second click acts on it. */
+    virtual void slotClicked(int slotIndex) = 0;
+
+    void scrollUp();
+    void scrollDown();
+    void scrollWithMouse();
+
+ protected:
+    /** @return Savegame slot indices shown in this menu, in display order. */
+    [[nodiscard]] virtual const std::vector<int> &menuSlots() const = 0;
+
+    void drawSaveLoad();
+
+ protected:
+    int _selectedSlot = 0;
+    int _scrollPosition = 0;
+};
+
+class GUIWindow_Save : public GUIWindow_SaveLoad {
  public:
     GUIWindow_Save();
-    virtual ~GUIWindow_Save() {}
 
     virtual void Update() override;
 
+    virtual void slotClicked(int slotIndex) override;
+
  protected:
-    // Image * main_menu_background;
+    [[nodiscard]] virtual const std::vector<int> &menuSlots() const override;
 
     GraphicsImage *saveload_ui_save_up = nullptr;
     GraphicsImage *saveload_ui_loadsave = nullptr;
@@ -21,23 +56,23 @@ class GUIWindow_Save : public GUIWindow {
     GraphicsImage *saveload_ui_x_u = nullptr;
 };
 
-class GUIWindow_Load : public GUIWindow {
+class GUIWindow_Load : public GUIWindow_SaveLoad {
  public:
     explicit GUIWindow_Load(bool ingame);
-    virtual ~GUIWindow_Load() {}
 
     virtual void Update() override;
 
-    void slotSelected(int slotIndex);
+    virtual void slotClicked(int slotIndex) override;
     void loadButtonPressed();
-    void downArrowPressed(int maxSlots);
+    void downArrowPressed();
     void upArrowPressed();
     void cancelButtonPressed();
-    void scroll(int maxSlots);
     void quickLoad();
 
  protected:
-    bool isLoadSlotClicked = false;
+    [[nodiscard]] virtual const std::vector<int> &menuSlots() const override;
+
+    bool _loadSlotClicked = false;
     GraphicsImage *main_menu_background = nullptr;
 
     GraphicsImage *saveload_ui_load_up = nullptr;

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -2,6 +2,9 @@
 
 #include "GUI/GUIWindow.h"
 
+/** Loads headers & thumbnails for all savegame slots and sorts them by display name. */
+void loadSaveHeaders();
+
 class GUIWindow_Save : public GUIWindow {
  public:
     GUIWindow_Save();

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -44,10 +44,6 @@ class GUIWindow_SaveLoad : public GUIWindow {
         _slots[_selectedSlot].header.name = name;
     }
 
-    [[nodiscard]] int scrollPosition() const {
-        return _scrollPosition;
-    }
-
     /**
      * Handles a click on one of the visible slot rows. First click selects the slot, second click acts on it.
      *
@@ -97,6 +93,7 @@ class GUIWindow_Load : public GUIWindow_SaveLoad {
     void quickLoad();
 
  protected:
+    // TODO(Nik-RE-dev): drop variable and load game only on double click.
     bool _loadSlotClicked = false;
     GraphicsImage *main_menu_background = nullptr;
 
@@ -105,3 +102,8 @@ class GUIWindow_Load : public GUIWindow_SaveLoad {
     GraphicsImage *saveload_ui_loadu = nullptr;
     GraphicsImage *saveload_ui_x_u = nullptr;
 };
+
+/**
+ * @return                      Currently open save/load menu. Should only be called when one is open.
+ */
+GUIWindow_SaveLoad *saveLoadMenu();

--- a/src/Utility/String/Ascii.cpp
+++ b/src/Utility/String/Ascii.cpp
@@ -44,13 +44,15 @@ bool noCaseEquals(std::string_view a, std::string_view b) {
     return noCaseCompare(a.data(), b.data(), a.size()) == 0;
 }
 
-bool noCaseLess(std::string_view a, std::string_view b) {
+int noCaseCompare(std::string_view a, std::string_view b) {
     int result = noCaseCompare(a.data(), b.data(), std::min(a.size(), b.size()));
-    if (result < 0)
-        return true;
-    if (result > 0)
-        return false;
-    return a.size() < b.size();
+    if (result != 0)
+        return result;
+    return a.size() < b.size() ? -1 : a.size() > b.size() ? 1 : 0;
+}
+
+bool noCaseLess(std::string_view a, std::string_view b) {
+    return noCaseCompare(a, b) < 0;
 }
 
 std::string toPrintable(std::string_view s, char placeholder) {

--- a/src/Utility/String/Ascii.h
+++ b/src/Utility/String/Ascii.h
@@ -30,6 +30,7 @@ std::string toUpper(std::string_view text);
 
 bool noCaseStartsWith(std::string_view s, std::string_view prefix);
 bool noCaseEquals(std::string_view a, std::string_view b);
+int noCaseCompare(std::string_view a, std::string_view b);
 bool noCaseLess(std::string_view a, std::string_view b);
 
 struct NoCaseLess {

--- a/src/Utility/String/Tests/Ascii_ut.cpp
+++ b/src/Utility/String/Tests/Ascii_ut.cpp
@@ -33,6 +33,16 @@ UNIT_TEST(Ascii, noCaseEquals) {
     EXPECT_FALSE(ascii::noCaseEquals("@", "`")); // \x40 vs \x60
 }
 
+UNIT_TEST(Ascii, noCaseCompare) {
+    EXPECT_LT(ascii::noCaseCompare("A", "AB"), 0);
+    EXPECT_GT(ascii::noCaseCompare("AB", "A"), 0);
+    EXPECT_LT(ascii::noCaseCompare("a", "B"), 0);
+    EXPECT_GT(ascii::noCaseCompare("B", "a"), 0);
+    EXPECT_EQ(ascii::noCaseCompare("b", "B"), 0);
+    EXPECT_EQ(ascii::noCaseCompare("", ""), 0);
+    EXPECT_LT(ascii::noCaseCompare("@", "`"), 0);
+}
+
 UNIT_TEST(Ascii, noCaseLess) {
     EXPECT_TRUE(ascii::noCaseLess("A", "AB"));
     EXPECT_FALSE(ascii::noCaseLess("AB", "A"));

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -57,8 +57,7 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
+    EXPECT_TRUE(saveLoadMenu()->slots().empty()); // No saves listed.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -58,8 +58,8 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (bool used : pSavegameList->pSavegameUsedSlots)
-        EXPECT_FALSE(used); // All slots unused.
+    for (const SavegameSlot &slot : pSavegameList->slots)
+        EXPECT_FALSE(slot.isUsed); // All slots unused.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -9,6 +9,7 @@
 #include "Arcomage/Arcomage.h"
 
 #include "GUI/GUIWindow.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 #include "GUI/GUIProgressBar.h"
 
@@ -56,8 +57,8 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (const SavegameSlot &slot : pSavegameList->slots())
-        EXPECT_FALSE(slot.isUsed); // All slots unused.
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -58,7 +58,7 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (const SavegameSlot &slot : pSavegameList->slots)
+    for (const SavegameSlot &slot : pSavegameList->slots())
         EXPECT_FALSE(slot.isUsed); // All slots unused.
 
     game.pressGuiButton("LoadMenu_Load");

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -9,6 +9,7 @@
 #include "Arcomage/Arcomage.h"
 
 #include "GUI/GUIWindow.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 #include "GUI/GUIProgressBar.h"
 
@@ -58,8 +59,8 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (const SavegameSlot &slot : pSavegameList->slots())
-        EXPECT_FALSE(slot.isUsed); // All slots unused.
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -56,8 +56,8 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (bool used : pSavegameList->pSavegameUsedSlots)
-        EXPECT_FALSE(used); // All slots unused.
+    for (const SavegameSlot &slot : pSavegameList->slots)
+        EXPECT_FALSE(slot.isUsed); // All slots unused.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -56,7 +56,7 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    for (const SavegameSlot &slot : pSavegameList->slots)
+    for (const SavegameSlot &slot : pSavegameList->slots())
         EXPECT_FALSE(slot.isUsed); // All slots unused.
 
     game.pressGuiButton("LoadMenu_Load");

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -59,8 +59,7 @@ GAME_TEST(Issues, Issue163) {
 
     game.pressGuiButton("MainMenu_LoadGame"); // Shouldn't crash.
     game.tick(10);
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
+    EXPECT_TRUE(saveLoadMenu()->slots().empty()); // No saves listed.
 
     game.pressGuiButton("LoadMenu_Load");
     game.tick(10);

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -385,8 +385,7 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    EXPECT_EQ(loadMenu->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
+    EXPECT_EQ(saveLoadMenu()->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -342,8 +342,7 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    EXPECT_EQ(loadMenu->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
+    EXPECT_EQ(saveLoadMenu()->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -342,7 +342,8 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    EXPECT_EQ(static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get())->selectedSlot(), 1);
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_EQ(loadMenu->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -7,6 +7,7 @@
 
 #include "GUI/GUIWindow.h"
 #include "GUI/UI/NPCTopics.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 
 #include "Engine/Tables/ItemTable.h"
@@ -384,7 +385,7 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    EXPECT_EQ(pSavegameList->selectedSlot, 1);
+    EXPECT_EQ(static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get())->selectedSlot(), 1);
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -385,7 +385,8 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    EXPECT_EQ(static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get())->selectedSlot(), 1);
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_EQ(loadMenu->selectedSlot().fileName, engine->_lastLoadedSaveFileName); // Last loaded save is pre-selected.
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -7,6 +7,7 @@
 
 #include "GUI/GUIWindow.h"
 #include "GUI/UI/NPCTopics.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 
 #include "Engine/Tables/ItemTable.h"
@@ -341,7 +342,7 @@ GAME_TEST(Issues, Issue626) {
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
 
-    EXPECT_EQ(pSavegameList->selectedSlot, 1);
+    EXPECT_EQ(static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get())->selectedSlot(), 1);
 }
 
 GAME_TEST(Issues, Issue645) {

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -431,8 +431,7 @@ GAME_TEST(Prs, Pr1694) {
     game.pressGuiButton("LoadMenu_Slot0"); // Should not crash.
     game.tick(1);
 
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
+    EXPECT_TRUE(saveLoadMenu()->slots().empty()); // No saves listed.
 }
 
 // 1700

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -430,8 +430,8 @@ GAME_TEST(Prs, Pr1694) {
     game.pressGuiButton("LoadMenu_Slot0"); // Should not crash.
     game.tick(1);
 
-    for (bool used : pSavegameList->pSavegameUsedSlots)
-        EXPECT_FALSE(used); // All slots unused.
+    for (const SavegameSlot &slot : pSavegameList->slots)
+        EXPECT_FALSE(slot.isUsed); // All slots unused.
 }
 
 // 1700

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -430,7 +430,7 @@ GAME_TEST(Prs, Pr1694) {
     game.pressGuiButton("LoadMenu_Slot0"); // Should not crash.
     game.tick(1);
 
-    for (const SavegameSlot &slot : pSavegameList->slots)
+    for (const SavegameSlot &slot : pSavegameList->slots())
         EXPECT_FALSE(slot.isUsed); // All slots unused.
 }
 

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -24,6 +24,7 @@
 #include "GUI/GUIWindow.h"
 #include "GUI/GUIMessageQueue.h"
 #include "GUI/UI/UIPartyCreation.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 #include "Engine/Graphics/BspRenderer.h"
 #include "Engine/Graphics/Outdoor.h"
@@ -430,8 +431,8 @@ GAME_TEST(Prs, Pr1694) {
     game.pressGuiButton("LoadMenu_Slot0"); // Should not crash.
     game.tick(1);
 
-    for (const SavegameSlot &slot : pSavegameList->slots())
-        EXPECT_FALSE(slot.isUsed); // All slots unused.
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_TRUE(loadMenu->slots().empty()); // No saves listed.
 }
 
 // 1700

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -27,6 +27,7 @@
 #include "GUI/GUIWindow.h"
 #include "GUI/GUIButton.h"
 #include "GUI/UI/UIChest.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 
 #include "Library/LodFormats/LodFormats.h"
@@ -1352,9 +1353,10 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 50); // All 50 saves are listed, +1 new save slot...
-    ASSERT_EQ(pSavegameList->selectedSlot, 50); // ...which is selected by default...
-    ASSERT_EQ(pSavegameList->saveListPosition, 0); // ...and shown first.
+    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 50); // All 50 saves are listed, +1 new save slot...
+    ASSERT_EQ(saveMenu->selectedSlot(), 50); // ...which is selected by default...
+    ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
     game.pressGuiButton("SaveMenu_Save");
@@ -1371,9 +1373,9 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    EXPECT_EQ(pSavegameList->numSavegameFiles, 51);
-    EXPECT_EQ(pSavegameList->slots[0].fileName, "save050.mm7");
-    EXPECT_EQ(pSavegameList->slots[0].header.name, "a");
+    EXPECT_EQ(pSavegameList->loadMenuSlots().size(), 51);
+    EXPECT_EQ(pSavegameList->slots()[0].fileName, "save050.mm7");
+    EXPECT_EQ(pSavegameList->slots()[0].header.name, "a");
     EXPECT_TRUE(pSavegameList->isSlotUsed(0));
 }
 
@@ -1389,8 +1391,8 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 1); // Just the autosave, the menu is still alive.
-    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 1); // Autosave is not shown in the save menu.
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 1); // Just the autosave, the menu is still alive.
+    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 1); // Autosave is not shown in the save menu.
 
     // And the menu is still fully functional.
     game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
@@ -1410,6 +1412,6 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 3); // Autosave, quicksave & our save...
-    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 2); // ...but only the new save slot & our save are shown.
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 3); // Autosave, quicksave & our save...
+    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1354,8 +1354,8 @@ GAME_TEST(Issues, Issue2551a) {
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
     GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 50); // All 50 saves are listed, +1 new save slot...
-    ASSERT_EQ(saveMenu->selectedSlot(), 50); // ...which is selected by default...
+    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot which...
+    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...is selected by default...
     ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
@@ -1373,15 +1373,14 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    EXPECT_EQ(pSavegameList->loadMenuSlots().size(), 51);
-    EXPECT_EQ(pSavegameList->slots()[0].fileName, "save050.mm7");
-    EXPECT_EQ(pSavegameList->slots()[0].header.name, "a");
-    EXPECT_TRUE(pSavegameList->isSlotUsed(0));
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_EQ(loadMenu->slots().size(), 51);
+    EXPECT_EQ(loadMenu->slots()[0].fileName, "save050.mm7");
+    EXPECT_EQ(loadMenu->slots()[0].header.name, "a");
 }
 
 GAME_TEST(Issues, Issue2551b) {
-    // Quickload is handled from inside menus, and with no quicksave to load it reinitializes the save list under the
-    // open save menu. Check that the menu survives this.
+    // Quickload is handled from inside menus, check that a failed quickload doesn't break the open save menu.
     game.startNewGame();
     game.tick(2);
 
@@ -1391,8 +1390,9 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 1); // Just the autosave, the menu is still alive.
-    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 1); // Autosave is not shown in the save menu.
+    ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
+    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(saveMenu->slots().size(), 1); // ...which is not shown in the save menu, so it's just the new save slot.
 
     // And the menu is still fully functional.
     game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
@@ -1412,6 +1412,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 3); // Autosave, quicksave & our save...
-    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 2); // ...but only the new save slot & our save are shown.
+    ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
+    GUIWindow_SaveLoad *saveMenu2 = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1358,8 +1358,8 @@ GAME_TEST(Issues, Issue2551a) {
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
     GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 50); // All 50 saves are listed, +1 new save slot...
-    ASSERT_EQ(saveMenu->selectedSlot(), 50); // ...which is selected by default...
+    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot which...
+    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...is selected by default...
     ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
@@ -1377,15 +1377,14 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    EXPECT_EQ(pSavegameList->loadMenuSlots().size(), 51);
-    EXPECT_EQ(pSavegameList->slots()[0].fileName, "save050.mm7");
-    EXPECT_EQ(pSavegameList->slots()[0].header.name, "a");
-    EXPECT_TRUE(pSavegameList->isSlotUsed(0));
+    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    EXPECT_EQ(loadMenu->slots().size(), 51);
+    EXPECT_EQ(loadMenu->slots()[0].fileName, "save050.mm7");
+    EXPECT_EQ(loadMenu->slots()[0].header.name, "a");
 }
 
 GAME_TEST(Issues, Issue2551b) {
-    // Quickload is handled from inside menus, and with no quicksave to load it reinitializes the save list under the
-    // open save menu. Check that the menu survives this.
+    // Quickload is handled from inside menus, check that a failed quickload doesn't break the open save menu.
     game.startNewGame();
     game.tick(2);
 
@@ -1395,8 +1394,9 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 1); // Just the autosave, the menu is still alive.
-    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 1); // Autosave is not shown in the save menu.
+    ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
+    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(saveMenu->slots().size(), 1); // ...which is not shown in the save menu, so it's just the new save slot.
 
     // And the menu is still fully functional.
     game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
@@ -1416,6 +1416,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 3); // Autosave, quicksave & our save...
-    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 2); // ...but only the new save slot & our save are shown.
+    ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
+    GUIWindow_SaveLoad *saveMenu2 = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1353,10 +1353,9 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot which...
-    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...is selected by default...
-    ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
+    GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
+    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot...
+    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...which is selected by default.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
     game.pressGuiButton("SaveMenu_Save");
@@ -1366,14 +1365,16 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_RETURN); // Confirm the name with Enter.
     game.tick(10);
-    EXPECT_TRUE(ufs->exists("saves/save050.mm7")); // New save went into a new file.
+    EXPECT_EQ(ufs->ls("saves").size(), 51); // New save went into a new file.
+    EXPECT_TRUE(ufs->exists("saves/save050.mm7"));
 
-    // The new save shows up in the load menu, sorted by display name - "a" comes before "saveNNN".
+    // The new save shows up in the load menu, sorted by display name - the other saves have blank titles & fall
+    // back to "saveNNN" display names, so "a" sorts first.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *loadMenu = saveLoadMenu();
     EXPECT_EQ(loadMenu->slots().size(), 51);
     EXPECT_EQ(loadMenu->slots()[0].fileName, "save050.mm7");
     EXPECT_EQ(loadMenu->slots()[0].header.name, "a");
@@ -1391,7 +1392,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
     ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
-    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
     ASSERT_EQ(saveMenu->slots().size(), 1); // ...which is not shown in the save menu, so it's just the new save slot.
 
     // And the menu is still fully functional.
@@ -1413,6 +1414,6 @@ GAME_TEST(Issues, Issue2551b) {
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
     ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
-    GUIWindow_SaveLoad *saveMenu2 = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *saveMenu2 = saveLoadMenu();
     ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1389,7 +1389,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9); // Try to quickload, there is no quicksave so this should fail.
     game.tick(3);
     ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
     GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
@@ -1407,7 +1407,7 @@ GAME_TEST(Issues, Issue2551b) {
     EXPECT_TRUE(ufs->exists("saves/save000.mm7"));
 
     // Quicksaves are also hidden from the save menu.
-    game.pressAndReleaseKey(PlatformKey::KEY_F5);
+    game.pressAndReleaseKey(PlatformKey::KEY_F5); // Quicksave.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
@@ -1416,4 +1416,49 @@ GAME_TEST(Issues, Issue2551b) {
     ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
     GUIWindow_SaveLoad *saveMenu2 = saveLoadMenu();
     ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
+}
+
+GAME_TEST(Issues, Issue2551c) {
+    // Quickload works from the game, from the in-game save menu & from the main menu.
+    game.startNewGame();
+    game.tick(2);
+    engine->config->gameplay.QuickSavesCount.setValue(4); // Quicksave counter wraps 4 -> 0.
+    game.pressAndReleaseKey(PlatformKey::KEY_F5); // Quicksave.
+    game.tick(2);
+    std::string quickSaveName = getCurrentQuickSave();
+    ASSERT_EQ(quickSaveName, "quicksave0.mm7");
+
+    auto checkQuickLoaded = [&] {
+        game.skipLoadingScreen();
+        game.tick(2);
+        EXPECT_EQ(current_screen_type, SCREEN_GAME);
+        EXPECT_EQ(engine->_lastLoadedSaveFileName, quickSaveName);
+        engine->_lastLoadedSaveFileName.clear(); // Make sure the next check is not vacuous.
+    };
+
+    // Quickload in-game.
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the in-game save menu.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(current_screen_type, SCREEN_SAVEGAME);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the main menu.
+    game.goToMainMenu();
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the load menu in the main menu.
+    game.goToMainMenu();
+    game.pressGuiButton("MainMenu_LoadGame");
+    game.tick(3);
+    ASSERT_EQ(current_screen_type, SCREEN_LOADGAME);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1094,14 +1094,13 @@ GAME_TEST(Issues, Issue2453) {
     game.skipLoadingScreen();
     game.tick(2);
 
-    // Save over the same slot — the existing title should be preserved, no need to retype. Slot #0 is the new save
-    // slot, the existing save is in slot #1.
+    // Save over the same save — it's pre-selected in the save menu, so just pressing the save button overwrites it,
+    // and the existing title is preserved, no need to retype.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot1");
-    game.tick(2);
+    EXPECT_EQ(saveLoadMenu()->selectedSlot().fileName, "save000.mm7");
     game.pressGuiButton("SaveMenu_Save");
     game.tick(10);
     EXPECT_EQ(ufs->ls("saves").size(), 1);
@@ -1109,6 +1108,15 @@ GAME_TEST(Issues, Issue2453) {
     EXPECT_NE(firstSave.str(), secondSave.str()); // Save was actually overwritten.
 
     EXPECT_GE(loadingTape.count(true), 1); // Loading screen was shown.
+
+    // Starting a new game drops the pre-selection — otherwise the save button would overwrite a save from a
+    // previous playthrough.
+    game.startNewGame();
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    EXPECT_TRUE(saveLoadMenu()->selectedSlot().fileName.empty()); // The new save slot is selected.
 }
 
 GAME_TEST(Issues, Issue2464) {
@@ -1355,7 +1363,7 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
     ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot...
-    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...which is selected by default.
+    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...which is selected, as this game wasn't loaded from a save.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
     game.pressGuiButton("SaveMenu_Save");

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -20,6 +20,7 @@
 #include "Engine/Objects/MonsterEnumFunctions.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/Resources/LOD.h"
+#include "Engine/SaveLoad.h"
 #include "Engine/Snapshots/CompositeSnapshots.h"
 
 #include "GUI/GUIProgressBar.h"
@@ -1092,12 +1093,13 @@ GAME_TEST(Issues, Issue2453) {
     game.skipLoadingScreen();
     game.tick(2);
 
-    // Save over the same slot — the existing title should be preserved, no need to retype.
+    // Save over the same slot — the existing title should be preserved, no need to retype. Slot #0 is the new save
+    // slot, the existing save is in slot #1.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.pressGuiButton("SaveMenu_Slot1");
     game.tick(2);
     game.pressGuiButton("SaveMenu_Save");
     game.tick(10);
@@ -1333,4 +1335,81 @@ GAME_TEST(Issues, Issue2507) {
     auto damageRange = hpTape.reverse().adjacentDeltas().minMax();
     EXPECT_GE(damageRange[0], 10);
     EXPECT_LE(damageRange[1], 80); // Per-hit damage is within the 10d8 range.
+}
+
+GAME_TEST(Issues, Issue2551a) {
+    // Save list was capped at 45 files, and saving past the cap produced saves that weren't listed in the load menu.
+    game.startNewGame();
+    game.tick(2);
+
+    // Fill the saves folder well past the old cap.
+    ufs->remove("saves/autosave.mm7");
+    Blob save = game.saveGame();
+    for (int i = 0; i < 50; i++)
+        ufs->write(fmt::format("saves/save{:03}.mm7", i), save);
+
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 50); // All 50 saves are listed, +1 new save slot...
+    ASSERT_EQ(pSavegameList->selectedSlot, 50); // ...which is selected by default...
+    ASSERT_EQ(pSavegameList->saveListPosition, 0); // ...and shown first.
+
+    // Pressing the save button right away shouldn't save, we want a save name typed in first.
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(2);
+    EXPECT_EQ(ufs->ls("saves").size(), 50);
+    game.pressAndReleaseKey(PlatformKey::KEY_A);
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_RETURN); // Confirm the name with Enter.
+    game.tick(10);
+    EXPECT_TRUE(ufs->exists("saves/save050.mm7")); // New save went into a new file.
+
+    // The new save shows up in the load menu, sorted by display name - "a" comes before "saveNNN".
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_LoadGame");
+    game.tick(3);
+    EXPECT_EQ(pSavegameList->numSavegameFiles, 51);
+    EXPECT_EQ(pSavegameList->slots[0].fileName, "save050.mm7");
+    EXPECT_EQ(pSavegameList->slots[0].header.name, "a");
+    EXPECT_TRUE(pSavegameList->isSlotUsed(0));
+}
+
+GAME_TEST(Issues, Issue2551b) {
+    // Quickload is handled from inside menus, and with no quicksave to load it reinitializes the save list under the
+    // open save menu. Check that the menu survives this.
+    game.startNewGame();
+    game.tick(2);
+
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    game.tick(3);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 1); // Just the autosave, the menu is still alive.
+    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 1); // Autosave is not shown in the save menu.
+
+    // And the menu is still fully functional.
+    game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Slot0"); // ...and click it again to start the name input.
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_A);
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(10);
+    EXPECT_TRUE(ufs->exists("saves/save000.mm7"));
+
+    // Quicksaves are also hidden from the save menu.
+    game.pressAndReleaseKey(PlatformKey::KEY_F5);
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 3); // Autosave, quicksave & our save...
+    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -20,6 +20,7 @@
 #include "Engine/Objects/MonsterEnumFunctions.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/Resources/LOD.h"
+#include "Engine/SaveLoad.h"
 #include "Engine/Snapshots/CompositeSnapshots.h"
 
 #include "GUI/GUIProgressBar.h"
@@ -1093,12 +1094,13 @@ GAME_TEST(Issues, Issue2453) {
     game.skipLoadingScreen();
     game.tick(2);
 
-    // Save over the same slot — the existing title should be preserved, no need to retype.
+    // Save over the same slot — the existing title should be preserved, no need to retype. Slot #0 is the new save
+    // slot, the existing save is in slot #1.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.pressGuiButton("SaveMenu_Slot1");
     game.tick(2);
     game.pressGuiButton("SaveMenu_Save");
     game.tick(10);
@@ -1337,4 +1339,81 @@ GAME_TEST(Issues, Issue2507) {
     auto damageRange = hpTape.reverse().adjacentDeltas().minMax();
     EXPECT_GE(damageRange[0], 10);
     EXPECT_LE(damageRange[1], 80); // Per-hit damage is within the 10d8 range.
+}
+
+GAME_TEST(Issues, Issue2551a) {
+    // Save list was capped at 45 files, and saving past the cap produced saves that weren't listed in the load menu.
+    game.startNewGame();
+    game.tick(2);
+
+    // Fill the saves folder well past the old cap.
+    ufs->remove("saves/autosave.mm7");
+    Blob save = game.saveGame();
+    for (int i = 0; i < 50; i++)
+        ufs->write(fmt::format("saves/save{:03}.mm7", i), save);
+
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 50); // All 50 saves are listed, +1 new save slot...
+    ASSERT_EQ(pSavegameList->selectedSlot, 50); // ...which is selected by default...
+    ASSERT_EQ(pSavegameList->saveListPosition, 0); // ...and shown first.
+
+    // Pressing the save button right away shouldn't save, we want a save name typed in first.
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(2);
+    EXPECT_EQ(ufs->ls("saves").size(), 50);
+    game.pressAndReleaseKey(PlatformKey::KEY_A);
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_RETURN); // Confirm the name with Enter.
+    game.tick(10);
+    EXPECT_TRUE(ufs->exists("saves/save050.mm7")); // New save went into a new file.
+
+    // The new save shows up in the load menu, sorted by display name - "a" comes before "saveNNN".
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_LoadGame");
+    game.tick(3);
+    EXPECT_EQ(pSavegameList->numSavegameFiles, 51);
+    EXPECT_EQ(pSavegameList->slots[0].fileName, "save050.mm7");
+    EXPECT_EQ(pSavegameList->slots[0].header.name, "a");
+    EXPECT_TRUE(pSavegameList->isSlotUsed(0));
+}
+
+GAME_TEST(Issues, Issue2551b) {
+    // Quickload is handled from inside menus, and with no quicksave to load it reinitializes the save list under the
+    // open save menu. Check that the menu survives this.
+    game.startNewGame();
+    game.tick(2);
+
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    game.tick(3);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 1); // Just the autosave, the menu is still alive.
+    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 1); // Autosave is not shown in the save menu.
+
+    // And the menu is still fully functional.
+    game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Slot0"); // ...and click it again to start the name input.
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_A);
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(10);
+    EXPECT_TRUE(ufs->exists("saves/save000.mm7"));
+
+    // Quicksaves are also hidden from the save menu.
+    game.pressAndReleaseKey(PlatformKey::KEY_F5);
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(pSavegameList->numSavegameFiles, 3); // Autosave, quicksave & our save...
+    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -27,6 +27,7 @@
 #include "GUI/GUIWindow.h"
 #include "GUI/GUIButton.h"
 #include "GUI/UI/UIChest.h"
+#include "GUI/UI/UISaveLoad.h"
 #include "GUI/UI/UIStatusBar.h"
 
 #include "Library/LodFormats/LodFormats.h"
@@ -1356,9 +1357,10 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 50); // All 50 saves are listed, +1 new save slot...
-    ASSERT_EQ(pSavegameList->selectedSlot, 50); // ...which is selected by default...
-    ASSERT_EQ(pSavegameList->saveListPosition, 0); // ...and shown first.
+    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 50); // All 50 saves are listed, +1 new save slot...
+    ASSERT_EQ(saveMenu->selectedSlot(), 50); // ...which is selected by default...
+    ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
     game.pressGuiButton("SaveMenu_Save");
@@ -1375,9 +1377,9 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    EXPECT_EQ(pSavegameList->numSavegameFiles, 51);
-    EXPECT_EQ(pSavegameList->slots[0].fileName, "save050.mm7");
-    EXPECT_EQ(pSavegameList->slots[0].header.name, "a");
+    EXPECT_EQ(pSavegameList->loadMenuSlots().size(), 51);
+    EXPECT_EQ(pSavegameList->slots()[0].fileName, "save050.mm7");
+    EXPECT_EQ(pSavegameList->slots()[0].header.name, "a");
     EXPECT_TRUE(pSavegameList->isSlotUsed(0));
 }
 
@@ -1393,8 +1395,8 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 1); // Just the autosave, the menu is still alive.
-    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 1); // Autosave is not shown in the save menu.
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 1); // Just the autosave, the menu is still alive.
+    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 1); // Autosave is not shown in the save menu.
 
     // And the menu is still fully functional.
     game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
@@ -1414,6 +1416,6 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    ASSERT_EQ(pSavegameList->numSavegameFiles, 3); // Autosave, quicksave & our save...
-    ASSERT_EQ(pSavegameList->saveMenuSlotCount(), 2); // ...but only the new save slot & our save are shown.
+    ASSERT_EQ(pSavegameList->loadMenuSlots().size(), 3); // Autosave, quicksave & our save...
+    ASSERT_EQ(pSavegameList->saveMenuSlots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1393,7 +1393,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9); // Try to quickload, there is no quicksave so this should fail.
     game.tick(3);
     ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
     GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
@@ -1411,7 +1411,7 @@ GAME_TEST(Issues, Issue2551b) {
     EXPECT_TRUE(ufs->exists("saves/save000.mm7"));
 
     // Quicksaves are also hidden from the save menu.
-    game.pressAndReleaseKey(PlatformKey::KEY_F5);
+    game.pressAndReleaseKey(PlatformKey::KEY_F5); // Quicksave.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
@@ -1420,4 +1420,49 @@ GAME_TEST(Issues, Issue2551b) {
     ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
     GUIWindow_SaveLoad *saveMenu2 = saveLoadMenu();
     ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
+}
+
+GAME_TEST(Issues, Issue2551c) {
+    // Quickload works from the game, from the in-game save menu & from the main menu.
+    game.startNewGame();
+    game.tick(2);
+    engine->config->gameplay.QuickSavesCount.setValue(4); // Quicksave counter wraps 4 -> 0.
+    game.pressAndReleaseKey(PlatformKey::KEY_F5); // Quicksave.
+    game.tick(2);
+    std::string quickSaveName = getCurrentQuickSave();
+    ASSERT_EQ(quickSaveName, "quicksave0.mm7");
+
+    auto checkQuickLoaded = [&] {
+        game.skipLoadingScreen();
+        game.tick(2);
+        EXPECT_EQ(current_screen_type, SCREEN_GAME);
+        EXPECT_EQ(engine->_lastLoadedSaveFileName, quickSaveName);
+        engine->_lastLoadedSaveFileName.clear(); // Make sure the next check is not vacuous.
+    };
+
+    // Quickload in-game.
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the in-game save menu.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    ASSERT_EQ(current_screen_type, SCREEN_SAVEGAME);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the main menu.
+    game.goToMainMenu();
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
+
+    // Quickload from the load menu in the main menu.
+    game.goToMainMenu();
+    game.pressGuiButton("MainMenu_LoadGame");
+    game.tick(3);
+    ASSERT_EQ(current_screen_type, SCREEN_LOADGAME);
+    game.pressAndReleaseKey(PlatformKey::KEY_F9);
+    checkQuickLoaded();
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1357,10 +1357,9 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
-    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot which...
-    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...is selected by default...
-    ASSERT_EQ(saveMenu->scrollPosition(), 0); // ...and shown first.
+    GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
+    ASSERT_EQ(saveMenu->slots().size(), 51); // All 50 saves are listed, plus the new save slot...
+    ASSERT_TRUE(saveMenu->selectedSlot().fileName.empty()); // ...which is selected by default.
 
     // Pressing the save button right away shouldn't save, we want a save name typed in first.
     game.pressGuiButton("SaveMenu_Save");
@@ -1370,14 +1369,16 @@ GAME_TEST(Issues, Issue2551a) {
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_RETURN); // Confirm the name with Enter.
     game.tick(10);
-    EXPECT_TRUE(ufs->exists("saves/save050.mm7")); // New save went into a new file.
+    EXPECT_EQ(ufs->ls("saves").size(), 51); // New save went into a new file.
+    EXPECT_TRUE(ufs->exists("saves/save050.mm7"));
 
-    // The new save shows up in the load menu, sorted by display name - "a" comes before "saveNNN".
+    // The new save shows up in the load menu, sorted by display name - the other saves have blank titles & fall
+    // back to "saveNNN" display names, so "a" sorts first.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_LoadGame");
     game.tick(3);
-    GUIWindow_SaveLoad *loadMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *loadMenu = saveLoadMenu();
     EXPECT_EQ(loadMenu->slots().size(), 51);
     EXPECT_EQ(loadMenu->slots()[0].fileName, "save050.mm7");
     EXPECT_EQ(loadMenu->slots()[0].header.name, "a");
@@ -1395,7 +1396,7 @@ GAME_TEST(Issues, Issue2551b) {
     game.pressAndReleaseKey(PlatformKey::KEY_F9);
     game.tick(3);
     ASSERT_EQ(ufs->ls("saves").size(), 1); // Just the autosave...
-    GUIWindow_SaveLoad *saveMenu = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *saveMenu = saveLoadMenu();
     ASSERT_EQ(saveMenu->slots().size(), 1); // ...which is not shown in the save menu, so it's just the new save slot.
 
     // And the menu is still fully functional.
@@ -1417,6 +1418,6 @@ GAME_TEST(Issues, Issue2551b) {
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
     ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave, quicksave & our save...
-    GUIWindow_SaveLoad *saveMenu2 = static_cast<GUIWindow_SaveLoad *>(pGUIWindow_CurrentMenu.get());
+    GUIWindow_SaveLoad *saveMenu2 = saveLoadMenu();
     ASSERT_EQ(saveMenu2->slots().size(), 2); // ...but only the new save slot & our save are shown.
 }

--- a/test/Data/issue_1706.json
+++ b/test/Data/issue_1706.json
@@ -51,11 +51,6 @@
                 "key": "wizard_eye",
                 "section": "debug",
                 "value": "true"
-            },
-            {
-                "key": "quick_saves_name",
-                "section": "gameplay",
-                "value": "quiksave"
             }
         ],
         "endState": {


### PR DESCRIPTION
Fixes #2551.

What's new:
* Savegame list is not limited in size.
* Quicksave filename is not configurable – we now rely on the name being fixed.
* Quicksave / Autosave titles are now translatable strings.
* Can quickload from anywhere.

Also dropped a lot of the old code that made no sense. `SavegameList` gone.

Added tests for the points above.