### PR TITLE
SubFileSystem::ls("") shouldn't throw for a bad base path

### DIFF
--- a/src/Library/FileSystem/Sub/SubFileSystem.cpp
+++ b/src/Library/FileSystem/Sub/SubFileSystem.cpp
@@ -23,6 +23,10 @@ FileStat SubFileSystem::_stat(FileSystemPathView path) const {
 }
 
 void SubFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntry> *entries) const {
+    // A root always exists, so ls("") has to work even if the base path doesn't, or isn't a directory.
+    if (path.isEmpty() && _base->stat(_basePath).type != FILE_DIRECTORY)
+        return;
+
     _base->ls(_basePath / path, entries);
 }
 

--- a/src/Library/FileSystem/Sub/SubFileSystem.h
+++ b/src/Library/FileSystem/Sub/SubFileSystem.h
@@ -13,6 +13,9 @@
  *
  * All paths are prefixed with the base path. This provides isolation - files outside the base path cannot be accessed.
  *
+ * All methods will work as if the base path exists on the underlying file system, even if it doesn't. So `ls("")`
+ * returns an empty list instead of throwing for a base path that doesn't exist, or that points to a file.
+ *
  * Usage:
  * ```
  * FileSystem *root = ...;

--- a/src/Library/FileSystem/Sub/Tests/SubFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Sub/Tests/SubFileSystem_ut.cpp
@@ -67,4 +67,54 @@ UNIT_TEST(SubFileSystem, CannotEscapeWithDotDot) {
     EXPECT_FALSE(sub.exists("../secret.txt"));
     EXPECT_ANY_THROW((void) sub.read("../secret.txt"));
     EXPECT_ANY_THROW((void) sub.openForReading("../secret.txt"));
+
+    // Same for pathological tails that try harder.
+    EXPECT_FALSE(sub.exists("../../.."));
+    EXPECT_FALSE(sub.exists("a/../../../secret.txt"));
+    EXPECT_ANY_THROW((void) sub.read("a/../../../secret.txt"));
+}
+
+UNIT_TEST(SubFileSystem, RootWhenBasePathDoesntExist) {
+    // Root of a FileSystem always exists, even if the base path doesn't exist on the underlying file system.
+    MemoryFileSystem base("memfs");
+    SubFileSystem sub("this_dir_doesnt_exist", &base);
+
+    EXPECT_TRUE(sub.exists(""));
+    EXPECT_EQ(sub.stat(""), FileStat(FILE_DIRECTORY, 0));
+    EXPECT_TRUE(sub.ls("").empty());
+
+    // But it's a directory, so we can't read or write it as a file.
+    EXPECT_ANY_THROW((void) sub.read(""));
+    EXPECT_ANY_THROW(sub.write("", Blob()));
+
+    // And ls of a non-root path that doesn't exist still throws.
+    EXPECT_ANY_THROW((void) sub.ls("subdir"));
+}
+
+UNIT_TEST(SubFileSystem, RootWhenBasePathIsFile) {
+    // Same deal when the base path points to a file.
+    MemoryFileSystem base("memfs");
+    base.write("1.txt", Blob::fromString("lol"));
+
+    SubFileSystem sub("1.txt", &base);
+
+    EXPECT_TRUE(sub.exists(""));
+    EXPECT_EQ(sub.stat(""), FileStat(FILE_DIRECTORY, 0));
+    EXPECT_TRUE(sub.ls("").empty());
+
+    EXPECT_ANY_THROW((void) sub.read(""));
+    EXPECT_ANY_THROW(sub.write("", Blob()));
+}
+
+UNIT_TEST(SubFileSystem, RootWhenBasePathIsEmpty) {
+    // An empty base path just means "the whole base file system".
+    MemoryFileSystem base("memfs");
+    base.write("1.txt", Blob::fromString("lol"));
+
+    SubFileSystem sub("", &base);
+
+    EXPECT_TRUE(sub.exists(""));
+    EXPECT_EQ(sub.stat(""), FileStat(FILE_DIRECTORY, 0));
+    EXPECT_EQ(sub.ls("").size(), 1);
+    EXPECT_EQ(sub.read("1.txt").str(), "lol");
 }


### PR DESCRIPTION
The root of a FileSystem always exists, so ls("") has to work, and the base
class documents that. SubFileSystem was passing the call straight through, so
it threw when the base path didn't exist on the underlying file system, or
pointed to a file.

