### PR TITLE
Add NativePath, the vocabulary type for native paths

### DIFF
--- a/src/Application/Startup/FileSystemStarter.cpp
+++ b/src/Application/Startup/FileSystemStarter.cpp
@@ -27,7 +27,7 @@ void FileSystemStarter::initUserFs(bool ramFs, std::string_view path) {
     if (ramFs) {
         _userFs = std::make_unique<MemoryFileSystem>("ramfs");
     } else {
-        _userFs = std::make_unique<DirectoryFileSystem>(path);
+        _userFs = std::make_unique<DirectoryFileSystem>(NativePath::fromWtf8(path));
     }
 
     ufs = _userFs.get();
@@ -37,7 +37,7 @@ void FileSystemStarter::initDataFs(std::string_view path, bool pathOverridesBuil
     assert(dfs == nullptr);
 
     _dataEmbeddedFs = std::make_unique<EmbeddedFileSystem>(cmrc::openenroth::get_filesystem(), "embedded");
-    _dataDirFs = std::make_unique<DirectoryFileSystem>(path);
+    _dataDirFs = std::make_unique<DirectoryFileSystem>(NativePath::fromWtf8(path));
     _dataDirLowercaseFs = std::make_unique<LowercaseFileSystem>(_dataDirFs.get());
 
     std::vector<const FileSystem *> baseFileSystems = {_dataDirLowercaseFs.get(), _dataEmbeddedFs.get()};

--- a/src/Application/Startup/GameStarterOptions.h
+++ b/src/Application/Startup/GameStarterOptions.h
@@ -6,8 +6,8 @@
 #include "Library/Logger/LogEnums.h"
 
 struct GameStarterOptions {
-    std::string dataPath; // Path to game data.
-    std::string userPath; // Path to user data.
+    std::string dataPath; // Path to game data. TODO(captainurist): Should be a NativePath.
+    std::string userPath; // Path to user data. TODO(captainurist): Should be a NativePath.
     std::optional<LogLevel> logLevel; // Override log level.
     bool ramFsUserData = false; // Use in-memory file system for user data, don't read/write config & saves
                                 // from/to disk. This also means that default config will be used.

--- a/src/Application/Startup/PathResolver.cpp
+++ b/src/Application/Startup/PathResolver.cpp
@@ -122,7 +122,7 @@ std::vector<std::string> resolveMm8Paths(Environment *environment) {
 }
 
 bool validateMm7Path(std::string_view dataPath, std::string *missingFile) {
-    DirectoryFileSystem dirFs(dataPath);
+    DirectoryFileSystem dirFs(NativePath::fromWtf8(dataPath));
     LowercaseFileSystem lowerFs(&dirFs);
 
     for (std::string_view entry : globalValidateList) {

--- a/src/Bin/LodTool/ArchiveReader.cpp
+++ b/src/Bin/LodTool/ArchiveReader.cpp
@@ -47,7 +47,7 @@ class UniversalReader : public ArchiveReader {
     Base _base;
 };
 
-std::unique_ptr<ArchiveReader> ArchiveReader::createArchiveReader(std::string_view path) {
+std::unique_ptr<ArchiveReader> ArchiveReader::createArchiveReader(const NativePath &path) {
     Blob data = Blob::fromFile(path);
     switch (magic(data)) {
     case MAGIC_LOD:

--- a/src/Bin/LodTool/ArchiveReader.h
+++ b/src/Bin/LodTool/ArchiveReader.h
@@ -7,7 +7,9 @@
 
 #include "Library/Lod/LodInfo.h"
 #include "Library/Magic/MagicEnums.h"
+
 #include "Utility/Memory/Blob.h"
+#include "Utility/System/NativePath.h"
 
 class ArchiveReader {
  public:
@@ -17,5 +19,5 @@ class ArchiveReader {
     virtual Blob read(std::string_view filename) const = 0;
     virtual std::vector<std::string> ls() const = 0;
 
-    static std::unique_ptr<ArchiveReader> createArchiveReader(std::string_view path);
+    static std::unique_ptr<ArchiveReader> createArchiveReader(const NativePath &path);
 };

--- a/src/Bin/LodTool/LodTool.cpp
+++ b/src/Bin/LodTool/LodTool.cpp
@@ -154,14 +154,14 @@ int runDump(const LodToolOptions &options) {
 
 int runCat(const LodToolOptions &options) {
     std::unique_ptr<ArchiveReader> reader = ArchiveReader::createArchiveReader(options.path);
-    std::unique_ptr<ArchiveReader> paletteReader = options.palettesLodPath.empty() ? nullptr : ArchiveReader::createArchiveReader(options.palettesLodPath);
+    std::unique_ptr<ArchiveReader> paletteReader = options.palettesLodPath.isEmpty() ? nullptr : ArchiveReader::createArchiveReader(options.palettesLodPath);
     auto [data, _] = std::move(decodeLodEntry(reader->read(options.cat.entry), options.cat.entry, options.raw, paletteReader.get())[0]);
     return fwrite(data.data(), data.size(), 1, stdout) != 1 ? 1 : 0;
 }
 
 int runExtract(const LodToolOptions &options) {
     std::unique_ptr<ArchiveReader> reader = ArchiveReader::createArchiveReader(options.path);
-    std::unique_ptr<ArchiveReader> paletteReader = options.palettesLodPath.empty() ? nullptr : ArchiveReader::createArchiveReader(options.palettesLodPath);
+    std::unique_ptr<ArchiveReader> paletteReader = options.palettesLodPath.isEmpty() ? nullptr : ArchiveReader::createArchiveReader(options.palettesLodPath);
     DirectoryFileSystem output(options.extract.output);
 
     for (const std::string &entryName : reader->ls())

--- a/src/Bin/LodTool/LodToolOptions.cpp
+++ b/src/Bin/LodTool/LodToolOptions.cpp
@@ -1,6 +1,7 @@
 #include "LodToolOptions.h"
 
 #include <memory>
+#include <string>
 
 #include "Library/Cli/CliApp.h"
 

--- a/src/Bin/LodTool/LodToolOptions.h
+++ b/src/Bin/LodTool/LodToolOptions.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "Utility/System/NativePath.h"
+
 struct LodToolOptions {
     enum class Subcommand {
         SUBCOMMAND_LS,
@@ -16,16 +18,16 @@ struct LodToolOptions {
     };
 
     struct ExtractOptions {
-        std::string output;
+        NativePath output;
     };
 
     Subcommand subcommand = SUBCOMMAND_DUMP;
-    std::string path;
+    NativePath path;
     bool helpPrinted = false; // True means that help message was already printed.
     CatOptions cat;
     ExtractOptions extract;
     bool raw = false; // Raw flag, shared by cat & extract.
-    std::string palettesLodPath; // Path to bitmaps.lod for sprite palettes.
+    NativePath palettesLodPath; // Path to bitmaps.lod for sprite palettes.
 
     static LodToolOptions parse(int argc, char **argv);
 };

--- a/src/Bin/OpenEnroth/OpenEnroth.cpp
+++ b/src/Bin/OpenEnroth/OpenEnroth.cpp
@@ -61,11 +61,11 @@ int runRetrace(const OpenEnrothOptions &options) {
         EngineTraceSimplePlayer *player = application->component<EngineTraceSimplePlayer>();
         EngineTraceRecorder *recorder = application->component<EngineTraceRecorder>();
 
-        for (const std::string &tracePath : options.retrace.traces) {
+        for (const NativePath &tracePath : options.retrace.traces) {
             fmt::println(stderr, "Retracing '{}'...", tracePath);
             auto startTime = std::chrono::steady_clock::now();
 
-            std::string savePath = tracePath.substr(0, tracePath.length() - 5) + ".mm7";
+            NativePath savePath = tracePath.withExtension(".mm7");
             Blob oldTraceBlob = Blob::fromFile(tracePath);
             Blob oldSaveBlob = Blob::fromFile(savePath);
 
@@ -75,7 +75,7 @@ int runRetrace(const OpenEnrothOptions &options) {
             EngineTraceStateAccessor::prepareForPlayback(engine->config.get(), oldTrace.header.config);
             recorder->startRecording(game, oldSaveBlob);
             engine->config->graphics.FPSLimit.setValue(0);
-            player->playTrace(game, std::move(oldTrace.events), tracePath, TRACE_PLAYBACK_SKIP_RANDOM_CHECKS | TRACE_PLAYBACK_SKIP_STATE_CHECKS);
+            player->playTrace(game, std::move(oldTrace.events), tracePath.toWtf8(), TRACE_PLAYBACK_SKIP_RANDOM_CHECKS | TRACE_PLAYBACK_SKIP_STATE_CHECKS);
             EngineTraceRecording recording = recorder->finishRecording(game);
 
             auto endTime = std::chrono::steady_clock::now();
@@ -99,10 +99,10 @@ int runPlay(const OpenEnrothOptions &options) {
     starter.runInstrumented([options, application = starter.application()] (EngineController *game) {
         EngineTracePlayer *player = application->component<EngineTracePlayer>();
 
-        for (const std::string &tracePath : options.play.traces) {
+        for (const NativePath &tracePath : options.play.traces) {
             fmt::println(stderr, "Playing back '{}'...", tracePath);
 
-            std::string savePath = tracePath.substr(0, tracePath.length() - 5) + ".mm7";
+            NativePath savePath = tracePath.withExtension(".mm7");
 
             EngineTraceRecording recording;
             recording.save = Blob::fromFile(savePath);

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.h
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.h
@@ -5,6 +5,8 @@
 
 #include "Application/Startup/GameStarterOptions.h"
 
+#include "Utility/System/NativePath.h"
+
 class GameConfig;
 class Platform;
 
@@ -26,12 +28,12 @@ struct OpenEnrothOptions : public GameStarterOptions {
     using enum Migration;
 
     struct RetraceOptions {
-        std::vector<std::string> traces;
+        std::vector<NativePath> traces;
         Migration migration = MIGRATION_NONE;
     };
 
     struct PlayOptions {
-        std::vector<std::string> traces;
+        std::vector<NativePath> traces;
         float speed = 1.0f;
     };
 

--- a/src/Library/Config/Config.cpp
+++ b/src/Library/Config/Config.cpp
@@ -15,12 +15,12 @@
 #include "Utility/String/Format.h"
 #include "Utility/String/Wrap.h"
 
-void Config::load(std::string_view path) {
+void Config::load(const NativePath &path) {
     FileInputStream stream(path); // Will throw if file doesn't exist.
     load(&stream);
 }
 
-void Config::save(std::string_view path) const {
+void Config::save(const NativePath &path) const {
     FileOutputStream stream(path);
     save(&stream);
 }

--- a/src/Library/Config/Config.h
+++ b/src/Library/Config/Config.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "Utility/String/TransparentFunctors.h"
+#include "Utility/System/NativePath.h"
 
 #include "ConfigFwd.h"
 #include "ConfigSection.h"
@@ -19,8 +20,8 @@ class Config {
     Config(const Config &other) = delete; // non-copyable
     Config(Config &&other) = delete; // non-movable
 
-    void load(std::string_view path);
-    void save(std::string_view path) const;
+    void load(const NativePath &path);
+    void save(const NativePath &path) const;
     void load(InputStream *stream);
     void save(OutputStream *stream) const;
 

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -10,14 +10,9 @@
 
 #include "Utility/Streams/FileInputStream.h"
 #include "Utility/Streams/FileOutputStream.h"
-#include "Utility/UnicodeCrt.h"
 
-DirectoryFileSystem::DirectoryFileSystem(std::string_view root) {
-    assert(UnicodeCrt::isInitialized()); // Otherwise std::filesystem will choke on Unicode paths.
-
-    // We need to explicitly check for empty() b/c libstdc++ std::filesystem::absolute chokes on empty path.
-    _root = root.empty() ? std::filesystem::current_path() : std::filesystem::absolute(root).lexically_normal();
-    _originalRoot = root;
+DirectoryFileSystem::DirectoryFileSystem(const NativePath &root) {
+    _root = root.absolute();
 }
 
 DirectoryFileSystem::~DirectoryFileSystem() = default;
@@ -26,13 +21,13 @@ bool DirectoryFileSystem::_exists(FileSystemPathView path) const {
     assert(!path.isEmpty());
 
     std::error_code ec;
-    return std::filesystem::exists(makeBasePath(path), ec); // Returns false on error.
+    return std::filesystem::exists(makeBasePath(path).toStdPath(), ec); // Returns false on error.
 }
 
 FileStat DirectoryFileSystem::_stat(FileSystemPathView path) const {
     assert(!path.isEmpty());
 
-    std::filesystem::path basePath = makeBasePath(path);
+    std::filesystem::path basePath = makeBasePath(path).toStdPath();
 
     std::error_code ec;
     std::filesystem::directory_entry entry(basePath, ec);
@@ -54,7 +49,7 @@ FileStat DirectoryFileSystem::_stat(FileSystemPathView path) const {
     return result;}
 
 void DirectoryFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntry> *entries) const {
-    std::filesystem::path basePath = makeBasePath(path);
+    std::filesystem::path basePath = makeBasePath(path).toStdPath();
 
     // Handle the known errors first.
     std::error_code ec;
@@ -70,7 +65,7 @@ void DirectoryFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntr
 
     // Then we do the regular ls and just ignore all errors. The errors we'll get here are most likely
     // permissions-related, and we're ignoring them in stat() and exists().
-    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(makeBasePath(path), ec)) {
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(basePath, ec)) {
         // Unfortunately, std::filesystem is retarded. We can get a directory_entry here for a dir that we don't have
         // permissions for, and which won't be stat-able. Seriously, entry.is_directory() returns true while
         // std::filesystem::exists(entry.path()) just throws. So we need to check for that.
@@ -94,39 +89,39 @@ void DirectoryFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntr
 
 Blob DirectoryFileSystem::_read(FileSystemPathView path) const {
     assert(!path.isEmpty());
-    return Blob::fromFile(makeBasePath(path).generic_string());
+    return Blob::fromFile(makeBasePath(path));
 }
 
 void DirectoryFileSystem::_write(FileSystemPathView path, const Blob &data) {
     assert(!path.isEmpty());
-    std::filesystem::path basePath = makeBasePath(path);
-    std::filesystem::create_directories(basePath.parent_path());
-    FileOutputStream stream(basePath.generic_string());
+    NativePath basePath = makeBasePath(path);
+    std::filesystem::create_directories(basePath.toStdPath().parent_path());
+    FileOutputStream stream(basePath);
     stream.write(data.data(), data.size());
     stream.close();
 }
 
 std::unique_ptr<InputStream> DirectoryFileSystem::_openForReading(FileSystemPathView path) const {
     assert(!path.isEmpty());
-    return std::make_unique<FileInputStream>(makeBasePath(path).generic_string());
+    return std::make_unique<FileInputStream>(makeBasePath(path));
 }
 
 std::unique_ptr<OutputStream> DirectoryFileSystem::_openForWriting(FileSystemPathView path) {
     assert(!path.isEmpty());
-    std::filesystem::path basePath = makeBasePath(path);
-    std::filesystem::create_directories(basePath.parent_path());
-    return std::make_unique<FileOutputStream>(basePath.generic_string());
+    NativePath basePath = makeBasePath(path);
+    std::filesystem::create_directories(basePath.toStdPath().parent_path());
+    return std::make_unique<FileOutputStream>(basePath);
 }
 
 bool DirectoryFileSystem::_remove(FileSystemPathView path) {
     assert(!path.isEmpty());
-    return std::filesystem::remove_all(makeBasePath(path)) > 0;
+    return std::filesystem::remove_all(makeBasePath(path).toStdPath()) > 0;
 }
 
 std::string DirectoryFileSystem::_displayPath(FileSystemPathView path) const {
-    return makeBasePath(path).generic_string();
+    return makeBasePath(path).toWtf8();
 }
 
-std::filesystem::path DirectoryFileSystem::makeBasePath(FileSystemPathView path) const {
-    return _root / path.string();
+NativePath DirectoryFileSystem::makeBasePath(FileSystemPathView path) const {
+    return _root / NativePath::fromWtf8(path.string());
 }

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.h
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.h
@@ -7,6 +7,8 @@
 
 #include "Library/FileSystem/Interface/FileSystem.h"
 
+#include "Utility/System/NativePath.h"
+
 /**
  * View over a directory on a file system.
  *
@@ -22,7 +24,7 @@
  */
 class DirectoryFileSystem : public FileSystem {
  public:
-    explicit DirectoryFileSystem(std::string_view root);
+    explicit DirectoryFileSystem(const NativePath &root);
     virtual ~DirectoryFileSystem();
 
  private:
@@ -36,9 +38,8 @@ class DirectoryFileSystem : public FileSystem {
     virtual bool _remove(FileSystemPathView path) override;
     virtual std::string _displayPath(FileSystemPathView path) const override;
 
-    std::filesystem::path makeBasePath(FileSystemPathView path) const;
+    NativePath makeBasePath(FileSystemPathView path) const;
 
  private:
-    std::string _originalRoot;
-    std::filesystem::path _root;
+    NativePath _root;
 };

--- a/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
@@ -33,15 +33,15 @@ UNIT_TEST(DirectoryFileSystem, LsRoot) {
     // Make sure passing empty paths works as intended.
     ScopedTestFile tmp("1.txt", "");
 
-    DirectoryFileSystem fs1(""); // Current dir.
+    DirectoryFileSystem fs1(NativePath::fromWtf8("")); // Current dir.
     std::vector<DirectoryEntry> entries = fs1.ls("");
     EXPECT_TRUE(std::ranges::find(entries, "1.txt", &DirectoryEntry::name) != std::ranges::end(entries))
         << "size = " << entries.size() << ", [0] = " << (entries.empty() ? "<nothing>" : entries[0].name);
 
-    DirectoryFileSystem fs2("this_dir_doesnt_exist"); // Non-existent dir.
+    DirectoryFileSystem fs2(NativePath::fromWtf8("this_dir_doesnt_exist")); // Non-existent dir.
     EXPECT_TRUE(fs2.ls("").empty());
 
-    DirectoryFileSystem fs3("1.txt"); // Not-a-dir.
+    DirectoryFileSystem fs3(NativePath::fromWtf8("1.txt")); // Not-a-dir.
     EXPECT_TRUE(fs3.ls("").empty());
 }
 
@@ -49,39 +49,39 @@ UNIT_TEST(DirectoryFileSystem, LsFile) {
     // Make sure ls() throws when called on a file.
     ScopedTestFile tmp("1.txt", "");
 
-    DirectoryFileSystem fs(""); // Current dir.
+    DirectoryFileSystem fs(NativePath::fromWtf8("")); // Current dir.
     EXPECT_ANY_THROW((void) fs.ls("1.txt"));
 }
 
 UNIT_TEST(DirectoryFileSystem, LsNonExistent) {
     // Make sure ls() throws when called on a folder that doesn't exist.
-    DirectoryFileSystem fs(""); // Current dir.
+    DirectoryFileSystem fs(NativePath::fromWtf8("")); // Current dir.
     EXPECT_ANY_THROW((void) fs.ls("this_dir_doesnt_exist"));
 }
 
 UNIT_TEST(DirectoryFileSystem, ExistsRoot) {
     // Make sure exists("") works as intented.
-    DirectoryFileSystem fs1(""); // Current dir.
+    DirectoryFileSystem fs1(NativePath::fromWtf8("")); // Current dir.
     EXPECT_TRUE(fs1.exists(""));
 
-    DirectoryFileSystem fs2("this_dir_doesnt_exist");
+    DirectoryFileSystem fs2(NativePath::fromWtf8("this_dir_doesnt_exist"));
     EXPECT_TRUE(fs2.exists(""));
 
     ScopedTestFile tmp("1.txt", "");
-    DirectoryFileSystem fs3("1.txt");
+    DirectoryFileSystem fs3(NativePath::fromWtf8("1.txt"));
     EXPECT_TRUE(fs3.exists(""));
 }
 
 UNIT_TEST(DirectoryFileSystem, StatRoot) {
     // Make sure stat("") works as intented.
-    DirectoryFileSystem fs1(""); // Current dir.
+    DirectoryFileSystem fs1(NativePath::fromWtf8("")); // Current dir.
     EXPECT_EQ(fs1.stat("").type, FILE_DIRECTORY);
 
-    DirectoryFileSystem fs2("this_dir_doesnt_exist"); // Non-existent dir.
+    DirectoryFileSystem fs2(NativePath::fromWtf8("this_dir_doesnt_exist")); // Non-existent dir.
     EXPECT_EQ(fs2.stat("").type, FILE_DIRECTORY);
 
     ScopedTestFile tmp("1.txt", "");
-    DirectoryFileSystem fs3("1.txt"); // Not-a-dir.
+    DirectoryFileSystem fs3(NativePath::fromWtf8("1.txt")); // Not-a-dir.
     EXPECT_EQ(fs3.stat("").type, FILE_DIRECTORY);
 }
 
@@ -89,20 +89,20 @@ UNIT_TEST(DirectoryFileSystem, ReadRootAsFile) {
     // Root is always assumed to be a dir, we can't read it as a file even if it IS a file.
     ScopedTestFile tmp("1.txt", "");
 
-    DirectoryFileSystem fs("1.txt");
+    DirectoryFileSystem fs(NativePath::fromWtf8("1.txt"));
     EXPECT_ANY_THROW((void) fs.read(""));
 }
 
 UNIT_TEST(DirectoryFileSystem, WriteRootAsFile) {
     // Root is always assumed to be a dir, we can't write it as a file if it doesn't exist.
-    DirectoryFileSystem fs("1.txt");
+    DirectoryFileSystem fs(NativePath::fromWtf8("1.txt"));
     EXPECT_ANY_THROW(fs.write("", Blob()));
 }
 
 UNIT_TEST(DirectoryFileSystem, DisplayPathSymmetry) {
     ScopedTestFile tmp("1.txt", "");
 
-    DirectoryFileSystem fs("");
+    DirectoryFileSystem fs(NativePath::fromWtf8(""));
     Blob blob = fs.read("1.txt");
     std::unique_ptr<InputStream> stream = fs.openForReading("1.txt");
 
@@ -116,7 +116,7 @@ UNIT_TEST(DirectoryFileSystem, EscapingPaths) {
     ScopedTestFile tmp2("1.txt", "");
     ScopedTestFile tmp3("a/1.txt", "");
 
-    DirectoryFileSystem fs("a");
+    DirectoryFileSystem fs(NativePath::fromWtf8("a"));
 
     EXPECT_FALSE(fs.exists(".."));
     EXPECT_FALSE(fs.stat(".."));
@@ -129,7 +129,7 @@ UNIT_TEST(DirectoryFileSystem, EscapingPaths) {
 }
 
 UNIT_TEST(DirectoryFileSystem, EscapingDisplayPath) {
-    DirectoryFileSystem fs("");
+    DirectoryFileSystem fs(NativePath::fromWtf8(""));
 
     EXPECT_TRUE(fs.displayPath("..").ends_with(".."));
 }

--- a/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
@@ -30,7 +30,7 @@ UNIT_TEST(LowercaseFileSystem, ExistsStatUppercase) {
 UNIT_TEST(LowercaseFileSystem, KeepEmptyFolders) {
     MM_AT_SCOPE_EXIT(std::filesystem::remove_all("tmp_dir"));
 
-    DirectoryFileSystem fs0("tmp_dir");
+    DirectoryFileSystem fs0(NativePath::fromWtf8("tmp_dir"));
     fs0.write("a/b/c.bin", Blob());
     fs0.write("a/c/b.bin", Blob());
 

--- a/src/Library/Lod/LodReader.cpp
+++ b/src/Library/Lod/LodReader.cpp
@@ -70,7 +70,7 @@ static std::vector<LodEntry> parseFileEntries(InputStream &stream, const LodEntr
 
 LodReader::LodReader() = default;
 
-LodReader::LodReader(std::string_view path, LodOpenFlags openFlags) {
+LodReader::LodReader(const NativePath &path, LodOpenFlags openFlags) {
     open(path, openFlags);
 }
 
@@ -82,7 +82,7 @@ LodReader::~LodReader() {
     close();
 }
 
-void LodReader::open(std::string_view path, LodOpenFlags openFlags) {
+void LodReader::open(const NativePath &path, LodOpenFlags openFlags) {
     open(Blob::fromFile(path), openFlags); // Blob::fromFile throws if the file doesn't exist.
 }
 

--- a/src/Library/Lod/LodReader.h
+++ b/src/Library/Lod/LodReader.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include "Utility/Memory/Blob.h"
+#include "Utility/System/NativePath.h"
 
 #include "LodEnums.h"
 #include "LodInfo.h"
@@ -21,7 +22,7 @@ class InputStream;
 class LodReader final {
  public:
     LodReader();
-    LodReader(std::string_view path, LodOpenFlags openFlags = 0);
+    explicit LodReader(const NativePath &path, LodOpenFlags openFlags = 0);
     LodReader(Blob blob, LodOpenFlags openFlags = 0);
     ~LodReader();
 
@@ -31,7 +32,7 @@ class LodReader final {
      * @throw Exception                 If the LOD couldn't be opened - e.g., if the file doesn't exist,
      *                                  or if it's not a LOD.
      */
-    void open(std::string_view path, LodOpenFlags openFlags = 0);
+    void open(const NativePath &path, LodOpenFlags openFlags = 0);
 
     /**
      * @param blob                      LOD data.

--- a/src/Library/Lod/LodWriter.cpp
+++ b/src/Library/Lod/LodWriter.cpp
@@ -14,7 +14,7 @@
 
 LodWriter::LodWriter() {}
 
-LodWriter::LodWriter(std::string_view path, LodInfo info) {
+LodWriter::LodWriter(const NativePath &path, LodInfo info) {
     open(path, std::move(info));
 }
 
@@ -26,7 +26,7 @@ LodWriter::~LodWriter() {
     close();
 }
 
-void LodWriter::open(std::string_view path, LodInfo info) {
+void LodWriter::open(const NativePath &path, LodInfo info) {
     std::unique_ptr<OutputStream> ownedStream = std::make_unique<FileOutputStream>(path); // If this throws, no field is overwritten.
     open(ownedStream.get(), std::move(info));
     _ownedStream = std::move(ownedStream);

--- a/src/Library/Lod/LodWriter.h
+++ b/src/Library/Lod/LodWriter.h
@@ -7,17 +7,18 @@
 
 #include "Utility/Streams/OutputStream.h"
 #include "Utility/Memory/Blob.h"
+#include "Utility/System/NativePath.h"
 
 #include "LodInfo.h"
 
 class LodWriter {
  public:
     LodWriter();
-    LodWriter(std::string_view path, LodInfo info);
+    LodWriter(const NativePath &path, LodInfo info);
     LodWriter(OutputStream *stream, LodInfo info);
     ~LodWriter();
 
-    void open(std::string_view path, LodInfo info);
+    void open(const NativePath &path, LodInfo info);
     void open(OutputStream *stream, LodInfo info);
 
     void close();

--- a/src/Library/Snd/SndReader.cpp
+++ b/src/Library/Snd/SndReader.cpp
@@ -18,7 +18,7 @@
 
 SndReader::SndReader() = default;
 
-SndReader::SndReader(std::string_view path) {
+SndReader::SndReader(const NativePath &path) {
     open(path);
 }
 
@@ -28,7 +28,7 @@ SndReader::SndReader(Blob blob) {
 
 SndReader::~SndReader() = default;
 
-void SndReader::open(std::string_view path) {
+void SndReader::open(const NativePath &path) {
     close();
     open(Blob::fromFile(path));
 }

--- a/src/Library/Snd/SndReader.h
+++ b/src/Library/Snd/SndReader.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Utility/Memory/Blob.h"
+#include "Utility/System/NativePath.h"
 
 #include "SndSnapshots.h"
 
@@ -19,7 +20,7 @@
 class SndReader {
  public:
     SndReader();
-    explicit SndReader(std::string_view path);
+    explicit SndReader(const NativePath &path);
     explicit SndReader(Blob blob);
     ~SndReader();
 
@@ -28,7 +29,7 @@ class SndReader {
      * @throw Exception                 If the SND couldn't be opened - e.g., if the file doesn't exist,
      *                                  or if it's not in SND format.
      */
-    void open(std::string_view path);
+    void open(const NativePath &path);
 
     /**
      * @param blob                      SND data.

--- a/src/Library/Vid/VidReader.cpp
+++ b/src/Library/Vid/VidReader.cpp
@@ -18,7 +18,7 @@
 
 VidReader::VidReader() = default;
 
-VidReader::VidReader(std::string_view path) {
+VidReader::VidReader(const NativePath &path) {
     open(path);
 }
 
@@ -28,7 +28,7 @@ VidReader::VidReader(Blob blob) {
 
 VidReader::~VidReader() = default;
 
-void VidReader::open(std::string_view path) {
+void VidReader::open(const NativePath &path) {
     close();
     open(Blob::fromFile(path));
 }

--- a/src/Library/Vid/VidReader.h
+++ b/src/Library/Vid/VidReader.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Utility/Memory/Blob.h"
+#include "Utility/System/NativePath.h"
 
 /**
  * Reader for Might&Magic VID files.
@@ -13,7 +14,7 @@
 class VidReader {
  public:
     VidReader();
-    explicit VidReader(std::string_view path);
+    explicit VidReader(const NativePath &path);
     explicit VidReader(Blob blob);
     ~VidReader();
 
@@ -22,7 +23,7 @@ class VidReader {
      * @throw Exception                 If the VID couldn't be opened - e.g., if the file doesn't exist,
      *                                  or if it's not in VID format.
      */
-    void open(std::string_view path);
+    void open(const NativePath &path);
 
     /**
      * @param blob                      VID data.

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UTILITY_SOURCES
         String/Ascii.cpp
         String/Encoding.cpp
         String/Transformations.cpp
+        System/NativePath.cpp
         UnicodeCrt.cpp
         String/Wrap.cpp)
 
@@ -42,6 +43,7 @@ set(UTILITY_HEADERS
         Streams/MemoryInputStream.h
         Streams/OutputStream.h
         Streams/StreamBuffer.h
+        System/NativePath.h
         String/Ascii.h
         String/Encoding.h
         String/Join.h
@@ -89,6 +91,7 @@ if(OE_BUILD_TESTS)
             String/Tests/TransparentFunctors_ut.cpp
             String/Tests/Ascii_ut.cpp
             String/Tests/Encoding_ut.cpp
+            System/Tests/NativePath_ut.cpp
             String/Tests/Split_ut.cpp
             String/Tests/Join_ut.cpp
             String/Tests/Wrap_ut.cpp)

--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -36,20 +36,20 @@ Blob Blob::fromMalloc(const void *data, size_t size) {
     return result;
 }
 
-Blob Blob::fromFile(std::string_view path) {
-    std::filesystem::path absolutePath = absolute(std::filesystem::path(path));
-    std::string pathString = absolutePath.generic_string();
+Blob Blob::fromFile(const NativePath &path) {
+    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
 
     // On Mac mapping an empty file throws, so we need to provide a workaround.
     std::error_code error;
-    uintmax_t size = std::filesystem::file_size(absolutePath, error);
+    uintmax_t size = std::filesystem::file_size(path.toStdPath(), error);
     if (!error && size == 0)
         return Blob().withDisplayPath(pathString);
 
-    // On Windows mio::mmap_source expects UTF8-encoded paths. If the file doesn't exist, std::system_error is thrown.
+    // native() is a wchar_t string on Windows, so a WTF16 name is passed as-is. Throws std::system_error if the
+    // file doesn't exist.
     std::shared_ptr<mio::mmap_source> mmap;
     try {
-        mmap = std::make_shared<mio::mmap_source>(pathString);
+        mmap = std::make_shared<mio::mmap_source>(path.toStdPath().native());
     } catch (const std::system_error &e) {
         // mio doesn't fill in the path component for std::system_error, so we need to do this ourselves.
         throw std::system_error(e.code(), pathString);

--- a/src/Utility/Memory/Blob.h
+++ b/src/Utility/Memory/Blob.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <type_traits>
 
+#include "Utility/System/NativePath.h"
+
 #include "FreeDeleter.h"
 
 class InputStream;
@@ -74,7 +76,7 @@ class Blob final {
      *                                  set to `path`.
      * @throws std::runtime_error       If file doesn't exist or on some other OS error.
      */
-    [[nodiscard]] static Blob fromFile(std::string_view path);
+    [[nodiscard]] static Blob fromFile(const NativePath &path);
 
     /**
      * @param string                    String to create a blob from.

--- a/src/Utility/Memory/Tests/Blob_ut.cpp
+++ b/src/Utility/Memory/Tests/Blob_ut.cpp
@@ -8,7 +8,7 @@
 #include "Utility/Streams/FileOutputStream.h"
 
 UNIT_TEST(Blob, FromFile) {
-    std::string fileName = "abcdefghijklmnopqrstuvwxyz.tmp";
+    NativePath fileName = NativePath::fromWtf8("abcdefghijklmnopqrstuvwxyz.tmp");
     std::string fileContents = "abcd";
 
     ScopedTestFileSlot tmp(fileName);
@@ -25,15 +25,16 @@ UNIT_TEST(Blob, FromFile) {
 }
 
 UNIT_TEST(Blob, FromEmptyFile) {
-    ScopedTestFile tmp("1.txt", "");
+    NativePath fileName = NativePath::fromWtf8("1.txt");
+    ScopedTestFile tmp(fileName, "");
 
-    Blob blob = Blob::fromFile("1.txt"); // Shouldn't throw.
+    Blob blob = Blob::fromFile(fileName); // Shouldn't throw.
     EXPECT_EQ(blob.size(), 0);
     EXPECT_TRUE(!blob);
 }
 
 UNIT_TEST(Blob, SharedFromFile) {
-    std::string fileName = "abcdefghijklmnopqrstuvwxyz1.tmp";
+    NativePath fileName = NativePath::fromWtf8("abcdefghijklmnopqrstuvwxyz1.tmp");
     std::string fileContents = "0123456789";
 
     ScopedTestFile tmp(fileName, fileContents);
@@ -57,33 +58,36 @@ UNIT_TEST(Blob, DisplayPathCopyShare) {
 }
 
 UNIT_TEST(Blob, DisplayPathFromFile) {
-    ScopedTestFile tmp("1.bin", "123");
+    NativePath fileName = NativePath::fromWtf8("1.bin");
+    ScopedTestFile tmp(fileName, "123");
 
-    std::string displayPath = Blob::fromFile("1.bin").displayPath();
+    std::string displayPath = Blob::fromFile(fileName).displayPath();
     EXPECT_TRUE(displayPath.ends_with("1.bin"));
     EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
 }
 
 UNIT_TEST(Blob, DisplayPathFromEmptyFile) {
-    ScopedTestFile tmp("1.txt", "");
+    NativePath fileName = NativePath::fromWtf8("1.txt");
+    ScopedTestFile tmp(fileName, "");
 
-    std::string displayPath = Blob::fromFile("1.txt").displayPath();
+    std::string displayPath = Blob::fromFile(fileName).displayPath();
     EXPECT_TRUE(displayPath.ends_with("1.txt"));
     EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
 }
 
 UNIT_TEST(Blob, DisplayPathFromStream) {
-    ScopedTestFile tmp("1.bin", "123");
+    NativePath fileName = NativePath::fromWtf8("1.bin");
+    ScopedTestFile tmp(fileName, "123");
 
-    FileInputStream in("1.bin");
+    FileInputStream in(fileName);
     std::string displayPath = Blob::read(&in, 2).displayPath();
     EXPECT_TRUE(displayPath.ends_with("1.bin"));
     EXPECT_TRUE(std::filesystem::path(displayPath).is_absolute());
 }
 
 UNIT_TEST(Blob, ExceptionMessages) {
-    const char *fileName = "lknjdfgsbiuherqbhvdfnjkkvsdhjkweqguy.txt";
+    NativePath fileName = NativePath::fromWtf8("lknjdfgsbiuherqbhvdfnjkkvsdhjkweqguy.txt");
 
-    EXPECT_FALSE(std::filesystem::exists(fileName));
-    EXPECT_THROW_MESSAGE((void) Blob::fromFile(fileName), fileName);
+    EXPECT_FALSE(std::filesystem::exists(fileName.toStdPath()));
+    EXPECT_THROW_MESSAGE((void) Blob::fromFile(fileName), fileName.toWtf8());
 }

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -8,14 +8,13 @@
 #include <filesystem>
 
 #include "Utility/Exception.h"
-#include "Utility/UnicodeCrt.h"
 
 #ifdef _WINDOWS
 #   define ftello _ftelli64
 #   define fseeko _fseeki64
 #endif
 
-FileInputStream::FileInputStream(std::string_view path, size_t bufferSize) {
+FileInputStream::FileInputStream(const NativePath &path, size_t bufferSize) {
     open(path, bufferSize);
 }
 
@@ -23,30 +22,35 @@ FileInputStream::~FileInputStream() {
     destroy();
 }
 
-void FileInputStream::open(std::string_view path, size_t bufferSize) {
-    assert(UnicodeCrt::isInitialized()); // Otherwise fopen on Windows will choke on UTF-8 paths.
+void FileInputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string absolutePath = absolute(std::filesystem::path(path)).generic_string();
-    _file = fopen(absolutePath.c_str(), "rb");
+    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
+
+    // Wide fopen on Windows - the narrow one converts the path per the C locale.
+#ifdef _WINDOWS
+    _file = _wfopen(path.toStdPath().c_str(), L"rb");
+#else
+    _file = fopen(path.toStdPath().c_str(), "rb");
+#endif
     if (!_file)
-        Exception::throwFromErrno(absolutePath);
+        Exception::throwFromErrno(pathString);
 
     // Disable libc buffering, we manage our own buffer.
     if (setvbuf(_file, nullptr, _IONBF, 0) != 0)
-        Exception::throwFromErrno(absolutePath);
+        Exception::throwFromErrno(pathString);
 
     // Compute file size at open time.
     if (fseeko(_file, 0, SEEK_END) != 0)
-        Exception::throwFromErrno(absolutePath);
+        Exception::throwFromErrno(pathString);
     int64_t fileEnd = ftello(_file);
     if (fileEnd == -1)
-        Exception::throwFromErrno(absolutePath);
+        Exception::throwFromErrno(pathString);
     if (fseeko(_file, 0, SEEK_SET) != 0)
-        Exception::throwFromErrno(absolutePath);
+        Exception::throwFromErrno(pathString);
 
     _bufSize = bufferSize;
-    base_type::open({}, fileEnd, absolutePath);
+    base_type::open({}, fileEnd, pathString);
 }
 
 size_t FileInputStream::_underflow(void *data, size_t size, Buffer *buffer) {

--- a/src/Utility/Streams/FileInputStream.h
+++ b/src/Utility/Streams/FileInputStream.h
@@ -2,7 +2,8 @@
 
 #include <cstdio>
 #include <memory>
-#include <string_view>
+
+#include "Utility/System/NativePath.h"
 
 #include "InputStream.h"
 
@@ -24,7 +25,7 @@ class FileInputStream : public InputStream {
      * @param bufferSize                Size of the internal read buffer.
      * @throws Exception                On error.
      */
-    explicit FileInputStream(std::string_view path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
+    explicit FileInputStream(const NativePath &path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
     virtual ~FileInputStream();
 
     /**
@@ -34,7 +35,7 @@ class FileInputStream : public InputStream {
      * @param bufferSize                Size of the internal read buffer.
      * @throws Exception                On error.
      */
-    void open(std::string_view path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
+    void open(const NativePath &path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
 
  private:
     virtual size_t _underflow(void *data, size_t size, Buffer *buffer) override;

--- a/src/Utility/Streams/FileOutputStream.cpp
+++ b/src/Utility/Streams/FileOutputStream.cpp
@@ -7,9 +7,8 @@
 #include <filesystem>
 
 #include "Utility/Exception.h"
-#include "Utility/UnicodeCrt.h"
 
-FileOutputStream::FileOutputStream(std::string_view path, size_t bufferSize) {
+FileOutputStream::FileOutputStream(const NativePath &path, size_t bufferSize) {
     open(path, bufferSize);
 }
 
@@ -17,21 +16,26 @@ FileOutputStream::~FileOutputStream() {
     destroy();
 }
 
-void FileOutputStream::open(std::string_view path, size_t bufferSize) {
-    assert(UnicodeCrt::isInitialized()); // Otherwise fopen on Windows will choke on UTF-8 paths.
+void FileOutputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string absPath = absolute(std::filesystem::path(path)).generic_string();
-    _file = fopen(absPath.c_str(), "wb");
+    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
+
+    // Wide fopen on Windows - the narrow one converts the path per the C locale.
+#ifdef _WINDOWS
+    _file = _wfopen(path.toStdPath().c_str(), L"wb");
+#else
+    _file = fopen(path.toStdPath().c_str(), "wb");
+#endif
     if (!_file)
-        Exception::throwFromErrno(absPath);
+        Exception::throwFromErrno(pathString);
 
     // Disable libc buffering, we manage our own buffer.
     if (setvbuf(_file, nullptr, _IONBF, 0) != 0)
-        Exception::throwFromErrno(absPath);
+        Exception::throwFromErrno(pathString);
 
     _bufSize = bufferSize;
-    base_type::open({}, absPath);
+    base_type::open({}, pathString);
 }
 
 void FileOutputStream::_overflow(Buffer *buffer, const void *data, size_t size) {

--- a/src/Utility/Streams/FileOutputStream.h
+++ b/src/Utility/Streams/FileOutputStream.h
@@ -2,7 +2,8 @@
 
 #include <cstdio>
 #include <memory>
-#include <string_view>
+
+#include "Utility/System/NativePath.h"
 
 #include "OutputStream.h"
 
@@ -24,7 +25,7 @@ class FileOutputStream : public OutputStream {
      * @param bufferSize                Size of the internal write buffer.
      * @throws Exception                On error.
      */
-    explicit FileOutputStream(std::string_view path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
+    explicit FileOutputStream(const NativePath &path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
     virtual ~FileOutputStream();
 
     /**
@@ -34,7 +35,7 @@ class FileOutputStream : public OutputStream {
      * @param bufferSize                Size of the internal write buffer.
      * @throws Exception                On error.
      */
-    void open(std::string_view path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
+    void open(const NativePath &path, size_t bufferSize = DEFAULT_BUFFER_SIZE);
 
  private:
     virtual void _overflow(Buffer *buffer, const void *data, size_t size) override;

--- a/src/Utility/Streams/Tests/FileInputStream_ut.cpp
+++ b/src/Utility/Streams/Tests/FileInputStream_ut.cpp
@@ -8,7 +8,7 @@
 #include "Utility/Streams/FileInputStream.h"
 
 UNIT_TEST(FileInputStream, Skip) {
-    const char *tmpfile = "tmp_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_test.txt");
     std::string data(3000, 'a');
 
     ScopedTestFileSlot tmp(tmpfile);
@@ -35,11 +35,11 @@ UNIT_TEST(FileInputStream, ExceptionMessages) {
     const char *fileName = "afjhrbluxnkskghelxrigjmgdhckeog.txt";
 
     EXPECT_FALSE(std::filesystem::exists(fileName));
-    EXPECT_THROW_MESSAGE(FileInputStream in(fileName), fileName);
+    EXPECT_THROW_MESSAGE(FileInputStream in(NativePath::fromWtf8(fileName)), fileName);
 }
 
 UNIT_TEST(FileInputStream, ReadUntil) {
-    const char *tmpfile = "tmp_readuntil_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readuntil_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -55,7 +55,7 @@ UNIT_TEST(FileInputStream, ReadUntil) {
 }
 
 UNIT_TEST(FileInputStream, ReadUntilLargeData) {
-    const char *tmpfile = "tmp_readuntil_large_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readuntil_large_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string first(10000, 'a');
@@ -75,7 +75,7 @@ UNIT_TEST(FileInputStream, ReadUntilLargeData) {
 }
 
 UNIT_TEST(FileInputStream, ReadSmallChunks) {
-    const char *tmpfile = "tmp_readchunks_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readchunks_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string data(20000, 'x');
@@ -99,7 +99,7 @@ UNIT_TEST(FileInputStream, ReadSmallChunks) {
 }
 
 UNIT_TEST(FileInputStream, ReadAllLargeFile) {
-    const char *tmpfile = "tmp_readall_large_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readall_large_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string data(50000, 'z');
@@ -113,7 +113,7 @@ UNIT_TEST(FileInputStream, ReadAllLargeFile) {
 }
 
 UNIT_TEST(FileInputStream, SkipAndRead) {
-    const char *tmpfile = "tmp_skipread_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_skipread_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string data(20000, 'a');
@@ -138,7 +138,7 @@ UNIT_TEST(FileInputStream, SkipAndRead) {
 }
 
 UNIT_TEST(FileInputStream, LargeSkip) {
-    const char *tmpfile = "tmp_largeskip_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_largeskip_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string data(2000, 'a');
@@ -166,7 +166,7 @@ UNIT_TEST(FileInputStream, LargeSkip) {
 }
 
 UNIT_TEST(FileInputStream, LargeSkipPastEnd) {
-    const char *tmpfile = "tmp_largeskip_end_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_largeskip_end_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -184,7 +184,7 @@ UNIT_TEST(FileInputStream, LargeSkipPastEnd) {
 }
 
 UNIT_TEST(FileInputStream, CloseIdempotent) {
-    const char *tmpfile = "tmp_closeidem_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_closeidem_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -199,8 +199,8 @@ UNIT_TEST(FileInputStream, CloseIdempotent) {
 }
 
 UNIT_TEST(FileInputStream, ReopenAfterClose) {
-    const char *tmpfile1 = "tmp_reopen1_test.txt";
-    const char *tmpfile2 = "tmp_reopen2_test.txt";
+    NativePath tmpfile1 = NativePath::fromWtf8("tmp_reopen1_test.txt");
+    NativePath tmpfile2 = NativePath::fromWtf8("tmp_reopen2_test.txt");
     ScopedTestFileSlot tmp1(tmpfile1);
     ScopedTestFileSlot tmp2(tmpfile2);
 
@@ -226,7 +226,7 @@ UNIT_TEST(FileInputStream, ReopenAfterClose) {
 }
 
 UNIT_TEST(FileInputStream, ReadUntilMultiRefill) {
-    const char *tmpfile = "tmp_readuntil_multirefill_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readuntil_multirefill_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     // 500 bytes of 'a', then a '\0' delimiter, then 200 bytes of 'b'.
@@ -248,7 +248,7 @@ UNIT_TEST(FileInputStream, ReadUntilMultiRefill) {
 }
 
 UNIT_TEST(FileInputStream, ReadUntilNotFound) {
-    const char *tmpfile = "tmp_readuntil_notfound_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readuntil_notfound_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     // No delimiter in data — readUntil should return everything.
@@ -265,7 +265,7 @@ UNIT_TEST(FileInputStream, ReadUntilNotFound) {
 }
 
 UNIT_TEST(FileInputStream, ReadAllEmpty) {
-    const char *tmpfile = "tmp_readall_empty_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_readall_empty_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -277,7 +277,7 @@ UNIT_TEST(FileInputStream, ReadAllEmpty) {
 }
 
 UNIT_TEST(FileInputStream, SizeMatchesFileSize) {
-    const char *tmpfile = "tmp_size_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_size_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -290,7 +290,7 @@ UNIT_TEST(FileInputStream, SizeMatchesFileSize) {
 }
 
 UNIT_TEST(FileInputStream, PositionStartsAtZero) {
-    const char *tmpfile = "tmp_pos_start_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_start_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -303,7 +303,7 @@ UNIT_TEST(FileInputStream, PositionStartsAtZero) {
 }
 
 UNIT_TEST(FileInputStream, PositionAdvancesOnRead) {
-    const char *tmpfile = "tmp_pos_read_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_read_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -318,7 +318,7 @@ UNIT_TEST(FileInputStream, PositionAdvancesOnRead) {
 }
 
 UNIT_TEST(FileInputStream, PositionAdvancesOnSkip) {
-    const char *tmpfile = "tmp_pos_skip_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_skip_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     std::string data(2000, 'x');
@@ -341,7 +341,7 @@ UNIT_TEST(FileInputStream, PositionAdvancesOnSkip) {
 }
 
 UNIT_TEST(FileInputStream, PositionAfterReadAll) {
-    const char *tmpfile = "tmp_pos_readall_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_readall_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -356,8 +356,8 @@ UNIT_TEST(FileInputStream, PositionAfterReadAll) {
 }
 
 UNIT_TEST(FileInputStream, PositionResetsOnReopen) {
-    const char *tmpfile1 = "tmp_pos_reopen1_test.txt";
-    const char *tmpfile2 = "tmp_pos_reopen2_test.txt";
+    NativePath tmpfile1 = NativePath::fromWtf8("tmp_pos_reopen1_test.txt");
+    NativePath tmpfile2 = NativePath::fromWtf8("tmp_pos_reopen2_test.txt");
     ScopedTestFileSlot tmp1(tmpfile1);
     ScopedTestFileSlot tmp2(tmpfile2);
 

--- a/src/Utility/Streams/Tests/FileOutputStream_ut.cpp
+++ b/src/Utility/Streams/Tests/FileOutputStream_ut.cpp
@@ -7,7 +7,7 @@
 #include "Utility/Streams/FileInputStream.h"
 
 UNIT_TEST(FileOutputStream, Write) {
-    const char *tmpfile = "tmp_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_test.txt");
     const char *tmpfilecontent = "1234\n";
     size_t tmpfilesize = strlen(tmpfilecontent);
 
@@ -30,7 +30,7 @@ UNIT_TEST(FileOutputStream, Write) {
 }
 
 UNIT_TEST(FileOutputStream, FlushMidStream) {
-    const char *tmpfile = "tmp_flush_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_flush_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -51,7 +51,7 @@ UNIT_TEST(FileOutputStream, FlushMidStream) {
 
 UNIT_TEST(FileOutputStream, LargeWriteBypassesBuffer) {
     // Use a small buffer so that a large write goes through the direct-write path in _overflow.
-    const char *tmpfile = "tmp_largewrite_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_largewrite_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile, 64);
@@ -64,7 +64,7 @@ UNIT_TEST(FileOutputStream, LargeWriteBypassesBuffer) {
 }
 
 UNIT_TEST(FileOutputStream, MixedSmallAndLargeWrites) {
-    const char *tmpfile = "tmp_mixed_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_mixed_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile, 64);
@@ -88,7 +88,7 @@ UNIT_TEST(FileOutputStream, MixedSmallAndLargeWrites) {
 }
 
 UNIT_TEST(FileOutputStream, CloseIdempotent) {
-    const char *tmpfile = "tmp_closeidem_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_closeidem_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -100,7 +100,7 @@ UNIT_TEST(FileOutputStream, CloseIdempotent) {
 }
 
 UNIT_TEST(FileOutputStream, ReopenAfterClose) {
-    const char *tmpfile = "tmp_reopen_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_reopen_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -116,7 +116,7 @@ UNIT_TEST(FileOutputStream, ReopenAfterClose) {
 }
 
 UNIT_TEST(FileOutputStream, PositionStartsAtZero) {
-    const char *tmpfile = "tmp_pos_start_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_start_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -125,7 +125,7 @@ UNIT_TEST(FileOutputStream, PositionStartsAtZero) {
 }
 
 UNIT_TEST(FileOutputStream, PositionAdvancesOnWrite) {
-    const char *tmpfile = "tmp_pos_write_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_write_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -137,7 +137,7 @@ UNIT_TEST(FileOutputStream, PositionAdvancesOnWrite) {
 }
 
 UNIT_TEST(FileOutputStream, PositionAfterFlush) {
-    const char *tmpfile = "tmp_pos_flush_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_flush_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);
@@ -150,7 +150,7 @@ UNIT_TEST(FileOutputStream, PositionAfterFlush) {
 }
 
 UNIT_TEST(FileOutputStream, PositionAfterLargeWrite) {
-    const char *tmpfile = "tmp_pos_large_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_large_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile, 64);
@@ -161,7 +161,7 @@ UNIT_TEST(FileOutputStream, PositionAfterLargeWrite) {
 }
 
 UNIT_TEST(FileOutputStream, DestructorFlushesBuffer) {
-    const char *tmpfile = "tmp_dtor_flush_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_dtor_flush_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     {
@@ -175,7 +175,7 @@ UNIT_TEST(FileOutputStream, DestructorFlushesBuffer) {
 }
 
 UNIT_TEST(FileOutputStream, PositionResetsOnReopen) {
-    const char *tmpfile = "tmp_pos_reopen_test.txt";
+    NativePath tmpfile = NativePath::fromWtf8("tmp_pos_reopen_test.txt");
     ScopedTestFileSlot tmp(tmpfile);
 
     FileOutputStream out(tmpfile);

--- a/src/Utility/System/NativePath.cpp
+++ b/src/Utility/System/NativePath.cpp
@@ -1,0 +1,21 @@
+#include "NativePath.h"
+
+#include <string>
+
+#include "Utility/String/Encoding.h"
+
+NativePath NativePath::fromWtf8(std::string_view path) {
+#ifdef _WINDOWS
+    return NativePath(std::filesystem::path(txt::wtf8ToWide(path)));
+#else
+    return NativePath(std::filesystem::path(path));
+#endif
+}
+
+std::string NativePath::toWtf8() const {
+#ifdef _WINDOWS
+    return txt::wideToWtf8(_path.generic_wstring());
+#else
+    return _path.generic_string();
+#endif
+}

--- a/src/Utility/System/NativePath.h
+++ b/src/Utility/System/NativePath.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "Utility/String/Format.h"
+
+/**
+ * The repo's vocabulary type for native paths - everything that takes a native path takes a `NativePath`.
+ *
+ * Unlike `std::filesystem::path`, this class does not depend on the C locale - on Windows constructing an
+ * `std::filesystem::path` from a narrow string converts it per the C locale, while here all charset conversions are
+ * done by our own code, and the underlying `std::filesystem::path` is only ever constructed from `wchar_t` strings
+ * on Windows. `fromWtf8` / `toWtf8` convert from and to our own strings, and `fromStdPath` / `toStdPath` are for
+ * talking to the OS, with no charset conversion whatsoever.
+ *
+ * Note that `fromWtf8` / `toWtf8` are named somewhat improperly - file names on Linux are arbitrary byte strings,
+ * and these bytes are passed through as-is. So the string returned by `toWtf8` is not necessarily valid UTF-8, and
+ * not even necessarily valid WTF-8 - it's guaranteed to be valid WTF-8 on Windows only. And MacOS is different
+ * again - APFS only takes file names that are valid UTF-8.
+ */
+class NativePath {
+ public:
+    NativePath() = default;
+
+    [[nodiscard]] static NativePath fromWtf8(std::string_view path);
+
+    [[nodiscard]] static NativePath fromStdPath(std::filesystem::path path) {
+        return NativePath(std::move(path));
+    }
+
+    // Deliberately dead for strings of all charsets, see the class docs. Use fromWtf8.
+    template<class T> static NativePath fromStdPath(const T &) = delete;
+
+    /**
+     * @return                          This path as a WTF-8 string, always using forward slashes. Never throws,
+     *                                  unlike `std::filesystem::path::generic_string()`.
+     */
+    [[nodiscard]] std::string toWtf8() const;
+
+    [[nodiscard]] const std::filesystem::path &toStdPath() const {
+        return _path;
+    }
+
+    /**
+     * @return                          Absolute copy of this path, resolved against the current directory. An empty
+     *                                  path resolves to the current directory itself.
+     */
+    [[nodiscard]] NativePath absolute() const {
+        return NativePath(_path.empty() ? std::filesystem::current_path() : std::filesystem::absolute(_path));
+    }
+
+    /**
+     * @param extension                 New extension, WTF-8, with or without the leading dot. Pass an empty string
+     *                                  to drop the extension.
+     * @return                          Copy of this path with the extension replaced.
+     */
+    [[nodiscard]] NativePath withExtension(std::string_view extension) const {
+        std::filesystem::path result = _path;
+        result.replace_extension(fromWtf8(extension).toStdPath());
+        return NativePath(std::move(result));
+    }
+
+    [[nodiscard]] bool isEmpty() const {
+        return _path.empty();
+    }
+
+    [[nodiscard]] NativePath operator/(const NativePath &tail) const {
+        return NativePath(_path / tail._path);
+    }
+
+    friend auto operator<=>(const NativePath &l, const NativePath &r) = default;
+
+    /**
+     * CLI11 picks this function up through ADL, so that options can bind `NativePath` fields directly. Note that
+     * `argv` is WTF-8, `UnicodeCrt` converts it from the wide command line on Windows.
+     */
+    friend bool lexical_cast(const std::string &input, NativePath &output) {
+        output = NativePath::fromWtf8(input);
+        return true;
+    }
+
+ private:
+    explicit NativePath(std::filesystem::path path) : _path(std::move(path)) {}
+
+ private:
+    std::filesystem::path _path;
+};
+
+template<>
+struct fmt::formatter<NativePath> : fmt::formatter<std::string> {
+    auto format(const NativePath &path, format_context &ctx) const {
+        return fmt::formatter<std::string>::format(path.toWtf8(), ctx);
+    }
+};

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -1,0 +1,55 @@
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+#include "Testing/Unit/UnitTest.h"
+
+#include "Utility/System/NativePath.h"
+
+UNIT_TEST(NativePath, Wtf8RoundTrip) {
+    // The conversion goes through wchar_t on Windows, so WTF-8 has to survive, unpaired surrogates included.
+    for (std::string_view path : {"a/b/c.txt", "\xd0\xbb\xd0\xbe\xd0\xbb.txt", "lol\xed\xb0\x80kek.txt"})
+        EXPECT_EQ(NativePath::fromWtf8(path).toWtf8(), path);
+}
+
+UNIT_TEST(NativePath, StdPathRoundTrip) {
+    std::filesystem::path cwd = std::filesystem::current_path();
+    EXPECT_EQ(NativePath::fromStdPath(cwd).toStdPath(), cwd);
+}
+
+UNIT_TEST(NativePath, Composition) {
+    EXPECT_EQ((NativePath::fromWtf8("a/b") / NativePath::fromWtf8("c.txt")).toWtf8(), "a/b/c.txt");
+}
+
+UNIT_TEST(NativePath, WithExtension) {
+    EXPECT_EQ(NativePath::fromWtf8("a/b.json").withExtension(".mm7").toWtf8(), "a/b.mm7");
+    EXPECT_EQ(NativePath::fromWtf8("a/b").withExtension(".mm7").toWtf8(), "a/b.mm7");
+    EXPECT_EQ(NativePath::fromWtf8("a/b.json").withExtension("").toWtf8(), "a/b");
+}
+
+UNIT_TEST(NativePath, Absolute) {
+    EXPECT_EQ(NativePath().absolute().toStdPath(), std::filesystem::current_path());
+    EXPECT_EQ(NativePath::fromWtf8("a").absolute().toStdPath(), std::filesystem::current_path() / "a");
+}
+
+#ifndef _WINDOWS
+UNIT_TEST(NativePath, InvalidUtf8FileNames) {
+    // File names on Linux are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is
+    // an incomplete UTF-8 sequence, "\xFF" can't appear in UTF-8 at all.
+    for (std::string_view name : {"tmp_lol\xD0kek.txt", "tmp_lol\xFFkek.txt", "tmp_trailing\xD0"}) {
+        NativePath path = NativePath::fromWtf8(name);
+        EXPECT_EQ(path.toWtf8(), name);
+
+        // APFS rejects such names, and so do APFS-backed mounts in a dev container, so we skip instead of asserting.
+        std::ofstream stream(path.toStdPath());
+        if (!stream.is_open())
+            GTEST_SKIP() << "File system rejected an invalid UTF-8 name.";
+        stream << "lol";
+        stream.close();
+
+        EXPECT_TRUE(std::filesystem::exists(path.toStdPath())) << name;
+        EXPECT_TRUE(std::filesystem::remove(path.toStdPath())) << name;
+    }
+}
+#endif

--- a/src/Utility/Tests/UnicodeCrt_ut.cpp
+++ b/src/Utility/Tests/UnicodeCrt_ut.cpp
@@ -2,10 +2,12 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "Testing/Unit/UnitTest.h"
 
 #include "Utility/Streams/FileOutputStream.h"
+#include "Utility/String/Encoding.h"
 #include "Utility/UnicodeCrt.h"
 
 static const char8_t *u8prefix = u8"\u0444\u0430\u0439\u043B"; // "File" in Russian.
@@ -61,7 +63,7 @@ UNIT_TEST(UnicodeCrt, filesystem_exists_remove) {
     std::u8string u8path = std::u8string(u8prefix) + u8"_exists";
     std::string path = reinterpret_cast<const char *>(u8path.c_str());
 
-    FileOutputStream s(path);
+    FileOutputStream s(NativePath::fromWtf8(path));
     s.write("something");
     s.close();
 
@@ -88,7 +90,7 @@ UNIT_TEST(UnicodeCrt, filesystem_rename) {
     std::string path = reinterpret_cast<const char *>(u8path.c_str());
     std::string path2 = path + "2";
 
-    FileOutputStream s(path);
+    FileOutputStream s(NativePath::fromWtf8(path));
     s.write("something_else");
     s.close();
 
@@ -128,3 +130,14 @@ UNIT_TEST(UnicodeCrt, fstreams) {
     EXPECT_TRUE(std::filesystem::remove(u8path));
     EXPECT_FALSE(std::filesystem::exists(u8path));
 }
+
+#ifdef _WINDOWS
+UNIT_TEST(UnicodeCrt, SurrogatesInCommandLine) {
+    // A lone surrogate in a command-line argument has to survive into argv.
+    std::vector<std::string> argv = detail::parseCommandLine(L"OpenEnroth.exe play \"lol\xDC00kek.json\"");
+    ASSERT_EQ(argv.size(), 3u);
+    EXPECT_EQ(argv[0], "OpenEnroth.exe");
+    EXPECT_EQ(argv[2], "lol\xed\xb0\x80kek.json");
+    EXPECT_EQ(txt::wtf8ToWide(argv[2]), L"lol\xDC00kek.json");
+}
+#endif

--- a/src/Utility/UnicodeCrt.cpp
+++ b/src/Utility/UnicodeCrt.cpp
@@ -1,6 +1,8 @@
 #include "UnicodeCrt.h"
 
 #include <cassert>
+#include <string>
+#include <vector>
 
 #ifdef _WINDOWS
 #   define WIN32_LEAN_AND_MEAN
@@ -33,14 +35,11 @@ UnicodeCrt::UnicodeCrt(int &argc, char **&argv) {
     // platformMain, argc and argv are already UTF8-encoded. However, SDL doesn't add/remove arguments, so it's safe to
     // run the same code again.
     //
-    // CommandLineToArgvW can return NULL when out of memory, which should never happen. We don't handle errors here.
-    std::unique_ptr<LPWSTR[], LocalFreeDeleter> argvw(CommandLineToArgvW(GetCommandLineW(), &argc)); // NOLINT
-
-    for (int i = 0; i < argc; i++)
-        _storage.push_back(txt::wideToUtf8(argvw[i]));
-    for (int i = 0; i < argc; i++)
-        _argv.push_back(_storage[i].data());
+    _storage = detail::parseCommandLine(GetCommandLineW());
+    for (std::string &arg : _storage)
+        _argv.push_back(arg.data());
     _argv.push_back(nullptr);
+    argc = static_cast<int>(_storage.size());
     argv = _argv.data();
 
     // Switch to UTF8 for CRT functions. Without this, std::filesystem won't be able to process UTF8 paths.
@@ -58,3 +57,16 @@ UnicodeCrt::UnicodeCrt(int &argc, char **&argv) {
 bool UnicodeCrt::isInitialized() {
     return globalUnicodeCrtInitialized;
 }
+
+#ifdef _WINDOWS
+std::vector<std::string> detail::parseCommandLine(const wchar_t *commandLine) {
+    // CommandLineToArgvW can return NULL when out of memory, which should never happen. We don't handle errors here.
+    int argc = 0;
+    std::unique_ptr<LPWSTR[], LocalFreeDeleter> argvw(CommandLineToArgvW(commandLine, &argc)); // NOLINT
+
+    std::vector<std::string> result;
+    for (int i = 0; i < argc; i++)
+        result.push_back(txt::wideToWtf8(argvw[i])); // WTF8, so that paths with unpaired surrogates survive.
+    return result;
+}
+#endif

--- a/src/Utility/UnicodeCrt.h
+++ b/src/Utility/UnicodeCrt.h
@@ -4,7 +4,7 @@
 #include <string>
 
 /**
- * Utility class that turns on UTF-8 for most of CRT, and converts command-line arguments to UTF-8. This is really only
+ * Utility class that turns on UTF-8 for most of CRT, and converts command-line arguments to WTF-8. This is really only
  * needed on Windows, and this class does nothing on POSIX.
  *
  * Use it like this:
@@ -26,6 +26,12 @@
  *
  * @see https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170#utf-8-support
  */
+#ifdef _WINDOWS
+namespace detail {
+std::vector<std::string> parseCommandLine(const wchar_t *commandLine); // Parses & converts to WTF-8.
+} // namespace detail
+#endif
+
 class UnicodeCrt {
  public:
     UnicodeCrt(int &argc, char **&argv);

--- a/test/Bin/GameTest/GameTestOptions.cpp
+++ b/test/Bin/GameTest/GameTestOptions.cpp
@@ -46,7 +46,7 @@ GameTestOptions GameTestOptions::parse(int argc, char **argv) {
 
     if (!result.listRequested && !result.helpPrinted && !testPath)
         throw CLI::RequiredError(testPathOption->get_name());
-    result.testPath = testPath.value_or("");
+    result.testPath = NativePath::fromWtf8(testPath.value_or(""));
 
     return result;
 }

--- a/test/Bin/GameTest/GameTestOptions.h
+++ b/test/Bin/GameTest/GameTestOptions.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <cfloat>
-#include <string>
 
 #include "Application/Startup/GameStarterOptions.h"
 
+#include "Utility/System/NativePath.h"
+
 struct GameTestOptions : GameStarterOptions {
-    std::string testPath;
+    NativePath testPath;
     float speed = FLT_MAX; // Test playback speed.
     bool helpPrinted = false;
     bool listRequested = false;

--- a/test/Bin/RetraceTest/RetraceTest.cpp
+++ b/test/Bin/RetraceTest/RetraceTest.cpp
@@ -19,6 +19,7 @@
 
 #include "Utility/String/Format.h"
 #include "Utility/String/Split.h"
+#include "Utility/System/NativePath.h"
 
 static EngineController *globalEngineController = nullptr;
 static PlatformApplication *globalApplication = nullptr;
@@ -51,7 +52,7 @@ void RetraceTest::init(EngineController *game, PlatformApplication *application)
 }
 
 void RetraceTest::TestBody() {
-    std::string savePath = _tracePath.substr(0, _tracePath.length() - 5) + ".mm7";
+    NativePath savePath = _tracePath.withExtension(".mm7");
     Blob oldTraceBlob = Blob::fromFile(_tracePath);
     Blob oldSaveBlob = Blob::fromFile(savePath);
 
@@ -63,13 +64,13 @@ void RetraceTest::TestBody() {
     EngineTraceStateAccessor::prepareForPlayback(engine->config.get(), oldTrace.header.config);
     recorder->startRecording(globalEngineController, oldSaveBlob);
     engine->config->graphics.FPSLimit.setValue(0);
-    player->playTrace(globalEngineController, std::move(oldTrace.events), _tracePath, TRACE_PLAYBACK_SKIP_RANDOM_CHECKS | TRACE_PLAYBACK_SKIP_STATE_CHECKS);
+    player->playTrace(globalEngineController, std::move(oldTrace.events), _tracePath.toWtf8(), TRACE_PLAYBACK_SKIP_RANDOM_CHECKS | TRACE_PLAYBACK_SKIP_STATE_CHECKS);
     EngineTraceRecording recording = recorder->finishRecording(globalEngineController);
 
     std::string oldTraceJson = EventTrace::normalizeJson(oldTraceBlob.str());
     std::string newTraceJson = EventTrace::normalizeJson(recording.trace.str());
     if (oldTraceJson != newTraceJson) {
         printTraceDiff(newTraceJson, oldTraceJson);
-        ADD_FAILURE() << "Trace '" << _tracePath << "' is not in canonical representation.";
+        ADD_FAILURE() << "Trace '" << _tracePath.toWtf8() << "' is not in canonical representation.";
     }
 }

--- a/test/Bin/RetraceTest/RetraceTest.h
+++ b/test/Bin/RetraceTest/RetraceTest.h
@@ -2,20 +2,21 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <utility>
+
+#include "Utility/System/NativePath.h"
 
 class EngineController;
 class PlatformApplication;
 
 class RetraceTest : public testing::Test {
  public:
-    explicit RetraceTest(std::string tracePath) : _tracePath(std::move(tracePath)) {}
+    explicit RetraceTest(NativePath tracePath) : _tracePath(std::move(tracePath)) {}
 
     static void init(EngineController *game, PlatformApplication *application);
 
     void TestBody() override;
 
  private:
-    std::string _tracePath;
+    NativePath _tracePath;
 };

--- a/test/Bin/RetraceTest/RetraceTestMain.cpp
+++ b/test/Bin/RetraceTest/RetraceTestMain.cpp
@@ -10,6 +10,7 @@
 #include "Library/StackTrace/StackTraceOnCrash.h"
 
 #include "Utility/String/Format.h"
+#include "Utility/System/NativePath.h"
 #include "Utility/UnicodeCrt.h"
 
 #include "RetraceTest.h"
@@ -23,14 +24,14 @@ int platformMain(int argc, char **argv) {
         if (opts.helpPrinted)
             return 1;
 
-        std::vector<std::string> tracePaths;
-        for (const auto &entry : std::filesystem::directory_iterator(opts.testPath))
+        std::vector<NativePath> tracePaths;
+        for (const auto &entry : std::filesystem::directory_iterator(opts.testPath.toStdPath()))
             if (entry.path().extension() == ".json")
-                tracePaths.push_back(entry.path().string());
+                tracePaths.push_back(NativePath::fromStdPath(entry.path()));
         std::ranges::sort(tracePaths);
 
-        for (const std::string &tracePath : tracePaths)
-            testing::RegisterTest("Retrace", std::filesystem::path(tracePath).stem().string().c_str(),
+        for (const NativePath &tracePath : tracePaths)
+            testing::RegisterTest("Retrace", tracePath.toStdPath().stem().string().c_str(),
                                   nullptr, nullptr, __FILE__, __LINE__,
                                   [tracePath] { return new RetraceTest(tracePath); });
 

--- a/test/Bin/RetraceTest/RetraceTestOptions.cpp
+++ b/test/Bin/RetraceTest/RetraceTestOptions.cpp
@@ -41,7 +41,7 @@ RetraceTestOptions RetraceTestOptions::parse(int argc, char **argv) {
 
     if (!result.listRequested && !result.helpPrinted && !testPath)
         throw CLI::RequiredError(testPathOption->get_name());
-    result.testPath = testPath.value_or("");
+    result.testPath = NativePath::fromWtf8(testPath.value_or(""));
 
     return result;
 }

--- a/test/Bin/RetraceTest/RetraceTestOptions.h
+++ b/test/Bin/RetraceTest/RetraceTestOptions.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-
 #include "Application/Startup/GameStarterOptions.h"
 
+#include "Utility/System/NativePath.h"
+
 struct RetraceTestOptions : GameStarterOptions {
-    std::string testPath;
+    NativePath testPath;
     bool helpPrinted = false;
     bool listRequested = false;
 

--- a/test/Testing/Extensions/ScopedTestFile.cpp
+++ b/test/Testing/Extensions/ScopedTestFile.cpp
@@ -4,7 +4,7 @@
 
 #include "Utility/Streams/FileOutputStream.h"
 
-ScopedTestFile::ScopedTestFile(std::string_view path, std::string_view contents) : _path(path) {
+ScopedTestFile::ScopedTestFile(const NativePath &path, std::string_view contents) : _path(path) {
     FileOutputStream stream(_path);
     stream.write(contents);
     stream.close();
@@ -12,5 +12,5 @@ ScopedTestFile::ScopedTestFile(std::string_view path, std::string_view contents)
 
 ScopedTestFile::~ScopedTestFile() {
     std::error_code ec;
-    std::filesystem::remove(_path, ec);
+    std::filesystem::remove(_path.toStdPath(), ec);
 }

--- a/test/Testing/Extensions/ScopedTestFile.h
+++ b/test/Testing/Extensions/ScopedTestFile.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string_view>
-#include <string>
+
+#include "Utility/System/NativePath.h"
 
 /**
  * Helper class to create a temporary file at the given path with the given contents & remove it when leaving the
@@ -9,9 +10,10 @@
  */
 class ScopedTestFile {
  public:
-    ScopedTestFile(std::string_view path, std::string_view contents);
+    ScopedTestFile(std::string_view path, std::string_view contents) : ScopedTestFile(NativePath::fromWtf8(path), contents) {}
+    ScopedTestFile(const NativePath &path, std::string_view contents);
     ~ScopedTestFile();
 
  private:
-    std::string _path;
+    NativePath _path;
 };

--- a/test/Testing/Extensions/ScopedTestFileSlot.cpp
+++ b/test/Testing/Extensions/ScopedTestFileSlot.cpp
@@ -2,12 +2,12 @@
 
 #include <filesystem>
 
-ScopedTestFileSlot::ScopedTestFileSlot(std::string_view path) : _path(path) {
+ScopedTestFileSlot::ScopedTestFileSlot(const NativePath &path) : _path(path) {
     std::error_code ec;
-    std::filesystem::remove(_path, ec);
+    std::filesystem::remove(_path.toStdPath(), ec);
 }
 
 ScopedTestFileSlot::~ScopedTestFileSlot() {
     std::error_code ec;
-    std::filesystem::remove(_path, ec);
+    std::filesystem::remove(_path.toStdPath(), ec);
 }

--- a/test/Testing/Extensions/ScopedTestFileSlot.h
+++ b/test/Testing/Extensions/ScopedTestFileSlot.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string_view>
-#include <string>
+
+#include "Utility/System/NativePath.h"
 
 /**
  * Helper class to remove a file in ctor and when leaving the current scope.
@@ -11,9 +12,10 @@
  */
 class ScopedTestFileSlot {
  public:
-    explicit ScopedTestFileSlot(std::string_view path);
+    explicit ScopedTestFileSlot(std::string_view path) : ScopedTestFileSlot(NativePath::fromWtf8(path)) {}
+    explicit ScopedTestFileSlot(const NativePath &path);
     ~ScopedTestFileSlot();
 
  private:
-    std::string _path;
+    NativePath _path;
 };


### PR DESCRIPTION
NativePath is a native OS path that does not depend on the C locale, which is
what sets it apart from std::filesystem::path - constructing the latter from
a narrow string converts it per the C locale on Windows. NativePath is
constructible only via fromWtf8, or via fromStdPath from a path the OS handed
us. Strings of all other charsets are compile errors.

Everything that takes a native path takes a NativePath now - Blob, the file
streams, DirectoryFileSystem, ArchiveReader, the Lod/Snd/Vid readers and
writer, Config, the test helpers, and the path fields of the CLI options
structs. Callers spell the conversion out: Blob::fromFile(NativePath::fromWtf8(path)).
CLI options bind NativePath fields directly, through a lexical_cast that CLI11
finds via ADL.

This also makes WTF8 paths actually work on Windows - the streams go through
the wide fopen, Blob hands mio the native wchar_t path, and UnicodeCrt now
converts argv to WTF8 instead of UTF8, so a path with an unpaired surrogate
in it survives all the way from the command line to CreateFile. The converted
classes no longer depend on the CRT locale at all, so their UnicodeCrt asserts
are gone.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
