### PR TITLE
Drop Bloodsplat::faceDist

### DIFF
--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -34,7 +34,6 @@ void BloodsplatContainer::AddBloodsplat(const Vec3f &pos, float radius, Color co
     splat.pos = pos;
     splat.radius = radius;
     splat.color = color;
-    splat.faceDist = 0;
     splat.blood_flags = DecalFlagsNone;
     splat.fade_timer = 0_ticks;
 
@@ -72,8 +71,8 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
 
     if (this->uNumSplatsThisFace > 0) {
         for (int i = 0; i < this->uNumSplatsThisFace; ++i) {
-            int thissplat = this->WhichSplatsOnThisFace[i];
-            Bloodsplat *buildsplat = &bloodsplat_container->pBloodsplats_to_apply[thissplat];
+            FaceSplat thissplat = this->WhichSplatsOnThisFace[i];
+            Bloodsplat *buildsplat = &bloodsplat_container->pBloodsplats_to_apply[thissplat.index];
             int point_light_level = GetLightLevelAtPoint(
                     light_level, uSectorID,
                     buildsplat->pos.x, buildsplat->pos.y, buildsplat->pos.z);
@@ -83,7 +82,7 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
                 buildsplat,
                 buildsplat->radius,
                 buildsplat->color,
-                buildsplat->faceDist,
+                thissplat.dist,
                 &static_FacePlane, NumFaceVerts, FaceVerts, ClipFlags))
                 MM_WARNING("Error: Failed to build decal geometry");
         }
@@ -194,9 +193,7 @@ bool DecalBuilder::ApplyBloodsplatDecalsToFace(BLVFace* pFace) {
         if (pFace->boundingBox.intersectsCube(pBloodsplat->pos, pBloodsplat->radius)) {
             double dotdist = dot(pFace->facePlane.normal, pBloodsplat->pos) + pFace->facePlane.dist;
             if (dotdist <= pBloodsplat->radius) {
-                // store splat
-                pBloodsplat->faceDist = dotdist;
-                WhichSplatsOnThisFace[uNumSplatsThisFace++] = i;
+                WhichSplatsOnThisFace[uNumSplatsThisFace++] = {static_cast<int>(i), static_cast<float>(dotdist)};
             }
         }
     }
@@ -232,10 +229,9 @@ bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, const Vec3f &terrnorm, 
             }
 
             bloodsplat_container->pBloodsplats_to_apply[whichsplat].fade_timer = gameTimer->time();
-            bloodsplat_container->pBloodsplats_to_apply[whichsplat].faceDist = planedist;
 
             // store this decal to apply
-            this->WhichSplatsOnThisFace[this->uNumSplatsThisFace] = whichsplat;
+            this->WhichSplatsOnThisFace[this->uNumSplatsThisFace] = {whichsplat, planedist};
             ++this->uNumSplatsThisFace;
         }
     }

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -71,18 +71,22 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
 
     if (this->uNumSplatsThisFace > 0) {
         for (int i = 0; i < this->uNumSplatsThisFace; ++i) {
-            FaceSplat thissplat = this->WhichSplatsOnThisFace[i];
-            Bloodsplat *buildsplat = &bloodsplat_container->pBloodsplats_to_apply[thissplat.index];
+            int thissplat = this->WhichSplatsOnThisFace[i];
+            Bloodsplat *buildsplat = &bloodsplat_container->pBloodsplats_to_apply[thissplat];
             int point_light_level = GetLightLevelAtPoint(
                     light_level, uSectorID,
                     buildsplat->pos.x, buildsplat->pos.y, buildsplat->pos.z);
+
+            float dist = dot(FacePlane.normal, buildsplat->pos) + FacePlane.dist;
+            if (locationFlags & LocationTerrain)
+                dist += 0.5f; // The overlap test in ApplyBloodSplatToTerrain measures the distance with this bias.
 
             if (!this->Build_Decal_Geometry(
                 point_light_level, locationFlags,
                 buildsplat,
                 buildsplat->radius,
                 buildsplat->color,
-                thissplat.dist,
+                dist,
                 &static_FacePlane, NumFaceVerts, FaceVerts, ClipFlags))
                 MM_WARNING("Error: Failed to build decal geometry");
         }
@@ -192,9 +196,8 @@ bool DecalBuilder::ApplyBloodsplatDecalsToFace(BLVFace* pFace) {
         Bloodsplat *pBloodsplat = &bloodsplat_container->pBloodsplats_to_apply[i];
         if (pFace->boundingBox.intersectsCube(pBloodsplat->pos, pBloodsplat->radius)) {
             double dotdist = dot(pFace->facePlane.normal, pBloodsplat->pos) + pFace->facePlane.dist;
-            if (dotdist <= pBloodsplat->radius) {
-                WhichSplatsOnThisFace[uNumSplatsThisFace++] = {static_cast<int>(i), static_cast<float>(dotdist)};
-            }
+            if (dotdist <= pBloodsplat->radius)
+                WhichSplatsOnThisFace[uNumSplatsThisFace++] = i;
         }
     }
 
@@ -231,7 +234,7 @@ bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, const Vec3f &terrnorm, 
             bloodsplat_container->pBloodsplats_to_apply[whichsplat].fade_timer = gameTimer->time();
 
             // store this decal to apply
-            this->WhichSplatsOnThisFace[this->uNumSplatsThisFace] = {whichsplat, planedist};
+            this->WhichSplatsOnThisFace[this->uNumSplatsThisFace] = whichsplat;
             ++this->uNumSplatsThisFace;
         }
     }

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -78,8 +78,6 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
                     buildsplat->pos.x, buildsplat->pos.y, buildsplat->pos.z);
 
             float dist = dot(FacePlane.normal, buildsplat->pos) + FacePlane.dist;
-            if (locationFlags & LocationTerrain)
-                dist += 0.5f; // The overlap test in ApplyBloodSplatToTerrain measures the distance with this bias.
 
             if (!this->Build_Decal_Geometry(
                 point_light_level, locationFlags,
@@ -217,7 +215,7 @@ bool DecalBuilder::ApplyBloodSplatToTerrain(bool fading, const Vec3f &terrnorm, 
     if (NumBloodsplats > 0) {
        // check plane distance
        *tridotdist = -dot(triverts->vWorldPosition, terrnorm);
-       float planedist = dot(terrnorm, bloodsplat_container->pBloodsplats_to_apply[whichsplat].pos) + *tridotdist + 0.5f;
+       float planedist = dot(terrnorm, bloodsplat_container->pBloodsplats_to_apply[whichsplat].pos) + *tridotdist;
 
         if (planedist <= bloodsplat_container->pBloodsplats_to_apply[whichsplat].radius) {
             // blood splat hits this terrain tri

--- a/src/Engine/Graphics/DecalBuilder.h
+++ b/src/Engine/Graphics/DecalBuilder.h
@@ -34,8 +34,6 @@ MM_DECLARE_OPERATORS_FOR_FLAGS(LocationFlags)
 struct Bloodsplat {
     Vec3f pos; // Bloodsplat origin, usually 30 units above ground level where the monster was killed.
     float radius = 0;
-    float faceDist = 0; // Signed distance from bloodsplat origin to the face plane (for the current face).
-                        // TODO(captainurist): doesn't belong to this struct, should be moved out.
     Color color;
     DecalFlags blood_flags = DecalFlagsNone;
     Duration fade_timer;
@@ -109,9 +107,15 @@ struct DecalBuilder {
     std::array<Decal, 1024> Decals;  // actual decal geom store
     unsigned int DecalsCount = 0;  // number of decals
 
+    // Bloodsplat overlapping the face currently being processed.
+    struct FaceSplat {
+        int index = 0; // Index into BloodsplatContainer::pBloodsplats_to_apply.
+        float dist = 0; // Signed distance from the bloodsplat origin to the face plane.
+    };
+
     // for building decal geom
     int uNumSplatsThisFace = 0;  // numeber of bloodsplats that overlap this face
-    std::array<int, 1024> WhichSplatsOnThisFace = {{}};  // stores which ith element of blodsplats to apply outdoor bloodsplats/decals store for calc
+    std::array<FaceSplat, 1024> WhichSplatsOnThisFace = {{}};
 
     // sizes for building decal geometry
     float field_30C010 = 0;

--- a/src/Engine/Graphics/DecalBuilder.h
+++ b/src/Engine/Graphics/DecalBuilder.h
@@ -107,15 +107,9 @@ struct DecalBuilder {
     std::array<Decal, 1024> Decals;  // actual decal geom store
     unsigned int DecalsCount = 0;  // number of decals
 
-    // Bloodsplat overlapping the face currently being processed.
-    struct FaceSplat {
-        int index = 0; // Index into BloodsplatContainer::pBloodsplats_to_apply.
-        float dist = 0; // Signed distance from the bloodsplat origin to the face plane.
-    };
-
     // for building decal geom
     int uNumSplatsThisFace = 0;  // numeber of bloodsplats that overlap this face
-    std::array<FaceSplat, 1024> WhichSplatsOnThisFace = {{}};
+    std::array<int, 1024> WhichSplatsOnThisFace = {{}};  // Indices into BloodsplatContainer::pBloodsplats_to_apply.
 
     // sizes for building decal geometry
     float field_30C010 = 0;


### PR DESCRIPTION
Resolves `TODO(captainurist): doesn't belong to this struct, should be moved out.` on `Bloodsplat::faceDist` - by deleting the field.

The field was per-face scratch - the signed distance from the splat origin to whatever face is currently being processed, overwritten face by face - living in the persistent 64-entry splat array. It turns out it never needed storing at all. The one reader, `BuildAndApplyDecals`, receives the face plane as a parameter, so it now recomputes the distance with the same dot product the overlap tests use. `WhichSplatsOnThisFace` stays a plain index array.

The terrain overlap test used to compute the distance with a `+ 0.5f` on it, and that's now gone too. In the original binary the 0.5 was the first half of a round-to-nearest - the result was truncated to int right after, `dot_dist` was stored as an integer. The float rewrite kept the 0.5 but lost the truncation, turning a rounding step into a half-unit bias that the indoor path never had. Dropping it makes both paths compute the same clean signed distance, at the cost of a sub-unit change on terrain: splats within half a unit of the acceptance boundary, and decal sizes by tenths of a percent. Current code isn't bit-identical to vanilla there either way, vanilla rounded.

The field had exactly one reader, fills and consumes are strictly interleaved per face, and nothing serializes `Bloodsplat`.

Heads-up: this textually conflicts with #2569 in three hunks (`AddBloodsplat`, the indoor fill condition, the header field block). Semantically the two compose fine - the sign of the distance is preserved, which #2569's `std::abs` change cares about - so it's purely a question of which lands first and who rebases. This one is the cheaper rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
