### PR TITLE
Require a valid map id in the level loaders

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -881,7 +881,7 @@ void BLV_UpdateActors() {
 }
 
 void loadAndPrepareBLV(MapId mapid, bool bLoading) {
-    assert(mapid != MAP_INVALID);
+    assert(isMapIndoor(mapid));
 
     unsigned int respawn_interval;  // ebx@1
     MapInfo *map_info;              // edi@9
@@ -909,8 +909,6 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
     alertStatus = GetAlertStatus();
 
-    if (!ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"))
-        throw Exception("Indoor map '{}' has a non-blv filename", mapFilename);
 
     pStationaryLightsStack->uNumLightsActive = 0;
     pIndoor->Load(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -881,6 +881,8 @@ void BLV_UpdateActors() {
 }
 
 void loadAndPrepareBLV(MapId mapid, bool bLoading) {
+    assert(mapid != MAP_INVALID);
+
     unsigned int respawn_interval;  // ebx@1
     MapInfo *map_info;              // edi@9
     bool v28;                       // zf@81
@@ -902,13 +904,13 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
 
-    assert(mapid != MAP_INVALID);
     mapFilename = pMapStats->pInfos[mapid].fileName;
     map_info = &pMapStats->pInfos[mapid];
     respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
     alertStatus = GetAlertStatus();
 
-    assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"));
+    if (!ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"))
+        throw Exception("Indoor map '{}' has a non-blv filename", mapFilename);
 
     pStationaryLightsStack->uNumLightsActive = 0;
     pIndoor->Load(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -888,7 +888,6 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
     std::string mapFilename;
 
-    respawn_interval = 0;
     pGameLoadingUI_ProgressBar->Reset(0x20u);
     uCurrentlyLoadedLevelType = LEVEL_INDOOR;
     pBLVRenderParams->uPartySectorID = 0;
@@ -903,18 +902,13 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
 
-    if (mapid != MAP_INVALID) {
-        mapFilename = pMapStats->pInfos[mapid].fileName;
-        map_info = &pMapStats->pInfos[mapid];
-        respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
-        alertStatus = GetAlertStatus();
+    assert(mapid != MAP_INVALID);
+    mapFilename = pMapStats->pInfos[mapid].fileName;
+    map_info = &pMapStats->pInfos[mapid];
+    respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
+    alertStatus = GetAlertStatus();
 
-        assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"));
-    } else {
-        // TODO(Nik-RE-dev): why there's logic for loading maps that are not listed in info?
-        mapFilename = "";
-        map_info = nullptr;
-    }
+    assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "blv"));
 
     pStationaryLightsStack->uNumLightsActive = 0;
     pIndoor->Load(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &indoor_was_respawned);
@@ -923,8 +917,6 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
         SpriteObject::InitializeSpriteObjects();
     }
     dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN;
-    if (mapid == MAP_INVALID)
-        indoor_was_respawned = false;
 
     if (indoor_was_respawned) {
         for (unsigned i = 0; i < pIndoor->pSpawnPoints.size(); ++i) {
@@ -994,11 +986,6 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
 
     for (Actor &actor : pActors) {
         if (actor.attributes & ACTOR_UNKNOW7) {
-            if (mapid == MAP_INVALID) {
-                actor.monsterInfo.field_3E = 19;
-                actor.attributes |= ACTOR_UNKNOW11;
-                continue;
-            }
             v28 = !alertStatus;
         } else {
             v28 = alertStatus;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1757,6 +1757,8 @@ void UpdateActors_ODM() {
  * @offset 0x47A384
  */
 static void loadAndPrepareODMInternal(MapId mapid) {
+    assert(mapid != MAP_INVALID);
+
     MapInfo *map_info;
     bool outdoor_was_respawned;
     unsigned int respawn_interval = 0;
@@ -1767,12 +1769,12 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     // thisa = (ODMRenderParams *)1;
     GetAlertStatus(); // Result unused.
     pParty->_delayedReactionTimer = 0_ticks;
-    assert(mapid != MAP_INVALID);
     mapFilename = pMapStats->pInfos[mapid].fileName;
     map_info = &pMapStats->pInfos[mapid];
     respawn_interval = map_info->respawnIntervalDays;
 
-    assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "odm"));
+    if (!ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "odm"))
+        throw Exception("Outdoor map '{}' has a non-odm filename", mapFilename);
     pOutdoor->loc_time.weatherFlags &= ~MAP_WEATHER_FOGGY;
     pOutdoor->Initialize(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &outdoor_was_respawned);
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1767,17 +1767,12 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     // thisa = (ODMRenderParams *)1;
     GetAlertStatus(); // Result unused.
     pParty->_delayedReactionTimer = 0_ticks;
-    if (mapid != MAP_INVALID) {
-        mapFilename = pMapStats->pInfos[mapid].fileName;
-        map_info = &pMapStats->pInfos[mapid];
-        respawn_interval = map_info->respawnIntervalDays;
+    assert(mapid != MAP_INVALID);
+    mapFilename = pMapStats->pInfos[mapid].fileName;
+    map_info = &pMapStats->pInfos[mapid];
+    respawn_interval = map_info->respawnIntervalDays;
 
-        assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "odm"));
-    } else {
-        // TODO(Nik-RE-dev): why there's logic for loading maps that are not listed in info?
-        mapFilename = "";
-        map_info = nullptr;
-    }
+    assert(ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "odm"));
     pOutdoor->loc_time.weatherFlags &= ~MAP_WEATHER_FOGGY;
     pOutdoor->Initialize(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &outdoor_was_respawned);
 
@@ -1787,7 +1782,7 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     }
     dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN;
 
-    if (outdoor_was_respawned && mapid != MAP_INVALID) {
+    if (outdoor_was_respawned) {
         for (unsigned i = 0; i < pOutdoor->pSpawnPoints.size(); ++i) {
             SpawnPoint *spawn = &pOutdoor->pSpawnPoints[i];
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1757,7 +1757,7 @@ void UpdateActors_ODM() {
  * @offset 0x47A384
  */
 static void loadAndPrepareODMInternal(MapId mapid) {
-    assert(mapid != MAP_INVALID);
+    assert(isMapOutdoor(mapid));
 
     MapInfo *map_info;
     bool outdoor_was_respawned;
@@ -1773,8 +1773,6 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     map_info = &pMapStats->pInfos[mapid];
     respawn_interval = map_info->respawnIntervalDays;
 
-    if (!ascii::noCaseEquals(mapFilename.substr(mapFilename.rfind('.') + 1), "odm"))
-        throw Exception("Outdoor map '{}' has a non-odm filename", mapFilename);
     pOutdoor->loc_time.weatherFlags &= ~MAP_WEATHER_FOGGY;
     pOutdoor->Initialize(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &outdoor_was_respawned);
 


### PR DESCRIPTION
Resolves the twin `TODO(Nik-RE-dev): why there's logic for loading maps that are not listed in info?` comments in the two level loaders.

The answer: a vanilla remnant with no working behavior left behind it. The indoor copy was unreachable - the only caller routes `MAP_INVALID` to the outdoor loader - and would throw from a substring operation on the empty filename if forced. The outdoor copy silently skipped loading, left the previous map in place, and read an uninitialized `outdoor_was_respawned` in its respawn guard on that path. Corrupted saves and bad event map names can't even reach here - `MapStats::GetMapInfo` has asserted on unknown names since 2023, so the loaders' else-branches were dead from every direction.

Both loaders now assert on entry, the assignments are unconditional, and the three `MAP_INVALID` special cases downstream go away - including the actor-state branch that was also behaviorally redundant, since the loop above it forces `alertStatus = false`, which takes the exact same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
