### PR TITLE
Eradicated chars should not be able to drink potions

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -280,6 +280,10 @@ class GameConfig : public Config {
 
         Bool ShowProtectionMagicPower = {this, "show_prot_magic_power", true, "Display the remaining power of Protection from Magic in the Party Buffs popup."};
 
+        Bool NoPotionsForEradicated = {this, "no_potions_for_eradicated", true,
+            "Don't let eradicated characters drink potions. In vanilla a potion dropped on an eradicated "
+            "character's portrait is drunk normally."};
+
      private:
         static int ValidateMaxFlightHeight(int max_flight_height) {
             if (max_flight_height <= 0 || max_flight_height > 16192)

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3076,6 +3076,12 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
     }
 
     if (pParty->pPickedItem.isPotion()) {
+        // Eradicated characters have no body left, so they can't drink potions. See issue #587.
+        if (playerAffected->IsEradicated()) {
+            engine->_statusBar->setEvent(LSTR_THAT_PLAYER_IS_S, localization->characterConditionName(playerAffected->GetMajorConditionIdx()));
+            pAudioPlayer->playUISound(SOUND_error);
+            return;
+        }
         // TODO(Nik-RE-dev): no CanAct check?
         int potionStrength = pParty->pPickedItem.potionPower;
         Duration buffDuration = Duration::fromMinutes(30 * potionStrength); // all buffs have same duration based on potion strength

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3076,8 +3076,8 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
     }
 
     if (pParty->pPickedItem.isPotion()) {
-        // Eradicated characters have no body left, so they can't drink potions. See issue #587.
-        if (playerAffected->IsEradicated()) {
+        // Eradicated characters have no body left to drink with. Vanilla lets them, so this is behind a config option.
+        if (engine->config->gameplay.NoPotionsForEradicated.value() && playerAffected->IsEradicated()) {
             engine->_statusBar->setEvent(LSTR_THAT_PLAYER_IS_S, localization->characterConditionName(playerAffected->GetMajorConditionIdx()));
             pAudioPlayer->playUISound(SOUND_error);
             return;

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -199,39 +199,46 @@ GAME_TEST(Issues, Issue578) {
 }
 
 GAME_TEST(Issues, Issue587) {
-    // Eradicated characters shouldn't be able to drink potions - they have no
-    // body left. Dropping a potion on one must be rejected (error sound + status
-    // message) and must neither consume the potion nor heal the character.
-    // This is an intentional change from the original game, where eradicated
-    // characters CAN drink potions (see issue #587).
-    auto healthTape = charTapes.hp(0);
-    auto soundsTape = tapes.sounds();
-    auto statusTape = tapes.statusBar();
-    game.startNewGame();
+    // Dropping a potion on an eradicated character's portrait used to drink it, wasting the potion. Test both sides
+    // of the config option - in vanilla the potion is still drunk, and Character::Heal refuses to heal an eradicated
+    // character, so it's simply lost.
+    for (bool noPotionsForEradicated : {true, false}) {
+        test.prepareForNextTest();
+        engine->config->gameplay.NoPotionsForEradicated.setValue(noPotionsForEradicated);
 
-    // Eradicate char 0 (the drinker). SetCondition(ERADICATED) zeroes HP, so
-    // afterwards wound it to a known value well below max - that way a Cure
-    // Wounds potion that wrongly took effect would visibly raise HP, and the
-    // "HP unchanged" assertion below can't pass vacuously from HP being maxed.
-    Character &drinker = pParty->pCharacters[0];
-    drinker.SetCondition(CONDITION_ERADICATED, 0);
-    drinker.health = 5;
-    ASSERT_LT(drinker.health, drinker.GetMaxHealth());
-    pParty->setActiveCharacterIndex(2); // Active "giver" must be a non-eradicated char.
+        auto healthTape = charTapes.hp(0);
+        auto soundsTape = tapes.sounds();
+        auto statusTape = tapes.statusBar();
+        game.startNewGame();
 
-    test.startTaping();
-    game.tick(); // Baseline tick records health == 5.
+        // Eradicating zeroes HP, so the HP we want to watch has to be set after it, not before. 5 is arbitrary, it
+        // just has to be below max - at max a potion that wrongly healed the drinker would clamp straight back, and
+        // the tape below wouldn't move.
+        Character &drinker = pParty->pCharacters[0];
+        drinker.SetCondition(CONDITION_ERADICATED, 0);
+        drinker.health = 5;
+        ASSERT_LT(drinker.health, drinker.GetMaxHealth());
+        pParty->setActiveCharacterIndex(2); // Active "giver" must be a non-eradicated char.
 
-    // Active character drags a Cure Wounds potion onto the eradicated character's portrait.
-    pParty->setHoldingItem(Item(ITEM_POTION_CURE_WOUNDS));
-    pParty->activeCharacter().useItem(0, true);
-    game.tick();
+        test.startTaping();
+        game.tick(); // Baseline tick records health == 5.
 
-    EXPECT_TRUE(drinker.conditions.has(CONDITION_ERADICATED)); // Still eradicated.
-    EXPECT_EQ(healthTape, tape(5)); // HP never moved from 5 - potion had no effect.
-    EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_POTION_CURE_WOUNDS); // Potion wasn't consumed.
-    EXPECT_CONTAINS(soundsTape.flatten(), SOUND_error);
-    EXPECT_CONTAINS(statusTape, "That player is Eradicated");
+        // Active character drags a Cure Wounds potion onto the eradicated character's portrait.
+        pParty->setHoldingItem(Item(ITEM_POTION_CURE_WOUNDS));
+        pParty->activeCharacter().useItem(0, true);
+        game.tick();
+
+        EXPECT_TRUE(drinker.conditions.has(CONDITION_ERADICATED)); // Still eradicated.
+        EXPECT_EQ(healthTape, tape(5)); // Heal() is a no-op on an eradicated character either way.
+        if (noPotionsForEradicated) {
+            EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_POTION_CURE_WOUNDS); // Potion wasn't consumed.
+            EXPECT_CONTAINS(soundsTape.flatten(), SOUND_error);
+            EXPECT_CONTAINS(statusTape, "That player is Eradicated");
+        } else {
+            EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_NULL); // Vanilla drinks the potion, to no effect.
+            EXPECT_CONTAINS(soundsTape.flatten(), SOUND_drink);
+        }
+    }
 }
 
 GAME_TEST(Issues, Issue598) {

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -198,6 +198,42 @@ GAME_TEST(Issues, Issue578) {
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_REST)); // and we never left the rest menu
 }
 
+GAME_TEST(Issues, Issue587) {
+    // Eradicated characters shouldn't be able to drink potions - they have no
+    // body left. Dropping a potion on one must be rejected (error sound + status
+    // message) and must neither consume the potion nor heal the character.
+    // This is an intentional change from the original game, where eradicated
+    // characters CAN drink potions (see issue #587).
+    auto healthTape = charTapes.hp(0);
+    auto soundsTape = tapes.sounds();
+    auto statusTape = tapes.statusBar();
+    game.startNewGame();
+
+    // Eradicate char 0 (the drinker). SetCondition(ERADICATED) zeroes HP, so
+    // afterwards wound it to a known value well below max - that way a Cure
+    // Wounds potion that wrongly took effect would visibly raise HP, and the
+    // "HP unchanged" assertion below can't pass vacuously from HP being maxed.
+    Character &drinker = pParty->pCharacters[0];
+    drinker.SetCondition(CONDITION_ERADICATED, 0);
+    drinker.health = 5;
+    ASSERT_LT(drinker.health, drinker.GetMaxHealth());
+    pParty->setActiveCharacterIndex(2); // Active "giver" must be a non-eradicated char.
+
+    test.startTaping();
+    game.tick(); // Baseline tick records health == 5.
+
+    // Active character drags a Cure Wounds potion onto the eradicated character's portrait.
+    pParty->setHoldingItem(Item(ITEM_POTION_CURE_WOUNDS));
+    pParty->activeCharacter().useItem(0, true);
+    game.tick();
+
+    EXPECT_TRUE(drinker.conditions.has(CONDITION_ERADICATED)); // Still eradicated.
+    EXPECT_EQ(healthTape, tape(5)); // HP never moved from 5 - potion had no effect.
+    EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_POTION_CURE_WOUNDS); // Potion wasn't consumed.
+    EXPECT_CONTAINS(soundsTape.flatten(), SOUND_error);
+    EXPECT_CONTAINS(statusTape, "That player is Eradicated");
+}
+
 GAME_TEST(Issues, Issue598) {
     // Assert when accessing character inventory from the shop screen
     auto screenTape = tapes.screen();


### PR DESCRIPTION
Supersedes #2518 by @Ensrick.

Fixes #587.