### PR TITLE
Drop the TODO questioning the spellbook highlight handler

### DIFF
--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1713,7 +1713,6 @@ void GameUI_handleHintMessage(UIMessageType type, int param) {
         }
 
         case UIMSG_Spellbook_ShowHightlightedSpellInfo: {
-            // TODO(pskelton): this used to check if character had the spell activated - no longer required here ??
             if (!pParty->hasActiveCharacter())
                 break;
             SpellId selectedSpell = static_cast<SpellId>(param);


### PR DESCRIPTION
Resolves `TODO(pskelton): this used to check if character had the spell activated - no longer required here ??` in `UIGame.cpp`.

The answer to the `??` is a definitive yes. The message is stored as the hover hint of spellbook buttons and dispatched synchronously by the hover pass - it never travels through the message queue, so no stale-state race exists. The spellbook creates those buttons only for spells the character has, and under `debug.all_magic` every spell button is legitimately castable, with the popup code already handling the unowned case (grandmaster fallback). Character switching while the spellbook is open is blocked on both the portrait and keyboard paths, so the buttons can't outlive their character.

History turned out even cleaner than the TODO implies: the "removed" check was never live code - it entered the repo already commented out as a decompilation artifact, was condensed into the TODO in 2023, and no regression ever existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
