### PR TITLE
Use -1 as the no-floor-face sentinel and document the reset

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -548,7 +548,9 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     engine->SetUnderwater(isMapUnderwater(engine->_transitionMapId));
 
-    pParty->floor_face_id = 0; // TODO(captainurist): drop?
+    // Pressure plates fire when the party's floor face changes, and face ids are per-map, so a leftover id
+    // could fire or suppress a plate right after the transition.
+    pParty->floor_face_id = 0;
 
     engine->_currentLoadedMapId = engine->_transitionMapId;
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -548,9 +548,9 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     engine->SetUnderwater(isMapUnderwater(engine->_transitionMapId));
 
-    // Need to zero this one out. Pressure plates fire when the party's floor face changes, face ids are
+    // Need to reset this one. Pressure plates fire when the party's floor face changes, face ids are
     // per-map, and a leftover id could fire or suppress a plate right after the transition.
-    pParty->floor_face_id = 0;
+    pParty->floor_face_id = -1;
 
     engine->_currentLoadedMapId = engine->_transitionMapId;
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -276,14 +276,14 @@ void Engine::DrawGUI() {
             floor_level_str = fmt::format("BLV_GetFloorLevel: {}   face_id {}\nNodes: {}, Faces: {} ({}), Sectors: {}\n", floor_level, uFaceID, pBspRenderer->num_nodes, pBspRenderer->num_faces, pBLVRenderParams->uNumFacesRenderedThisFrame, pBspRenderer->uNumVisibleNotEmptySectors);
         } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
             bool on_water = false;
-            int bmodel_pid;
-            float floor_level = ODM_GetFloorLevel(pParty->pos, &on_water, &bmodel_pid);
+            int floor_face_id;
+            float floor_level = ODM_GetFloorLevel(pParty->pos, &on_water, &floor_face_id);
             floor_level_str = fmt::format(
                 "ODM_GetFloorLevel: {}   on_water: {}  on: {}\n",
                 floor_level, on_water ? "true" : "false",
-                bmodel_pid == -1
+                floor_face_id == -1
                     ? "---"
-                    : fmt::format("BModel={} Face={}", bmodel_pid >> 6, bmodel_pid & 0x3F)
+                    : fmt::format("BModel={} Face={}", floor_face_id >> 6, floor_face_id & 0x3F)
             );
         }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -548,8 +548,8 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
 
     engine->SetUnderwater(isMapUnderwater(engine->_transitionMapId));
 
-    // Pressure plates fire when the party's floor face changes, and face ids are per-map, so a leftover id
-    // could fire or suppress a plate right after the transition.
+    // Need to zero this one out. Pressure plates fire when the party's floor face changes, face ids are
+    // per-map, and a leftover id could fire or suppress a plate right after the transition.
     pParty->floor_face_id = 0;
 
     engine->_currentLoadedMapId = engine->_transitionMapId;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -281,7 +281,7 @@ void Engine::DrawGUI() {
             floor_level_str = fmt::format(
                 "ODM_GetFloorLevel: {}   on_water: {}  on: {}\n",
                 floor_level, on_water ? "true" : "false",
-                bmodel_pid == 0
+                bmodel_pid == -1
                     ? "---"
                     : fmt::format("BModel={} Face={}", bmodel_pid >> 6, bmodel_pid & 0x3F)
             );

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -785,13 +785,13 @@ void ProcessActorCollisionsODM(Actor &actor, bool isFlying) {
 
         Vec3f newPos = actor.pos + collision_state.adjusted_move_distance * collision_state.direction;
         bool isOnWater = false;
-        int modelPid = 0;
+        int modelPid = -1;
         float newFloorZ = ODM_GetFloorLevel(newPos, &isOnWater, &modelPid);
         if (isOnWater) {
             if (actor.pos.z < newFloorZ + 60) {
                 if (actor.aiState == Dead || actor.aiState == Dying ||
                     actor.aiState == Removed || actor.aiState == Disabled) {
-                    SpriteObject::createSplashObject(Vec3f(actor.pos.x, actor.pos.y, modelPid ? newFloorZ + 30 : newFloorZ + 60));
+                    SpriteObject::createSplashObject(Vec3f(actor.pos.x, actor.pos.y, modelPid != -1 ? newFloorZ + 30 : newFloorZ + 60));
                     actor.aiState = Removed;
                     break;
                 }
@@ -1085,7 +1085,7 @@ void ProcessPartyCollisionsODM(Vec3f *partyNewPos, Vec3f *partyInputSpeed, int *
         bool terr_slope_advance_y = pOutdoor->pTerrain.isSlopeTooHighByPos(Vec3f(partyNewPos->x, newPosLow.y, 0.0f));
 
         *partyNotOnModel = false;
-        if (!party_y_pid && !party_x_pid && !*floorFaceId) *partyNotOnModel = true;
+        if (party_y_pid == -1 && party_x_pid == -1 && *floorFaceId == -1) *partyNotOnModel = true;
 
         bool move_in_y = true;
         bool move_in_x = true;

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -785,13 +785,13 @@ void ProcessActorCollisionsODM(Actor &actor, bool isFlying) {
 
         Vec3f newPos = actor.pos + collision_state.adjusted_move_distance * collision_state.direction;
         bool isOnWater = false;
-        int modelPid = -1;
-        float newFloorZ = ODM_GetFloorLevel(newPos, &isOnWater, &modelPid);
+        int floorFaceId = -1;
+        float newFloorZ = ODM_GetFloorLevel(newPos, &isOnWater, &floorFaceId);
         if (isOnWater) {
             if (actor.pos.z < newFloorZ + 60) {
                 if (actor.aiState == Dead || actor.aiState == Dying ||
                     actor.aiState == Removed || actor.aiState == Disabled) {
-                    SpriteObject::createSplashObject(Vec3f(actor.pos.x, actor.pos.y, modelPid != -1 ? newFloorZ + 30 : newFloorZ + 60));
+                    SpriteObject::createSplashObject(Vec3f(actor.pos.x, actor.pos.y, floorFaceId != -1 ? newFloorZ + 30 : newFloorZ + 60));
                     actor.aiState = Removed;
                     break;
                 }
@@ -1077,15 +1077,15 @@ void ProcessPartyCollisionsODM(Vec3f *partyNewPos, Vec3f *partyInputSpeed, int *
 
         bool isOnWater = false;
         float allnewfloor = ODM_GetFloorLevel(newPosLow, &isOnWater, floorFaceId);
-        int party_y_pid;
-        float x_advance_floor = ODM_GetFloorLevel(Vec3f(newPosLow.x, partyNewPos->y, newPosLow.z), &isOnWater, &party_y_pid);
-        int party_x_pid;
-        float y_advance_floor = ODM_GetFloorLevel(Vec3f(partyNewPos->x, newPosLow.y, newPosLow.z), &isOnWater, &party_x_pid);
+        int party_y_face_id;
+        float x_advance_floor = ODM_GetFloorLevel(Vec3f(newPosLow.x, partyNewPos->y, newPosLow.z), &isOnWater, &party_y_face_id);
+        int party_x_face_id;
+        float y_advance_floor = ODM_GetFloorLevel(Vec3f(partyNewPos->x, newPosLow.y, newPosLow.z), &isOnWater, &party_x_face_id);
         bool terr_slope_advance_x = pOutdoor->pTerrain.isSlopeTooHighByPos(Vec3f(newPosLow.x, partyNewPos->y, 0.0f));
         bool terr_slope_advance_y = pOutdoor->pTerrain.isSlopeTooHighByPos(Vec3f(partyNewPos->x, newPosLow.y, 0.0f));
 
         *partyNotOnModel = false;
-        if (party_y_pid == -1 && party_x_pid == -1 && *floorFaceId == -1) *partyNotOnModel = true;
+        if (party_y_face_id == -1 && party_x_face_id == -1 && *floorFaceId == -1) *partyNotOnModel = true;
 
         bool move_in_y = true;
         bool move_in_x = true;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1755,7 +1755,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         int dist_x;
         bool not_in_model = false;
         bool bInWater = false;
-        int modelPID = -1;
+        int floorFaceId = -1;
 
         // 100 attempts to make a usuable spawn point
         for (; loop_cnt < 100; ++loop_cnt) {
@@ -1769,7 +1769,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
             enc_spawn_point.monsterIndex = enc_index;
 
             // get proposed floor level
-            enc_spawn_point.position.z = ODM_GetFloorLevel(enc_spawn_point.position, &bInWater, &modelPID);
+            enc_spawn_point.position.z = ODM_GetFloorLevel(enc_spawn_point.position, &bInWater, &floorFaceId);
 
             // check spawn point is not in a model
             for (BSPModel &model : pOutdoor->pBModels) {

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1755,7 +1755,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         int dist_x;
         bool not_in_model = false;
         bool bInWater = false;
-        int modelPID = 0;
+        int modelPID = -1;
 
         // 100 attempts to make a usuable spawn point
         for (; loop_cnt < 100; ++loop_cnt) {

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1495,7 +1495,7 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
     }
 
     // not hovering & stepped onto a new face => activate potential pressure plate.
-    if (!isAboveGround && pParty->floor_face_id != 0 && pParty->floor_face_id != faceId) {
+    if (!isAboveGround && pParty->floor_face_id != -1 && pParty->floor_face_id != faceId) {
         if (pIndoor->faces[faceId].attributes & FACE_PRESSURE_PLATE)
             faceEvent = pIndoor->faces[faceId].eventId;
     }

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -357,9 +357,9 @@ void OutdoorLocation::UpdateFog() {
 
 int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3f &pos) {
     bool is_on_water = false;
-    int bmodel_standing_on_pid = -1;
-    ODM_GetFloorLevel(pos, &is_on_water, &bmodel_standing_on_pid);
-    if (pParty->isAirborne() || bmodel_standing_on_pid != -1 || is_on_water) {
+    int floor_face_id = -1;
+    ODM_GetFloorLevel(pos, &is_on_water, &floor_face_id);
+    if (pParty->isAirborne() || floor_face_id != -1 || is_on_water) {
         return 2;
     }
 
@@ -1609,10 +1609,10 @@ void UpdateActors_ODM() {
             uIsFlying = 0;
 
         bool Slope_High = pOutdoor->pTerrain.isSlopeTooHighByPos(actor.pos);
-        int Model_On_PID = -1;
+        int Floor_Face_Id = -1;
         bool uIsOnWater = false;
-        float Floor_Level = ODM_GetFloorLevel(actor.pos, &uIsOnWater, &Model_On_PID);
-        bool Actor_On_Terrain = Model_On_PID == -1;
+        float Floor_Level = ODM_GetFloorLevel(actor.pos, &uIsOnWater, &Floor_Face_Id);
+        bool Actor_On_Terrain = Floor_Face_Id == -1;
 
         bool uIsAboveFloor = (actor.pos.z > (Floor_Level + 1));
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1477,7 +1477,8 @@ void ODM_ProcessPartyActions() {
                 if (!partyNotTouchingFloor || partyCloseToGround) {
                     int modelId = pParty->floor_face_id >> 6;
                     int faceId = pParty->floor_face_id & 0x3F;
-                    bool isModelWalk = !partyNotOnModel && pOutdoor->pBModels[modelId].faces[faceId].Visible();
+                    bool isModelWalk = !partyNotOnModel && pParty->floor_face_id != -1 &&
+                                       pOutdoor->pBModels[modelId].faces[faceId].Visible();
                     SoundId sound = SOUND_Invalid;
                     if (partyIsRunning) {
                         if (walkDelta >= 4) {

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -357,9 +357,9 @@ void OutdoorLocation::UpdateFog() {
 
 int OutdoorLocation::getNumFoodRequiredToRestInCurrentPos(const Vec3f &pos) {
     bool is_on_water = false;
-    int bmodel_standing_on_pid = 0;
+    int bmodel_standing_on_pid = -1;
     ODM_GetFloorLevel(pos, &is_on_water, &bmodel_standing_on_pid);
-    if (pParty->isAirborne() || bmodel_standing_on_pid || is_on_water) {
+    if (pParty->isAirborne() || bmodel_standing_on_pid != -1 || is_on_water) {
         return 2;
     }
 
@@ -842,10 +842,13 @@ float ODM_GetFloorLevel(const Vec3f &pos, bool *pIsOnWater, int *faceId) {
             if (surface_count >= 20)
                 break;
         }
+
+        if (surface_count >= 20)
+            break; // The break above only exits the face loop, without this one the next model overruns the arrays.
     }
 
     if (surface_count == 1) {
-        *faceId = 0;
+        *faceId = -1;
         return odm_floor_level[0]; // No bmodels, just the terrain.
     }
 
@@ -862,10 +865,7 @@ float ODM_GetFloorLevel(const Vec3f &pos, bool *pIsOnWater, int *faceId) {
             current_idx = i;
         }
     }
-    if (!current_idx)
-        *faceId = 0;
-    else
-        *faceId = current_Face_id[current_idx] | (current_BModel_id[current_idx] << 6);
+    *faceId = current_Face_id[current_idx] | (current_BModel_id[current_idx] << 6); // -1 for terrain, the sentinels merge.
 
     if (current_idx)
         *pIsOnWater = pOutdoor->pBModels[current_BModel_id[current_idx]].faces[current_Face_id[current_idx]].isFluid();
@@ -940,11 +940,11 @@ void ODM_ProcessPartyActions() {
             waterWalkActive = false;
     }
 
-    int floorFaceId = 0;
+    int floorFaceId = -1;
     bool partyIsOnWater = false;
 
     float floorZ = ODM_GetFloorLevel(pParty->pos, &partyIsOnWater, &floorFaceId);
-    bool partyNotOnModel = floorFaceId == 0;
+    bool partyNotOnModel = floorFaceId == -1;
     int currentGroundLevel = floorZ + 1;
 
     bool partyHasFeatherFall = pParty->FeatherFallActive() || pParty->wearsItem(ITEM_ARTIFACT_LADYS_ESCORT)
@@ -983,7 +983,7 @@ void ODM_ProcessPartyActions() {
      // is party standing on any trigger faces
     int triggerID = 0;
     if (!partyNotTouchingFloor) {
-        if (pParty->floor_face_id != floorFaceId && floorFaceId) {
+        if (pParty->floor_face_id != floorFaceId && floorFaceId != -1) {
             int BModel_id = floorFaceId >> 6;
             if (BModel_id < pOutdoor->pBModels.size()) {
                 int face_id = floorFaceId & 0x3F;
@@ -1136,7 +1136,7 @@ void ODM_ProcessPartyActions() {
                         partyInputSpeed.x += 4 * dx;
                         partyInputSpeed.y += 4 * dy;
                     }
-                } else if (partyAtHighSlope && !floorFaceId) {
+                } else if (partyAtHighSlope && floorFaceId == -1) {
                     partyInputSpeed.x += dx;
                     partyInputSpeed.y += dy;
                     partyIsWalking = true;
@@ -1204,7 +1204,7 @@ void ODM_ProcessPartyActions() {
                 break;
 
             case PARTY_Jump:
-                if ((!partyAtHighSlope || floorFaceId) &&
+                if ((!partyAtHighSlope || floorFaceId != -1) &&
                     // to avoid jump hesitancy when moving downhill
                     (!partyNotTouchingFloor || (partyCloseToGround && partyInputSpeed.z <= 0)) &&
                     pParty->jump_strength &&
@@ -1282,7 +1282,7 @@ void ODM_ProcessPartyActions() {
     if (partyNotTouchingFloor && !pParty->bFlying) {  // add gravity
         partyInputSpeed.z += -2.0f * gameTimer->dt().ticks() * GetGravityStrength();
     } else if (!partyNotTouchingFloor) {
-        if (!floorFaceId) {
+        if (floorFaceId == -1) {
             // rolling down the hill
             // how it's done: you get a little bit pushed in the air along
             // terrain normal, getting in the air and falling to the gravity,
@@ -1609,10 +1609,10 @@ void UpdateActors_ODM() {
             uIsFlying = 0;
 
         bool Slope_High = pOutdoor->pTerrain.isSlopeTooHighByPos(actor.pos);
-        int Model_On_PID = 0;
+        int Model_On_PID = -1;
         bool uIsOnWater = false;
         float Floor_Level = ODM_GetFloorLevel(actor.pos, &uIsOnWater, &Model_On_PID);
-        bool Actor_On_Terrain = Model_On_PID == 0;
+        bool Actor_On_Terrain = Model_On_PID == -1;
 
         bool uIsAboveFloor = (actor.pos.z > (Floor_Level + 1));
 

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -145,13 +145,13 @@ static void createSpriteTrailParticle(Vec3f pos, ObjectDescFlags flags) {
 void SpriteObject::updateObjectODM(unsigned int uLayingItemID) {
     ObjectDesc *object = &pObjectList->pObjects[pSpriteObjects[uLayingItemID].uObjectDescID];
     bool isHighSlope = pOutdoor->pTerrain.isSlopeTooHighByPos(pSpriteObjects[uLayingItemID].vPosition);
-    int bmodelPid = 0;
+    int bmodelPid = -1;
     bool onWater = false;
     float level = ODM_GetFloorLevel(pSpriteObjects[uLayingItemID].vPosition, &onWater, &bmodelPid);
     bool isAboveGround = pSpriteObjects[uLayingItemID].vPosition.z > level + 1;
     if (!isAboveGround && onWater) {
         int splashZ = level + 60;
-        if (bmodelPid) {
+        if (bmodelPid != -1) {
             splashZ = level + 30;
         }
         createSplashObject(Vec3f(pSpriteObjects[uLayingItemID].vPosition.x, pSpriteObjects[uLayingItemID].vPosition.y, splashZ));
@@ -250,13 +250,13 @@ void SpriteObject::updateObjectODM(unsigned int uLayingItemID) {
         }
         int collisionZ = collision_state.new_position_lo.z - collision_state.radius_lo;
         bool collisionOnWater = false;
-        int collisionBmodelPid = 0;
+        int collisionBmodelPid = -1;
         Vec3f collisionPos = collision_state.new_position_lo - Vec3f(0, 0, collision_state.radius_lo);
         float collisionLevel = ODM_GetFloorLevel(collisionPos, &collisionOnWater, &collisionBmodelPid);
         // TOOD(Nik-RE-dev): why initail "onWater" is used?
         if (onWater && collisionZ < (collisionLevel + 60)) {
             int splashZ = level + 60;
-            if (collisionBmodelPid) {
+            if (collisionBmodelPid != -1) {
                 splashZ = collisionLevel + 30;
             }
             createSplashObject(Vec3f(pSpriteObjects[uLayingItemID].vPosition.x, pSpriteObjects[uLayingItemID].vPosition.y, splashZ));

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -145,13 +145,13 @@ static void createSpriteTrailParticle(Vec3f pos, ObjectDescFlags flags) {
 void SpriteObject::updateObjectODM(unsigned int uLayingItemID) {
     ObjectDesc *object = &pObjectList->pObjects[pSpriteObjects[uLayingItemID].uObjectDescID];
     bool isHighSlope = pOutdoor->pTerrain.isSlopeTooHighByPos(pSpriteObjects[uLayingItemID].vPosition);
-    int bmodelPid = -1;
+    int floorFaceId = -1;
     bool onWater = false;
-    float level = ODM_GetFloorLevel(pSpriteObjects[uLayingItemID].vPosition, &onWater, &bmodelPid);
+    float level = ODM_GetFloorLevel(pSpriteObjects[uLayingItemID].vPosition, &onWater, &floorFaceId);
     bool isAboveGround = pSpriteObjects[uLayingItemID].vPosition.z > level + 1;
     if (!isAboveGround && onWater) {
         int splashZ = level + 60;
-        if (bmodelPid != -1) {
+        if (floorFaceId != -1) {
             splashZ = level + 30;
         }
         createSplashObject(Vec3f(pSpriteObjects[uLayingItemID].vPosition.x, pSpriteObjects[uLayingItemID].vPosition.y, splashZ));
@@ -250,13 +250,13 @@ void SpriteObject::updateObjectODM(unsigned int uLayingItemID) {
         }
         int collisionZ = collision_state.new_position_lo.z - collision_state.radius_lo;
         bool collisionOnWater = false;
-        int collisionBmodelPid = -1;
+        int collisionFloorFaceId = -1;
         Vec3f collisionPos = collision_state.new_position_lo - Vec3f(0, 0, collision_state.radius_lo);
-        float collisionLevel = ODM_GetFloorLevel(collisionPos, &collisionOnWater, &collisionBmodelPid);
+        float collisionLevel = ODM_GetFloorLevel(collisionPos, &collisionOnWater, &collisionFloorFaceId);
         // TOOD(Nik-RE-dev): why initail "onWater" is used?
         if (onWater && collisionZ < (collisionLevel + 60)) {
             int splashZ = level + 60;
-            if (collisionBmodelPid != -1) {
+            if (collisionFloorFaceId != -1) {
                 splashZ = collisionLevel + 30;
             }
             createSplashObject(Vec3f(pSpriteObjects[uLayingItemID].vPosition.x, pSpriteObjects[uLayingItemID].vPosition.y, splashZ));

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -81,7 +81,7 @@ void Party::Zero() {
     _viewYaw = 0;
     _viewPitch = 0;
     sPartySavedFlightZ = 0;
-    floor_face_id = 0;
+    floor_face_id = -1;
     currentWalkingSound = SOUND_Invalid;
     _6FC_water_lava_timer = Time();
     uFallStartZ = 0;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -291,7 +291,7 @@ struct Party {
     int _viewYaw = 0; // View yaw in polar coordinates, 0 is positive X, 512 (pi/2) is positive Y.
     int _viewPitch = 0; // View pitch in polar coordinates, 0 is horizontal, positive is looking up, negative is looking down.
     int sPartySavedFlightZ = 0;  // this saves the Z position when flying without bob mods
-    int floor_face_id = 0;  // face we are standing at
+    int floor_face_id = -1;  // Face the party is standing on, -1 for none.
     SoundId currentWalkingSound = SOUND_Invalid; // previously was 'walk_sound_timer'
     Time _6FC_water_lava_timer;
     int uFallStartZ = 0;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -465,9 +465,9 @@ struct Party_MM7 {
     int32_t fallSpeed;
     int32_t field_6EC;
     int32_t savedFlightZ;
-    int32_t floorFacePidUnused; // Face the party is standing at. Face id indoors, face pid outdoors.
-                                // Always set to zero on level loading, so in OE we are just saving 0 and
-                                // not using it when loading a savegame.
+    int32_t floorFaceIdUnused; // Face the party is standing on - blv face id indoors, composite
+                               // model << 6 | face id outdoors. Vanilla reset it on level load before
+                               // ever reading it, so in OE we just save 0 and ignore it on load.
     int32_t walkSoundTimerUnused; // This was removed in OE and we're just saving 0 in this field.
     int32_t waterLavaTimer; // Next game time when water/lava damage should be processed. This value will
                             // overflow after ~16 in-game years, and then the lava logic will trigger on


### PR DESCRIPTION
Resolves `TODO(captainurist): drop?` on the `floor_face_id` reset in `Engine.cpp` - the answer is no, and the review rounds grew the documentation into a proper sentinel cleanup across the whole outdoor floor pipeline.

Pressure plates fire when the party's remembered floor face changes, and face ids are only meaningful within one map. Dropping the reset would let a stale id from the previous map instantly trigger an indoor plate the party spawns on, or silently suppress an outdoor plate whose composite id happens to match. The field is also not serialized, so save loads run through this same line and need it just as much.

Sentinel changes, both from review discussion:
- `pParty->floor_face_id` uses -1 for "none" - 0 is a real face id indoors, so a party standing on face 0 was indistinguishable from a party standing on nothing. The outdoor walking-sound branch gets an explicit guard for the airborne-after-load window where the old code would have indexed `pBModels[-1]`.
- `ODM_GetFloorLevel`'s out-parameter uses -1 too - 0 is the real composite id of model 0 face 0 outdoors, so a pressure plate there could never fire, walking on it played terrain sounds, and the jump/slope logic misclassified it. All 16 call sites audited, eleven consumers converted, five ignore the id.

Also fixes a latent array overrun found during review: the function's 20-surface cap only broke the face loop, so a second model containing the position kept writing past the arrays (unreachable in shipping data).

Local battery: 382 unit tests, 351/351 game tests - all trace replays drive party, actor and sprite physics through these functions and are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)