### PR TITLE
Replace a confusing return with break in party BLV collisions

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -912,8 +912,8 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
 
         float adjusted_floor_z = GetIndoorFloorZ(adjusted_pos + Vec3f(0, 0, collision_state.radius_lo), &collision_state.uSectorID, faceId);
         if (adjusted_floor_z == -30000 || adjusted_floor_z - pParty->pos.z > 128) {
-            // intended world position isnt valid so dont move there
-            return; // TODO: whaaa?
+            // New pos is out of bounds, running more iterations won't help.
+            break;
         }
 
         collision_state.total_move_distance += collision_state.adjusted_move_distance;

--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -911,10 +911,8 @@ void ProcessPartyCollisionsBLV(int sectorId, int min_party_move_delta_sqr, int *
         collision_state.collisionPos -= closestdist * collision_state.direction;
 
         float adjusted_floor_z = GetIndoorFloorZ(adjusted_pos + Vec3f(0, 0, collision_state.radius_lo), &collision_state.uSectorID, faceId);
-        if (adjusted_floor_z == -30000 || adjusted_floor_z - pParty->pos.z > 128) {
-            // New pos is out of bounds, running more iterations won't help.
-            break;
-        }
+        if (adjusted_floor_z == -30000 || adjusted_floor_z - pParty->pos.z > 128)
+            break; // New pos is out of bounds, running more iterations won't help.
 
         collision_state.total_move_distance += collision_state.adjusted_move_distance;
         pParty->pos = adjusted_pos;


### PR DESCRIPTION
Resolves `return; // TODO: whaaa?` in `ProcessPartyCollisionsBLV`.

The collision loop is the whole function body, so the return was behaviorally identical to a break - it came straight out of the decompile that way, never as a deliberate choice. The structurally identical out-of-bounds check on the actor side already uses `break` with a proper comment, and the party side now matches it. The velocity-decay retry logic sits after this check in the iteration body, so when the branch is taken nothing has changed and further iterations would fail identically - the comment's claim holds on both sides.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
