### PR TITLE
Rename GUIButton::sLabel to label

### DIFF
--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -32,7 +32,7 @@ class GUIButton {
     GUIWindow *pParent = nullptr;
     std::vector<GraphicsImage*> vTextures;
     InputAction action = INPUT_ACTION_INVALID;
-    std::string sLabel = ""; // TODO(Nik-RE-dev): rename properly. In most cases it is a hover hint for status bar.
+    std::string label = ""; // Shown in the status bar on hover. Dialogue options draw it as the option text.
     std::string field_75 = "";
 };
 

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -391,7 +391,7 @@ GUIButton *GUIWindow::CreateButton(Pointi position, Sizei dimensions,
     pButton->msg = msg;
     pButton->msg_param = msg_param;
     pButton->action = action;
-    pButton->sLabel = label;
+    pButton->label = label;
     pButton->vTextures = textures;
 
     vButtons.push_back(pButton);

--- a/src/GUI/UI/UIDialogue.cpp
+++ b/src/GUI/UI/UIDialogue.cpp
@@ -253,8 +253,8 @@ void GUIWindow_Dialogue::Update() {
         }
 
         DialogueId topic = (DialogueId)pButton->msg_param;
-        pButton->sLabel = npcDialogueOptionString(topic, pNPC);
-        if (pButton->sLabel.empty() && topic >= DIALOGUE_SCRIPTED_LINE_1 && topic <= DIALOGUE_SCRIPTED_LINE_6) {
+        pButton->label = npcDialogueOptionString(topic, pNPC);
+        if (pButton->label.empty() && topic >= DIALOGUE_SCRIPTED_LINE_1 && topic <= DIALOGUE_SCRIPTED_LINE_6) {
             pButton->msg_param = 0;
         }
 
@@ -271,7 +271,7 @@ void GUIWindow_Dialogue::Update() {
                 }
             }
             if (num_dead_actors == pActors.size()) {
-                pButton->sLabel = localization->str(LSTR_COLLECT_PRIZE);
+                pButton->label = localization->str(LSTR_COLLECT_PRIZE);
             }
         }
     }
@@ -286,7 +286,7 @@ void GUIWindow_Dialogue::Update() {
         GUIButton *pButton = pDialogueWindow->GetControl(i);
         if (!pButton)
             break;
-        all_text_height += assets->pFontArrus->CalcTextHeight(pButton->sLabel, window.w, 0);
+        all_text_height += assets->pFontArrus->CalcTextHeight(pButton->label, window.w, 0);
         index++;
     }
 
@@ -300,14 +300,14 @@ void GUIWindow_Dialogue::Update() {
             if (!pButton)
                 break;
             pButton->rect.y = v45 + v42;
-            int pTextHeight = assets->pFontArrus->CalcTextHeight(pButton->sLabel, window.w, 0);
+            int pTextHeight = assets->pFontArrus->CalcTextHeight(pButton->label, window.w, 0);
             pButton->rect.h = pTextHeight + 1;
             v42 = pButton->rect.y + pTextHeight - 1;
             Color pTextColor = ui_game_dialogue_option_normal_color;
             if (pDialogueWindow->pCurrentPosActiveItem == i) {
                 pTextColor = ui_game_dialogue_option_highlight_color;
             }
-            DrawTitleText(assets->pFontArrus.get(), 0, pButton->rect.y, pTextColor, pButton->sLabel, 3, window);
+            DrawTitleText(assets->pFontArrus.get(), 0, pButton->rect.y, pTextColor, pButton->label, 3, window);
         }
     }
     render->DrawQuad2D(ui_exit_cancel_button_background, {471, 445});

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1026,7 +1026,7 @@ void GameUI_WritePointedObjectStatusString() {
                         case BUTTON_TYPE_NORMAL:  // for dialogue window
                             if (pButton->Contains(pX, pY)) {
                                 if (shouldMirror(pWindow)) {
-                                    engine->_statusBar->setPermanent(pButton->sLabel);
+                                    engine->_statusBar->setPermanent(pButton->label);
                                 }
                                 pMessageType1 = (UIMessageType)pButton->uData;
                                 if (pMessageType1)
@@ -1049,7 +1049,7 @@ void GameUI_WritePointedObjectStatusString() {
                                     (pButton->rect.h * pButton->rect.h);
 
                                 if (ratioX + ratioY < 1.0) {
-                                    engine->_statusBar->setPermanent(pButton->sLabel);  // for character name
+                                    engine->_statusBar->setPermanent(pButton->label);  // for character name
                                     pMessageType2 = (UIMessageType)pButton->uData;
                                     if (pMessageType2 != 0)
                                         GameUI_handleHintMessage(pMessageType2, pButton->msg_param);
@@ -1138,7 +1138,7 @@ void GameUI_WritePointedObjectStatusString() {
                         if (pButton->Contains(mousePos)) {
                             pMessageType3 = (UIMessageType)pButton->uData;
                             if (pMessageType3 == 0) {  // For books
-                                engine->_statusBar->setPermanent(pButton->sLabel);
+                                engine->_statusBar->setPermanent(pButton->label);
                             } else {
                                 GameUI_handleHintMessage(pMessageType3, pButton->msg_param);
                             }
@@ -1158,7 +1158,7 @@ void GameUI_WritePointedObjectStatusString() {
                                 (pButton->rect.h * pButton->rect.h);
 
                             if (ratioX + ratioY < 1.0) {
-                                engine->_statusBar->setPermanent(pButton->sLabel);  // for character name
+                                engine->_statusBar->setPermanent(pButton->label);  // for character name
                                 pMessageType2 = (UIMessageType)pButton->uData;
                                 if (pMessageType2 != 0)
                                     GameUI_handleHintMessage(pMessageType2, pButton->msg_param);

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -848,7 +848,7 @@ void GUIWindow_House::drawOptions(std::vector<std::string> &optionsText, Color s
             int textHeight = assets->pFontArrus->CalcTextHeight(optionsText[i], window.w, 0);
             button->rect.y = spacing + offset;
             button->rect.h = textHeight + 6;
-            button->sLabel = optionsText[i];
+            button->label = optionsText[i];
             if (denseSpacing) {
                 offset += assets->pFontArrus->GetHeight() - 3 + textHeight;
             } else {
@@ -858,7 +858,7 @@ void GUIWindow_House::drawOptions(std::vector<std::string> &optionsText, Color s
         } else if (button) {
             button->rect.y = 0;
             button->rect.h = 0;
-            button->sLabel.clear();
+            button->label.clear();
         }
     }
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1128,7 +1128,7 @@ GAME_TEST(Issues, Issue2464) {
     // Find \"Goodbye\" button or any button with a label
     GUIButton *pTargetBtn = nullptr;
     for (GUIButton *pBtn : pDialogueWindow->vButtons) {
-        if (pBtn->uButtonType == BUTTON_TYPE_NORMAL && !pBtn->sLabel.empty()) {
+        if (pBtn->uButtonType == BUTTON_TYPE_NORMAL && !pBtn->label.empty()) {
             pTargetBtn = pBtn;
             break;
         }
@@ -1142,7 +1142,7 @@ GAME_TEST(Issues, Issue2464) {
     game.tick(10);
 
     // The status bar SHOULD contain the label for regular NPCs
-    EXPECT_EQ(engine->_statusBar->get(), pTargetBtn->sLabel);
+    EXPECT_EQ(engine->_statusBar->get(), pTargetBtn->label);
     test.stopTaping();
 
     // Exit dialogue
@@ -1167,7 +1167,7 @@ GAME_TEST(Issues, Issue2464) {
         // Find a service button in the house (like \"Exit Building\")
         GUIButton *pServiceBtn = nullptr;
         for (GUIButton *pBtn : pDialogueWindow->vButtons) {
-            if (pBtn->uButtonType == BUTTON_TYPE_NORMAL && !pBtn->sLabel.empty()) {
+            if (pBtn->uButtonType == BUTTON_TYPE_NORMAL && !pBtn->label.empty()) {
                 pServiceBtn = pBtn;
                 break;
             }
@@ -1180,7 +1180,7 @@ GAME_TEST(Issues, Issue2464) {
             game.tick(10);
 
             // The status bar should NOT contain the label for vendors/shops
-            EXPECT_FALSE(statusTape.contains(pServiceBtn->sLabel));
+            EXPECT_FALSE(statusTape.contains(pServiceBtn->label));
         }
     }
 }


### PR DESCRIPTION
Resolves `TODO(Nik-RE-dev): rename properly. In most cases it is a hover hint for status bar.`

"In most cases" was the catch - `UIGame.cpp` mirrors the field into the status bar on hover, but dialogue options draw it with `DrawTitleText` as the visible option text, so a hint-flavored name would be wrong for a third of the users. `label` matches the naming of the sibling fields and of `HouseNpcDesc::label` that feeds it, and the replacing comment states both roles.

Pure rename, 18 sites across 6 files, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
