### PR TITLE
Drop FileSystem::rename

### DIFF
--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -118,21 +118,6 @@ std::unique_ptr<OutputStream> DirectoryFileSystem::_openForWriting(FileSystemPat
     return std::make_unique<FileOutputStream>(basePath.generic_string());
 }
 
-void DirectoryFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    assert(!srcPath.isEmpty());
-    assert(!dstPath.isEmpty());
-
-    std::filesystem::path srcBasePath = makeBasePath(srcPath);
-    std::filesystem::path dstBasePath = makeBasePath(dstPath);
-
-    std::error_code ec;
-    if (std::filesystem::is_directory(dstBasePath, ec))
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
-
-    // This call will copy the file if POSIX rename() fails, so if it throws then we can't really do anything either.
-    std::filesystem::rename(srcBasePath, dstBasePath);
-}
-
 bool DirectoryFileSystem::_remove(FileSystemPathView path) {
     assert(!path.isEmpty());
     return std::filesystem::remove_all(makeBasePath(path)) > 0;

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.h
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.h
@@ -33,7 +33,6 @@ class DirectoryFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
@@ -126,8 +126,6 @@ UNIT_TEST(DirectoryFileSystem, EscapingPaths) {
     EXPECT_ANY_THROW(fs.write("../1.txt", Blob()));
     EXPECT_ANY_THROW((void) fs.openForWriting("../1.txt"));
     EXPECT_ANY_THROW(fs.remove("../1.txt"));
-    EXPECT_ANY_THROW(fs.rename("../1.txt", "2.txt"));
-    EXPECT_ANY_THROW(fs.rename("1.txt", "../2.txt"));
 }
 
 UNIT_TEST(DirectoryFileSystem, EscapingDisplayPath) {

--- a/src/Library/FileSystem/Interface/FileSystem.cpp
+++ b/src/Library/FileSystem/Interface/FileSystem.cpp
@@ -1,6 +1,5 @@
 #include "FileSystem.h"
 
-#include <cassert>
 #include <vector>
 #include <memory>
 #include <string>
@@ -8,8 +7,6 @@
 #include "FileSystemPath.h"
 
 #include "FileSystemException.h"
-
-static constexpr size_t COPY_BUFFER_SIZE = 1024 * 1024;
 
 bool FileSystem::exists(std::string_view path) const {
     return exists(FileSystemPath(path));
@@ -106,26 +103,6 @@ std::unique_ptr<OutputStream> FileSystem::openForWriting(FileSystemPathView path
     return _openForWriting(path);
 }
 
-void FileSystem::rename(std::string_view srcPath, std::string_view dstPath) {
-    return rename(FileSystemPath(srcPath), FileSystemPath(dstPath));
-}
-
-void FileSystem::rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    if (srcPath.isEmpty())
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_NOT_WRITEABLE, srcPath, dstPath);
-    if (srcPath.isEscaping())
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_NOT_ACCESSIBLE, srcPath, dstPath);
-    if (dstPath.isEmpty())
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-    if (dstPath.isEscaping())
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_ACCESSIBLE, srcPath, dstPath);
-    if (srcPath == dstPath)
-        return;
-    if (srcPath.isPrefixOf(dstPath))
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_IS_PARENT_OF_DST, srcPath, dstPath);
-    _rename(srcPath, dstPath);
-}
-
 bool FileSystem::remove(std::string_view path) {
     return remove(FileSystemPath(path));
 }
@@ -144,54 +121,4 @@ std::string FileSystem::displayPath(std::string_view path) const {
 
 std::string FileSystem::displayPath(FileSystemPathView path) const {
     return _displayPath(path);
-}
-
-void FileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    assert(!srcPath.isEmpty());
-    assert(!dstPath.isEmpty());
-
-    FileStat srcStat = stat(srcPath);
-    if (!srcStat)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_DOESNT_EXIST, srcPath, dstPath);
-
-    FileStat dstStat = stat(dstPath);
-    if (dstStat.type == FILE_DIRECTORY)
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
-    if (dstStat.type == FILE_REGULAR && srcStat.type == FILE_DIRECTORY)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_IS_DIR_DST_IS_FILE, srcPath, dstPath);
-    if (dstStat)
-        remove(dstPath);
-
-    std::unique_ptr<char[]> buffer;
-    auto copyFile = [this, &buffer](FileSystemPathView srcPath, FileSystemPathView dstPath) -> void {
-        std::unique_ptr<InputStream> input = openForReading(srcPath);
-        std::unique_ptr<OutputStream> output = openForWriting(dstPath);
-
-        if (!buffer)
-            buffer = std::make_unique_for_overwrite<char[]>(COPY_BUFFER_SIZE);
-
-        while (true) {
-            size_t bytes = input->read(buffer.get(), COPY_BUFFER_SIZE);
-            if (!bytes)
-                break;
-            output->write(buffer.get(), bytes);
-        }
-    };
-
-    auto copyDir = [this] (FileSystemPathView srcPath, FileSystemPathView dstPath, const auto &copyAny) -> void {
-        for (const DirectoryEntry &entry : ls(srcPath))
-            copyAny(entry.type, srcPath / entry.name, dstPath / entry.name, copyAny);
-    };
-
-    auto copyAny = [this, &copyFile, &copyDir] (FileType type, FileSystemPathView srcPath, FileSystemPathView dstPath, const auto &copyAny) -> void {
-        if (type == FILE_REGULAR) {
-            copyFile(srcPath, dstPath);
-        } else {
-            assert(type == FILE_DIRECTORY);
-            copyDir(srcPath, dstPath, copyAny);
-        }
-    };
-
-    copyAny(srcStat.type, srcPath, dstPath, copyAny);
-    remove(srcPath);
 }

--- a/src/Library/FileSystem/Interface/FileSystem.h
+++ b/src/Library/FileSystem/Interface/FileSystem.h
@@ -65,7 +65,7 @@ struct DirectoryEntry {
  * root-relative paths, so `"foo/bar"` and `"/foo/bar"` are equivalent.
  *
  * Root folder of the file system always exists. Thus, `exists("")` always returns `true`, `stat("")` always returns
- * `FILE_DIRECTORY`, `ls("")` never throws, `remove("")` and `rename("", "foo")` always throw.
+ * `FILE_DIRECTORY`, `ls("")` never throws, and `remove("")` always throws.
  *
  * @see ReadOnlyFileSystem
  */
@@ -136,22 +136,6 @@ class FileSystem {
     [[nodiscard]] std::unique_ptr<OutputStream> openForWriting(FileSystemPathView path);
 
     /**
-     * Renames a file or a folder.
-     *
-     * Default implementation removes `dstPath` first, then copies the `srcPath` over, then removes `srcPath`.
-     *
-     * Derived classes working on top of an actual file system might implement this using POSIX `rename`.
-     *
-     * @param srcPath                   Source path for renaming. Path must exist and must not be root.
-     * @param dstPath                   Target path for renaming. If source path is a directory, then target path must
-     *                                  not exist. If source path is a file, then target path must either not exist, or
-     *                                  be a file. If parent directory of `dstPath` doesn't exist, it will be created.
-     * @throws std::runtime_error       On error, e.g. if the current user doesn't have the necessary permissions.
-     */
-    void rename(std::string_view srcPath, std::string_view dstPath);
-    void rename(FileSystemPathView srcPath, FileSystemPathView dstPath);
-
-    /**
      * @param path                      Path to a file or a directory to remove. A directory will be removed even if it
      *                                  is not empty. Must not be root.
      * @return                          `true` if the file or folder was deleted, `false` if it did not exist.
@@ -184,7 +168,6 @@ class FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) = 0;
     [[nodiscard]] virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const = 0;
     [[nodiscard]] virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) = 0;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath);
     virtual bool _remove(FileSystemPathView path) = 0;
     [[nodiscard]] virtual std::string _displayPath(FileSystemPathView path) const = 0;
 };

--- a/src/Library/FileSystem/Interface/FileSystemEnums.h
+++ b/src/Library/FileSystem/Interface/FileSystemEnums.h
@@ -12,7 +12,7 @@ using enum FileType;
  *
  * Reasons are sorted by priority. It is expected that if an operation fails due to several different problems, then
  * the highest priority `Code` will be used. E.g. if a filesystem isn't writeable, it doesn't matter if we're trying
- * to remove root - the error on `rename` is always that the target is not writeable (because it can't be).
+ * to remove root - the error on `remove` is always that the path is not writeable (because it can't be).
  */
 enum class FileSystemError {
     FS_LS_FAILED_PATH_DOESNT_EXIST,
@@ -28,15 +28,6 @@ enum class FileSystemError {
     FS_WRITE_FAILED_FILE_IN_PATH, // Writing to "a/b.txt/c" where "a/b.txt" is an existing file.
     FS_WRITE_FAILED_PATH_IS_DIR,
     FS_WRITE_FAILED_PATH_NOT_ACCESSIBLE,
-
-    FS_RENAME_FAILED_DST_NOT_WRITEABLE,
-    FS_RENAME_FAILED_SRC_NOT_WRITEABLE, // E.g. is root.
-    FS_RENAME_FAILED_DST_NOT_ACCESSIBLE,
-    FS_RENAME_FAILED_SRC_NOT_ACCESSIBLE,
-    FS_RENAME_FAILED_SRC_DOESNT_EXIST,
-    FS_RENAME_FAILED_DST_IS_DIR,
-    FS_RENAME_FAILED_SRC_IS_DIR_DST_IS_FILE,
-    FS_RENAME_FAILED_SRC_IS_PARENT_OF_DST,
 
     FS_REMOVE_FAILED_PATH_NOT_WRITEABLE, // E.g. is root.
     FS_REMOVE_FAILED_PATH_NOT_ACCESSIBLE,

--- a/src/Library/FileSystem/Interface/FileSystemException.cpp
+++ b/src/Library/FileSystem/Interface/FileSystemException.cpp
@@ -6,11 +6,11 @@
 #include "FileSystemPath.h"
 #include "FileSystem.h"
 
-FileSystemException::FileSystemException(FileSystemError error, std::string_view arg0, std::string_view arg1) :
-    Exception("{}", formatMessage(error, arg0, arg1))
+FileSystemException::FileSystemException(FileSystemError error, std::string_view arg0) :
+    Exception("{}", formatMessage(error, arg0))
 {}
 
-std::string FileSystemException::formatMessage(FileSystemError error, std::string_view arg0, std::string_view arg1) {
+std::string FileSystemException::formatMessage(FileSystemError error, std::string_view arg0) {
     switch (error) {
     default: assert(false); [[fallthrough]];
 
@@ -39,23 +39,6 @@ std::string FileSystemException::formatMessage(FileSystemError error, std::strin
     case FS_WRITE_FAILED_PATH_NOT_ACCESSIBLE:
         return fmt::format("Could not write to '{}' because the provided path is not accessible.", arg0);
 
-    case FS_RENAME_FAILED_DST_NOT_WRITEABLE:
-        return fmt::format("Could not rename '{}' to '{}' because destination path is not writeable.", arg0, arg1);
-    case FS_RENAME_FAILED_SRC_NOT_WRITEABLE:
-        return fmt::format("Could not rename '{}' to '{}' because source path is not writeable.", arg0, arg1);
-    case FS_RENAME_FAILED_DST_NOT_ACCESSIBLE:
-        return fmt::format("Could not rename '{}' to '{}' because destination path is not accessible.", arg0, arg1);
-    case FS_RENAME_FAILED_SRC_NOT_ACCESSIBLE:
-        return fmt::format("Could not rename '{}' to '{}' because source path is not accessible.", arg0, arg1);
-    case FS_RENAME_FAILED_SRC_DOESNT_EXIST:
-        return fmt::format("Could not rename '{}' to '{}' because source path doesn't exist.", arg0, arg1);
-    case FS_RENAME_FAILED_DST_IS_DIR:
-        return fmt::format("Could not rename '{}' to '{}' because destination path is a directory.", arg0, arg1);
-    case FS_RENAME_FAILED_SRC_IS_DIR_DST_IS_FILE:
-        return fmt::format("Could not rename '{}' to '{}' because source path is a directory and destination path is an exiting file.", arg0, arg1);
-    case FS_RENAME_FAILED_SRC_IS_PARENT_OF_DST:
-        return fmt::format("Could not rename '{}' to '{}' because moving a directory into one of its subdirectories is not supported.", arg0, arg1);
-
     case FS_REMOVE_FAILED_PATH_NOT_WRITEABLE:
         return fmt::format("Could not remove '{}' because the provided path is not writeable.", arg0);
     case FS_REMOVE_FAILED_PATH_NOT_ACCESSIBLE:
@@ -65,8 +48,4 @@ std::string FileSystemException::formatMessage(FileSystemError error, std::strin
 
 [[noreturn]] void FileSystemException::raise(const FileSystem *fs, FileSystemError error, FileSystemPathView arg0) {
     throw FileSystemException(error, fs->displayPath(arg0));
-}
-
-[[noreturn]] void FileSystemException::raise(const FileSystem *fs, FileSystemError error, FileSystemPathView arg0, FileSystemPathView arg1) {
-    throw FileSystemException(error, fs->displayPath(arg0), fs->displayPath(arg1));
 }

--- a/src/Library/FileSystem/Interface/FileSystemException.h
+++ b/src/Library/FileSystem/Interface/FileSystemException.h
@@ -10,11 +10,10 @@
 
 class FileSystemException : public Exception {
  public:
-    FileSystemException(FileSystemError error, std::string_view arg0, std::string_view arg1 = {});
+    FileSystemException(FileSystemError error, std::string_view arg0);
 
     [[noreturn]] static void raise(const FileSystem *fs, FileSystemError error, FileSystemPathView arg0);
-    [[noreturn]] static void raise(const FileSystem *fs, FileSystemError error, FileSystemPathView arg0, FileSystemPathView arg1);
 
  private:
-    std::string formatMessage(FileSystemError error, std::string_view arg0, std::string_view arg1);
+    std::string formatMessage(FileSystemError error, std::string_view arg0);
 };

--- a/src/Library/FileSystem/Interface/FileSystemPath.h
+++ b/src/Library/FileSystem/Interface/FileSystemPath.h
@@ -51,10 +51,6 @@ class FileSystemPath {
         return _path.empty();
     }
 
-    [[nodiscard]] bool isPrefixOf(FileSystemPathView path) const {
-        return FileSystemPathView(*this).isPrefixOf(path);
-    }
-
     [[nodiscard]] bool isEscaping() const {
         return FileSystemPathView(*this).isEscaping();
     }

--- a/src/Library/FileSystem/Interface/FileSystemPathView.h
+++ b/src/Library/FileSystem/Interface/FileSystemPathView.h
@@ -28,19 +28,6 @@ class FileSystemPathView {
         return _path.empty();
     }
 
-    /**
-     * @param path                      Path to check against.
-     * @return                          Whether this path is a starting subpath of `path`. Note that this is different
-     *                                  from just checking whether this path is a lexicographical prefix of `path`.
-     *                                  Every path is always a starting subpath of itself.
-     */
-    [[nodiscard]] bool isPrefixOf(FileSystemPathView path) const {
-        return
-            path._path.size() >= _path.size() &&
-            path._path.starts_with(_path) &&
-            (path._path.size() == _path.size() || _path.empty() || path._path[_path.size()] == '/');
-    }
-
     [[nodiscard]] bool isEscaping() const {
         return _path == ".." || _path.starts_with("../");
     }

--- a/src/Library/FileSystem/Interface/ReadOnlyFileSystem.cpp
+++ b/src/Library/FileSystem/Interface/ReadOnlyFileSystem.cpp
@@ -12,10 +12,6 @@ std::unique_ptr<OutputStream> ReadOnlyFileSystem::_openForWriting(FileSystemPath
     reportWriteError(path);
 }
 
-void ReadOnlyFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-}
-
 bool ReadOnlyFileSystem::_remove(FileSystemPathView path) {
     if (!_exists(path))
         return false;

--- a/src/Library/FileSystem/Interface/ReadOnlyFileSystem.h
+++ b/src/Library/FileSystem/Interface/ReadOnlyFileSystem.h
@@ -11,7 +11,6 @@ class ReadOnlyFileSystem : public FileSystem {
  private:
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
 
     [[noreturn]] void reportWriteError(FileSystemPathView path) const;

--- a/src/Library/FileSystem/Interface/Tests/FileSystemPath_ut.cpp
+++ b/src/Library/FileSystem/Interface/Tests/FileSystemPath_ut.cpp
@@ -49,28 +49,6 @@ UNIT_TEST(FileSystemPath, Normalization) {
     EXPECT_EQ(FileSystemPath("foo/.../bar/...").string(), "foo/.../bar/...");
 }
 
-UNIT_TEST(FileSystemPath, Prefix) {
-    EXPECT_TRUE(FileSystemPath("foo").isPrefixOf(FileSystemPath("foo")));
-    EXPECT_TRUE(FileSystemPath("").isPrefixOf(FileSystemPath("")));
-
-    EXPECT_TRUE(FileSystemPath("").isPrefixOf(FileSystemPath("a")));
-    EXPECT_TRUE(FileSystemPath("").isPrefixOf(FileSystemPath("a/b")));
-    EXPECT_TRUE(FileSystemPath("a").isPrefixOf(FileSystemPath("a/b")));
-
-    EXPECT_FALSE(FileSystemPath("a").isPrefixOf(FileSystemPath("aa/bb")));
-    EXPECT_FALSE(FileSystemPath("aa/b").isPrefixOf(FileSystemPath("aa/bb")));
-
-    EXPECT_FALSE(FileSystemPath("a/b").isPrefixOf(FileSystemPath("a")));
-    EXPECT_FALSE(FileSystemPath("a/b").isPrefixOf(FileSystemPath("")));
-    EXPECT_FALSE(FileSystemPath("a").isPrefixOf(FileSystemPath("")));
-
-    EXPECT_FALSE(FileSystemPath("..").isPrefixOf(FileSystemPath("")));
-    EXPECT_FALSE(FileSystemPath("../..").isPrefixOf(FileSystemPath("")));
-    EXPECT_TRUE(FileSystemPath("").isPrefixOf(FileSystemPath("..")));
-    EXPECT_TRUE(FileSystemPath("").isPrefixOf(FileSystemPath("../..")));
-    EXPECT_TRUE(FileSystemPath("..").isPrefixOf(FileSystemPath("../..")));
-}
-
 UNIT_TEST(FileSystemPath, EmptyChunks) {
     EXPECT_TRUE(FileSystemPath().split().empty());
     EXPECT_TRUE(FileSystemPath(".").split().empty());

--- a/src/Library/FileSystem/Lowercase/LowercaseFileSystem.cpp
+++ b/src/Library/FileSystem/Lowercase/LowercaseFileSystem.cpp
@@ -79,38 +79,6 @@ std::unique_ptr<OutputStream> LowercaseFileSystem::_openForWriting(FileSystemPat
     return result;
 }
 
-void LowercaseFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    if (hasUpper(dstPath.string()))
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-
-    auto [srcBasePath, srcNode, srcTail] = walk(srcPath);
-    if (!srcTail.isEmpty())
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_DOESNT_EXIST, srcPath, dstPath);
-    if (srcNode->value().conflicting)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_NOT_WRITEABLE, srcPath, dstPath);
-
-    auto [dstBasePath, dstNode, dstTail] = walk(dstPath);
-    if (dstNode->value().type == FILE_DIRECTORY && dstTail.isEmpty())
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
-    if (srcNode->value().type == FILE_DIRECTORY && dstTail.isEmpty())
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_IS_DIR_DST_IS_FILE, srcPath, dstPath);
-    if (dstNode->value().conflicting)
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-
-    dstBasePath /= dstTail;
-    try {
-        _base->rename(srcBasePath, dstBasePath);
-    } catch (...) {
-        // We have no idea about the state of the underlying FS now. Don't bother checking, just invalidate the caches.
-        invalidateLs(srcNode->parent());
-        invalidateLs(dstTail.isEmpty() ? dstNode->parent() : dstNode);
-        throw;
-    }
-
-    cacheInsert(dstNode, dstTail, srcNode->value().type);
-    cacheRemove(srcNode);
-}
-
 bool LowercaseFileSystem::_remove(FileSystemPathView path) {
     assert(!path.isEmpty());
 

--- a/src/Library/FileSystem/Lowercase/LowercaseFileSystem.h
+++ b/src/Library/FileSystem/Lowercase/LowercaseFileSystem.h
@@ -61,7 +61,6 @@ class LowercaseFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
@@ -81,7 +81,6 @@ UNIT_TEST(LowercaseFileSystem, Conflict) {
     EXPECT_ANY_THROW((void) fs.openForReading("a.bin"));
     EXPECT_ANY_THROW((void) fs.openForWriting("a.bin"));
     EXPECT_ANY_THROW((void) fs.remove("a.bin"));
-    EXPECT_ANY_THROW(fs.rename("a.bin", "b.bin"));
 
     EXPECT_TRUE(fs0.exists("A.bin"));
     EXPECT_TRUE(fs0.exists("a.bin"));
@@ -157,91 +156,12 @@ UNIT_TEST(LowercaseFileSystem, PruneRemove) {
     EXPECT_FALSE(fs0.exists("a")); // Because memory fs doesn't support empty dirs either.
 }
 
-UNIT_TEST(LowercaseFileSystem, PruneRename) {
-    MemoryFileSystem fs0("");
-    fs0.write("A/A/A", Blob::fromString("123"));
-
-    LowercaseFileSystem fs(&fs0);
-    fs.rename("a/a/a", "b/b/b");
-
-    EXPECT_FALSE(fs.exists("a")); // Pruning happened.
-    EXPECT_TRUE(fs.exists("b"));
-    EXPECT_EQ(fs.read("b/b/b").str(), "123");
-
-    EXPECT_FALSE(fs0.exists("A"));
-    EXPECT_TRUE(fs0.exists("b"));
-    EXPECT_EQ(fs0.read("b/b/b").str(), "123");
-}
-
-UNIT_TEST(LowercaseFileSystem, RenameReplace) {
-    MemoryFileSystem fs0("");
-    fs0.write("A/A/A", Blob::fromString("AAA"));
-    fs0.write("B/B/B", Blob::fromString("BBB"));
-
-    LowercaseFileSystem fs(&fs0);
-    fs.rename("a/a/a", "b/b/b");
-
-    EXPECT_FALSE(fs.exists("a"));
-    EXPECT_TRUE(fs.exists("b"));
-    EXPECT_EQ(fs.read("b/b/b").str(), "AAA");
-
-    EXPECT_FALSE(fs0.exists("A"));
-    EXPECT_TRUE(fs0.exists("B"));
-    EXPECT_EQ(fs0.read("B/B/B").str(), "AAA");
-}
-
-UNIT_TEST(LowercaseFileSystem, RenameFolder) {
-    MemoryFileSystem fs0("");
-    fs0.write("A/A/A/A", Blob::fromString("AAAA"));
-    fs0.write("B/tmp", Blob());
-
-    LowercaseFileSystem fs(&fs0);
-    fs.rename("a/a", "b/b");
-
-    EXPECT_FALSE(fs.exists("a"));
-    EXPECT_TRUE(fs.exists("b/b/a/a"));
-    EXPECT_TRUE(fs.exists("b/tmp"));
-
-    EXPECT_FALSE(fs0.exists("A"));
-    EXPECT_TRUE(fs0.exists("B/b/A/A"));
-    EXPECT_EQ(fs0.read("B/b/A/A").str(), "AAAA");
-}
-
 UNIT_TEST(LowercaseFileSystem, WriteUppercase) {
     MemoryFileSystem fs0("");
     LowercaseFileSystem fs(&fs0);
 
     EXPECT_ANY_THROW(fs.write("A", Blob()));
     EXPECT_ANY_THROW((void) fs.openForWriting("A"));
-}
-
-UNIT_TEST(LowercaseFileSystem, RenameRepeatedly) {
-    MemoryFileSystem fs0("");
-    fs0.write("A", Blob::fromString("A"));
-
-    LowercaseFileSystem fs(&fs0);
-    fs.rename("a", "b");
-    fs.rename("b", "c");
-    fs.rename("c", "d");
-    fs.rename("d", "e/f/g/h");
-    fs.rename("e/f/g/h", "a");
-
-    EXPECT_TRUE(fs.exists("a"));
-    EXPECT_EQ(fs.read("a").str(), "A");
-    EXPECT_EQ(fs.ls(""), std::vector<DirectoryEntry>({{"a", FILE_REGULAR}}));
-    EXPECT_FALSE(fs0.exists("A"));
-    EXPECT_EQ(fs0.read("a").str(), "A");
-    EXPECT_EQ(fs0.ls(""), std::vector<DirectoryEntry>({{"a", FILE_REGULAR}}));
-}
-
-UNIT_TEST(LowercaseFileSystem, RenameUppercase) {
-    MemoryFileSystem fs0("");
-    fs0.write("A", Blob::fromString("A"));
-
-    LowercaseFileSystem fs(&fs0);
-    EXPECT_ANY_THROW(fs.rename("a", "B"));
-    EXPECT_TRUE(fs.exists("a"));
-    EXPECT_EQ(fs.read("a").str(), "A");
 }
 
 UNIT_TEST(LowercaseFileSystem, RemoveRepeatedly) {
@@ -297,25 +217,3 @@ UNIT_TEST(LowercaseFileSystem, RemoveDeep) {
     EXPECT_EQ(fs0.ls("A/B"), std::vector<DirectoryEntry>({{"1", FILE_REGULAR}}));
 }
 
-UNIT_TEST(LowercaseFileSystem, RenameOverConflict) {
-    MemoryFileSystem fs0("ram");
-    fs0.write("A", Blob::fromString(""));
-    fs0.write("AAA", Blob::fromString(""));
-    fs0.write("AAa", Blob::fromString(""));
-
-    LowercaseFileSystem fs(&fs0);
-    EXPECT_ANY_THROW(fs.rename("a", "aaa/b"));
-}
-
-UNIT_TEST(LowercaseFileSystem, SelfRename) {
-    MemoryFileSystem fs0("ram");
-    fs0.write("ABC", Blob::fromString("abc"));
-
-    LowercaseFileSystem fs(&fs0);
-
-    fs.rename("abc", "abc");
-
-    EXPECT_TRUE(fs.exists("abc"));
-    EXPECT_EQ(fs.read("abc").str(), "abc");
-    EXPECT_EQ(fs.ls(""), std::vector<DirectoryEntry>({{"abc", FILE_REGULAR}}));
-}

--- a/src/Library/FileSystem/Masking/MaskingFileSystem.cpp
+++ b/src/Library/FileSystem/Masking/MaskingFileSystem.cpp
@@ -109,14 +109,6 @@ std::unique_ptr<OutputStream> MaskingFileSystem::_openForWriting(FileSystemPathV
     return ProxyFileSystem::_openForWriting(path);
 }
 
-void MaskingFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    if (isMasked(srcPath))
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_DOESNT_EXIST, srcPath, dstPath);
-    if (isMasked(dstPath))
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-    return ProxyFileSystem::_rename(srcPath, dstPath);
-}
-
 bool MaskingFileSystem::_remove(FileSystemPathView path) {
     if (isMasked(path))
         return false;

--- a/src/Library/FileSystem/Masking/MaskingFileSystem.h
+++ b/src/Library/FileSystem/Masking/MaskingFileSystem.h
@@ -31,7 +31,6 @@ class MaskingFileSystem : public ProxyFileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Memory/MemoryFileSystem.cpp
+++ b/src/Library/FileSystem/Memory/MemoryFileSystem.cpp
@@ -68,26 +68,6 @@ std::unique_ptr<OutputStream> MemoryFileSystem::_openForWriting(FileSystemPathVi
     return std::make_unique<detail::MemoryFileSystemOutputStream>(nodeForWriting(path)->value(), displayPath(path));
 }
 
-void MemoryFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    assert(!srcPath.isEmpty());
-    assert(!dstPath.isEmpty());
-
-    Node *srcNode = _trie.find(srcPath);
-    if (!srcNode)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_DOESNT_EXIST, srcPath, dstPath);
-
-    FileSystemPathView dstTail;
-    Node *dstNode = _trie.walk(dstPath, &dstTail);
-    if (dstTail.isEmpty()) { // dstPath exists.
-        if (!dstNode->hasValue())
-            FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
-        if (!srcNode->hasValue())
-            FileSystemException::raise(this, FS_RENAME_FAILED_SRC_IS_DIR_DST_IS_FILE, srcPath, dstPath);
-    }
-
-    _trie.insertOrAssign(dstNode, dstTail, _trie.extract(srcNode));
-}
-
 bool MemoryFileSystem::_remove(FileSystemPathView path) {
     assert(!path.isEmpty());
 

--- a/src/Library/FileSystem/Memory/MemoryFileSystem.h
+++ b/src/Library/FileSystem/Memory/MemoryFileSystem.h
@@ -44,7 +44,6 @@ class MemoryFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Memory/Tests/MemoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Memory/Tests/MemoryFileSystem_ut.cpp
@@ -20,11 +20,8 @@ UNIT_TEST(MemoryFileSystem, EmptyRoot) {
     EXPECT_ANY_THROW((void) fs.openForReading(""));
     EXPECT_ANY_THROW((void) fs.openForWriting(""));
     EXPECT_ANY_THROW(fs.remove(""));
-    EXPECT_ANY_THROW(fs.rename("", ""));
-    EXPECT_ANY_THROW(fs.rename("", "new"));
 
     fs.write("a/b.bin", Blob());
-    EXPECT_ANY_THROW(fs.rename("a", ""));
 }
 
 UNIT_TEST(MemoryFileSystem, Ls) {
@@ -193,36 +190,6 @@ UNIT_TEST(MemoryFileSystem, DestructorFlushesData) {
     EXPECT_EQ(fs.read("a").str(), "123");
 }
 
-UNIT_TEST(MemoryFileSystem, Rename) {
-    MemoryFileSystem fs("");
-
-    fs.write("a/b/c", Blob::fromString("123"));
-
-    std::unique_ptr<InputStream> input = fs.openForReading("a/b/c");
-    std::unique_ptr<OutputStream> output = fs.openForWriting("a/b/d");
-
-    EXPECT_ANY_THROW(fs.rename("a/b", "a/b/c"));
-    EXPECT_ANY_THROW(fs.rename("a/b", "a/b/d"));
-    EXPECT_ANY_THROW(fs.rename("a/b", "a/b/1"));
-    EXPECT_ANY_THROW(fs.rename("a/b", "a"));
-
-    fs.rename("a/b", "x/y");
-    EXPECT_FALSE(fs.exists("a")); // "a" is now empty, so was trimmed.
-    EXPECT_ANY_THROW((void) fs.ls("a"));
-
-    EXPECT_EQ(input->readAll(), "123"); // Moving files around keeps the streams valid.
-    output->write("1234");
-    output->close();
-
-    EXPECT_EQ(dumpFileSystem(&fs, FILE_SYSTEM_DUMP_WITH_CONTENTS), std::vector<FileSystemDumpEntry>({
-        {"", FILE_DIRECTORY},
-        {"x", FILE_DIRECTORY},
-        {"x/y", FILE_DIRECTORY},
-        {"x/y/c", FILE_REGULAR, "123"},
-        {"x/y/d", FILE_REGULAR, "1234"}
-    }));
-}
-
 UNIT_TEST(MemoryFileSystem, Overwrite) {
     MemoryFileSystem fs("");
     fs.write("a", Blob::fromString("a"));
@@ -260,18 +227,3 @@ UNIT_TEST(MemoryFileSystem, ExceptionMessage) {
     EXPECT_THROW_MESSAGE((void) fs.ls("a"), "mem://a");
 }
 
-UNIT_TEST(MemoryFileSystem, SelfRename) {
-    MemoryFileSystem fs("");
-
-    fs.write("a", Blob::fromString("123"));
-    fs.rename("a", "a");
-
-    EXPECT_TRUE(fs.exists("a"));
-    EXPECT_EQ(fs.read("a").str(), "123");
-
-    fs.write("d/x", Blob::fromString("456"));
-    fs.rename("d", "d");
-
-    EXPECT_TRUE(fs.exists("d/x"));
-    EXPECT_EQ(fs.read("d/x").str(), "456");
-}

--- a/src/Library/FileSystem/Mounting/MountingFileSystem.cpp
+++ b/src/Library/FileSystem/Mounting/MountingFileSystem.cpp
@@ -113,28 +113,6 @@ std::unique_ptr<OutputStream> MountingFileSystem::_openForWriting(FileSystemPath
     return mount->openForWriting(tail);
 }
 
-void MountingFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    auto [srcNode, srcMount, srcTail] = walk(srcPath);
-    auto [dstNode, dstMount, dstTail] = walk(dstPath);
-
-    if (srcNode)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_NOT_WRITEABLE, srcPath, dstPath);
-    if (dstNode)
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_IS_DIR, srcPath, dstPath);
-    if (!srcMount)
-        FileSystemException::raise(this, FS_RENAME_FAILED_SRC_DOESNT_EXIST, srcPath, dstPath);
-    if (!dstMount)
-        FileSystemException::raise(this, FS_RENAME_FAILED_DST_NOT_WRITEABLE, srcPath, dstPath);
-
-    if (srcMount == dstMount) {
-        srcMount->rename(srcTail, dstTail);
-    } else {
-        // Just forward to recursive copy & remove. Every call will resolve the mount points again and again, so
-        // suboptimal, but OK for now.
-        FileSystem::_rename(srcPath, dstPath);
-    }
-}
-
 bool MountingFileSystem::_remove(FileSystemPathView path) {
     auto [node, mount, tail] = walk(path);
     if (node)

--- a/src/Library/FileSystem/Mounting/MountingFileSystem.h
+++ b/src/Library/FileSystem/Mounting/MountingFileSystem.h
@@ -25,8 +25,8 @@
  * In the example above, repeated calls to `mount` create a hierarchy of virtual directories. These virtual directories
  * override everything with the same name that existed in the underlying file systems.
  *
- * Note that `rename` and `remove` only work on regular files, and will fail on virtual directories. If you want to
- * tweak the virtual directory tree, use `mount` and `unmount`.
+ * Note that `remove` only works on regular files, and will fail on virtual directories. If you want to tweak the
+ * virtual directory tree, use `mount` and `unmount`.
  */
 class MountingFileSystem : public FileSystem {
  public:
@@ -48,7 +48,6 @@ class MountingFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Mounting/Tests/MountingFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Mounting/Tests/MountingFileSystem_ut.cpp
@@ -127,38 +127,6 @@ UNIT_TEST(MountingFileSystem, Remove) {
     EXPECT_FALSE(fs.remove("a/a"));
 }
 
-UNIT_TEST(MountingFileSystem, RenameSameFs) {
-    MemoryFileSystem mfs("");
-
-    MountingFileSystem fs("");
-    fs.mount("a", &mfs);
-
-    mfs.write("a", Blob::fromString("123"));
-
-    fs.rename("a/a", "a/b");
-
-    EXPECT_EQ(mfs.read("b").str(), "123");
-    EXPECT_EQ(fs.read("a/b").str(), "123");
-    EXPECT_EQ(fs.ls("a"), std::vector<DirectoryEntry>({{"b", FILE_REGULAR}}));
-}
-
-UNIT_TEST(MountingFileSystem, RenameDifferentFs) {
-    MemoryFileSystem mfs1("");
-    MemoryFileSystem mfs2("");
-
-    MountingFileSystem fs("");
-    fs.mount("1", &mfs1);
-    fs.mount("2", &mfs2);
-
-    mfs1.write("a", Blob::fromString("123"));
-
-    fs.rename("1/a", "2/a");
-
-    EXPECT_FALSE(mfs1.exists("a"));
-    EXPECT_TRUE(mfs2.exists("a"));
-    EXPECT_EQ(mfs2.read("a").str(), "123");
-}
-
 UNIT_TEST(MountingFileSystem, Binary) {
     MountingFileSystem fs("");
     fs.mount("0", &fs);

--- a/src/Library/FileSystem/Proxy/ProxyFileSystem.cpp
+++ b/src/Library/FileSystem/Proxy/ProxyFileSystem.cpp
@@ -33,10 +33,6 @@ std::unique_ptr<OutputStream> ProxyFileSystem::_openForWriting(FileSystemPathVie
     return nonNullBase()->_openForWriting(path);
 }
 
-void ProxyFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    return nonNullBase()->_rename(srcPath, dstPath);
-}
-
 bool ProxyFileSystem::_remove(FileSystemPathView path) {
     return nonNullBase()->_remove(path);
 }

--- a/src/Library/FileSystem/Proxy/ProxyFileSystem.h
+++ b/src/Library/FileSystem/Proxy/ProxyFileSystem.h
@@ -26,7 +26,6 @@ class ProxyFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Sub/SubFileSystem.cpp
+++ b/src/Library/FileSystem/Sub/SubFileSystem.cpp
@@ -42,10 +42,6 @@ std::unique_ptr<OutputStream> SubFileSystem::_openForWriting(FileSystemPathView 
     return _base->openForWriting(_basePath / path);
 }
 
-void SubFileSystem::_rename(FileSystemPathView srcPath, FileSystemPathView dstPath) {
-    _base->rename(_basePath / srcPath, _basePath / dstPath);
-}
-
 bool SubFileSystem::_remove(FileSystemPathView path) {
     return _base->remove(_basePath / path);
 }

--- a/src/Library/FileSystem/Sub/SubFileSystem.h
+++ b/src/Library/FileSystem/Sub/SubFileSystem.h
@@ -37,7 +37,6 @@ class SubFileSystem : public FileSystem {
     virtual void _write(FileSystemPathView path, const Blob &data) override;
     virtual std::unique_ptr<InputStream> _openForReading(FileSystemPathView path) const override;
     virtual std::unique_ptr<OutputStream> _openForWriting(FileSystemPathView path) override;
-    virtual void _rename(FileSystemPathView srcPath, FileSystemPathView dstPath) override;
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 

--- a/src/Library/FileSystem/Trie/FileSystemTrie.h
+++ b/src/Library/FileSystem/Trie/FileSystemTrie.h
@@ -198,56 +198,6 @@ class FileSystemTrie {
         return insertOrAssign(root(), path, std::move(value));
     }
 
-    std::unique_ptr<Node> extract(Node *node) {
-        assert(node);
-
-        Node *parent = node->_parent;
-        if (parent) {
-            auto pos = parent->_children.find(node->_key);
-
-            std::unique_ptr<Node> result = std::move(pos->second);
-            result->_parent = nullptr;
-            result->_key.clear();
-
-            parent->_children.erase(pos);
-            _prune(parent); // parent might have become empty as a result.
-
-            return result;
-        } else {
-            // Extracting root node.
-            std::unique_ptr<Node> result = std::make_unique<Node>(nullptr, "");
-            swap(result, _root);
-            return result;
-        }
-    }
-
-    Node *insertOrAssign(Node *base, FileSystemPathView relativePath, std::unique_ptr<Node> node) {
-        assert(base);
-        assert(node);
-        assert(node->_parent == nullptr);
-        assert(node->_key.empty());
-
-        if (base == root() && relativePath.isEmpty()) { // Replacing root.
-            _root = std::move(node);
-            return root();
-        }
-
-        if (!node->hasValue() && node->children().empty()) { // Replacing with an empty node == node deletion.
-            erase(base, relativePath);
-            return nullptr;
-        }
-
-        // We need to preserve pointer values so will have to jump through hoops here a bit.
-        Node *branch = _grow(base, relativePath);
-        node->_parent = branch->_parent;
-        node->_key = std::move(branch->_key); // Can move the string out as branch will be destroyed in the next statement.
-        return (node->_parent->_children[node->_key] = std::move(node)).get();
-    }
-
-    Node *insertOrAssign(FileSystemPathView path, std::unique_ptr<Node> node) {
-        return insertOrAssign(root(), path, std::move(node));
-    }
-
     void clear() {
         erase(root());
     }

--- a/src/Library/FileSystem/Trie/Tests/FileSystemTrie_ut.cpp
+++ b/src/Library/FileSystem/Trie/Tests/FileSystemTrie_ut.cpp
@@ -86,37 +86,3 @@ UNIT_TEST(FileSystemTrie, WalkClearsTail) {
     EXPECT_EQ(tail1, FileSystemPath());
 }
 
-UNIT_TEST(FileSystemTrie, ExtractInsert) {
-    using namespace detail; // NOLINT
-
-    FileSystemTrie<int> trie;
-    FileSystemTrieNode<int> *nodea = trie.insertOrAssign(FileSystemPath("a"), 10);
-
-    std::unique_ptr<FileSystemTrieNode<int>> extracted = trie.extract(nodea);
-    EXPECT_EQ(extracted->parent(), nullptr);
-    EXPECT_EQ(trie.find(FileSystemPath("a")), nullptr);
-
-    FileSystemTrieNode<int> *nodeb = trie.insertOrAssign(FileSystemPath("b"), std::move(extracted));
-    EXPECT_EQ(nodea, nodeb); // Checking that pointers are preserved.
-    EXPECT_EQ(nodeb->parent(), trie.root());
-
-    EXPECT_TRUE(trie.erase(nodeb));
-    EXPECT_TRUE(trie.isEmpty());
-}
-
-UNIT_TEST(FileSystemTrie, ExtractInsertRoot) {
-    using namespace detail; // NOLINT
-
-    FileSystemTrie<int> trie0;
-    FileSystemTrieNode<int> *node = trie0.insertOrAssign(FileSystemPath("a"), 10);
-    FileSystemTrieNode<int> *root0 = trie0.root();
-
-    FileSystemTrie<int> trie1;
-    trie1.insertOrAssign(FileSystemPath(), trie0.extract(root0));
-
-    EXPECT_NE(trie0.root(), nullptr); // New root was created.
-    EXPECT_TRUE(trie0.isEmpty());
-    EXPECT_FALSE(trie1.isEmpty());
-    EXPECT_EQ(trie1.root(), root0);
-    EXPECT_EQ(trie1.find(FileSystemPath("a")), node);
-}


### PR DESCRIPTION
Subj.

We used to call rename at some point, but that was dropped. I kept it for symmetry – if a design supports renaming, then it's a sound design.

Well, it's proved to be too much hassle to support.