### PR TITLE
Rename ITEM_TYPE_NONE to ITEM_TYPE_MISC

### DIFF
--- a/src/Engine/Objects/ItemEnumFunctions.h
+++ b/src/Engine/Objects/ItemEnumFunctions.h
@@ -262,7 +262,7 @@ inline Segment<ItemSlot> itemSlotsForItemType(ItemType type) {
     case ITEM_TYPE_MESSAGE_SCROLL:
     case ITEM_TYPE_GOLD:
     case ITEM_TYPE_GEM:
-    case ITEM_TYPE_NONE:
+    case ITEM_TYPE_MISC:
         return {};
     }
 }

--- a/src/Engine/Objects/ItemEnums.h
+++ b/src/Engine/Objects/ItemEnums.h
@@ -1035,10 +1035,10 @@ enum class ItemType {
     ITEM_TYPE_MESSAGE_SCROLL = 17,
     ITEM_TYPE_GOLD = 18,
     ITEM_TYPE_GEM = 19,
-    ITEM_TYPE_NONE = 20, // Ores, quest items. // TODO(captainurist): come up with a better name for this value.
+    ITEM_TYPE_MISC = 20, // Items with no type in items.txt - quest items, ores, and unused placeholder entries.
 
     ITEM_TYPE_FIRST = ITEM_TYPE_SINGLE_HANDED,
-    ITEM_TYPE_LAST = ITEM_TYPE_NONE,
+    ITEM_TYPE_LAST = ITEM_TYPE_MISC,
 
     ITEM_TYPE_FIRST_SPECIAL_ENCHANTABLE = ITEM_TYPE_SINGLE_HANDED,
     ITEM_TYPE_LAST_SPECIAL_ENCHANTABLE = ITEM_TYPE_AMULET,

--- a/src/Engine/Tables/ItemTable.cpp
+++ b/src/Engine/Tables/ItemTable.cpp
@@ -142,7 +142,7 @@ void ItemTable::LoadItems(const Blob &itemsBlob) {
         items[item_counter].iconName = unquote(tokens[1]);
         items[item_counter].name = unquote(tokens[2]);
         items[item_counter].baseValue = fromString<int>(tokens[3]);
-        items[item_counter].type = valueOr(equipStatMap, tokens[4], ITEM_TYPE_NONE);
+        items[item_counter].type = valueOr(equipStatMap, tokens[4], ITEM_TYPE_MISC);
         items[item_counter].skill = valueOr(equipSkillMap, tokens[5], SKILL_MISC);
         std::array<std::string_view, 2> diceRollTokens = split(tokens[6]).by('d');
         char damagePrefix = tolower(diceRollTokens[0][0]);


### PR DESCRIPTION
It isn't the absence of a type, it's the fallback for items with no equip
slot - ores, quest items and the like. SKILL_MISC plays exactly the same role
for the column next to it in items.txt.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
