### PR TITLE
Scan face 0 in the indoor by-cog face loops

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -897,7 +897,7 @@ int GetGravityStrength() {
 }
 
 void sub_44861E_set_texture_indoor(unsigned int uFaceCog, std::string_view filename) {
-    for (unsigned i = 1; i < pIndoor->faces.size(); ++i) {
+    for (unsigned i = 0; i < pIndoor->faces.size(); ++i) {
         if (pIndoor->faces[i].cogNumber == uFaceCog) {
             pIndoor->faces[i].SetTexture(filename);
         }
@@ -934,8 +934,7 @@ void setTexture(unsigned int uFaceCog, std::string_view pFilename) {
 void setFacesBit(int sCogNumber, FaceAttribute bit, int on) {
     if (sCogNumber) {
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-            // TODO(pskelton): starts at 1?
-            for (int i = 1; i < pIndoor->faces.size(); ++i) {
+            for (unsigned i = 0; i < pIndoor->faces.size(); ++i) {
                 if (pIndoor->faces[i].cogNumber == sCogNumber) {
                     if (on)
                         pIndoor->faces[i].attributes |= bit;


### PR DESCRIPTION
Resolves `TODO(pskelton): starts at 1?` in `setFacesBit`, and applies the same fix to the structurally identical loop in `sub_44861E_set_texture_indoor`.

The TODO's suspicion was right, and the answer has a concrete history: skipping index 0 was correct back when these loops iterated `faceExtras`, where entry 0 is the no-extra sentinel. #2513 switched them to iterate `faces` directly - where index 0 is real geometry like any other - and mechanically kept the offset, which since then silently skipped face 0. In vanilla, face 0 was reachable through its own extra, so this restores vanilla behavior for any map whose face 0 carries a scripted cog.

Cog-0 requests are filtered out before both loops (`setTexture` and `setFacesBit` both guard), so scanning from 0 can't make un-cogged faces match. The outdoor branches already scan everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
