### PR TITLE
Logging macros

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1083,9 +1083,9 @@ void Game::processQueuedMessages() {
                     continue;
                 } else {
                     if (pParty->uFlags & PARTY_FLAG_AIRBORNE)
-                        logger->trace("Party is airborne");
+                        MM_TRACE("Party is airborne");
                     if (pParty->uFlags & PARTY_FLAG_STANDING_ON_WATER)
-                        logger->trace("Party on water");
+                        MM_TRACE("Party on water");
                 }
 
                 if (pParty->bTurnBasedModeOn) {
@@ -1491,7 +1491,7 @@ void Game::processQueuedMessages() {
                 quickLoadGame();
                 continue;
             default:
-                logger->warning("Game::processQueuedMessages - Unhandled message type: {}", static_cast<int>(uMessage));
+                MM_WARNING("Game::processQueuedMessages - Unhandled message type: {}", static_cast<int>(uMessage));
                 continue;
         }
     }

--- a/src/Application/GameStates/MainMenuState.cpp
+++ b/src/Application/GameStates/MainMenuState.cpp
@@ -65,7 +65,7 @@ FsmAction MainMenuState::update() {
                 SetCurrentMenuID(MENU_LoadingProcInMainMenu);
                 transition = "quickLoadGame";
             } else {
-                logger->debug("UIMSG_QuickLoad - No quick save could be found!");
+                MM_DEBUG("UIMSG_QuickLoad - No quick save could be found!");
                 pAudioPlayer->playUISound(SOUND_error);
             }
             break;

--- a/src/Application/GameTraceHandler.cpp
+++ b/src/Application/GameTraceHandler.cpp
@@ -29,7 +29,7 @@ bool GameTraceHandler::keyPressEvent(const PlatformKeyEvent *event) {
                 // TODO(captainurist): do this properly, trace00001.json, etc.
                 ufs->write("trace.json", recording.trace);
                 ufs->write("trace.mm7", recording.save);
-                logger->info("Trace saved to {} and {}", ufs->displayPath("trace.json"), ufs->displayPath("trace.mm7"));
+                MM_INFO("Trace saved to {} and {}", ufs->displayPath("trace.json"), ufs->displayPath("trace.mm7"));
             } else {
                 tracer->startRecording(game);
             }

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -550,9 +550,9 @@ bool GameWindowHandler::closeEvent(const PlatformWindowEvent *event) {
 }
 
 bool GameWindowHandler::gamepadConnectionEvent(const PlatformGamepadEvent *event) {
-    logger->info("Gamepad {}, model='{}', serial='{}'",
-                 event->type == EVENT_GAMEPAD_CONNECTED ? "connected" : "disconnected",
-                 event->gamepad->model(), event->gamepad->serial());
+    MM_INFO("Gamepad {}, model='{}', serial='{}'",
+            event->type == EVENT_GAMEPAD_CONNECTED ? "connected" : "disconnected",
+            event->gamepad->model(), event->gamepad->serial());
     return false;
 }
 

--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -63,7 +63,7 @@ GameStarter::GameStarter(GameStarterOptions options): _options(std::move(options
     try {
         initialize();
     } catch (const std::exception &e) {
-        logger->critical("Terminated with exception: {}", e.what());
+        MM_CRITICAL("Terminated with exception: {}", e.what());
         throw;
     }
 }
@@ -75,21 +75,21 @@ void GameStarter::initialize() {
     // Resolve user path & create user fs.
     resolveUserPath(_environment.get(), &_options);
     _fsStarter.initUserFs(_options.ramFsUserData, _options.userPath);
-    logger->info("Using user path '{}'.", ufs->displayPath(""));
+    MM_INFO("Using user path '{}'.", ufs->displayPath(""));
 
     // Init config.
     _config = std::make_shared<GameConfig>();
     if (ufs->exists(configName)) {
         _config->load(ufs->openForReading(configName).get());
-        logger->info("Configuration file '{}' loaded!", ufs->displayPath(configName));
+        MM_INFO("Configuration file '{}' loaded!", ufs->displayPath(configName));
     } else {
         _config->reset();
 #ifdef OE_DISTRIBUTION_BUILD
         _config->window.Mode.setValue(WINDOW_MODE_FULLSCREEN_BORDERLESS);
 #endif
-        logger->info("Could not read configuration file '{}'! Loaded default configuration instead!", ufs->displayPath(configName));
+        MM_INFO("Could not read configuration file '{}'! Loaded default configuration instead!", ufs->displayPath(configName));
     }
-    logger->info("Built in resource override is {}.", _config->debug.OverrideBuiltInResources.value() ? "enabled" : "disabled");
+    MM_INFO("Built in resource override is {}.", _config->debug.OverrideBuiltInResources.value() ? "enabled" : "disabled");
 
     // Patch config.
     if (_options.quickStart)
@@ -102,7 +102,7 @@ void GameStarter::initialize() {
     // TODO(captainurist): actually move datapath to config?
     resolveDataPath(_environment.get(), &_options);
     _fsStarter.initDataFs(_options.dataPath, _config->debug.OverrideBuiltInResources.value());
-    logger->info("Using data path '{}'.", _options.dataPath); // Can't use dfs->displayPath("") b/c it'll show "embedded://"...
+    MM_INFO("Using data path '{}'.", _options.dataPath); // Can't use dfs->displayPath("") b/c it'll show "embedded://"...
 
     // Migrate saves if needed. We don't migrate anything else.
     if (!_options.ramFsUserData && _options.dataPath != _options.userPath)
@@ -235,11 +235,11 @@ void GameStarter::resolveDataPath(Environment *environment, GameStarterOptions *
     for (int i = 0; i < candidates.size(); i++) {
         std::string missingFile;
         if (!std::filesystem::exists(candidates[i])) {
-            logger->info("Data path #{} ('{}') doesn't exist.", i + 1, candidates[i]);
+            MM_INFO("Data path #{} ('{}') doesn't exist.", i + 1, candidates[i]);
         } else if (!validateMm7Path(candidates[i], &missingFile)) {
-            logger->info("Data path #{} ('{}') is missing file '{}'.", i + 1, candidates[i], missingFile);
+            MM_INFO("Data path #{} ('{}') is missing file '{}'.", i + 1, candidates[i], missingFile);
         } else {
-            logger->info("Data path #{} ('{}') is OK!", i + 1, candidates[i]);
+            MM_INFO("Data path #{} ('{}') is OK!", i + 1, candidates[i]);
             options->dataPath = candidates[i];
             break;
         }
@@ -267,18 +267,18 @@ void GameStarter::failOnInvalidPath(std::string_view dataPath, Platform *platfor
 }
 
 void GameStarter::migrateSaves() {
-    logger->info("Migrating save files from '{}' to '{}'...", dfs->displayPath("saves"), ufs->displayPath("saves"));
+    MM_INFO("Migrating save files from '{}' to '{}'...", dfs->displayPath("saves"), ufs->displayPath("saves"));
 
     if (ufs->exists("saves") && !ufs->ls("saves").empty()) {
-        logger->info("    Target saves directory is not empty, skipping saves migration.");
+        MM_INFO("    Target saves directory is not empty, skipping saves migration.");
     } else if (!dfs->exists("saves")) {
-        logger->info("    No save files to migrate.");
+        MM_INFO("    No save files to migrate.");
     } else {
         for (const DirectoryEntry &entry : dfs->ls("saves")) {
             if (entry.type == FILE_REGULAR) {
                 std::string path = fmt::format("saves/{}", entry.name);
                 ufs->write(path, dfs->read(path));
-                logger->info("    Copied '{}'.", entry.name);
+                MM_INFO("    Copied '{}'.", entry.name);
             }
         }
     }
@@ -290,10 +290,10 @@ void GameStarter::run() {
 
         _application->component<GameWindowHandler>()->UpdateConfigFromWindow(_config.get());
         _config->save(ufs->openForWriting(configName).get());
-        logger->info("Configuration file '{}' saved!", ufs->displayPath(configName));
+        MM_INFO("Configuration file '{}' saved!", ufs->displayPath(configName));
     } catch (const std::exception &e) {
         // Log the exception so that it goes to all registered loggers.
-        logger->critical("Terminated with exception: {}", e.what());
+        MM_CRITICAL("Terminated with exception: {}", e.what());
         throw;
     }
 }

--- a/src/Application/Startup/LogStarter.cpp
+++ b/src/Application/Startup/LogStarter.cpp
@@ -18,7 +18,7 @@ LogStarter::LogStarter() {
     _rootLogSink->addLogSink(_bufferLogSink.get());
 
     // Quiet down FFMPEG logs a little.
-    logger->setLevel(*LogCategory::instance("ffmpeg"), LOG_ERROR);
+    _logger->setLevel(*LogCategory::instance("ffmpeg"), LOG_ERROR);
 }
 
 LogStarter::~LogStarter() {
@@ -46,7 +46,7 @@ void LogStarter::initialize(FileSystem *userFs, LogLevel logLevel) {
             _userLogSink = std::make_unique<RotatingLogSink>("logs/openenroth.log", userFs);
             _rootLogSink->addLogSink(_userLogSink.get());
         } catch (const std::exception &e) {
-            _logger->log(LOG_ERROR, "Could not open log file for writing: {}", e.what());
+            MM_ERROR("Could not open log file for writing: {}", e.what());
             _userLogSink.reset();
         }
     }

--- a/src/Application/Startup/PathResolver.cpp
+++ b/src/Application/Startup/PathResolver.cpp
@@ -68,7 +68,7 @@ static std::vector<std::string> resolvePaths(Environment *environment, const Pat
     // If we have a path override then it'll be the only path we'll check.
     std::string envPath = environment->getenv(config.overrideEnvKey);
     if (!envPath.empty()) {
-        logger->info("Path override provided, '{}={}'.", config.overrideEnvKey, envPath);
+        MM_INFO("Path override provided, '{}={}'.", config.overrideEnvKey, envPath);
         return {envPath};
     }
 

--- a/src/Engine/AssetsManager.cpp
+++ b/src/Engine/AssetsManager.cpp
@@ -40,7 +40,7 @@ static void ReloadFonts() {
 }
 
 void AssetsManager::releaseAllTextures() {
-    logger->trace("Render - Releasing Textures.");
+    MM_TRACE("Render - Releasing Textures.");
     // clears any textures from gpu
     for (auto img : images) {
         img.second->releaseRenderId();

--- a/src/Engine/Components/Trace/EngineTraceRecorder.cpp
+++ b/src/Engine/Components/Trace/EngineTraceRecorder.cpp
@@ -67,7 +67,7 @@ void EngineTraceRecorder::startRecording(EngineController *game, const Blob &sav
 
     component<EngineTraceSimpleRecorder>()->startRecording();
 
-    logger->info("Tracing started.");
+    MM_INFO("Tracing started.");
 }
 
 EngineTraceRecording EngineTraceRecorder::finishRecording(EngineController *game) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -418,8 +418,8 @@ Engine::~Engine() {
 }
 
 void Engine::LogEngineBuildInfo() {
-    logger->info("OpenEnroth, revision {} built on {}", gitRevision(), buildTime());
-    logger->info("Extra build information: {}/{}/{} {}", OE_BUILD_PLATFORM, OE_BUILD_ARCHITECTURE, OE_BUILD_COMPILER, PROJECT_VERSION);
+    MM_INFO("OpenEnroth, revision {} built on {}", gitRevision(), buildTime());
+    MM_INFO("Extra build information: {}/{}/{} {}", OE_BUILD_PLATFORM, OE_BUILD_ARCHITECTURE, OE_BUILD_COMPILER, PROJECT_VERSION);
 }
 
 //----- (0044EA5E) --------------------------------------------------------

--- a/src/Engine/Evt/EvtProgram.cpp
+++ b/src/Engine/Evt/EvtProgram.cpp
@@ -120,12 +120,12 @@ std::string EvtProgram::hint(int eventId) const {
 void EvtProgram::dump(int eventId) const {
     const auto *events = valuePtr(_eventsById, eventId);
     if (events) {
-        logger->trace("Event: {}", eventId);
+        MM_TRACE("Event: {}", eventId);
         for (const EvtInstruction &ir : *events) {
-            logger->trace("{}", ir.toString());
+            MM_TRACE("{}", ir.toString());
         }
     } else {
-        logger->trace("Event {} not found", eventId);
+        MM_TRACE("Event {} not found", eventId);
     }
 }
 

--- a/src/Engine/Evt/Processor.cpp
+++ b/src/Engine/Evt/Processor.cpp
@@ -154,7 +154,7 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
     dword_5B65C4_cancelEventProcessing = 0; // TODO: rename and contain in this module or better remove it altogether
 
     EvtInterpreter interpreter;
-    logger->trace("Executing regular event starting from step {}", startStep);
+    MM_TRACE("Executing regular event starting from step {}", startStep);
     if (activeLevelDecoration) {
         engine->_globalEventMap.dump(eventId);
         interpreter.prepare(engine->_globalEventMap, eventId, targetObj, canShowMessages);
@@ -164,7 +164,7 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
     }
 
     if (!interpreter.isValid()) {
-        logger->info("Face has invalid event ID");
+        MM_INFO("Face has invalid event ID");
         engine->_statusBar->nothingHere();
         return;
     }
@@ -181,7 +181,7 @@ bool npcDialogueEventProcessor(int eventId, int startStep) {
 
     EvtInterpreter interpreter;
 
-    logger->trace("Executing NPC dialogue event starting from step {}", startStep);
+    MM_TRACE("Executing NPC dialogue event starting from step {}", startStep);
     LevelDecoration *oldDecoration = activeLevelDecoration;
     activeLevelDecoration = (LevelDecoration *)1; // Required for correct printing of messages
     engine->_globalEventMap.dump(eventId);

--- a/src/Engine/Graphics/BspRenderer.cpp
+++ b/src/Engine/Graphics/BspRenderer.cpp
@@ -181,7 +181,7 @@ void BspRenderer::AddFace(const int node_id, const int uFaceID) {
         //                   there are lots of portals in sight from there
         // drop all sectors beyond config limit
         if (uNumVisibleNotEmptySectors >= engine->config->graphics.MaxVisibleSectors.value()) {
-            logger->warning("Hit visible sector limit but needed to add new one!");
+            MM_WARNING("Hit visible sector limit but needed to add new one!");
         } else {
             AddSector(newNode->uSectorID);
         }

--- a/src/Engine/Graphics/ClippingFunctions.cpp
+++ b/src/Engine/Graphics/ClippingFunctions.cpp
@@ -26,7 +26,7 @@ bool ClippingFunctions::ClipVertsToPortal(RenderVertexSoft *pPortalBounding,  //
     // return true;  // testing bypass
 
     if (pPortalBounding->vWorldPosition.x == 0 && pPortalBounding->vWorldPosition.y == 0 && pPortalBounding->vWorldPosition.z == 0) {
-        logger->info("no portal bounding");
+        MM_INFO("no portal bounding");
         return true;
     }
 

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -144,7 +144,7 @@ static bool CollideSphereWithFace(BLVFace* face, const Vec3f& pos, float radius,
         if (face->Contains(projected_pos, model_idx)) {
             *out_move_distance = move_distance;
             *out_collision_point = projected_pos;
-            //logger->warning("Error: collide with face md: {}", move_distance);
+            //MM_WARNING("Error: collide with face md: {}", move_distance);
             return true;
         }
     }

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -85,7 +85,7 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
                 buildsplat->color,
                 buildsplat->faceDist,
                 &static_FacePlane, NumFaceVerts, FaceVerts, ClipFlags))
-                logger->warning("Error: Failed to build decal geometry");
+                MM_WARNING("Error: Failed to build decal geometry");
         }
     }
     return 1;

--- a/src/Engine/Graphics/ImageLoader.cpp
+++ b/src/Engine/Graphics/ImageLoader.cpp
@@ -167,7 +167,7 @@ bool PCX_Loader::InternalLoad(const Blob &data, RgbaImage *rgbaImage) {
 bool PCX_LOD_Raw_Loader::Load(RgbaImage *rgbaImage) {
     Blob data = lod->read(resource_name);
     if (!data) {
-        logger->warning("Unable to load {}", this->resource_name);
+        MM_WARNING("Unable to load {}", this->resource_name);
         return false;
     }
 
@@ -177,7 +177,7 @@ bool PCX_LOD_Raw_Loader::Load(RgbaImage *rgbaImage) {
 bool PCX_LOD_Compressed_Loader::Load(RgbaImage *rgbaImage) {
     Blob pcx_data = blob_func();
     if (!pcx_data) {
-        logger->warning("Unable to load {}", resource_name);
+        MM_WARNING("Unable to load {}", resource_name);
         return false;
     }
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -298,7 +298,7 @@ void IndoorLocation::Load(std::string_view filename, int num_days_played, int re
             if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && pMapStats->GetMapInfo(filename) != MAP_CASTLE_HARMONDALE)
                 respawnTimed = true;
         } catch (const Exception &e) {
-            logger->error("Failed to load '{}', respawning location: {}", dlv_filename, e.what());
+            MM_ERROR("Failed to load '{}', respawning location: {}", dlv_filename, e.what());
             respawnInitial = true;
         }
     }
@@ -390,10 +390,10 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
     // No face found - outside of level
     if (!NumFoundFaceStore) {
         if (!backupboundingsector) {
-            logger->warning("GetSector fail: {}, {}, {}", sX, sY, sZ);
+            MM_WARNING("GetSector fail: {}, {}, {}", sX, sY, sZ);
             return 0;
         } else {
-            logger->warning("GetSector fail: {}, {}, {}  Returning backup sector bounding!", sX, sY, sZ);
+            MM_WARNING("GetSector fail: {}, {}, {}  Returning backup sector bounding!", sX, sY, sZ);
             return backupboundingsector;
         }
     }
@@ -726,7 +726,7 @@ void BLV_UpdateDoorGeometry(BLVDoor* door, int distance) {
 void switchDoorAnimation(unsigned int uDoorID, DoorAction action) {
     auto pos = std::ranges::find(pIndoor->doors, uDoorID, &BLVDoor::doorId);
     if (pos == pIndoor->doors.end()) {
-        logger->error("Unable to find Door ID: {}!", uDoorID);
+        MM_ERROR("Unable to find Door ID: {}!", uDoorID);
         return;
     }
 
@@ -1102,7 +1102,7 @@ float BLV_GetFloorLevel(const Vec3f &pos, int uSectorID, int *pFaceID) {
 
     // no face found - probably wrong sector supplied
     if (!FacesFound) {
-        logger->trace("Floorlvl fail: {} {} {}", pos.x, pos.y, pos.z);
+        MM_TRACE("Floorlvl fail: {} {} {}", pos.x, pos.y, pos.z);
 
         if (pFaceID)
             *pFaceID = -1;
@@ -1430,7 +1430,7 @@ char DoInteractionWithTopmostZObject(Pid pid) {
             break;
 
         default:
-            logger->warning("Warning: Invalid ID reached!");
+            MM_WARNING("Warning: Invalid ID reached!");
             return 1;
     }
 

--- a/src/Engine/Graphics/LightsStack.cpp
+++ b/src/Engine/Graphics/LightsStack.cpp
@@ -13,7 +13,7 @@ LightsStack_MobileLight_::LightsStack_MobileLight_() {
 //----- (00467D88) --------------------------------------------------------
 bool LightsStack_MobileLight_::AddLight(const Vec3f &pos, int uSectorID, int uRadius, Color color, char uLightType) {
     if (uNumLightsActive >= 400) {
-        logger->warning("Too many mobile lights!");
+        MM_WARNING("Too many mobile lights!");
         return false;
     }
 
@@ -30,7 +30,7 @@ bool LightsStack_MobileLight_::AddLight(const Vec3f &pos, int uSectorID, int uRa
 
 bool LightsStack_StationaryLight_::AddLight(const Vec3f &pos, int16_t radius, Color color, char uLightType) {
     if (uNumLightsActive >= 400) {
-        logger->warning("Too many stationary lights!");
+        MM_WARNING("Too many stationary lights!");
         return false;
     }
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -488,7 +488,7 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
             if (!respawnInitial && days_played - delta.header.info.lastRespawnDay >= respawn_interval_days)
                 respawnTimed = true;
         } catch (const Exception &e) {
-            logger->error("Failed to load '{}', respawning location: {}", ddm_filename, e.what());
+            MM_ERROR("Failed to load '{}', respawning location: {}", ddm_filename, e.what());
             respawnInitial = true;
         }
     }
@@ -1835,7 +1835,7 @@ Color GetLevelFogColor() {
     if (pOutdoor->loc_time.weatherFlags & MAP_WEATHER_FOGGY) {
         if (pWeather->bNight) {  // night-time fog
             if (false) {
-                logger->error("decompilation can be inaccurate, please send savegame to Nomad");
+                MM_ERROR("decompilation can be inaccurate, please send savegame to Nomad");
                 assert(false);
             }
             if (pWeather->bNight) {

--- a/src/Engine/Graphics/PortalFunctions.cpp
+++ b/src/Engine/Graphics/PortalFunctions.cpp
@@ -305,7 +305,7 @@ bool CalcFaceBounding(const BLVFace *pFace, RenderVertexSoft *pFaceLimits,
                 (v25.vWorldPosition.y - pCamera3D->vCameraPos.y) * a1.y +
                 (v25.vWorldPosition.z - pCamera3D->vCameraPos.z) * a1.z;
     if (fabs(_dp) < 1e-6f) {
-        logger->info("Epsilon check");
+        MM_INFO("Epsilon check");
         v25 = pOutBounding[1];
         pOutBounding[1] = pOutBounding[3];
         pOutBounding[3] = v25;

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -65,7 +65,7 @@ void BaseRenderer::DrawSpriteObjects() {
     for (unsigned int i = 0; i < pSpriteObjects.size(); ++i) {
         // exit if we are at max sprites
         if (::uNumBillboardsToDraw >= 500) {
-            logger->warning("Billboards Full");
+            MM_WARNING("Billboards Full");
             break;
         }
 
@@ -98,7 +98,7 @@ void BaseRenderer::DrawSpriteObjects() {
              (object->spriteId < SPRITE_TRAP_FIRE || object->spriteId > SPRITE_TRAP_BODY))) { // Not a trap.
             SpriteFrame *frame = object->spriteFrame();
             if (frame->spriteName == "null" || frame->textureName == "null") {
-                logger->trace("Trying to draw sprite with null frame");
+                MM_TRACE("Trying to draw sprite with null frame");
                 continue;
             }
 
@@ -108,7 +108,7 @@ void BaseRenderer::DrawSpriteObjects() {
 
             // error catching
             if (frame->sprites[octant]->texture->height() == 0 || frame->sprites[octant]->texture->width() == 0) {
-                logger->trace("Trying to draw sprite with empty octant texture");
+                MM_TRACE("Trying to draw sprite with empty octant texture");
                 continue;
             }
 
@@ -152,7 +152,7 @@ void BaseRenderer::PrepareDecorationsRenderList_ODM() {
 
     for (unsigned int i = 0; i < pLevelDecorations.size(); ++i) {
         if (::uNumBillboardsToDraw >= 500) {
-            logger->warning("Billboards Full");
+            MM_WARNING("Billboards Full");
             return;
         }
 
@@ -266,7 +266,7 @@ void BaseRenderer::TransformBillboards() {
         if (p->hwsprite) {
             TransformBillboard(p, i);
         } else {
-            logger->trace("Billboard with no sprite!");
+            MM_TRACE("Billboard with no sprite!");
         }
     }
 }

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -93,7 +93,7 @@ void GL_Check_Errors(void *ret, const char *name, GLADapiproc apiproc, int len_a
         if (!detail_gl_error::trySerialize(err, &error))
             error = "Unknown Error";
 
-        logger->warning("OpenGL error ({}): {} from function {}", err, error, name);
+        MM_WARNING("OpenGL error ({}): {} from function {}", err, error, name);
 
         err = glad_glGetError();
     }
@@ -117,7 +117,7 @@ void GL_Check_Framebuffer(const char *name) {
     if (!detail_fb_error::trySerialize(status, &error))
         return;
 
-    logger->warning("OpenGL Framebuffer error ({}): {} from function {}", status, error, name);
+    MM_WARNING("OpenGL Framebuffer error ({}): {} from function {}", status, error, name);
 }
 
 // sky billboard stuff
@@ -201,7 +201,7 @@ OpenGLRenderer::OpenGLRenderer(
 ) : BaseRenderer(config, decal_builder, spellfx, particle_engine, vis) {}
 
 OpenGLRenderer::~OpenGLRenderer() {
-    logger->info("RenderGl - Destructor");
+    MM_INFO("RenderGl - Destructor");
     _shutdownImGui();
 }
 
@@ -233,7 +233,7 @@ void OpenGLRenderer::ClearTarget(Color uColor) {
 
 void OpenGLRenderer::BeginLines2D() {
     if (!_lineVertices.empty())
-        logger->trace("BeginLines with points still stored in buffer");
+        MM_TRACE("BeginLines with points still stored in buffer");
 
     DrawTwodVerts();
 
@@ -475,7 +475,7 @@ void OpenGLRenderer::ScreenFade(Color color, float t) {
 
 void OpenGLRenderer::DrawImage(GraphicsImage *img, const Recti &rect, int paletteid, Color uColor32) {
     if (!img) {
-        logger->trace("Null img passed to DrawImage");
+        MM_TRACE("Null img passed to DrawImage");
         return;
     }
 
@@ -861,7 +861,7 @@ void OpenGLRenderer::EndDecals() {
 
 void OpenGLRenderer::DrawDecal(Decal *pDecal, float z_bias) {
     if (pDecal->uNumVertices < 3) {
-        logger->warning("Decal has < 3 vertices");
+        MM_WARNING("Decal has < 3 vertices");
         return;
     }
 
@@ -1041,7 +1041,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                     }
 
                     if (i == 8) {
-                        logger->warning("Texture unit full - draw terrain!");
+                        MM_WARNING("Texture unit full - draw terrain!");
                         tileunit = 0;
                         tilelayer = 0;
                     } else {
@@ -1057,7 +1057,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
                             terraintexmap.insert(std::make_pair(tile.textureName, encode));
                             numterraintexloaded[i]++;
                         } else {
-                            logger->warning("Texture layer full - draw terrain!");
+                            MM_WARNING("Texture layer full - draw terrain!");
                             tileunit = 0;
                             tilelayer = 0;
                         }
@@ -1731,7 +1731,7 @@ void OpenGLRenderer::DoRenderBillboards_D3D() {
     _set_ortho_modelview();
 
     if (!_billboardVertices.empty())
-        logger->trace("Billboard shader store isnt empty!");
+        MM_TRACE("Billboard shader store isnt empty!");
 
     // track loaded tex
     float gltexid = 0;
@@ -1973,7 +1973,7 @@ void OpenGLRenderer::BeginScene2D() {
 
 void OpenGLRenderer::DrawQuad2D(GraphicsImage *texture, const Recti &srcRect, const Recti &dstRect, Color color) {
     if (!texture) {
-        logger->trace("Null texture passed to DrawQuad2D");
+        MM_TRACE("Null texture passed to DrawQuad2D");
         return;
     }
 
@@ -2351,7 +2351,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                                 }
 
                                 if (i == 16) {
-                                    logger->warning("Texture unit full - draw building!");
+                                    MM_WARNING("Texture unit full - draw building!");
                                     texunit = 0;
                                     texlayer = 0;
                                 } else {
@@ -2371,7 +2371,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                                         outbuildtexmap.insert(std::make_pair(texname, encode));
                                         numoutbuildtexloaded[i]++;
                                     } else {
-                                        logger->warning("Texture layer full - draw building!");
+                                        MM_WARNING("Texture layer full - draw building!");
                                         texunit = 0;
                                         texlayer = 0;
                                     }
@@ -2496,7 +2496,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
                                         face.texlayer = texlayer = unitlayer & 0xFF;
                                         face.texunit = texunit = (unitlayer & 0xFF00) >> 8;
                                     } else {
-                                        logger->warning("Texture not found in map!");
+                                        MM_WARNING("Texture not found in map!");
                                         // TODO(pskelton): set to water for now - fountains in walls of mist
                                         texunit = face.texlayer = 0;
                                         texlayer = face.texunit = 0;
@@ -2776,7 +2776,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
                 if (pStationaryLightsStack->pLights[lightscnt].uSectorID == 0) cntnosect++;
             }
             if (cntnosect)
-                logger->warning("{} lights - sector not found", cntnosect);
+                MM_WARNING("{} lights - sector not found", cntnosect);
 
             // initialize vertex vectors
             for (int i = 0; i < 16; i++) {
@@ -2848,7 +2848,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
                         }
 
                         if (i == 16) {
-                            logger->warning("Texture unit full - draw Indoor faces!");
+                            MM_WARNING("Texture unit full - draw Indoor faces!");
                             texunit = 0;
                             texlayer = 0;
                         } else {
@@ -2868,7 +2868,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
                                 bsptexmap.insert(std::make_pair(texname, encode));
                                 bsptexloaded[i]++;
                             } else {
-                                logger->warning("Texture layer full - draw indoor faces!");
+                                MM_WARNING("Texture layer full - draw indoor faces!");
                                 texunit = 0;
                                 texlayer = 0;
                             }
@@ -3012,7 +3012,7 @@ void OpenGLRenderer::DrawIndoorFaces() {
                         face->texlayer = texlayer = unitlayer & 0xFF;
                         face->texunit = texunit = (unitlayer & 0xFF00) >> 8;
                     } else {
-                        logger->warning("Texture not found in map!");
+                        MM_WARNING("Texture not found in map!");
                         // TODO(pskelton): set to water for now - fountains in walls of mist
                         texlayer = face->texlayer = 0;
                         texunit = face->texunit = 0;
@@ -3354,11 +3354,11 @@ bool OpenGLRenderer::Initialize() {
     };
 
     if (!version) {
-        logger->error("GLAD: Failed to initialize the OpenGL loader");
+        MM_ERROR("GLAD: Failed to initialize the OpenGL loader");
     } else {
-        logger->info("OpenGL version: {}.{}", GLAD_VERSION_MAJOR(version), GLAD_VERSION_MINOR(version));
-        logger->info("OpenGL version string: {}", glGetStringSafe(GL_VERSION));
-        logger->info("GLSL version: {}", glGetStringSafe(GL_SHADING_LANGUAGE_VERSION));
+        MM_INFO("OpenGL version: {}.{}", GLAD_VERSION_MAJOR(version), GLAD_VERSION_MINOR(version));
+        MM_INFO("OpenGL version string: {}", glGetStringSafe(GL_VERSION));
+        MM_INFO("GLSL version: {}", glGetStringSafe(GL_SHADING_LANGUAGE_VERSION));
         // TODO(captainurist): this is probably the place to check OpenGL version & exit.
         //                     openenroth requires opengl core 4.1 or opengles 3.2 capable gpu to run.
     }
@@ -3524,7 +3524,7 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
 }
 
 bool OpenGLRenderer::ReloadShaders() {
-    logger->info("Reloading shaders...");
+    MM_INFO("Reloading shaders...");
 
     ReleaseTerrain();
     ReleaseBSP();
@@ -3576,7 +3576,7 @@ bool OpenGLRenderer::ReloadShaders() {
         }
     }
 
-    logger->info("Shaders reloaded.");
+    MM_INFO("Shaders reloaded.");
     return true;
 }
 

--- a/src/Engine/Graphics/Renderer/OpenGLShader.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLShader.cpp
@@ -58,7 +58,7 @@ bool OpenGLShader::load(const Blob &vertSource, const Blob &fragSource, bool ope
 
     std::string errors = compileErrors(result);
     if (!errors.empty()) {
-        logger->error("Could not link shader program '{}+{}':\n{}", vertSource.displayPath(), fragSource.displayPath(), errors);
+        MM_ERROR("Could not link shader program '{}+{}':\n{}", vertSource.displayPath(), fragSource.displayPath(), errors);
         glDeleteProgram(result);
         return false;
     }
@@ -81,7 +81,7 @@ int OpenGLShader::uniformLocation(const char *name) const {
 
     int location = glGetUniformLocation(_id, name);
     if (location == -1)
-        logger->error("Uniform '{}' not found in shader program '{}'", name, _paths);
+        MM_ERROR("Uniform '{}' not found in shader program '{}'", name, _paths);
     return location;
 }
 
@@ -105,7 +105,7 @@ unsigned OpenGLShader::loadShader(const Blob &source, int type, bool openGLES, c
         static constexpr std::string_view glslDirectives[] = {"version", "extension"};
         preprocessedSource = pp::preprocess(source, pwd, preamble, glslDirectives);
     } catch (const std::exception &e) {
-        logger->error("Could not preprocess shader '{}': {}", source.displayPath(), e.what());
+        MM_ERROR("Could not preprocess shader '{}': {}", source.displayPath(), e.what());
         return 0;
     }
 
@@ -119,11 +119,11 @@ unsigned OpenGLShader::loadShader(const Blob &source, int type, bool openGLES, c
 
     std::string errors = compileErrors(result);
     if (!errors.empty()) {
-        logger->error("Could not compile shader '{}':\n{}", source.displayPath(), errors);
+        MM_ERROR("Could not compile shader '{}':\n{}", source.displayPath(), errors);
         glDeleteShader(result);
         return 0;
     }
 
-    logger->info("Loaded shader '{}'.", source.displayPath());
+    MM_INFO("Loaded shader '{}'.", source.displayPath());
     return result;
 }

--- a/src/Engine/Graphics/Renderer/RendererFactory.cpp
+++ b/src/Engine/Graphics/Renderer/RendererFactory.cpp
@@ -12,7 +12,7 @@
 std::unique_ptr<Renderer> RendererFactory::createRenderer(RendererType type, std::shared_ptr<GameConfig> config) {
     switch (type) {
     case RENDERER_OPENGL:
-        logger->info("Initializing OpenGL renderer...");
+        MM_INFO("Initializing OpenGL renderer...");
         return std::make_unique<OpenGLRenderer>(
             config,
             EngineIocContainer::ResolveDecalBuilder(),
@@ -22,7 +22,7 @@ std::unique_ptr<Renderer> RendererFactory::createRenderer(RendererType type, std
         );
 
     case RENDERER_OPENGL_ES:
-        logger->info("Initializing OpenGL ES renderer...");
+        MM_INFO("Initializing OpenGL ES renderer...");
         return std::make_unique<OpenGLRenderer>(
             config,
             EngineIocContainer::ResolveDecalBuilder(),
@@ -36,7 +36,7 @@ std::unique_ptr<Renderer> RendererFactory::createRenderer(RendererType type, std
         [[fallthrough]];
 
     case RENDERER_NULL:
-        logger->info("Initializing null renderer...");
+        MM_INFO("Initializing null renderer...");
         return std::make_unique<NullRenderer>(
             config,
             EngineIocContainer::ResolveDecalBuilder(),

--- a/src/Engine/Graphics/Sprites.cpp
+++ b/src/Engine/Graphics/Sprites.cpp
@@ -51,7 +51,7 @@ void SpriteFrameTable::InitializeSprite(signed int uSpriteID) {
                     if (uFlags & SPRITE_FRAME_IMAGE1) {
                         Sprite *sprite = pSprites_LOD->loadSprite(pSpriteSFrames[iter_uSpriteID].textureName);
                         if (sprite == nullptr)
-                            logger->warning("Sprite {} not loaded!", pSpriteSFrames[iter_uSpriteID].textureName);
+                            MM_WARNING("Sprite {} not loaded!", pSpriteSFrames[iter_uSpriteID].textureName);
                         for (unsigned i = 0; i < 8; ++i)
                             pSpriteSFrames[iter_uSpriteID].sprites[i] = sprite;
                     } else if (uFlags & SPRITE_FRAME_IMAGES3) {

--- a/src/Engine/Graphics/TileGenerator.cpp
+++ b/src/Engine/Graphics/TileGenerator.cpp
@@ -59,7 +59,7 @@ void TileGenerator::ensureTile(std::string_view name) {
 RgbaImage TileGenerator::generateTile(Tileset tileset, TileVariant variant) {
     assert(allGeneratedTileVariants().contains(variant));
 
-    logger->info("Generating tile {}_{}.", toString(tileset), toString(variant));
+    MM_INFO("Generating tile {}_{}.", toString(tileset), toString(variant));
 
     Directions currentDirections = 0;
     Directions targetDirections = transitionDirectionsForTileVariant(variant);

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -435,7 +435,7 @@ Vis_PIDAndDepth Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
         }
 
         default:
-            logger->warning("Undefined type requested for: CVis::get_object_zbuf_val()");
+            MM_WARNING("Undefined type requested for: CVis::get_object_zbuf_val()");
             return Vis_PIDAndDepth();
     }
 }
@@ -620,7 +620,7 @@ void Vis_SelectionList::create_object_pointers(PointerCreationType type) {
         } break;
 
         default:
-            logger->warning("Unknown pointer creation flag passed to ::create_object_pointers()");
+            MM_WARNING("Unknown pointer creation flag passed to ::create_object_pointers()");
     }
 }
 
@@ -703,7 +703,7 @@ Vis_PIDAndDepth Vis::PickMouse(float fDepth, float fMouseX, float fMouseY,
     } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
         PickOutdoorFaces_Mouse(fDepth, rayOrigin, rayStep, &_selectionList, face_filter, false);
     } else {
-        logger->warning("Picking mouse in undefined level");  // picking in main menu is
+        MM_WARNING("Picking mouse in undefined level");  // picking in main menu is
                                                   // default (buggy) game
                                                   // behaviour. should've
                                                   // returned false in
@@ -756,7 +756,7 @@ bool Vis::isBillboardPartOfSelection(int billboardId, Vis_SelectionFilter *filte
     if (filter->select_flags & ExclusionIfNoEvent) {
         if (object_type != filter->object_type) return true;
         if (filter->object_type != OBJECT_Decoration) {
-            logger->warning("Unsupported \"exclusion if no event\" type in CVis::isBillboardPartOfSelection");
+            MM_WARNING("Unsupported \"exclusion if no event\" type in CVis::isBillboardPartOfSelection");
             return true;
         }
         if (pLevelDecorations[object_idx].uCog ||
@@ -766,7 +766,7 @@ bool Vis::isBillboardPartOfSelection(int billboardId, Vis_SelectionFilter *filte
     }
     if (object_type == filter->object_type) {
         if (object_type != OBJECT_Actor) {
-            logger->warning("Default case reached in VIS");
+            MM_WARNING("Default case reached in VIS");
             return true;
         }
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -545,7 +545,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
 
         case SPELL_LIGHT_PARALYZE:
             // TODO(pskelton): This is a vanilla bug - monsters with instant targeting spells can't actually use them - #1246
-            logger->info("Spell Paralyze cast - replaced with dispel");
+            MM_INFO("Spell Paralyze cast - replaced with dispel");
             [[fallthrough]];
         case SPELL_LIGHT_DISPEL_MAGIC:
             for (SpellBuff &buff : pParty->pPartyBuffs) {
@@ -751,7 +751,7 @@ void Actor::AI_RangedAttack(unsigned int uActorID, AIDirection *pDir,
 
     a1.uObjectDescID = pObjectList->ObjectIDByItemID(a1.spriteId);
     if (a1.uObjectDescID == 0) {
-        logger->error("Item not found");
+        MM_ERROR("Item not found");
         return;
     }
     a1.containing_item.Reset();

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3701,7 +3701,7 @@ bool Character::CompareVariable(EvtVariable VarNum, int pValue) {
         case VAR_DarkResistance:
             return this->sResDarkBase >= pValue;
         case VAR_PhysicalResistance:
-            logger->error("Physical resistance isn't used in events");
+            MM_ERROR("Physical resistance isn't used in events");
             return false;
         case VAR_MagicResistance:
             return this->sResMagicBase >= pValue;
@@ -4250,7 +4250,7 @@ void Character::SetVariable(EvtVariable var_type, int var_value) {
             PlayAwardSound_Anim_Face(SPEECH_STAT_BONUS_INC);
             return;
         case VAR_PhysicalResistanceBonus:
-            logger->error("Physical res. bonus not used");
+            MM_ERROR("Physical res. bonus not used");
             return;
         case VAR_MagicResistanceBonus:
             this->sResMagicBonus = (uint8_t)var_value;
@@ -4507,7 +4507,7 @@ void Character::SetVariable(EvtVariable var_type, int var_value) {
             SetSkillReaction();
             return;
         case VAR_ThieverySkill:
-            logger->error("Thieving unsupported");
+            MM_ERROR("Thieving unsupported");
             return;
         case VAR_DisarmTrapSkill:
             pActiveSkills[SKILL_TRAP_DISARM] = CombinedSkillValue::fromJoined(var_value);
@@ -5090,7 +5090,7 @@ void Character::AddVariable(EvtVariable var_type, signed int val) {
             PlayAwardSound_Anim97();
             return;
         case VAR_ThieverySkill:
-            logger->error("Thieving unsupported");
+            MM_ERROR("Thieving unsupported");
             return;
         case VAR_DisarmTrapSkill:
             AddSkillByEvent(SKILL_TRAP_DISARM, val);
@@ -5499,7 +5499,7 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             PlayAwardSound_AnimSubtract();
             return;
         case VAR_ThieverySkill:
-            logger->error("Thieving unsupported");
+            MM_ERROR("Thieving unsupported");
             return;
         case VAR_DisarmTrapSkill:
             SubtractSkillByEvent(SKILL_TRAP_DISARM, pValue);

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -218,7 +218,7 @@ void Chest::PlaceItems(int uChestID) { // only used for setup
         }
 
         if (entry.zone() == INVENTORY_ZONE_STASH)
-            logger->trace("Cannot place item with id {} in the chest!", std::to_underlying(entry->itemId));
+            MM_TRACE("Cannot place item with id {} in the chest!", std::to_underlying(entry->itemId));
     }
 
     chest.SetInitialized(true);

--- a/src/Engine/Objects/Decoration.cpp
+++ b/src/Engine/Objects/Decoration.cpp
@@ -308,7 +308,7 @@ int LevelDecoration::GetGlobalEvent() {
             return 0;
 
         default:
-            logger->error("Invalid DecorationDescID: {}", std::to_underlying(uDecorationDescID));
+            MM_ERROR("Invalid DecorationDescID: {}", std::to_underlying(uDecorationDescID));
             return 0;
     }
 }

--- a/src/Engine/Objects/Monsters.cpp
+++ b/src/Engine/Objects/Monsters.cpp
@@ -63,7 +63,7 @@ SpellId ParseSpellType(std::string_view name) {
     auto it = monsterSpellMap.find(name);
     if (it != monsterSpellMap.end())
         return it->second;
-    logger->warning("Unknown monster spell {}", name);
+    MM_WARNING("Unknown monster spell {}", name);
     return SPELL_NONE;
 }
 
@@ -225,7 +225,7 @@ MonsterSpecialAttack ParseSpecialAttack(std::string_view spec_att_str) {
     else if (tmp.starts_with("none") || tmp.starts_with("0"))
         return SPECIAL_ATTACK_NONE;
     else
-        logger->warning("ParseSpecialAttack:: Unknown monster special attack '{}'", tmp);
+        MM_WARNING("ParseSpecialAttack:: Unknown monster special attack '{}'", tmp);
 
     return SPECIAL_ATTACK_NONE;
 }
@@ -562,7 +562,7 @@ MonsterId MonsterList::GetMonsterIDByName(std::string_view pMonsterName) {
         if (ascii::noCaseEquals(monsters[i].internalMonsterName, pMonsterName))
             return i;
     }
-    logger->error("Monster not found: {}", pMonsterName);
+    MM_ERROR("Monster not found: {}", pMonsterName);
     return MONSTER_INVALID;
 }
 

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -31,7 +31,7 @@ NPCData *getNPCData(int npcId) {
     if (npcId >= 0) {
         if (npcId < 5000) {
             if (npcId >= 501) {
-                logger->warning("NPC id exceeds MAX_DATA!");
+                MM_WARNING("NPC id exceeds MAX_DATA!");
             }
             return &pNPCStats->pNPCData[npcId];
         } else {

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -957,7 +957,7 @@ bool Party::addItemToParty(Item *pItem, bool isSilent) {
             }
         }
     } else {
-        logger->warning("Invalid picture_name detected ::addItem()");
+        MM_WARNING("Invalid picture_name detected ::addItem()");
     }
     return false;
 }

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -43,7 +43,7 @@ void loadGame(std::string_view fileName) {
     std::string path = fmt::format("saves/{}", fileName);
     if (!ufs->exists(path)) {
         pAudioPlayer->playUISound(SOUND_error);
-        logger->warning("loadGame: '{}' doesn't exist", fileName);
+        MM_WARNING("loadGame: '{}' doesn't exist", fileName);
         return;
     }
     engine->_lastLoadedSaveFileName = fileName;
@@ -106,7 +106,7 @@ void loadGame(std::string_view fileName) {
     SetUserInterface(pParty->alignment);
 
     if (!pGames_LOD->exists(state.header.locationName)) {
-        logger->error("Unable to find: {}!", state.header.locationName);
+        MM_ERROR("Unable to find: {}!", state.header.locationName);
     }
 
     engine->_transitionMapId = pMapStats->GetMapInfo(state.header.locationName);
@@ -193,7 +193,7 @@ SaveGameHeader saveGame(bool isAutoSave, bool resetWorld, std::string_view path,
         ufs->write(path, blob);
     } catch (const std::exception &e) {
         if (isAutoSave) {
-            logger->warning("saveGame: failed to write autosave: {}", e.what());
+            MM_WARNING("saveGame: failed to write autosave: {}", e.what());
             return {};
         }
         throw;
@@ -259,7 +259,7 @@ void quickLoadGame() {
         uGameState = GAME_STATE_LOADING_GAME;
         pAudioPlayer->playUISound(SOUND_StartMainChoice02);
     } else {
-        logger->error("QuickLoadGame:: No quick save could be found!");
+        MM_ERROR("QuickLoadGame:: No quick save could be found!");
         pAudioPlayer->playUISound(SOUND_error);
     }
 }

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1158,20 +1158,20 @@ void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<i
             index--;
 
             if (index > maxIndex) {
-                logger->warning("Invalid item reference in backpack for character #{}, itemId={}, index={}, pos=({},{})",
-                                *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Invalid item reference in backpack for character #{}, itemId={}, index={}, pos=({},{})",
+                           *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 
             if (items[index].itemId == ITEM_NULL) {
-                logger->warning("Null item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
-                                *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Null item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
+                           *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 
             if (processed[index]) {
-                logger->warning("Duplicate item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
-                                *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Duplicate item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
+                           *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 
@@ -1180,8 +1180,8 @@ void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<i
                 dst->addAt({x, y}, items[index], index); // We need to preserve item indices.
             } else {
                 pending[index] = true;
-                logger->warning("Overlapping item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
-                                *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Overlapping item in backpack for character #{}, itemId={}, index={}, pos=({},{})",
+                           *characterIndex, std::to_underlying(items[index].itemId), index, x, y);
             }
         }
     }
@@ -1193,20 +1193,20 @@ void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<i
         index--;
 
         if (index > maxIndex) {
-            logger->warning("Invalid item reference in equipment for character #{}, itemId={}, index={}, slot={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
+            MM_WARNING("Invalid item reference in equipment for character #{}, itemId={}, index={}, slot={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
             continue;
         }
 
         if (items[index].itemId == ITEM_NULL) {
-            logger->warning("Null item in equipment for character #{}, itemId={}, index={}, slot={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
+            MM_WARNING("Null item in equipment for character #{}, itemId={}, index={}, slot={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
             continue;
         }
 
         if (processed[index]) {
-            logger->warning("Duplicate item in equipment for character #{}, itemId={}, index={}, slot={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
+            MM_WARNING("Duplicate item in equipment for character #{}, itemId={}, index={}, slot={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
             continue;
         }
 
@@ -1215,8 +1215,8 @@ void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<i
             dst->equipAt(slot, items[index], index); // We need to preserve item indices.
         } else {
             pending[index] = true;
-            logger->warning("Overlapping items in equipment for character #{}, itemId={}, index={}, slot={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
+            MM_WARNING("Overlapping items in equipment for character #{}, itemId={}, index={}, slot={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index, std::to_underlying(slot));
         }
     }
 
@@ -1225,13 +1225,13 @@ void reconstruct(const Character_MM7 &src, CharacterInventory *dst, ContextTag<i
             continue;
 
         if (!pending[index]) {
-            logger->warning("Invisible item was dropped from inventory for character #{}, itemId={}, index={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index);
+            MM_WARNING("Invisible item was dropped from inventory for character #{}, itemId={}, index={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index);
         } else if (std::optional<Pointi> pos = dst->findSpace(items[index])) {
             dst->addAt(*pos, items[index], index);
         } else {
-            logger->warning("Overlapping item was dropped from inventory for character #{}, itemId={}, index={}",
-                            *characterIndex, std::to_underlying(items[index].itemId), index);
+            MM_WARNING("Overlapping item was dropped from inventory for character #{}, itemId={}, index={}",
+                       *characterIndex, std::to_underlying(items[index].itemId), index);
         }
     }
 }
@@ -1717,20 +1717,20 @@ void reconstruct(const Chest_MM7 &src, ChestInventory *dst, ContextTag<int> ches
             index--;
 
             if (index > maxIndex) {
-                logger->warning("Invalid item reference in chest #{} item grid, itemId={}, index={}, pos=({},{})",
-                                *chestId, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Invalid item reference in chest #{} item grid, itemId={}, index={}, pos=({},{})",
+                           *chestId, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 
             if (items[index].itemId == ITEM_NULL) {
-                logger->warning("Null item in chest #{}, itemId={}, index={}, pos=({},{})",
-                                *chestId, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Null item in chest #{}, itemId={}, index={}, pos=({},{})",
+                           *chestId, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 
             if (processed[index]) {
-                logger->warning("Duplicate item in chest #{}, itemId={}, index={}, pos=({},{})",
-                                *chestId, std::to_underlying(items[index].itemId), index, x, y);
+                MM_WARNING("Duplicate item in chest #{}, itemId={}, index={}, pos=({},{})",
+                           *chestId, std::to_underlying(items[index].itemId), index, x, y);
                 continue;
             }
 

--- a/src/Engine/TeleportPoint.cpp
+++ b/src/Engine/TeleportPoint.cpp
@@ -27,7 +27,7 @@ void TeleportPoint::doTeleport(bool keepOnZero) {
     // Test target position is valid
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
         if (!pIndoor->GetSector(_pos)) {
-            logger->error("TeleportPoint::doTeleport - Cannot GetSector for target position ({}, {}, {}), skipping teleport", _pos.x, _pos.y, _pos.z);
+            MM_ERROR("TeleportPoint::doTeleport - Cannot GetSector for target position ({}, {}, {}), skipping teleport", _pos.x, _pos.y, _pos.z);
             return;
         }
     } else {
@@ -36,12 +36,12 @@ void TeleportPoint::doTeleport(bool keepOnZero) {
         float newFloorLevel = ODM_GetFloorLevel(_pos, &partyIsOnWater, &floorFaceId);
         if (_pos.x < -maxPartyAxisDistance || _pos.x > maxPartyAxisDistance ||
             _pos.y < -maxPartyAxisDistance || _pos.y > maxPartyAxisDistance ) {
-            logger->error("TeleportPoint::doTeleport - Target position ({}, {}, {}) is out of bounds, skipping teleport", _pos.x, _pos.y, _pos.z);
+            MM_ERROR("TeleportPoint::doTeleport - Target position ({}, {}, {}) is out of bounds, skipping teleport", _pos.x, _pos.y, _pos.z);
             return;
         }
         // Warn about teleport height - party will be correctly z positioned on next update
         if (_pos.z < newFloorLevel)
-            logger->warning("TeleportPoint::doTeleport - Target position ({}, {}, {}) is below the floor level of {}", _pos.x, _pos.y, _pos.z, newFloorLevel);
+            MM_WARNING("TeleportPoint::doTeleport - Target position ({}, {}, {}) is below the floor level of {}", _pos.x, _pos.y, _pos.z, newFloorLevel);
     }
 
     Vec3f newPos = pParty->pos;

--- a/src/Engine/mm7text_ru.cpp
+++ b/src/Engine/mm7text_ru.cpp
@@ -673,7 +673,7 @@ static int genderOf(std::string_view name) {
         return pos->second;
 
     if (shouldWarnAbout(name))
-        logger->warning("sprintfex: unknown gender: {}", txt::encodedToUtf8(name, ENCODING_WINDOWS_1251));
+        MM_WARNING("sprintfex: unknown gender: {}", txt::encodedToUtf8(name, ENCODING_WINDOWS_1251));
     return 0;
 }
 
@@ -846,7 +846,7 @@ std::string sprintfex(std::string_view str) {
             pos += consumed;
         } else {
             if (shouldWarnAbout(str))
-                logger->warning("sprintfex: malformed token in \"{}\"", txt::encodedToUtf8(str, ENCODING_WINDOWS_1251));
+                MM_WARNING("sprintfex: malformed token in \"{}\"", txt::encodedToUtf8(str, ENCODING_WINDOWS_1251));
             result += '^'; // Malformed tokens are copied through verbatim.
             pos++;
         }

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -183,7 +183,7 @@ GUIWindow::~GUIWindow() {
     DeleteButtons();
     lWindowList.remove(this);
     // TODO(captainurist): logger can be NULL here if we're called from cxa_finalize.
-    logger->trace("Release window: {}", toString(eWindowType));
+    MM_TRACE("Release window: {}", toString(eWindowType));
 }
 
 void GUIWindow::DeleteButtons() {
@@ -443,7 +443,7 @@ void GUIWindow::DrawFlashingInputCursor(int uX, int uY, GUIFont *a2, Recti frame
 GUIWindow::GUIWindow(WindowType windowType, Pointi position, Sizei dimensions, std::string_view hint): eWindowType(windowType) {
     this->mouse = EngineIocContainer::ResolveMouse();
 
-    logger->trace("New window: {}", toString(windowType));
+    MM_TRACE("New window: {}", toString(windowType));
     lWindowList.push_front(this);
     frameRect = Recti(position.x, position.y, dimensions.w, dimensions.h);
 

--- a/src/GUI/Overlay/OverlaySystem.cpp
+++ b/src/GUI/Overlay/OverlaySystem.cpp
@@ -28,7 +28,7 @@ OverlaySystem::~OverlaySystem() {
 
 void OverlaySystem::addOverlay(std::string_view name, std::unique_ptr<Overlay> overlay) {
     if (_overlays.contains(name)) {
-        logger->error(OverlayLogCategory, "Can't add overlay \"{}\". Another overlay with the same name already exists.", name);
+        MM_ERROR_IN(OverlayLogCategory, "Can't add overlay \"{}\". Another overlay with the same name already exists.", name);
         return;
     }
 

--- a/src/GUI/Overlay/ScriptedOverlay.cpp
+++ b/src/GUI/Overlay/ScriptedOverlay.cpp
@@ -53,5 +53,5 @@ void ScriptedOverlay::_setErrorHandler(sol::protected_function &function) {
 }
 
 void ScriptedOverlay::_logMissingFunctionWarning(std::string_view functionName) {
-    logger->warning(ScriptingSystem::ScriptingLogCategory, "Missing [{}] function for the Scripted Overlay: {}", functionName, _name);
+    MM_WARNING_IN(ScriptingSystem::ScriptingLogCategory, "Missing [{}] function for the Scripted Overlay: {}", functionName, _name);
 }

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1792,7 +1792,7 @@ void GameUI_handleHintMessage(UIMessageType type, int param) {
         }
 
         default: {
-            logger->warning("GameUI_handleHintMessage - Unhandled message type: {}", static_cast<int>(type));
+            MM_WARNING("GameUI_handleHintMessage - Unhandled message type: {}", static_cast<int>(type));
             break;
         }
     }

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -784,7 +784,7 @@ bool PartyCreationUI_LoopInternal() {
                 pParty->pCharacters[i].inventory.add(Item(ITEM_MACE));
                 break;
             case SKILL_BLASTER:
-                logger->error("No blasters at startup :p");
+                MM_ERROR("No blasters at startup :p");
                 break;
             case SKILL_SHIELD:
                 pParty->pCharacters[i].inventory.add(Item(ITEM_WOODEN_BUCKLER));
@@ -828,10 +828,10 @@ bool PartyCreationUI_LoopInternal() {
                 break;
             case SKILL_LIGHT:
             case SKILL_DARK:
-                logger->error("No light/dark magic at startup");
+                MM_ERROR("No light/dark magic at startup");
                 break;
             case SKILL_DIPLOMACY:
-                logger->error("No diplomacy in mm7 (yet)");
+                MM_ERROR("No diplomacy in mm7 (yet)");
                 break;
             case SKILL_ITEM_ID:
             case SKILL_REPAIR:

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -64,7 +64,7 @@ static std::vector<SavegameSlot> loadMenuSlots() {
         try {
             deserialize(ufs->read(fmt::format("saves/{}", entry.name)), &save, tags::via<SaveGameLite_MM7>);
         } catch (const std::exception &e) {
-            logger->warning("Couldn't load savegame '{}': {}", entry.name, e.what()); // Don't list unreadable saves.
+            MM_WARNING("Couldn't load savegame '{}': {}", entry.name, e.what()); // Don't list unreadable saves.
             continue;
         }
         slot.header = save.header;
@@ -85,7 +85,7 @@ static std::vector<SavegameSlot> loadMenuSlots() {
             if (slot.thumbnail->width() == 0)
                 slot.thumbnail = nullptr;
         } catch (const Exception &e) {
-            logger->debug("Savegame thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
+            MM_DEBUG("Savegame thumbnail exception: {}", e.what()); // swallow it - bad pcx thumbnail is fine
             slot.thumbnail = nullptr;
         }
 
@@ -393,7 +393,7 @@ void GUIWindow_Load::quickLoad() {
         _selectedSlot = pos - _slots.begin();
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
     } else {
-        logger->error("QuickLoadGame:: No quick save could be found!");
+        MM_ERROR("QuickLoadGame:: No quick save could be found!");
         pAudioPlayer->playUISound(SOUND_error);
     }
 }

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -212,6 +212,6 @@ void GUIWindow_IndoorEntryExit::Update() {
         unsigned int vertMargin = (212 - assets->pFontCreate->CalcTextHeight(str, transition_window.w, 0)) / 2 + 101;
         DrawTitleText(assets->pFontCreate.get(), 0, vertMargin, colorTable.White, str, 3, transition_window);
     } else {
-        logger->error("Troubles in da house");
+        MM_ERROR("Troubles in da house");
     }
 }

--- a/src/Library/Config/Config.cpp
+++ b/src/Library/Config/Config.cpp
@@ -39,8 +39,8 @@ void Config::load(InputStream *stream) {
                     try {
                         entry->setString(iniValue.as<std::string_view>());
                     } catch (const std::exception &e) {
-                        logger->warning("Could not load config entry '[{}]/{}': {}. Value unchanged.",
-                                        sectionName, entryName, e.what());
+                        MM_WARNING("Could not load config entry '[{}]/{}': {}. Value unchanged.",
+                                   sectionName, entryName, e.what());
                     }
                 }
             }

--- a/src/Library/Fsm/FsmBuilder.cpp
+++ b/src/Library/Fsm/FsmBuilder.cpp
@@ -21,14 +21,14 @@ FsmBuilder &FsmBuilder::state(std::string_view stateName, std::unique_ptr<FsmSta
 FsmBuilder &FsmBuilder::on(std::string_view transitionName) {
     _latestOnTransition.clear();
     if (!_latestState) {
-        logger->error(Fsm::fsmLogCategory, "Can't create a transition with name [{}]. No state has been setup in the FsmBuilder",
+        MM_ERROR_IN(Fsm::fsmLogCategory, "Can't create a transition with name [{}]. No state has been setup in the FsmBuilder",
             transitionName);
         assert(false && "Can't create a transition without a declared state");
         return *this;
     }
 
     if (_latestState->transitions.contains(transitionName)) {
-        logger->error(Fsm::fsmLogCategory, "Can't create a transition with the same name [{}]. State [{}]",
+        MM_ERROR_IN(Fsm::fsmLogCategory, "Can't create a transition with the same name [{}]. State [{}]",
             transitionName, _latestState->name);
         assert(false && "Can't create a transition with the same name");
         return *this;
@@ -49,14 +49,14 @@ FsmBuilder &FsmBuilder::exitFsm() {
 
 FsmBuilder &FsmBuilder::jumpTo(std::function<bool()> condition, std::string_view targetState) {
     if (!_latestState) {
-        logger->error(Fsm::fsmLogCategory, "Can't add a target state to jumpTo. No state has been setup in the FsmBuilder. TargetState [{}]",
+        MM_ERROR_IN(Fsm::fsmLogCategory, "Can't add a target state to jumpTo. No state has been setup in the FsmBuilder. TargetState [{}]",
             targetState);
         assert(false && "Can't add a target state to jumpTo without a valid state.");
         return *this;
     }
 
     if (_latestOnTransition.empty()) {
-        logger->error(Fsm::fsmLogCategory, "Can't add a target state to jumpTo. No 'on' event has been defined yet. State [{}], TargetState [{}]",
+        MM_ERROR_IN(Fsm::fsmLogCategory, "Can't add a target state to jumpTo. No 'on' event has been defined yet. State [{}], TargetState [{}]",
             _latestState->name, targetState);
         assert(false && "Can't add a target state to jumpTo without a valid event.");
         return *this;

--- a/src/Library/Logger/Logger.cpp
+++ b/src/Library/Logger/Logger.cpp
@@ -11,7 +11,7 @@ static constinit FallbackLogSink fallbackSink;
 
 constinit Logger Logger::fallbackLogger = Logger(detail::detached, LOG_TRACE, &fallbackSink);
 
-constinit Logger *logger = detail::fallbackLogger();
+constinit Logger *detail::logger = detail::fallbackLogger();
 
 Logger::Logger(LogLevel level, LogSink *sink) {
     assert(sink);
@@ -20,16 +20,16 @@ Logger::Logger(LogLevel level, LogSink *sink) {
     _defaultCategory._adjustedLevel = LogCategory::adjustLevel(level);
     _sink = sink;
 
-    assert(logger == &fallbackLogger);
-    logger = this;
+    assert(detail::logger == &fallbackLogger);
+    detail::logger = this;
 }
 
 Logger::~Logger() {
     if (this == &fallbackLogger)
         return;
 
-    assert(logger == this);
-    logger = &fallbackLogger;
+    assert(detail::logger == this);
+    detail::logger = &fallbackLogger;
 }
 
 void Logger::logV(const LogCategory &category, LogLevel level, fmt::string_view fmt, fmt::format_args args) {

--- a/src/Library/Logger/Logger.h
+++ b/src/Library/Logger/Logger.h
@@ -184,13 +184,14 @@ extern constinit Logger *logger; // Singleton logger instance, never null - use 
  * The `_IN` variants take a `LogCategory`, the ones without it log into the default category.
  *
  * @param LEVEL                         Level to log at.
- * @param ...                           Format string and format arguments.
+ * @param FMT                           Format string, in `fmt::format` form.
+ * @param ...                           Format arguments.
  */
-#define MM_LOG(LEVEL, ...) \
+#define MM_LOG(LEVEL, FMT, ...) \
     do { \
         LogLevel localLevel = (LEVEL); \
         if (::detail::logger->shouldLog(localLevel)) \
-            ::detail::logger->log(localLevel, __VA_ARGS__); \
+            ::detail::logger->log(localLevel, (FMT) __VA_OPT__(,) __VA_ARGS__); \
     } while (false)
 
 /**
@@ -198,14 +199,15 @@ extern constinit Logger *logger; // Singleton logger instance, never null - use 
  *
  * @param CATEGORY                      `LogCategory` to log into.
  * @param LEVEL                         Level to log at.
- * @param ...                           Format string and format arguments.
+ * @param FMT                           Format string, in `fmt::format` form.
+ * @param ...                           Format arguments.
  */
-#define MM_LOG_IN(CATEGORY, LEVEL, ...) \
+#define MM_LOG_IN(CATEGORY, LEVEL, FMT, ...) \
     do { \
         const LogCategory &localCategory = (CATEGORY); \
         LogLevel localLevel = (LEVEL); \
         if (::detail::logger->shouldLog(localCategory, localLevel)) \
-            ::detail::logger->log(localCategory, localLevel, __VA_ARGS__); \
+            ::detail::logger->log(localCategory, localLevel, (FMT) __VA_OPT__(,) __VA_ARGS__); \
     } while (false)
 
 #define MM_TRACE(...) MM_LOG(LOG_TRACE, __VA_ARGS__)

--- a/src/Library/Logger/Logger.h
+++ b/src/Library/Logger/Logger.h
@@ -177,13 +177,14 @@ extern constinit Logger *logger; // Singleton logger instance, never null - use 
 } // namespace detail
 
 /**
- * Logging macros.
+ * Logging macros - this is how you log.
  *
- * These call into the global logger, and unlike the `Logger` methods, they don't evaluate the message arguments
- * when the message is dropped by the log level check. This is why the global `logger` is hidden away in `detail` -
- * logging is supposed to go through the macros.
+ * Message arguments are not evaluated when the message is dropped by the log level check.
  *
  * The `_IN` variants take a `LogCategory`, the ones without it log into the default category.
+ *
+ * @param LEVEL                         Level to log at.
+ * @param ...                           Format string and format arguments.
  */
 #define MM_LOG(LEVEL, ...) \
     do { \
@@ -192,6 +193,13 @@ extern constinit Logger *logger; // Singleton logger instance, never null - use 
             ::detail::logger->log(localLevel, __VA_ARGS__); \
     } while (false)
 
+/**
+ * Same as `MM_LOG`, but logs into the provided category.
+ *
+ * @param CATEGORY                      `LogCategory` to log into.
+ * @param LEVEL                         Level to log at.
+ * @param ...                           Format string and format arguments.
+ */
 #define MM_LOG_IN(CATEGORY, LEVEL, ...) \
     do { \
         const LogCategory &localCategory = (CATEGORY); \

--- a/src/Library/Logger/Logger.h
+++ b/src/Library/Logger/Logger.h
@@ -180,7 +180,8 @@ extern constinit Logger *logger; // Singleton logger instance, never null - use 
  * Logging macros.
  *
  * These call into the global logger, and unlike the `Logger` methods, they don't evaluate the message arguments
- * when the message is dropped by the log level check. Prefer them over calling `logger` directly.
+ * when the message is dropped by the log level check. This is why the global `logger` is hidden away in `detail` -
+ * logging is supposed to go through the macros.
  *
  * The `_IN` variants take a `LogCategory`, the ones without it log into the default category.
  */

--- a/src/Library/Logger/Logger.h
+++ b/src/Library/Logger/Logger.h
@@ -172,7 +172,44 @@ namespace detail {
 constexpr Logger *fallbackLogger() {
     return &Logger::fallbackLogger;
 }
+
+extern constinit Logger *logger; // Singleton logger instance, never null - use the macros below.
 } // namespace detail
 
-extern constinit Logger *logger; // Singleton logger instance, never null.
+/**
+ * Logging macros.
+ *
+ * These call into the global logger, and unlike the `Logger` methods, they don't evaluate the message arguments
+ * when the message is dropped by the log level check. Prefer them over calling `logger` directly.
+ *
+ * The `_IN` variants take a `LogCategory`, the ones without it log into the default category.
+ */
+#define MM_LOG(LEVEL, ...) \
+    do { \
+        LogLevel localLevel = (LEVEL); \
+        if (::detail::logger->shouldLog(localLevel)) \
+            ::detail::logger->log(localLevel, __VA_ARGS__); \
+    } while (false)
+
+#define MM_LOG_IN(CATEGORY, LEVEL, ...) \
+    do { \
+        const LogCategory &localCategory = (CATEGORY); \
+        LogLevel localLevel = (LEVEL); \
+        if (::detail::logger->shouldLog(localCategory, localLevel)) \
+            ::detail::logger->log(localCategory, localLevel, __VA_ARGS__); \
+    } while (false)
+
+#define MM_TRACE(...) MM_LOG(LOG_TRACE, __VA_ARGS__)
+#define MM_DEBUG(...) MM_LOG(LOG_DEBUG, __VA_ARGS__)
+#define MM_INFO(...) MM_LOG(LOG_INFO, __VA_ARGS__)
+#define MM_WARNING(...) MM_LOG(LOG_WARNING, __VA_ARGS__)
+#define MM_ERROR(...) MM_LOG(LOG_ERROR, __VA_ARGS__)
+#define MM_CRITICAL(...) MM_LOG(LOG_CRITICAL, __VA_ARGS__)
+
+#define MM_TRACE_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_TRACE, __VA_ARGS__)
+#define MM_DEBUG_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_DEBUG, __VA_ARGS__)
+#define MM_INFO_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_INFO, __VA_ARGS__)
+#define MM_WARNING_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_WARNING, __VA_ARGS__)
+#define MM_ERROR_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_ERROR, __VA_ARGS__)
+#define MM_CRITICAL_IN(CATEGORY, ...) MM_LOG_IN(CATEGORY, LOG_CRITICAL, __VA_ARGS__)
 

--- a/src/Library/Logger/Tests/Logger_ut.cpp
+++ b/src/Library/Logger/Tests/Logger_ut.cpp
@@ -20,16 +20,16 @@ class TestLogSink : public LogSink {
 
 UNIT_TEST(Logger, GlobalLoggerIsAlwaysUsable) {
     // The global logger is never null - it points at the fallback until a user-created `Logger` takes over.
-    ASSERT_NE(logger, nullptr);
-    EXPECT_EQ(logger, detail::fallbackLogger());
-    EXPECT_NE(logger->sink(), nullptr);
+    ASSERT_NE(detail::logger, nullptr);
+    EXPECT_EQ(detail::logger, detail::fallbackLogger());
+    EXPECT_NE(detail::logger->sink(), nullptr);
 }
 
 UNIT_TEST(Logger, FallbackLoggerWritesToStderr) {
-    ASSERT_EQ(logger, detail::fallbackLogger()); // Otherwise a stray user-created logger is still installed.
+    ASSERT_EQ(detail::logger, detail::fallbackLogger()); // Otherwise a stray user-created logger is still installed.
 
     testing::internal::CaptureStderr();
-    logger->error("fallback message");
+    MM_ERROR("fallback message");
     std::string captured = testing::internal::GetCapturedStderr();
 
     EXPECT_TRUE(captured.contains("fallback message"));
@@ -37,18 +37,18 @@ UNIT_TEST(Logger, FallbackLoggerWritesToStderr) {
 }
 
 UNIT_TEST(Logger, UserLoggerReplacesFallbackAndGivesItBack) {
-    ASSERT_EQ(logger, detail::fallbackLogger());
+    ASSERT_EQ(detail::logger, detail::fallbackLogger());
 
     TestLogSink sink;
     std::unique_ptr<Logger> userLogger = std::make_unique<Logger>(LOG_TRACE, &sink);
 
-    EXPECT_EQ(logger, userLogger.get());
-    logger->info("routed to the sink");
+    EXPECT_EQ(detail::logger, userLogger.get());
+    MM_INFO("routed to the sink");
     ASSERT_EQ(sink.messages.size(), 1);
     EXPECT_EQ(sink.messages[0], "routed to the sink");
 
     userLogger.reset();
 
     // Destroying a user-created logger puts the fallback back, so that logging during shutdown still works.
-    EXPECT_EQ(logger, detail::fallbackLogger());
+    EXPECT_EQ(detail::logger, detail::fallbackLogger());
 }

--- a/src/Library/Platform/Null/NullEventLoop.cpp
+++ b/src/Library/Platform/Null/NullEventLoop.cpp
@@ -24,5 +24,5 @@ void NullEventLoop::processMessages(PlatformEventHandler *eventHandler) {
 
 void NullEventLoop::waitForMessages() {
     // Null platform doesn't receive messages. In theory, we should deadlock here, but this makes no sense tbh.
-    logger->error("Calls to NullEventLoop::waitForMessages should never happen. Null platform never waits.");
+    MM_ERROR("Calls to NullEventLoop::waitForMessages should never happen. Null platform never waits.");
 }

--- a/src/Library/Platform/Null/NullPlatform.cpp
+++ b/src/Library/Platform/Null/NullPlatform.cpp
@@ -5,14 +5,11 @@
 #include <vector>
 #include <string>
 
-#include "Library/Logger/Logger.h"
-
 #include "NullPlatformSharedState.h"
 #include "NullWindow.h"
 #include "NullEventLoop.h"
 
 NullPlatform::NullPlatform(NullPlatformOptions options): _state(std::make_unique<NullPlatformSharedState>(std::move(options))) {
-    assert(logger); // Some of NullPlatform classes log.
 }
 
 NullPlatform::~NullPlatform() = default;

--- a/src/Library/Platform/Sdl/SdlPlatform.cpp
+++ b/src/Library/Platform/Sdl/SdlPlatform.cpp
@@ -2,7 +2,6 @@
 
 #include <SDL3/SDL.h>
 
-#include <cassert>
 #include <memory>
 #include <vector>
 #include <string>
@@ -21,12 +20,10 @@ static void SDLCALL sdlLogCallback(void *userdata, int category, SDL_LogPriority
     if (category == SDL_LOG_CATEGORY_ASSERT)
         level = LOG_CRITICAL; // This is an assertion, damn it! But SDL issues these at SDL_LOG_PRIORITY_WARN.
 
-    logger->log(SdlPlatformSharedState::logCategory(), level, "{}", message);
+    MM_LOG_IN(SdlPlatformSharedState::logCategory(), level, "{}", message);
 }
 
 SdlPlatform::SdlPlatform() {
-    assert(logger);
-
     _state = std::make_unique<SdlPlatformSharedState>();
 
     SDL_SetLogOutputFunction(&sdlLogCallback, _state.get());

--- a/src/Library/Platform/Sdl/SdlPlatformSharedState.cpp
+++ b/src/Library/Platform/Sdl/SdlPlatformSharedState.cpp
@@ -28,7 +28,7 @@ void SdlPlatformSharedState::logSdlError(const char *sdlFunctionName) {
     const char *errorMessage = SDL_GetError();
     if (!errorMessage || *errorMessage == '\0') // Not sure if SDL_GetError can return nullptr, but it definitely can return an empty string.
         errorMessage = "No error";
-    logger->error(logCategory(), "SDL error in {}: {}", sdlFunctionName, errorMessage);
+    MM_ERROR_IN(logCategory(), "SDL error in {}: {}", sdlFunctionName, errorMessage);
 }
 
 const LogCategory &SdlPlatformSharedState::logCategory() {

--- a/src/Library/Snd/SndReader.cpp
+++ b/src/Library/Snd/SndReader.cpp
@@ -85,11 +85,11 @@ Blob SndReader::read(std::string_view filename) const {
         } catch (const Exception &e) {
             result = zlib::uncompressBestEffort(compressed, entry.decompressedSize);
             if (!result) {
-                logger->warning("SndReader: failed to decompress '{}', skipping: {}", path, e.what());
+                MM_WARNING("SndReader: failed to decompress '{}', skipping: {}", path, e.what());
                 return Blob();
             }
-            logger->warning("SndReader: '{}' has corrupt checksum, recovered {} of {} expected bytes",
-                            path, result.size(), entry.decompressedSize);
+            MM_WARNING("SndReader: '{}' has corrupt checksum, recovered {} of {} expected bytes",
+                       path, result.size(), entry.decompressedSize);
         }
     }
     return result.withDisplayPath(path);

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -57,7 +57,7 @@ void AudioPlayer::MusicPlayTrack(MusicId eTrack) {
 
         std::string file_path = fmt::format("music/{}.mp3", std::to_underlying(eTrack));
         if (!dfs->exists(file_path)) {
-            logger->warning("AudioPlayer: {} not found", file_path);
+            MM_WARNING("AudioPlayer: {} not found", file_path);
             return;
         }
 
@@ -197,7 +197,7 @@ void AudioPlayer::playSound(SoundId eSoundID, SoundPlaybackMode mode, Pid pid) {
 
     SoundInfo *si = pSoundList->soundInfo(eSoundID);
     if (!si) {
-        logger->warning("AudioPlayer: sound id {} not found", std::to_underlying(eSoundID));
+        MM_WARNING("AudioPlayer: sound id {} not found", std::to_underlying(eSoundID));
         return;
     }
 
@@ -307,7 +307,7 @@ void AudioPlayer::playSound(SoundId eSoundID, SoundPlaybackMode mode, Pid pid) {
 
             default: {
                 result = _regularSoundPool.playNew(sample, si->dataSource);
-                logger->warning("Unexpected object type from Pid in playSound");
+                MM_WARNING("Unexpected object type from Pid in playSound");
                 break;
             }
         }
@@ -322,23 +322,23 @@ void AudioPlayer::playSound(SoundId eSoundID, SoundPlaybackMode mode, Pid pid) {
     switch (result) {
         case SOUND_PLAYBACK_FAILED:
             if (si->name.empty()) {
-                logger->warning("AudioPlayer: failed to play audio {} with name '{}'", std::to_underlying(eSoundID), si->name);
+                MM_WARNING("AudioPlayer: failed to play audio {} with name '{}'", std::to_underlying(eSoundID), si->name);
             } else {
-                logger->warning("AudioPlayer: failed to play audio {}", std::to_underlying(eSoundID));
+                MM_WARNING("AudioPlayer: failed to play audio {}", std::to_underlying(eSoundID));
             }
             break;
         case SOUND_PLAYBACK_SKIPPED:
             if (si->name.empty()) {
-                logger->trace("AudioPlayer: skipped playing sound {}", std::to_underlying(eSoundID));
+                MM_TRACE("AudioPlayer: skipped playing sound {}", std::to_underlying(eSoundID));
             } else {
-                logger->trace("AudioPlayer: skipped playing sound {} with name '{}'", std::to_underlying(eSoundID), si->name);
+                MM_TRACE("AudioPlayer: skipped playing sound {} with name '{}'", std::to_underlying(eSoundID), si->name);
             }
             break;
         case SOUND_PLAYBACK_SUCCEEDED:
             if (si->name.empty()) {
-                logger->trace("AudioPlayer: playing sound {}", std::to_underlying(eSoundID));
+                MM_TRACE("AudioPlayer: playing sound {}", std::to_underlying(eSoundID));
             } else {
-                logger->trace("AudioPlayer: playing sound {} with name '{}'", std::to_underlying(eSoundID), si->name);
+                MM_TRACE("AudioPlayer: playing sound {} with name '{}'", std::to_underlying(eSoundID), si->name);
             }
             break;
         default:
@@ -358,13 +358,13 @@ bool AudioPlayer::loadSoundDataSource(SoundInfo* si) {
         }
 
         if (!buffer) {
-            logger->warning("AudioPlayer: failed to load sound {} ({})", std::to_underlying(si->soundId), si->name);
+            MM_WARNING("AudioPlayer: failed to load sound {} ({})", std::to_underlying(si->soundId), si->name);
             return false;
         }
 
         si->dataSource = CreateAudioBufferDataSource(std::move(buffer));
         if (!si->dataSource) {
-            logger->warning("AudioPlayer: failed to create sound data source {} ({})", std::to_underlying(si->soundId), si->name);
+            MM_WARNING("AudioPlayer: failed to create sound data source {} ({})", std::to_underlying(si->soundId), si->name);
             return false;
         }
 
@@ -426,7 +426,7 @@ bool AudioPlayer::isWalkingSoundPlays() {
 float AudioPlayer::getSoundLength(SoundId eSoundID) {
     SoundInfo* si = pSoundList->soundInfo(eSoundID);
     if (!si) {
-        logger->warning("AudioPlayer: sound id {} not found", std::to_underlying(eSoundID));
+        MM_WARNING("AudioPlayer: sound id {} not found", std::to_underlying(eSoundID));
         return 0.0f;
     }
 
@@ -467,7 +467,7 @@ void PlayLevelMusic() {
 
 Blob AudioPlayer::LoadSound(std::string_view pSoundName) {
     if (!_sndReader.exists(pSoundName)) {
-        logger->warning("AudioPlayer: {} can't load sound header!", pSoundName);
+        MM_WARNING("AudioPlayer: {} can't load sound header!", pSoundName);
         return Blob();
     }
 

--- a/src/Media/Audio/OpenALAudioDataSource.cpp
+++ b/src/Media/Audio/OpenALAudioDataSource.cpp
@@ -49,7 +49,7 @@ bool OpenALAudioDataSource::Open() {
                         break;
                 }
             }
-            logger->error("Unsupported number of audio channels: {}", num_channels);
+            MM_ERROR("Unsupported number of audio channels: {}", num_channels);
     }
 
     while (true) {

--- a/src/Media/Audio/OpenALSoundProvider.cpp
+++ b/src/Media/Audio/OpenALSoundProvider.cpp
@@ -16,7 +16,7 @@ bool checkOpenALError() {
     }
 
     const char *message = alGetString(code1);
-    logger->warning("OpenAL: error #{} \"{}\"", code1, message ? message : "");
+    MM_WARNING("OpenAL: error #{} \"{}\"", code1, message ? message : "");
 
     return true;
 }
@@ -44,7 +44,7 @@ bool OpenALSoundProvider::Initialize() {
 
     if (device_names) {
         for (const char *device_name = device_names; device_name[0]; device_name += strlen(device_name) + 1) {
-            logger->info("OpenAL: device found \"{}\"", device_name);
+            MM_INFO("OpenAL: device found \"{}\"", device_name);
         }
     }
 
@@ -53,7 +53,7 @@ bool OpenALSoundProvider::Initialize() {
     device = alcOpenDevice(defname);
     if (device == nullptr) {
         checkOpenALError();
-        logger->warning("OpenAL: Default sound device not present");
+        MM_WARNING("OpenAL: Default sound device not present");
         return false;
     }
 
@@ -125,19 +125,19 @@ void OpenALSoundProvider::DeleteBuffers(StreamingTrackBuffer *track, int type) {
     int count = 0;
     alGetSourcei(track->source_id, type, &count);
     if (checkOpenALError()) {
-        logger->warning("OpenAL: Fail to get buffers count.");
+        MM_WARNING("OpenAL: Fail to get buffers count.");
         assert(false);
     }
     if (count > 0) {
         unsigned int *buffer_ids = new unsigned int[count];
         alSourceUnqueueBuffers(track->source_id, count, buffer_ids);
         if (checkOpenALError()) {
-            logger->warning("OpenAL: Fail to unqueue buffers.");
+            MM_WARNING("OpenAL: Fail to unqueue buffers.");
             assert(false);
         } else {
             alDeleteBuffers(count, buffer_ids);
             if (checkOpenALError()) {
-                logger->warning("OpenAL: Fail to delete buffers.");
+                MM_WARNING("OpenAL: Fail to delete buffers.");
                 assert(false);
             }
         }
@@ -157,7 +157,7 @@ void OpenALSoundProvider::DeleteStreamingTrack(StreamingTrackBuffer **buffer) {
     }
     alSourcei(track->source_id, AL_LOOPING, AL_FALSE);
     if (checkOpenALError()) {
-        logger->warning("OpenAL: Fail to disable looping.");
+        MM_WARNING("OpenAL: Fail to disable looping.");
         assert(false);
     }
 
@@ -201,7 +201,7 @@ OpenALSoundProvider::CreateStreamingTrack16(int num_channels, int sample_rate,
                         break;
                 }
             }
-            logger->error("Unsupported number of audio channels: {}", num_channels);
+            MM_ERROR("Unsupported number of audio channels: {}", num_channels);
     }
 
     unsigned int al_source = -1;

--- a/src/Media/Audio/OpenALTrack16.cpp
+++ b/src/Media/Audio/OpenALTrack16.cpp
@@ -162,7 +162,7 @@ void OpenALTrack16::DrainBuffers() {
     ALint num_processed_buffers = 0;
     alGetSourcei(al_source, AL_BUFFERS_PROCESSED, &num_processed_buffers);
     if (checkOpenALError()) {
-        logger->warning("OpenAL: Failed to get played buffers");
+        MM_WARNING("OpenAL: Failed to get played buffers");
         return;
     }
 
@@ -170,14 +170,14 @@ void OpenALTrack16::DrainBuffers() {
         ALuint buffer;
         alSourceUnqueueBuffers(al_source, 1, &buffer);
         if (checkOpenALError()) {
-            logger->warning("OpenAL: Failed to unqueue played buffer");
+            MM_WARNING("OpenAL: Failed to unqueue played buffer");
         } else {
             ALint size = 0;
             alGetBufferi(buffer, AL_SIZE, &size);
             uiReservedData -= size;
             alDeleteBuffers(1, &buffer);
             if (checkOpenALError()) {
-                logger->warning("OpenAL: Failed to delete played buffer");
+                MM_WARNING("OpenAL: Failed to delete played buffer");
             }
         }
     }

--- a/src/Media/AudioBaseDataSource.cpp
+++ b/src/Media/AudioBaseDataSource.cpp
@@ -25,7 +25,7 @@ bool AudioBaseDataSource::Open() {
     // Retrieve stream information
     if (avformat_find_stream_info(pFormatContext, nullptr) < 0) {
         Close();
-        logger->warning("ffmpeg: Unable to find stream info");
+        MM_WARNING("ffmpeg: Unable to find stream info");
         return false;
     }
 
@@ -38,7 +38,7 @@ bool AudioBaseDataSource::Open() {
                                        -1, &codec, 0);
     if (iStreamIndex < 0) {
         Close();
-        logger->warning("ffmpeg: Unable to find audio stream");
+        MM_WARNING("ffmpeg: Unable to find audio stream");
         return false;
     }
 
@@ -66,12 +66,12 @@ bool AudioBaseDataSource::Open() {
         pCodecContext->sample_fmt, pCodecContext->sample_rate, 0, nullptr);
     if (status < 0) {
         Close();
-        logger->warning("ffmpeg: Failed to set converter options");
+        MM_WARNING("ffmpeg: Failed to set converter options");
         return false;
     }
     if (swr_init(pConverter) < 0) {
         Close();
-        logger->warning("ffmpeg: Failed to create converter");
+        MM_WARNING("ffmpeg: Failed to create converter");
         return false;
     }
 

--- a/src/Media/AudioBufferDataSource.cpp
+++ b/src/Media/AudioBufferDataSource.cpp
@@ -29,7 +29,7 @@ bool AudioBufferDataSource::Open() {
 
     // Open audio file
     if (avformat_open_input(&pFormatContext, _ioContext.blob().displayPath().c_str(), nullptr, nullptr) < 0) {
-        logger->warning("ffmpeg: Unable to open input buffer");
+        MM_WARNING("ffmpeg: Unable to open input buffer");
         return false;
     }
 

--- a/src/Media/FFmpegLogProxy.cpp
+++ b/src/Media/FFmpegLogProxy.cpp
@@ -7,6 +7,8 @@ extern "C" {
 #include <cassert>
 #include <mutex>
 
+#include "Library/Logger/Logger.h"
+
 #include "FFmpegLogSource.h"
 
 // Category should be a global so that it's registered at program startup.
@@ -24,8 +26,7 @@ static void ffmpegLogCallback(void *ptr, int level, const char *format, va_list 
     globalFFmpegLogger->log(ptr, level, format, args);
 }
 
-FFmpegLogProxy::FFmpegLogProxy(Logger *logger): _logger(logger) {
-    assert(logger);
+FFmpegLogProxy::FFmpegLogProxy() {
     assert(globalFFmpegLogger == nullptr);
     globalFFmpegLogger = this;
 
@@ -46,12 +47,12 @@ void FFmpegLogProxy::log(void *ptr, int level, const char *format, va_list args)
     char buffer[4096];
     int status = av_log_format_line2(ptr, level, format, args, buffer, sizeof(buffer), &state.prefixFlag);
     if (status < 0) {
-        _logger->trace(globalFFmpegLogCategory, "av_log_format_line2 failed with error code {}", status);
+        MM_TRACE_IN(globalFFmpegLogCategory, "av_log_format_line2 failed with error code {}", status);
     } else {
         state.message += buffer;
         if (state.message.ends_with('\n')) {
             state.message.pop_back(); // Drop the '\n'.
-            _logger->log(globalFFmpegLogCategory, FFmpegLogSource::translateFFmpegLogLevel(level), "{}", state.message);
+            MM_LOG_IN(globalFFmpegLogCategory, FFmpegLogSource::translateFFmpegLogLevel(level), "{}", state.message);
             state.message.clear();
         }
     }

--- a/src/Media/FFmpegLogProxy.h
+++ b/src/Media/FFmpegLogProxy.h
@@ -6,11 +6,9 @@
 #include <string>
 #include <thread>
 
-#include "Library/Logger/Logger.h"
-
 class FFmpegLogProxy {
  public:
-    explicit FFmpegLogProxy(Logger *logger);
+    FFmpegLogProxy();
     ~FFmpegLogProxy();
 
     void log(void *ptr, int level, const char *format, va_list args);
@@ -22,6 +20,5 @@ class FFmpegLogProxy {
     };
 
  private:
-    Logger *_logger = nullptr;
     std::unordered_map<std::thread::id, LogState> _stateByThreadId;
 };

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -32,6 +32,8 @@ extern "C" {
 
 #include "GUI/GUIMessageQueue.h"
 
+#include "Library/Logger/Logger.h"
+
 #include "Media/Audio/AudioPlayer.h"
 #include "Media/Audio/OpenALSoundProvider.h"
 #include "Media/FFmpegLogProxy.h"
@@ -76,7 +78,7 @@ class AVStreamWrapper {
         if (dec_ctx != nullptr) {
             // Close the codec and free the context.
             avcodec_free_context(&dec_ctx);
-            logger->trace("ffmpeg: close decoder context file");
+            MM_TRACE("ffmpeg: close decoder context file");
         }
     }
 
@@ -86,7 +88,7 @@ class AVStreamWrapper {
         stream_idx = av_find_best_stream(format_ctx, type_, -1, -1, &dec, 0);
         if (stream_idx < 0) {
             close();
-            logger->warning("ffmpeg: unable to find audio stream");
+            MM_WARNING("ffmpeg: unable to find audio stream");
             return false;
         }
 
@@ -136,13 +138,13 @@ class AVAudioStream : public AVStreamWrapper {
             dec_ctx->sample_rate, &dec_ctx->ch_layout, dec_ctx->sample_fmt,
             dec_ctx->sample_rate, 0, nullptr);
         if (status < 0) {
-            logger->warning("ffmpeg: swr_alloc_set_opts2 failed");
+            MM_WARNING("ffmpeg: swr_alloc_set_opts2 failed");
             swr_free(&converter);
             converter = nullptr;
             return false;
         }
         if (swr_init(converter) < 0) {
-            logger->warning("ffmpeg: swr_init failed");
+            MM_WARNING("ffmpeg: swr_init failed");
             swr_free(&converter);
             converter = nullptr;
             return false;
@@ -338,7 +340,7 @@ class Movie : public IMovie {
         if (format_ctx) {
             // Close the video file
             avformat_close_input(&format_ctx);
-            logger->trace("close video format context file\n");
+            MM_TRACE("close video format context file\n");
             format_ctx = nullptr;
         }
     }
@@ -346,14 +348,14 @@ class Movie : public IMovie {
     bool Load(const std::string &fileName) {  // Загрузка
         // Open video file
         if (avformat_open_input(&format_ctx, fileName.c_str(), nullptr, nullptr) < 0) {
-            logger->warning("ffmpeg: Unable to open input file");
+            MM_WARNING("ffmpeg: Unable to open input file");
             Close();
             return false;
         }
 
         // Retrieve stream information
         if (avformat_find_stream_info(format_ctx, nullptr) < 0) {
-            logger->warning("ffmpeg: Unable to find stream info");
+            MM_WARNING("ffmpeg: Unable to find stream info");
             Close();
             return false;
         }
@@ -364,7 +366,7 @@ class Movie : public IMovie {
         audio.open(format_ctx);
 
         if (!video.open(format_ctx)) {
-            logger->error("Cannot open video stream: {}", fileName);
+            MM_ERROR("Cannot open video stream: {}", fileName);
             Close();
             return false;
         }
@@ -478,17 +480,17 @@ class Movie : public IMovie {
                 if (buffer) buffq.push(std::move(buffer));
             }
         }
-        logger->trace("Audio Packets Queued");
+        MM_TRACE("Audio Packets Queued");
 
         // reset video to start
         int err = avformat_seek_file(format_ctx, -1, 0, 0, 0, AVSEEK_FLAG_BACKWARD);
         //int err = av_seek_frame(format_ctx, -1, 0, AVSEEK_FLAG_BACKWARD | AVSEEK_FLAG_ANY);
         if (err < 0) {
-            logger->warning("Seek to start failed! - Exit Movie");
+            MM_WARNING("Seek to start failed! - Exit Movie");
             return;
         }
         start_time = std::chrono::system_clock::now();
-        logger->trace("Video stream reset");
+        MM_TRACE("Video stream reset");
 
         int lastvideopts = -1;
         int desired_frame_number;
@@ -594,17 +596,17 @@ class Movie : public IMovie {
                     if (buffer) _binkBuffer.push(std::move(buffer));
                 }
             }
-            logger->trace("Audio Packets Queued");
+            MM_TRACE("Audio Packets Queued");
 
             // reset video to start
             int err = avformat_seek_file(format_ctx, -1, 0, 0, 0, AVSEEK_FLAG_BACKWARD);
             //int err = av_seek_frame(format_ctx, -1, 0, AVSEEK_FLAG_BACKWARD | AVSEEK_FLAG_ANY);
             if (err < 0) {
-                logger->warning("Seek to start failed! - Exit Movie");
+                MM_WARNING("Seek to start failed! - Exit Movie");
                 return false;
             }
             start_time = std::chrono::system_clock::now();
-            logger->trace("Video stream reset");
+            MM_TRACE("Video stream reset");
 
             _lastVideoPts = -1;
             _currentTime = std::chrono::system_clock::now();
@@ -838,7 +840,7 @@ void MPlayer::PlayFullscreenMovie(std::string_view pFilename) {
     pMovie_Track->Play();
 
     if (pMovie->GetFormat() == "bink") {
-        logger->trace("bink file");
+        MM_TRACE("bink file");
         pMovie->PlayBink();
     } else {
         GraphicsImage *tex = nullptr;
@@ -936,7 +938,7 @@ void MPlayer::Unload() {
 // for video//////////////////////////////////////////////////////////////////
 
 MPlayer::MPlayer() {
-    logProxy = std::make_unique<FFmpegLogProxy>(logger);
+    logProxy = std::make_unique<FFmpegLogProxy>();
     pMovie_Track = nullptr;
 
     if (!provider) {

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -374,7 +374,7 @@ Character *getCharacterByIndex(int characterIndex) {
         return &pParty->pCharacters[characterIndex];
     }
 
-    logger->warning("Invalid character index. Asked for: {} but the party size is: {}", characterIndex, pParty->pCharacters.size());
+    MM_WARNING("Invalid character index. Asked for: {} but the party size is: {}", characterIndex, pParty->pCharacters.size());
     return nullptr;
 }
 

--- a/src/Scripting/InputScriptEventHandler.cpp
+++ b/src/Scripting/InputScriptEventHandler.cpp
@@ -21,7 +21,7 @@ bool InputScriptEventHandler::keyPressEvent(const PlatformKeyEvent *event) {
                 return result;
             }
         } catch (const sol::error &e) {
-            logger->error(ScriptingSystem::ScriptingLogCategory, "An unexpected error has occurred: {}", e.what());
+            MM_ERROR_IN(ScriptingSystem::ScriptingLogCategory, "An unexpected error has occurred: {}", e.what());
         }
     }
 

--- a/src/Scripting/LoggerBindings.cpp
+++ b/src/Scripting/LoggerBindings.cpp
@@ -2,13 +2,27 @@
 
 #include "Library/Logger/Logger.h"
 
+#include "ScriptingSystem.h"
+
 sol::table LoggerBindings::createBindingTable(sol::state_view &solState) const {
     return solState.create_table_with(
-        "info", sol::as_function([](std::string_view message) { logger->info("{}", message); }),
-        "trace", sol::as_function([](std::string_view message) { logger->trace("{}", message); }),
-        "debug", sol::as_function([](std::string_view message) { logger->debug("{}", message); }),
-        "warning", sol::as_function([](std::string_view message) { logger->warning("{}", message); }),
-        "error", sol::as_function([](std::string_view message) { logger->error("{}", message); }),
-        "critical", sol::as_function([](std::string_view message) { logger->critical("{}", message); })
+        "info", sol::as_function([](std::string_view message) {
+            MM_INFO_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        }),
+        "trace", sol::as_function([](std::string_view message) {
+            MM_TRACE_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        }),
+        "debug", sol::as_function([](std::string_view message) {
+            MM_DEBUG_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        }),
+        "warning", sol::as_function([](std::string_view message) {
+            MM_WARNING_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        }),
+        "error", sol::as_function([](std::string_view message) {
+            MM_ERROR_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        }),
+        "critical", sol::as_function([](std::string_view message) {
+            MM_CRITICAL_IN(ScriptingSystem::ScriptingLogCategory, "{}", message);
+        })
     );
 }

--- a/src/Scripting/ScriptingSystem.cpp
+++ b/src/Scripting/ScriptingSystem.cpp
@@ -91,7 +91,7 @@ void ScriptingSystem::_initBindingFunction() {
         if (auto itr = _bindings.find(tableName); itr != _bindings.end()) {
             return itr->second->createBindingTable(*_solState);
         }
-        logger->warning(ScriptingLogCategory, "Can't find a binding table with name: {}", tableName);
+        MM_WARNING_IN(ScriptingLogCategory, "Can't find a binding table with name: {}", tableName);
         return _solState->create_table();
     });
 }


### PR DESCRIPTION
Calling the Logger methods directly evaluates the message arguments even when the message is dropped by the log level check. The macros check
  the level first, so a disabled MM_TRACE costs a load and a compare.

  * `MM_LOG(level, ...)` plus `MM_TRACE` / `MM_DEBUG` / `MM_INFO` / `MM_WARNING` / `MM_ERROR` / `MM_CRITICAL` for the default category.
  * `MM_LOG_IN(category, level, ...)` plus the matching `_IN` variants for an explicit category.
  * All ~220 call sites migrated. The three that logged through a stored Logger pointer are gone too - `FFmpegLogProxy` no longer keeps one, and
  `LogStarter` uses the one it owns.
  * The global logger pointer moved into `namespace detail`, so the macros are the API. Two dead `assert(logger)` checks dropped along the way.
  * The Lua log bindings now log into the script category instead of the default one.

  Based on #2584, which the first commit belongs to.