### PR TITLE
Auto-cancel superseded CI runs

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -30,10 +30,7 @@ on:
     types:
       - published
 
-# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
-# and nightly builds never queue behind or cancel each other. The group name starts with a literal because
-# `github.run_id` is the caller's id inside a reusable workflow, and the workflows called from the nightly build must
-# not end up sharing a group.
+# A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
   group: build-all-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -30,6 +30,14 @@ on:
     types:
       - published
 
+# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
+# and nightly builds never queue behind or cancel each other. The group name starts with a literal because
+# `github.run_id` is the caller's id inside a reusable workflow, and the workflows called from the nightly build must
+# not end up sharing a group.
+concurrency:
+  group: build-all-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # This version is referenced in android/openenroth/build.gradle.
   # When updating the version here you should also update it in the Dependencies repo!

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,8 +14,7 @@ on:
     types:
       - published
 
-# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
-# builds never queue behind or cancel each other.
+# A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
   group: doxygen-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,6 +14,12 @@ on:
     types:
       - published
 
+# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
+# builds never queue behind or cancel each other.
+concurrency:
+  group: doxygen-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   generate_documentation:
     runs-on: ubuntu-22.04

--- a/.github/workflows/linux_flatpak.yml
+++ b/.github/workflows/linux_flatpak.yml
@@ -30,6 +30,14 @@ on:
     types:
       - published
 
+# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
+# and nightly builds never queue behind or cancel each other. The group name starts with a literal because
+# `github.run_id` is the caller's id inside a reusable workflow, and the workflows called from the nightly build must
+# not end up sharing a group.
+concurrency:
+  group: linux-flatpak-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CCACHE_COMPILERCHECK: content
     

--- a/.github/workflows/linux_flatpak.yml
+++ b/.github/workflows/linux_flatpak.yml
@@ -30,10 +30,7 @@ on:
     types:
       - published
 
-# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
-# and nightly builds never queue behind or cancel each other. The group name starts with a literal because
-# `github.run_id` is the caller's id inside a reusable workflow, and the workflows called from the nightly build must
-# not end up sharing a group.
+# A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
   group: linux-flatpak-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -14,8 +14,7 @@ on:
     types:
       - published
 
-# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
-# builds never queue behind or cancel each other.
+# A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
   group: shaders-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -14,6 +14,12 @@ on:
     types:
       - published
 
+# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
+# builds never queue behind or cancel each other.
+concurrency:
+  group: shaders-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_shaders:
     runs-on: ubuntu-22.04

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,6 +14,12 @@ on:
     types:
       - published
 
+# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
+# builds never queue behind or cancel each other.
+concurrency:
+  group: style-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   LLS_TAG: '3.9.1'
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,8 +14,7 @@ on:
     types:
       - published
 
-# A new push into a PR auto-cancels the run for the previous one. Everything else lands in a group of one, so master
-# builds never queue behind or cancel each other.
+# A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
   group: style-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
This is so that I suffer less from slow CI builds