### PR TITLE
Rename LightmapBuilder.cpp/.h to Lighting.cpp/.h

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -19,7 +19,7 @@
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Graphics/ParticleEngine.h"
 #include "Engine/Graphics/LightsStack.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Objects/Decoration.h"
 #include "Engine/Graphics/Outdoor.h"

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -14,7 +14,7 @@
 #include "Engine/Objects/DecorationList.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Objects/Decoration.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/LightsStack.h"
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/Indoor.h"

--- a/src/Engine/Graphics/CMakeLists.txt
+++ b/src/Engine/Graphics/CMakeLists.txt
@@ -13,7 +13,7 @@ set(ENGINE_GRAPHICS_SOURCES
         Image.cpp
         ImageLoader.cpp
         Indoor.cpp
-        LightmapBuilder.cpp
+        Lighting.cpp
         LightsStack.cpp
         LocationFunctions.cpp
         Outdoor.cpp
@@ -41,7 +41,7 @@ set(ENGINE_GRAPHICS_HEADERS
         Image.h
         ImageLoader.h
         Indoor.h
-        LightmapBuilder.h
+        Lighting.h
         LightsStack.h
         LocationFunctions.h
         LocationInfo.h

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -12,7 +12,7 @@
 
 #include "Library/Logger/Logger.h"
 
-#include "LightmapBuilder.h"
+#include "Lighting.h"
 
 //----- (0043B570) --------------------------------------------------------
 float Decal::Fade_by_time() {

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -13,7 +13,7 @@
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Objects/DecorationList.h"
 #include "Engine/Objects/Decoration.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/LightsStack.h"
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/ParticleEngine.h"

--- a/src/Engine/Graphics/Lighting.cpp
+++ b/src/Engine/Graphics/Lighting.cpp
@@ -1,6 +1,4 @@
-#include "LightmapBuilder.h"
-
-// TODO(pskelton): rename - lighting functions
+#include "Lighting.h"
 
 #include "Engine/Engine.h"
 

--- a/src/Engine/Graphics/Lighting.h
+++ b/src/Engine/Graphics/Lighting.h
@@ -1,12 +1,8 @@
 #pragma once
 
-// TODO(pskelton): rename - lighting functions
-
 struct LightsStack_StationaryLight_;
 struct LightsStack_MobileLight_;
 struct RenderBillboard;
-
-#define LIGHTMAP_FLAGS_USE_SPECULAR 0x01
 
 extern LightsStack_StationaryLight_ *pStationaryLightsStack;
 extern LightsStack_MobileLight_ *pMobileLightsStack;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -13,7 +13,7 @@
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Objects/DecorationList.h"
 #include "Engine/Objects/Decoration.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/LightsStack.h"
 #include "Engine/Graphics/ParticleEngine.h"
 #include "Engine/Graphics/Sprites.h"

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -14,7 +14,7 @@
 #include "Engine/Objects/SpriteObject.h"
 
 #include "Engine/Graphics/Camera.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/LightsStack.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/BspRenderer.h"

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -23,7 +23,7 @@
 #include "Engine/Graphics/BspRenderer.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/ImageLoader.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Objects/Decoration.h"
 #include "Engine/Graphics/LightsStack.h"

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -9,7 +9,7 @@
 
 #include "Engine/Graphics/Camera.h"
 #include "Engine/Graphics/Indoor.h"
-#include "Engine/Graphics/LightmapBuilder.h"
+#include "Engine/Graphics/Lighting.h"
 #include "Engine/Graphics/LightsStack.h"
 #include "Engine/Graphics/ParticleEngine.h"
 #include "Engine/Graphics/Sprites.h"


### PR DESCRIPTION
Nothing in these files builds lightmaps anymore - what's left is lighting
helpers and the light stack globals. Also drop LIGHTMAP_FLAGS_USE_SPECULAR,
which had no uses.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
