### PR TITLE
Move setNPCNamesOnLoad out of NPCStats

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -557,7 +557,7 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     else
         loadAndPrepareODM(engine->_transitionMapId, bLoading);
 
-    pNPCStats->setNPCNamesOnLoad();
+    setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
     if (engine->_currentLoadedMapId == MAP_BREEDING_ZONE || engine->_currentLoadedMapId == MAP_WALLS_OF_MIST) {
         // spawning grounds & walls of mist - no loot & exp from monsters

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -289,3 +289,13 @@ NPCSacrificeStatus *FlatHirelings::GetSacrificeStatus(size_t index) const {
     else
         return nullptr;
 }
+
+void setNPCNamesOnLoad() {
+    for (unsigned int i = 1; i < pNPCStats->uNumNewNPCs; ++i)
+        pNPCStats->pNPCData[i].name = pNPCStats->pNPCUnicNames[i];
+
+    if (!pParty->pHirelings[0].name.empty())
+        pParty->pHirelings[0].name = pParty->pHireling1Name;
+    if (!pParty->pHirelings[1].name.empty())
+        pParty->pHirelings[1].name = pParty->pHireling2Name;
+}

--- a/src/Engine/Objects/NPC.h
+++ b/src/Engine/Objects/NPC.h
@@ -37,6 +37,13 @@ const std::string &GetProfessionActionText(NpcProfession prof);
 NPCData *getNPCData(int npcId);
 
 /**
+ * Restores NPC names from the npcdata.txt name table and hireling names from party data on level load.
+ *
+ * @offset 0x476C60
+ */
+void setNPCNamesOnLoad();
+
+/**
  * @offset 0x445C8B
  */
 NpcType getNPCType(int npcId);

--- a/src/Engine/Tables/NPCTable.cpp
+++ b/src/Engine/Tables/NPCTable.cpp
@@ -7,7 +7,6 @@
 #include "Engine/MapEnumFunctions.h"
 #include "Engine/Objects/NPC.h"
 #include "Engine/Objects/MonsterEnumFunctions.h"
-#include "Engine/Party.h"
 #include "Engine/Objects/NPCEnumFunctions.h"
 #include "Engine/Resources/ResourceManager.h"
 #include "Engine/Random/Random.h"
@@ -53,17 +52,6 @@ void NPCStats::InitializeNPCDist(const Blob &npcDist) {
     for (MapId map : allMaps())
         for (NpcProfession prof : allNpcProfessions())
             pProfessionChance[map].total += pProfessionChance[map].chanceByProfession[prof];
-}
-
-// TODO(Nik-RE-dev): move out of table back to Engine/Objects/NPC.cpp
-void NPCStats::setNPCNamesOnLoad() {
-    for (unsigned int i = 1; i < uNumNewNPCs; ++i)
-        pNPCData[i].name = pNPCUnicNames[i];
-
-    if (!pParty->pHirelings[0].name.empty())
-        pParty->pHirelings[0].name = pParty->pHireling1Name;
-    if (!pParty->pHirelings[1].name.empty())
-        pParty->pHirelings[1].name = pParty->pHireling2Name;
 }
 
 //----- (00476CB5) --------------------------------------------------------

--- a/src/Engine/Tables/NPCTable.h
+++ b/src/Engine/Tables/NPCTable.h
@@ -97,11 +97,6 @@ struct NPCStats {
     void InitializeAdditionalNPCs(NPCData *pNPCDataBuff, MonsterId npc_uid,
                                   HouseId uLocation2D, MapId uMapId);
     /**
-     * @offset 0x476C60
-     */
-    void setNPCNamesOnLoad();
-
-    /**
      * Returns a random NPC name of the given gender starting with the same letter as `firstLetter`. Backs the
      * `%13` placeholder in `BuildDialogueString` - NPC dialogue templates that address the player by a similar-
      * sounding (mispronounced) name, e.g. "O Ho! %13! Er, %13. I think. Whatever...".


### PR DESCRIPTION
Resolves `TODO(Nik-RE-dev): move out of table back to Engine/Objects/NPC.cpp`.

The function restores NPC names from the npcdata.txt table and hireling names from party data on level load - it was never about the tables, and it was the tables' only `Party` dependency. It moves back to `NPC.cpp` as a free function next to the other `pNPCStats`-based helpers (history: it started life there as `OnLoadSetNPC_Names` and got dragged into Tables when the whole `NPCStats` class moved in 2023). The `Engine/Party.h` include is gone from `NPCTable.cpp` with it, so the Tables -> Party edge is genuinely cut, and the `@offset` annotation travels along.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
