### PR TITLE
Drop the starting_map config option

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -166,10 +166,7 @@ bool Game::loop() {
 
             pParty->pPickedItem.itemId = ITEM_NULL;
 
-            engine->_transitionMapId = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
-
-            // TODO(Nik-RE-dev): should not be an assert but an exception or error message.
-            assert(engine->_transitionMapId != MAP_INVALID);
+            engine->_transitionMapId = MAP_EMERALD_ISLAND;
 
             bFlashQuestBook = true;
             pMediaPlayer->PlayFullscreenMovie("Intro Post");
@@ -1681,9 +1678,7 @@ void Game::gameLoop() {
                 } else {
                     pParty->pos = Vec3f(12552, 1816, 193); // respawn on emerald isle
                     pParty->_viewYaw = 512;
-                    mapid = pMapStats->GetMapInfo(_config->gameplay.StartingMap.value());
-                    // TODO(Nik-RE-dev): should not be an assert but an exception or error message.
-                    assert(mapid != MAP_INVALID);
+                    mapid = MAP_EMERALD_ISLAND;
                 }
                 pParty->uFallStartZ = pParty->pos.z;
                 pParty->_viewPitch = 0;

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -212,9 +212,6 @@ class GameConfig : public Config {
         Int NewGameGold = {this, "new_game_gold", 200,
             "Starting gold."};
 
-        String StartingMap = String(this, "starting_map", "out01.odm",
-            "New Game starting map.");
-
         Int PartyEyeLevel = {this, "party_eye_level", 160,
             "Party eye level."};
 


### PR DESCRIPTION
I don't think it's useful, there are hardcoded emerald island coords in the code, I'd rather drop it than make it work properly.