### PR TITLE
Drop the experience comparison TODO

### DIFF
--- a/src/Engine/Evt/EvtInstruction.h
+++ b/src/Engine/Evt/EvtInstruction.h
@@ -51,6 +51,8 @@ class EvtInstruction {
         } npc_item_descr;
         struct {
             EvtVariable type;
+            // TODO(captainurist): parsed from a uint32 wire field, so on-disk values above INT_MAX wrap negative
+            //                     here and then trip asserts or corrupt uint64 counters like experience downstream.
             int value;
         } variable_descr;
         struct {

--- a/src/Engine/Evt/EvtInstruction.h
+++ b/src/Engine/Evt/EvtInstruction.h
@@ -51,8 +51,6 @@ class EvtInstruction {
         } npc_item_descr;
         struct {
             EvtVariable type;
-            // TODO(captainurist): parsed from a uint32 wire field, so on-disk values above INT_MAX wrap negative
-            //                     here and then trip asserts or corrupt uint64 counters like experience downstream.
             int value;
         } variable_descr;
         struct {

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3618,7 +3618,7 @@ bool Character::CompareVariable(EvtVariable VarNum, int pValue) {
         case VAR_Award:
             return _achievedAwardsBits[static_cast<AwardId>(pValue)];
         case VAR_Experience:
-            return this->experience >= pValue;  // TODO(_) change pValue to long long
+            return this->experience >= pValue;
         case VAR_QBits_QuestsDone:
             return pParty->_questBits[static_cast<QuestBit>(pValue)]; // TODO(captainurist): values coming from scripts should be bound-checked.
         case VAR_PlayerItemInHands:


### PR DESCRIPTION
Removes `TODO(_) change pValue to long long` from the `VAR_Experience` comparison in `Character.cpp` without acting on it, because the suggested fix would fix nothing and the scenario it guards against does not occur in practice.

The truncation the TODO was gesturing at happens at parse time: `variable_descr.value` is filled from a uint32 wire field into an `int`, so an on-disk threshold above INT_MAX has already wrapped negative before `CompareVariable` ever runs, and the always-on assert there turns it into a crash. The comparison itself is safe for everything that survives the assert, since `experience` is `uint64_t` and non-negative ints convert cleanly. Per review, event script values in unmodded play top out in the low millions, nowhere near INT_MAX, so the wire-width concern is theoretical and not worth a TODO either - the first commit moved it to the wire field where the wrap actually occurs, the second dropped it entirely.

Review of the surrounding code turned up real, currently unmarked int-width bugs in the sibling paths, deliberately left out of this comment-only PR as follow-up candidates:

- `SetVariable` (`Character.cpp:4072`): no non-negativity assert, a wrapped negative value sign-extends into `experience` as ~1.8e19
- `SubtractVariable` (`Character.cpp:5198`): `experience -= pValue` underflows when `pValue > experience` - the mana case above it clamps, experience doesn't, and this needs no out-of-range data to fire
- `AddVariable` (`Character.cpp:4684`): negative value wraps through uint64 addition and gets capped to 4e9
- Lua xp setter (`GameBindings.cpp:122`): assigns through `int`

🤖 Generated with [Claude Code](https://claude.com/claude-code)