### PR TITLE
Rework the mouse picks into purpose-named functions

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -781,7 +781,7 @@ void Game::processQueuedMessages() {
                     interactionPossible = !(pObjectList->pObjects[pSpriteObjects[id].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE);
                 }
                 if (type == OBJECT_Decoration) {
-                    interactionPossible = pLevelDecorations[id].uEventID != 0;
+                    interactionPossible = pLevelDecorations[id].uEventID != 0 || pLevelDecorations[id].IsInteractive();
                 }
                 if (type == OBJECT_Face) {
                     if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -770,7 +770,7 @@ void Game::processQueuedMessages() {
                 current_screen_type = SCREEN_GAME;
                 continue;
             case UIMSG_CastSpell_Telekinesis: {
-                Pid pid = engine->PickMouseTarget().pid;
+                Pid pid = engine->PickMouseForTargeting().pid;
                 ObjectType type = pid.type();
                 int id = pid.id();
                 bool interactionPossible = false;
@@ -960,7 +960,7 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpell_TargetActorBuff:
             case UIMSG_CastSpell_TargetActor: {
-                Vis_PIDAndDepth object = engine->PickMouseTarget();
+                Vis_PIDAndDepth object = engine->PickMouseForTargeting();
                 Pid pid = object.pid;
                 int depth = object.depth;
                 if (pid.type() == OBJECT_Actor && depth < engine->config->gameplay.RangedAttackDepth.value()) {

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -223,7 +223,8 @@ class GameConfig : public Config {
         Int RangedAttackDepth = {this, "ranged_attack_depth", 5120, &ValidateRangedAttackDepth,
             "Max depth for ranged attacks and ranged spells. "
             "It's impossible to target monsters that are further away than this value. "
-            "This is also the depth at which status bar tips are displayed on mouse over."};
+            "Status bar tips on mouse over also use this depth, except for monsters, "
+            "which use the monster popup depth."};
 
         Int AoeDamageDistance = {this, "aoe_damage_distance", 512, &ValidateAoeDistance,
             "Distance from point of impact of harmful AOE spell. "

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -198,11 +198,13 @@ class GameConfig : public Config {
 
         Int MouseInfoDepthIndoor = {this, "mouse_info_depth_indoor", 16192, &ValidateInteractionDepth,
             "Maximum range at which right clicking on a monster produces a popup indoors. "
+            "Status bar tips on mouse over use the same depth. "
             "Also this is the max range for the souldrinker spell indoors."};
 
         Int MouseInfoDepthOutdoor = {this, "mouse_info_depth_outdoor", 12800, &ValidateInteractionDepth,
             "Maximum range at which right clicking on a monster produces a popup outdoors. "
             "Default value is 12800 = 25 * 512, 25 map cells. "
+            "Status bar tips on mouse over use the same depth. "
             "Also this is the max range for the souldrinker spell outdoors."};
 
         Int NewGameFood = {this, "new_game_food", 7,
@@ -222,9 +224,7 @@ class GameConfig : public Config {
 
         Int RangedAttackDepth = {this, "ranged_attack_depth", 5120, &ValidateRangedAttackDepth,
             "Max depth for ranged attacks and ranged spells. "
-            "It's impossible to target monsters that are further away than this value. "
-            "Status bar tips on mouse over also use this depth, except for monsters, "
-            "which use the monster popup depth."};
+            "It's impossible to target monsters that are further away than this value."};
 
         Int AoeDamageDistance = {this, "aoe_damage_distance", 512, &ValidateAoeDistance,
             "Distance from point of impact of harmful AOE spell. "

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -197,6 +197,11 @@ class GameConfig : public Config {
             "Max depth for ranged attacks and ranged spells. "
             "It's impossible to target monsters that are further away than this value."};
 
+        Int MassSpellDepth = {this, "mass_spell_depth", 4096, &ValidateRangedAttackDepth,
+            "Max depth for mass spells, the ones that hit every monster in the viewport - Inferno, Turn Undead, "
+            "Mass Fear, Dispel Magic, Prismatic Light and Souldrinker. Vanilla used 4096 for all of them except "
+            "Souldrinker, which reached to the mouse info depth of 12800 outdoors and 16192 indoors."};
+
         Int MinRecoveryMelee = {this, "minimum_recovery_melee", 30, &ValidateRecovery,
             "Minimum recovery time for melee weapons. Was 30 in vanilla."};
 

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -184,6 +184,19 @@ class GameConfig : public Config {
         Int MouseInteractionDepth = {this, "mouse_interaction_depth", 512, &ValidateInteractionDepth,
             "Maximum range for item pickup / opening chests / activating levers / etc with a mouse."};
 
+        Int MouseInfoDepthIndoor = {this, "mouse_info_depth_indoor", 16192, &ValidateInteractionDepth,
+            "Maximum range at which right clicking on a monster produces a popup indoors. "
+            "Status bar tips on mouse over use the same depth."};
+
+        Int MouseInfoDepthOutdoor = {this, "mouse_info_depth_outdoor", 12800, &ValidateInteractionDepth,
+            "Maximum range at which right clicking on a monster produces a popup outdoors. "
+            "Default value is 12800 = 25 * 512, 25 map cells. "
+            "Status bar tips on mouse over use the same depth."};
+
+        Int RangedAttackDepth = {this, "ranged_attack_depth", 5120, &ValidateRangedAttackDepth,
+            "Max depth for ranged attacks and ranged spells. "
+            "It's impossible to target monsters that are further away than this value."};
+
         Int MinRecoveryMelee = {this, "minimum_recovery_melee", 30, &ValidateRecovery,
             "Minimum recovery time for melee weapons. Was 30 in vanilla."};
 
@@ -195,17 +208,6 @@ class GameConfig : public Config {
 
         Int MaxFlightHeight = {this, "max_flight_height", 4000, &ValidateMaxFlightHeight,
             "Maximum height for the fly spell."};
-
-        Int MouseInfoDepthIndoor = {this, "mouse_info_depth_indoor", 16192, &ValidateInteractionDepth,
-            "Maximum range at which right clicking on a monster produces a popup indoors. "
-            "Status bar tips on mouse over use the same depth. "
-            "Also this is the max range for the souldrinker spell indoors."};
-
-        Int MouseInfoDepthOutdoor = {this, "mouse_info_depth_outdoor", 12800, &ValidateInteractionDepth,
-            "Maximum range at which right clicking on a monster produces a popup outdoors. "
-            "Default value is 12800 = 25 * 512, 25 map cells. "
-            "Status bar tips on mouse over use the same depth. "
-            "Also this is the max range for the souldrinker spell outdoors."};
 
         Int NewGameFood = {this, "new_game_food", 7,
             "Starting food."};
@@ -221,10 +223,6 @@ class GameConfig : public Config {
 
         Int PartyWalkSpeed = {this, "party_walk_speed", 384,
             "Party walk speed."};
-
-        Int RangedAttackDepth = {this, "ranged_attack_depth", 5120, &ValidateRangedAttackDepth,
-            "Max depth for ranged attacks and ranged spells. "
-            "It's impossible to target monsters that are further away than this value."};
 
         Int AoeDamageDistance = {this, "aoe_damage_distance", 512, &ValidateAoeDistance,
             "Distance from point of impact of harmful AOE spell. "

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -212,7 +212,7 @@ void GameWindowHandler::OnMouseRightClick(Pointi position) {
     position = mouse->setPosition(position);
 
     if (engine)
-        engine->PickMouse(pCamera3D->GetMouseInfoDepth(), position.x, position.y, &vis_allsprites_filter, &vis_door_filter);
+        engine->PickMouse(pCamera3D->GetMouseInfoDepth(), position.x, position.y, &vis_anything_filter, &vis_door_filter);
 
     // Decide here whether the right-press should enter "show popup" mode.
     if (current_screen_type == SCREEN_VIDEO || GetCurrentMenuID() == MENU_MAIN)

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -117,6 +117,18 @@ void EngineController::releaseButton(PlatformMouseButton button, int x, int y) {
     pressOrReleaseButton(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
 }
 
+void EngineController::pressButton(PlatformMouseButton button, Pointi point, bool isDoubleClick) {
+    pressButton(button, point.x, point.y, isDoubleClick);
+}
+
+void EngineController::releaseButton(PlatformMouseButton button, Pointi point) {
+    releaseButton(button, point.x, point.y);
+}
+
+void EngineController::moveMouse(Pointi point) {
+    moveMouse(point.x, point.y);
+}
+
 void EngineController::moveMouse(int x, int y) {
     std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
     event->type = EVENT_MOUSE_MOVE;

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <memory>
 
-
 #include "GUI/GUIProgressBar.h"
 #include "GUI/GUIWindow.h"
 #include "GUI/GUIButton.h"
@@ -113,20 +112,16 @@ void EngineController::pressButton(PlatformMouseButton button, int x, int y, boo
     pressOrReleaseButton(EVENT_MOUSE_BUTTON_PRESS, button, x, y, isDoubleClick);
 }
 
-void EngineController::releaseButton(PlatformMouseButton button, int x, int y) {
-    pressOrReleaseButton(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
-}
-
 void EngineController::pressButton(PlatformMouseButton button, Pointi point, bool isDoubleClick) {
     pressButton(button, point.x, point.y, isDoubleClick);
 }
 
-void EngineController::releaseButton(PlatformMouseButton button, Pointi point) {
-    releaseButton(button, point.x, point.y);
+void EngineController::releaseButton(PlatformMouseButton button, int x, int y) {
+    pressOrReleaseButton(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
 }
 
-void EngineController::moveMouse(Pointi point) {
-    moveMouse(point.x, point.y);
+void EngineController::releaseButton(PlatformMouseButton button, Pointi point) {
+    releaseButton(button, point.x, point.y);
 }
 
 void EngineController::moveMouse(int x, int y) {
@@ -138,6 +133,10 @@ void EngineController::moveMouse(int x, int y) {
     event->pos = render->MapToPresent({ x, y });
     event->isDoubleClick = false;
     postEvent(std::move(event));
+}
+
+void EngineController::moveMouse(Pointi point) {
+    moveMouse(point.x, point.y);
 }
 
 void EngineController::pressAndReleaseKey(PlatformKey key) {
@@ -411,6 +410,23 @@ void EngineController::castQuickSpell(int characterIndex, SpellId spell) {
     character.uQuickSpell = oldQuickSpell;
 }
 
+void EngineController::pointMouseAtActor(int actorId) {
+    // Camera matrices are updated when a frame is rendered, so if the party was teleported without ticking, the
+    // camera is still at the old position. Tick once to let it catch up.
+    tick(1);
+
+    Vec3f center = pActors[actorId].pos + Vec3f(0, 0, pActors[actorId].height / 2);
+    Vec3f viewPos = pCamera3D->ViewTransform(&center);
+    if (viewPos.x <= 0)
+        throw Exception("Actor #{} is behind the camera", actorId);
+    Vec2f screenPos = pCamera3D->Project(viewPos);
+
+    moveMouse(screenPos.x, screenPos.y);
+    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
+    if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Actor, actorId))
+        throw Exception("Failed to point mouse at actor #{}", actorId);
+}
+
 void EngineController::pointMouseAtDecoration(int decorationId) {
     // Camera matrices are updated when a frame is rendered, so if the party was teleported without ticking, the
     // camera is still at the old position. Tick once to let it catch up.
@@ -427,23 +443,6 @@ void EngineController::pointMouseAtDecoration(int decorationId) {
     tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
     if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Decoration, decorationId))
         throw Exception("Failed to point mouse at decoration #{}", decorationId);
-}
-
-void EngineController::pointMouseAtActor(int actorId) {
-    // Camera matrices are updated when a frame is rendered, so if the party was teleported without ticking, the
-    // camera is still at the old position. Tick once to let it catch up.
-    tick(1);
-
-    Vec3f center = pActors[actorId].pos + Vec3f(0, 0, pActors[actorId].height / 2);
-    Vec3f viewPos = pCamera3D->ViewTransform(&center);
-    if (viewPos.x <= 0)
-        throw Exception("Actor #{} is behind the camera", actorId);
-    Vec2f screenPos = pCamera3D->Project(viewPos);
-
-    moveMouse(screenPos.x, screenPos.y);
-    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
-    if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Actor, actorId))
-        throw Exception("Failed to point mouse at actor #{}", actorId);
 }
 
 void EngineController::goToGameOrMainMenu() {

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -305,6 +305,10 @@ Actor *EngineController::spawnMonster(Vec3f position, MonsterId id, SpawnFlags f
 
     if (flags & SPAWN_STATIONARY)
         actor->moveSpeed = 1;
+    if (flags & SPAWN_FRIENDLY) {
+        actor->attributes &= ~ACTOR_AGGRESSOR;
+        actor->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
+    }
     if (flags & SPAWN_NO_RESISTANCES) {
         actor->monsterInfo.resFire = 0;
         actor->monsterInfo.resAir = 0;

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -138,6 +138,10 @@ void EngineController::pressAndReleaseButton(PlatformMouseButton button, int x, 
     releaseButton(button, x, y);
 }
 
+void EngineController::pressAndReleaseButton(PlatformMouseButton button, Pointi point) {
+    pressAndReleaseButton(button, point.x, point.y);
+}
+
 void EngineController::pressGuiButton(std::string_view buttonId) {
     GUIButton *button = existingButton(buttonId);
     Pointi center = button->rect.center();

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -422,7 +422,7 @@ void EngineController::pointMouseAtActor(int actorId) {
     Vec2f screenPos = pCamera3D->Project(viewPos);
 
     moveMouse(screenPos.x, screenPos.y);
-    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
+    tick(1); // The mouse move is a queued event, the pick sees the new position only once it's processed.
     if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Actor, actorId))
         throw Exception("Failed to point mouse at actor #{}", actorId);
 }
@@ -440,7 +440,7 @@ void EngineController::pointMouseAtDecoration(int decorationId) {
     Vec2f screenPos = pCamera3D->Project(viewPos);
 
     moveMouse(screenPos.x, screenPos.y);
-    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
+    tick(1); // The mouse move is a queued event, the pick sees the new position only once it's processed.
     if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Decoration, decorationId))
         throw Exception("Failed to point mouse at decoration #{}", decorationId);
 }

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -323,6 +323,7 @@ Actor *EngineController::spawnMonster(Vec3f position, MonsterId id, SpawnFlags f
     if (flags & SPAWN_FRIENDLY) {
         actor->attributes &= ~ACTOR_AGGRESSOR;
         actor->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
+        actor->hostilityGroup = MONSTER_TYPE_INVALID; // The party's own faction, what summons and resurrects get.
     }
     if (flags & SPAWN_NO_RESISTANCES) {
         actor->monsterInfo.resFire = 0;

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -401,8 +401,8 @@ void EngineController::pointMouseAtActor(int actorId) {
     Vec2f screenPos = pCamera3D->Project(viewPos);
 
     moveMouse(screenPos.x, screenPos.y);
-    tick(1); // Wait for Mouse::uPointingObjectID to pick up the new mouse position.
-    if (mouse->uPointingObjectID != Pid(OBJECT_Actor, actorId))
+    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
+    if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Actor, actorId))
         throw Exception("Failed to point mouse at actor #{}", actorId);
 }
 

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -22,6 +22,8 @@
 #include "Engine/Evt/Processor.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Objects/Actor.h"
+#include "Engine/Objects/Decoration.h"
+#include "Engine/Objects/DecorationList.h"
 #include "Engine/Objects/MonsterEnumFunctions.h"
 #include "Engine/Graphics/Camera.h"
 #include "Engine/Graphics/Vis.h"
@@ -387,6 +389,24 @@ void EngineController::castQuickSpell(int characterIndex, SpellId spell) {
     // roll back the quick spell. Thus two ticks.
     tick(2);
     character.uQuickSpell = oldQuickSpell;
+}
+
+void EngineController::pointMouseAtDecoration(int decorationId) {
+    // Camera matrices are updated when a frame is rendered, so if the party was teleported without ticking, the
+    // camera is still at the old position. Tick once to let it catch up.
+    tick(1);
+
+    const DecorationDesc *desc = pDecorationList->GetDecoration(pLevelDecorations[decorationId].uDecorationDescID);
+    Vec3f center = pLevelDecorations[decorationId].vPosition + Vec3f(0, 0, desc->uDecorationHeight / 2);
+    Vec3f viewPos = pCamera3D->ViewTransform(&center);
+    if (viewPos.x <= 0)
+        throw Exception("Decoration #{} is behind the camera", decorationId);
+    Vec2f screenPos = pCamera3D->Project(viewPos);
+
+    moveMouse(screenPos.x, screenPos.y);
+    tick(1); // The pick reads render billboards, so the new mouse position needs a rendered frame.
+    if (engine->PickMouseForTargeting().pid != Pid(OBJECT_Decoration, decorationId))
+        throw Exception("Failed to point mouse at decoration #{}", decorationId);
 }
 
 void EngineController::pointMouseAtActor(int actorId) {

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -24,7 +24,8 @@ enum class SpawnFlag {
     SPAWN_STATIONARY = 0x1, // Set moveSpeed to 1 so that the monster stays in place.
     SPAWN_NO_RESISTANCES = 0x2, // Zero out all resistances. Note that you might also want to set `SPAWN_LEVEL_1`.
     SPAWN_LEVEL_1 = 0x4, // Set level to 1. Level is used in to-hit, resistance and special attack rolls.
-    SPAWN_FRIENDLY = 0x8, // Make the monster friendly to the party instead of unconditionally hostile.
+    SPAWN_FRIENDLY = 0x8, // Drop the aggressor flag and set friendly hostility. The monster type's own hostility
+                          // table still applies, so spawn something table-friendly, like a peasant.
 
     // A predictable stationary target for damage-related tests.
     SPAWN_DUMMY = SPAWN_STATIONARY | SPAWN_NO_RESISTANCES | SPAWN_LEVEL_1,

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -24,8 +24,7 @@ enum class SpawnFlag {
     SPAWN_STATIONARY = 0x1, // Set moveSpeed to 1 so that the monster stays in place.
     SPAWN_NO_RESISTANCES = 0x2, // Zero out all resistances. Note that you might also want to set `SPAWN_LEVEL_1`.
     SPAWN_LEVEL_1 = 0x4, // Set level to 1. Level is used in to-hit, resistance and special attack rolls.
-    SPAWN_FRIENDLY = 0x8, // Drop the aggressor flag and set friendly hostility. The monster type's own hostility
-                          // table still applies, so spawn something table-friendly, like a peasant.
+    SPAWN_FRIENDLY = 0x8, // Make the monster friendly to the party, whatever the hostility table says about its type.
 
     // A predictable stationary target for damage-related tests.
     SPAWN_DUMMY = SPAWN_STATIONARY | SPAWN_NO_RESISTANCES | SPAWN_LEVEL_1,

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -7,6 +7,7 @@
 #include "Engine/Objects/MonsterEnums.h"
 #include "Engine/MapEnums.h"
 
+#include "Library/Geometry/Point.h"
 #include "Library/Platform/Interface/PlatformEnums.h"
 #include "Library/Platform/Interface/PlatformEvents.h"
 
@@ -63,6 +64,7 @@ class EngineController {
 
     void pressAndReleaseKey(PlatformKey key);
     void pressAndReleaseButton(PlatformMouseButton button, int x, int y);
+    void pressAndReleaseButton(PlatformMouseButton button, Pointi point);
 
     /**
      * Presses a GUI button identified by the provided id by sending a mouse press and release event.

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -23,6 +23,7 @@ enum class SpawnFlag {
     SPAWN_STATIONARY = 0x1, // Set moveSpeed to 1 so that the monster stays in place.
     SPAWN_NO_RESISTANCES = 0x2, // Zero out all resistances. Note that you might also want to set `SPAWN_LEVEL_1`.
     SPAWN_LEVEL_1 = 0x4, // Set level to 1. Level is used in to-hit, resistance and special attack rolls.
+    SPAWN_FRIENDLY = 0x8, // Make the monster friendly to the party instead of unconditionally hostile.
 
     // A predictable stationary target for damage-related tests.
     SPAWN_DUMMY = SPAWN_STATIONARY | SPAWN_NO_RESISTANCES | SPAWN_LEVEL_1,

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -59,8 +59,11 @@ class EngineController {
     void pressAutoRepeatedKey(PlatformKey key);
     void releaseKey(PlatformKey key);
     void pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick = false);
+    void pressButton(PlatformMouseButton button, Pointi point, bool isDoubleClick = false);
     void releaseButton(PlatformMouseButton button, int x, int y);
+    void releaseButton(PlatformMouseButton button, Pointi point);
     void moveMouse(int x, int y);
+    void moveMouse(Pointi point);
 
     void pressAndReleaseKey(PlatformKey key);
     void pressAndReleaseButton(PlatformMouseButton button, int x, int y);

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -161,6 +161,14 @@ class EngineController {
      */
     void pointMouseAtActor(int actorId);
 
+    /**
+     * Finds a screen position at which the mouse points at the provided decoration & moves the mouse there.
+     *
+     * @param decorationId              Id of the decoration to point at.
+     * @throws Exception                If pointing at the decoration is not possible, e.g. it's not on the screen.
+     */
+    void pointMouseAtDecoration(int decorationId);
+
  private:
     void goToGameOrMainMenu();
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -448,8 +448,6 @@ Vis_PIDAndDepth Engine::PickKeyboard(float pick_depth, Vis_SelectionFilter *spri
 
 Vis_PIDAndDepth Engine::PickMouseInfoPopup() {
     Pointi pt = mouse->position();
-    // TODO(captainurist): Right now we can have popups for monsters that are not reachable with a bow, and this is OK.
-    //                     However, such monsters also don't get a hint displayed on mouseover. Probably should fix this?
     return PickMouse(pCamera3D->GetMouseInfoDepth(), pt.x, pt.y, &vis_allsprites_filter, &vis_face_filter);
 }
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -461,6 +461,11 @@ Vis_PIDAndDepth Engine::PickMouseForInteraction() {
     return PickMouse(config->gameplay.MouseInteractionDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
 }
 
+Vis_PIDAndDepth Engine::PickMouseForCombatClick() {
+    Pointi pt = mouse->position();
+    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
+}
+
 void Engine::toggleOverlays() {
     bool isEnabled = _overlaySystem.isEnabled();
     _overlaySystem.setEnabled(!isEnabled);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -446,19 +446,19 @@ Vis_PIDAndDepth Engine::PickKeyboard(float pick_depth, Vis_SelectionFilter *spri
     }
 }
 
-Vis_PIDAndDepth Engine::PickMouseInfoPopup() {
+Vis_PIDAndDepth Engine::PickMouseForInfo() {
     Pointi pt = mouse->position();
-    return PickMouse(pCamera3D->GetMouseInfoDepth(), pt.x, pt.y, &vis_allsprites_filter, &vis_face_filter);
+    return PickMouse(pCamera3D->GetMouseInfoDepth(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
 }
 
-Vis_PIDAndDepth Engine::PickMouseTarget() {
+Vis_PIDAndDepth Engine::PickMouseForTargeting() {
     Pointi pt = mouse->position();
-    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_sprite_targets_filter, &vis_face_filter);
+    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_no_decorations_filter, &vis_face_filter);
 }
 
-Vis_PIDAndDepth Engine::PickMouseNormal() {
+Vis_PIDAndDepth Engine::PickMouseForInteraction() {
     Pointi pt = mouse->position();
-    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_items_filter, &vis_face_filter);
+    return PickMouse(config->gameplay.MouseInteractionDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
 }
 
 void Engine::toggleOverlays() {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -453,17 +453,12 @@ Vis_PIDAndDepth Engine::PickMouseForInfo() {
 
 Vis_PIDAndDepth Engine::PickMouseForTargeting() {
     Pointi pt = mouse->position();
-    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_no_decorations_filter, &vis_face_filter);
+    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
 }
 
 Vis_PIDAndDepth Engine::PickMouseForInteraction() {
     Pointi pt = mouse->position();
     return PickMouse(config->gameplay.MouseInteractionDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
-}
-
-Vis_PIDAndDepth Engine::PickMouseForCombatClick() {
-    Pointi pt = mouse->position();
-    return PickMouse(config->gameplay.RangedAttackDepth.value(), pt.x, pt.y, &vis_anything_filter, &vis_face_filter);
 }
 
 void Engine::toggleOverlays() {

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -88,8 +88,8 @@ class Engine {
     Vis_PIDAndDepth PickMouseForInfo();
 
     /**
-     * Picks a combat target under the cursor for attacks and targeted spells. Reaches to the ranged attack
-     * depth and matches anything, so a decoration in front of a monster eats the pick.
+     * Picks whatever is under the cursor for attacks, targeted spells and viewport clicks. Reaches to the
+     * ranged attack depth and matches anything, so a decoration in front of a monster eats the pick.
      */
     Vis_PIDAndDepth PickMouseForTargeting();
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -94,8 +94,8 @@ class Engine {
     Vis_PIDAndDepth PickMouseForTargeting();
 
     /**
-     * Picks whatever is under the cursor for a viewport click - item pickup, corpse looting, talking and
-     * levers. Reaches to the mouse interaction depth, matches anything.
+     * Picks the actor under the cursor for stealing from it. Reaches to the mouse interaction depth,
+     * matches anything.
      */
     Vis_PIDAndDepth PickMouseForInteraction();
 

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -81,9 +81,23 @@ class Engine {
                               Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
     Vis_PIDAndDepth PickKeyboard(float pick_depth, Vis_SelectionFilter *sprite_filter, Vis_SelectionFilter *face_filter);
 
-    Vis_PIDAndDepth PickMouseInfoPopup();
-    Vis_PIDAndDepth PickMouseTarget();
-    Vis_PIDAndDepth PickMouseNormal();
+    /**
+     * Picks whatever is under the cursor for display purposes - monster popups and status bar hints.
+     * Reaches to the monster popup depth, matches anything.
+     */
+    Vis_PIDAndDepth PickMouseForInfo();
+
+    /**
+     * Picks a combat target under the cursor for attacks and targeted spells. Reaches to the ranged attack
+     * depth, matches anything except decorations.
+     */
+    Vis_PIDAndDepth PickMouseForTargeting();
+
+    /**
+     * Picks whatever is under the cursor for a viewport click - item pickup, corpse looting, talking and
+     * levers. Reaches to the mouse interaction depth, matches anything.
+     */
+    Vis_PIDAndDepth PickMouseForInteraction();
 
     /**
      * @offset 0x42213C

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -100,6 +100,12 @@ class Engine {
     Vis_PIDAndDepth PickMouseForInteraction();
 
     /**
+     * Picks what a viewport click sees beyond interaction reach. Reaches to the ranged attack depth and
+     * matches anything, so a decoration in front of a monster still eats the click.
+     */
+    Vis_PIDAndDepth PickMouseForCombatClick();
+
+    /**
      * @offset 0x42213C
      */
     void onGameViewportClick();

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -89,7 +89,7 @@ class Engine {
 
     /**
      * Picks a combat target under the cursor for attacks and targeted spells. Reaches to the ranged attack
-     * depth, matches anything except decorations.
+     * depth and matches anything, so a decoration in front of a monster eats the pick.
      */
     Vis_PIDAndDepth PickMouseForTargeting();
 
@@ -98,12 +98,6 @@ class Engine {
      * levers. Reaches to the mouse interaction depth, matches anything.
      */
     Vis_PIDAndDepth PickMouseForInteraction();
-
-    /**
-     * Picks what a viewport click sees beyond interaction reach. Reaches to the ranged attack depth and
-     * matches anything, so a decoration in front of a monster still eats the click.
-     */
-    Vis_PIDAndDepth PickMouseForCombatClick();
 
     /**
      * @offset 0x42213C

--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -494,6 +494,15 @@ int EvtInterpreter::executeOneEvent(int step, bool isNpc) {
             break;
         }
         case EVENT_ChangeEvent:
+            // The operand is the absolute id of the global event to run on the next click, and the byte in decorVars
+            // stores it relative to the dispatch base of 380. The -124 is -380 folded through the mod-256 store, so
+            // the round trip only works for ids in [380, 635], and all shipped MM6 and MM7 records fit - every
+            // non-zero operand in both games' evt files is in [383, 443]. MM8 data doesn't fit. Its global.evt uses
+            // ids 268-289 and 531-570, and its engine maps them piecewise - states 0-21 are events 268-289, states
+            // 23-62 are events 531-570, everything else passes through unchanged. Read out of the PS2 SLPS_250.31
+            // binary at 0xa33e0 and 0xa3418, the PC MM8.exe is presumed to match.
+            // TODO(captainurist): make the state<->event mapping per-game before feeding MM8 data through here, and
+            //                     spell the MM7 store as -380 while at it.
             if (ir.data.event_id) {
                 engine->_persistentVariables.decorVars[activeLevelDecoration->eventVarId] = ir.data.event_id - 124;
             } else {

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -213,54 +213,19 @@ void DecorationInteraction(unsigned int id, Pid pid) {
 }
 
 void Engine::onGameViewportClick() {
-    int16_t clickable_distance = 512;
-
     // bug fix - stops you entering shops while dialog still open.
     // was SCREEN_NPC_DIALOGUE
     if (current_screen_type != SCREEN_GAME) {
         return;
     }
 
-    auto pidAndDepth = engine->PickMouseNormal();
-    Pid pid = pidAndDepth.pid;
-    int16_t distance = pidAndDepth.depth;
-    bool in_range = distance < clickable_distance;
-
-    if (pid.type() == OBJECT_Sprite) {
-        int item_id = pid.id();
-        // v21 = (signed int)(uint16_t)v0 >> 3;
-        if (pSpriteObjects[item_id].IsUnpickable() || item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID || !in_range) {
-            pParty->dropHeldItem();
-        } else {
-            ItemInteraction(item_id);
-        }
-    } else if (pid.type() == OBJECT_Actor) {
-        int mon_id = pid.id();
-
-        if (pActors[mon_id].aiState == Dead) {
-            if (in_range) {
-                pActors[mon_id].LootActor();
+    // A combat click - the actor is either hostile or out of interaction reach.
+    auto combatClickOnActor = [this] {
+        if (!keyboardInputHandler->IsCastOnClickToggled()) {
+            if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
+                pTurnEngine->flags |= TE_FLAG_8_finished;
             } else {
-                pParty->dropHeldItem();
-            }
-        } else if (!keyboardInputHandler->IsCastOnClickToggled()) {
-            if (CanInteractWithActor(mon_id)) {
-                if (in_range) {
-                    if (pParty->hasActiveCharacter()) {
-                        InteractWithActor(mon_id);
-                    } else {
-                        // Do not interact with actors with no active character
-                        engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
-                    }
-                } else {
-                    pParty->dropHeldItem();
-                }
-            } else {
-                if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
-                    pTurnEngine->flags |= TE_FLAG_8_finished;
-                } else {
-                    engine->_messageQueue->addMessageCurrentFrame(UIMSG_Attack, 0, 0);
-                }
+                engine->_messageQueue->addMessageCurrentFrame(UIMSG_Attack, 0, 0);
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->setAirborne(true);
@@ -273,19 +238,41 @@ void Engine::onGameViewportClick() {
         } else {
             pAudioPlayer->playUISound(SOUND_error);
         }
-    } else if (pid.type() == OBJECT_Decoration) {
-        int id = pid.id();
-        if (distance - pDecorationList->GetDecoration(pLevelDecorations[id].uDecorationDescID)->uRadius < clickable_distance) {
+    };
+
+    Pid pid = engine->PickMouseForInteraction().pid;
+
+    if (pid.type() == OBJECT_Sprite) {
+        int item_id = pid.id();
+        if (pSpriteObjects[item_id].IsUnpickable() || item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID) {
+            pParty->dropHeldItem();
+        } else {
+            ItemInteraction(item_id);
+        }
+    } else if (pid.type() == OBJECT_Actor) {
+        int mon_id = pid.id();
+
+        if (pActors[mon_id].aiState == Dead) {
+            pActors[mon_id].LootActor();
+        } else if (CanInteractWithActor(mon_id) && !keyboardInputHandler->IsCastOnClickToggled()) {
             if (pParty->hasActiveCharacter()) {
-                // Do not interact with decoration with no active character
-                DecorationInteraction(id, pid);
+                InteractWithActor(mon_id);
             } else {
+                // Do not interact with actors with no active character
                 engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
             }
         } else {
-            pParty->dropHeldItem();
+            combatClickOnActor();
         }
-    } else if (pid.type() == OBJECT_Face && in_range) {
+    } else if (pid.type() == OBJECT_Decoration) {
+        int id = pid.id();
+        if (pParty->hasActiveCharacter()) {
+            // Do not interact with decoration with no active character
+            DecorationInteraction(id, pid);
+        } else {
+            engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
+        }
+    } else if (pid.type() == OBJECT_Face) {
         int eventId = 0;
 
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
@@ -320,6 +307,12 @@ void Engine::onGameViewportClick() {
             engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
         }
     } else {
-        pParty->dropHeldItem();
+        // Nothing in interaction reach, but a live actor within targeting reach still takes the click as combat.
+        Pid target = engine->PickMouseForTargeting().pid;
+        if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
+            combatClickOnActor();
+        } else {
+            pParty->dropHeldItem();
+        }
     }
 }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -307,8 +307,9 @@ void Engine::onGameViewportClick() {
             engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
         }
     } else {
-        // Nothing in interaction reach, but a live actor within targeting reach still takes the click as combat.
-        Pid target = engine->PickMouseForTargeting().pid;
+        // Nothing in interaction reach, but an unobstructed live actor within ranged reach still takes the
+        // click as combat - a decoration in front of the actor eats the click instead.
+        Pid target = engine->PickMouseForCombatClick().pid;
         if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
             combatClickOnActor();
         } else {

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -213,19 +213,53 @@ void DecorationInteraction(unsigned int id, Pid pid) {
 }
 
 void Engine::onGameViewportClick() {
+    int clickable_distance = engine->config->gameplay.MouseInteractionDepth.value();
+
     // bug fix - stops you entering shops while dialog still open.
     // was SCREEN_NPC_DIALOGUE
     if (current_screen_type != SCREEN_GAME) {
         return;
     }
 
-    // A combat click - the actor is either hostile or out of interaction reach.
-    auto combatClickOnActor = [this] {
-        if (!keyboardInputHandler->IsCastOnClickToggled()) {
-            if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
-                pTurnEngine->flags |= TE_FLAG_8_finished;
+    auto pidAndDepth = engine->PickMouseForTargeting();
+    Pid pid = pidAndDepth.pid;
+    int distance = pidAndDepth.depth;
+    bool in_range = distance < clickable_distance;
+
+    if (pid.type() == OBJECT_Sprite) {
+        int item_id = pid.id();
+        if (pSpriteObjects[item_id].IsUnpickable() || !pSpriteObjects[item_id].uObjectDescID || !in_range) {
+            pParty->dropHeldItem();
+        } else {
+            ItemInteraction(item_id);
+        }
+    } else if (pid.type() == OBJECT_Actor) {
+        int mon_id = pid.id();
+
+        if (pActors[mon_id].aiState == Dead) {
+            if (in_range) {
+                pActors[mon_id].LootActor();
             } else {
-                engine->_messageQueue->addMessageCurrentFrame(UIMSG_Attack, 0, 0);
+                pParty->dropHeldItem();
+            }
+        } else if (!keyboardInputHandler->IsCastOnClickToggled()) {
+            if (CanInteractWithActor(mon_id)) {
+                if (in_range) {
+                    if (pParty->hasActiveCharacter()) {
+                        InteractWithActor(mon_id);
+                    } else {
+                        // Do not interact with actors with no active character
+                        engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
+                    }
+                } else {
+                    pParty->dropHeldItem();
+                }
+            } else {
+                if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
+                    pTurnEngine->flags |= TE_FLAG_8_finished;
+                } else {
+                    engine->_messageQueue->addMessageCurrentFrame(UIMSG_Attack, 0, 0);
+                }
             }
         } else if (pParty->bTurnBasedModeOn && pTurnEngine->turn_stage == TE_MOVEMENT) {
             pParty->setAirborne(true);
@@ -238,41 +272,19 @@ void Engine::onGameViewportClick() {
         } else {
             pAudioPlayer->playUISound(SOUND_error);
         }
-    };
-
-    Pid pid = engine->PickMouseForInteraction().pid;
-
-    if (pid.type() == OBJECT_Sprite) {
-        int item_id = pid.id();
-        if (pSpriteObjects[item_id].IsUnpickable() || !pSpriteObjects[item_id].uObjectDescID) {
-            pParty->dropHeldItem();
-        } else {
-            ItemInteraction(item_id);
-        }
-    } else if (pid.type() == OBJECT_Actor) {
-        int mon_id = pid.id();
-
-        if (pActors[mon_id].aiState == Dead) {
-            pActors[mon_id].LootActor();
-        } else if (CanInteractWithActor(mon_id) && !keyboardInputHandler->IsCastOnClickToggled()) {
+    } else if (pid.type() == OBJECT_Decoration) {
+        int id = pid.id();
+        if (distance - pDecorationList->GetDecoration(pLevelDecorations[id].uDecorationDescID)->uRadius < clickable_distance) {
             if (pParty->hasActiveCharacter()) {
-                InteractWithActor(mon_id);
+                // Do not interact with decoration with no active character
+                DecorationInteraction(id, pid);
             } else {
-                // Do not interact with actors with no active character
                 engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
             }
         } else {
-            combatClickOnActor();
+            pParty->dropHeldItem();
         }
-    } else if (pid.type() == OBJECT_Decoration) {
-        int id = pid.id();
-        if (pParty->hasActiveCharacter()) {
-            // Do not interact with decoration with no active character
-            DecorationInteraction(id, pid);
-        } else {
-            engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
-        }
-    } else if (pid.type() == OBJECT_Face) {
+    } else if (pid.type() == OBJECT_Face && in_range) {
         int eventId = 0;
 
         if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
@@ -307,24 +319,6 @@ void Engine::onGameViewportClick() {
             engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
         }
     } else {
-        // Nothing in interaction reach, but an unobstructed live actor within ranged reach still takes the
-        // click as combat - a decoration in front of the actor eats the click instead.
-        Vis_PIDAndDepth object = engine->PickMouseForTargeting();
-        Pid target = object.pid;
-        if (target.type() == OBJECT_Decoration &&
-            object.depth - pDecorationList->GetDecoration(pLevelDecorations[target.id()].uDecorationDescID)->uRadius <
-                engine->config->gameplay.MouseInteractionDepth.value()) {
-            // A decoration's clickable reach extends by its radius, so a big one is clickable past interaction depth.
-            if (pParty->hasActiveCharacter()) {
-                DecorationInteraction(target.id(), target);
-            } else {
-                engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
-            }
-        } else if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead &&
-                   (!CanInteractWithActor(target.id()) || keyboardInputHandler->IsCastOnClickToggled())) {
-            combatClickOnActor(); // With cast-on-click held, a friendly actor takes the quick spell too, as in vanilla.
-        } else {
-            pParty->dropHeldItem();
-        }
+        pParty->dropHeldItem();
     }
 }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -206,7 +206,7 @@ void DecorationInteraction(unsigned int id, Pid pid) {
     } else {
         if (pLevelDecorations[id].IsInteractive()) {
             activeLevelDecoration = &pLevelDecorations[id];
-            eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[id].eventVarId] + 380, Pid(), 1);
+            eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[id].eventVarId] + 380, Pid(), 1); // 380 is the MM7 dispatch base, see EVENT_ChangeEvent.
             activeLevelDecoration = nullptr;
         }
     }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -244,7 +244,7 @@ void Engine::onGameViewportClick() {
 
     if (pid.type() == OBJECT_Sprite) {
         int item_id = pid.id();
-        if (pSpriteObjects[item_id].IsUnpickable() || item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID) {
+        if (pSpriteObjects[item_id].IsUnpickable() || !pSpriteObjects[item_id].uObjectDescID) {
             pParty->dropHeldItem();
         } else {
             ItemInteraction(item_id);

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -320,8 +320,9 @@ void Engine::onGameViewportClick() {
             } else {
                 engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
             }
-        } else if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
-            combatClickOnActor();
+        } else if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead &&
+                   (!CanInteractWithActor(target.id()) || keyboardInputHandler->IsCastOnClickToggled())) {
+            combatClickOnActor(); // With cast-on-click held, a friendly actor takes the quick spell too, as in vanilla.
         } else {
             pParty->dropHeldItem();
         }

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -309,8 +309,18 @@ void Engine::onGameViewportClick() {
     } else {
         // Nothing in interaction reach, but an unobstructed live actor within ranged reach still takes the
         // click as combat - a decoration in front of the actor eats the click instead.
-        Pid target = engine->PickMouseForTargeting().pid;
-        if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
+        Vis_PIDAndDepth object = engine->PickMouseForTargeting();
+        Pid target = object.pid;
+        if (target.type() == OBJECT_Decoration &&
+            object.depth - pDecorationList->GetDecoration(pLevelDecorations[target.id()].uDecorationDescID)->uRadius <
+                engine->config->gameplay.MouseInteractionDepth.value()) {
+            // A decoration's clickable reach extends by its radius, so a big one is clickable past interaction depth.
+            if (pParty->hasActiveCharacter()) {
+                DecorationInteraction(target.id(), target);
+            } else {
+                engine->_statusBar->setEvent(LSTR_NOBODY_IS_IN_CONDITION);
+            }
+        } else if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
             combatClickOnActor();
         } else {
             pParty->dropHeldItem();

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -309,7 +309,7 @@ void Engine::onGameViewportClick() {
     } else {
         // Nothing in interaction reach, but an unobstructed live actor within ranged reach still takes the
         // click as combat - a decoration in front of the actor eats the click instead.
-        Pid target = engine->PickMouseForCombatClick().pid;
+        Pid target = engine->PickMouseForTargeting().pid;
         if (target.type() == OBJECT_Actor && pActors[target.id()].aiState != Dead && !CanInteractWithActor(target.id())) {
             combatClickOnActor();
         } else {

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -26,18 +26,16 @@
 
 static Vis_SelectionList Vis_static_sub_4C1944_stru_F8BDE8;
 
-Vis_SelectionFilter vis_sprite_targets_filter = {
+Vis_SelectionFilter vis_no_decorations_filter = {
     VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType};  // 00F93E1C
-Vis_SelectionFilter vis_allsprites_filter = {
-    VisObjectType_Sprite, OBJECT_None, 0, 0, ExcludeType};  // 00F93E30
+Vis_SelectionFilter vis_anything_filter = {
+    VisObjectType_Sprite, OBJECT_None, 0, 0, ExcludeType};  // 00F93E30, "exclude nothing" matches every billboard.
 Vis_SelectionFilter vis_face_filter = {
     VisObjectType_Face, OBJECT_None, -1, 0, None};  // 00F93E44
 Vis_SelectionFilter vis_door_filter = {
     VisObjectType_Face, OBJECT_Door, -1, static_cast<int>(FACE_HAS_HINT), None };  // 00F93E58
 Vis_SelectionFilter vis_decoration_noevent_filter = {
     VisObjectType_Sprite, OBJECT_Decoration, -1, 0, ExclusionIfNoEvent};  // 00F93E6C
-Vis_SelectionFilter vis_items_filter = {
-    VisObjectType_Any, OBJECT_Sprite, -1, 0, None };  // static to sub_44EEA7
 
 //----- (004C1026) --------------------------------------------------------
 Vis_ObjectInfo *Vis::DetermineFacetIntersection(BLVFace *face, Pid pid, float pick_depth) {

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -26,8 +26,6 @@
 
 static Vis_SelectionList Vis_static_sub_4C1944_stru_F8BDE8;
 
-Vis_SelectionFilter vis_no_decorations_filter = {
-    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType};  // 00F93E1C
 Vis_SelectionFilter vis_anything_filter = {
     VisObjectType_Sprite, OBJECT_None, 0, 0, ExcludeType};  // 00F93E30, "exclude nothing" matches every billboard.
 Vis_SelectionFilter vis_face_filter = {

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -38,12 +38,11 @@ struct Vis_SelectionFilter {  // stru157
     VisSelectFlags select_flags;
 };
 
-extern Vis_SelectionFilter vis_sprite_targets_filter;  // 00F93E1C
-extern Vis_SelectionFilter vis_allsprites_filter;  // 00F93E30
+extern Vis_SelectionFilter vis_no_decorations_filter;  // 00F93E1C
+extern Vis_SelectionFilter vis_anything_filter;  // 00F93E30
 extern Vis_SelectionFilter vis_face_filter;      // 00F93E44
 extern Vis_SelectionFilter vis_door_filter;      // 00F93E58
 extern Vis_SelectionFilter vis_decoration_noevent_filter;  // 00F93E6C
-extern Vis_SelectionFilter vis_items_filter;  // static to sub_44EEA7
 
 struct Vis_PIDAndDepth {
     Pid pid;

--- a/src/Engine/Graphics/Vis.h
+++ b/src/Engine/Graphics/Vis.h
@@ -38,7 +38,6 @@ struct Vis_SelectionFilter {  // stru157
     VisSelectFlags select_flags;
 };
 
-extern Vis_SelectionFilter vis_no_decorations_filter;  // 00F93E1C
 extern Vis_SelectionFilter vis_anything_filter;  // 00F93E30
 extern Vis_SelectionFilter vis_face_filter;      // 00F93E44
 extern Vis_SelectionFilter vis_door_filter;      // 00F93E58

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Spells/CastSpellInfo.h"
 #include "Engine/Spells/Spells.h"
 #include "Engine/Spells/SpellEnumFunctions.h"
+#include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
@@ -6339,7 +6340,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
         }
     }
 
-    Pid target_pid = mouse->uPointingObjectID;
+    Pid target_pid = engine->PickMouseForTargeting().pid;
     ObjectType target_type = target_pid.type();
     int target_id = target_pid.id();
     if (target_type != OBJECT_Actor || !pActors[target_id].CanBeDamaged()) {

--- a/src/Engine/Objects/Decoration.h
+++ b/src/Engine/Objects/Decoration.h
@@ -25,4 +25,5 @@ struct LevelDecoration {
 
 extern std::vector<LevelDecoration> pLevelDecorations;
 extern std::vector<int> decorationsWithSound;
+// TODO(captainurist): should be passed to eventProcessor explicitly, not smuggled in through a global.
 extern LevelDecoration *activeLevelDecoration;  // 5C3420

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2187,6 +2187,7 @@ void CastSpellInfoHelpers::castSpell() {
                         OpenedTelekinesis = true;
                         if (pLevelDecorations[obj_id].uEventID) {
                             eventProcessor(pLevelDecorations[obj_id].uEventID, spell_targeted_at, 1);
+                            pLevelDecorations[obj_id].uFlags |= LEVEL_DECORATION_VISIBLE_ON_MAP;
                         } else if (pLevelDecorations[obj_id].IsInteractive()) {
                             activeLevelDecoration = &pLevelDecorations[obj_id];
                             eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[obj_id].eventVarId] + 380, Pid(), 1); // 380 is the MM7 dispatch base, see EVENT_ChangeEvent.

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -10,6 +10,7 @@
 #include "Engine/Graphics/Camera.h"
 #include "Engine/Objects/Decoration.h"
 #include "Engine/Graphics/Outdoor.h"
+#include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Localization.h"
@@ -150,11 +151,10 @@ void CastSpellInfoHelpers::castSpell() {
         Pid spell_targeted_at = pCastSpell->targetPid;
 
         // First try to pick live actor mouse is pointing at
-        if (!spell_targeted_at &&
-                mouse->uPointingObjectID &&
-                mouse->uPointingObjectID.type() == OBJECT_Actor &&
-                pActors[mouse->uPointingObjectID.id()].CanBeDamaged()) {
-            spell_targeted_at = mouse->uPointingObjectID;
+        if (!spell_targeted_at) {
+            Pid pointed = engine->PickMouseForTargeting().pid;
+            if (pointed.type() == OBJECT_Actor && pActors[pointed.id()].CanBeDamaged())
+                spell_targeted_at = pointed;
         }
 
         // Otherwise pick closest live actor

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2189,7 +2189,7 @@ void CastSpellInfoHelpers::castSpell() {
                             eventProcessor(pLevelDecorations[obj_id].uEventID, spell_targeted_at, 1);
                         } else if (pLevelDecorations[obj_id].IsInteractive()) {
                             activeLevelDecoration = &pLevelDecorations[obj_id];
-                            eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[obj_id].eventVarId] + 380, Pid(), 1);
+                            eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[obj_id].eventVarId] + 380, Pid(), 1); // 380 is the MM7 dispatch base, see EVENT_ChangeEvent.
                             activeLevelDecoration = nullptr;
                         }
                     }

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2187,9 +2187,7 @@ void CastSpellInfoHelpers::castSpell() {
                         OpenedTelekinesis = true;
                         if (pLevelDecorations[obj_id].uEventID) {
                             eventProcessor(pLevelDecorations[obj_id].uEventID, spell_targeted_at, 1);
-                        }
-                        // TODO(captainurist): investigate, that's a very weird std::to_underlying call.
-                        if (pLevelDecorations[std::to_underlying(pSpriteObjects[obj_id].containing_item.itemId)].IsInteractive()) {
+                        } else if (pLevelDecorations[obj_id].IsInteractive()) {
                             activeLevelDecoration = &pLevelDecorations[obj_id];
                             eventProcessor(engine->_persistentVariables.decorVars[pLevelDecorations[obj_id].eventVarId] + 380, Pid(), 1);
                             activeLevelDecoration = nullptr;

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2844,6 +2844,8 @@ void CastSpellInfoHelpers::castSpell() {
                 case SPELL_DARK_SOULDRINKER:
                 {
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
+                    // Vanilla swept to the mouse info depth here - 25 map cells outdoors, three times the reach
+                    // of any targeted attack.
                     std::vector<Actor*> actorsInViewport = render->getActorsInViewport(engine->config->gameplay.RangedAttackDepth.value());
                     for (Actor *actor : actorsInViewport) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -2844,7 +2844,7 @@ void CastSpellInfoHelpers::castSpell() {
                 case SPELL_DARK_SOULDRINKER:
                 {
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    std::vector<Actor*> actorsInViewport = render->getActorsInViewport(pCamera3D->GetMouseInfoDepth());
+                    std::vector<Actor*> actorsInViewport = render->getActorsInViewport(engine->config->gameplay.RangedAttackDepth.value());
                     for (Actor *actor : actorsInViewport) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                         pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -1021,7 +1021,7 @@ void CastSpellInfoHelpers::castSpell() {
                         continue;
                     }
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    for (Actor *actor : render->getActorsInViewport(4096)) {
+                    for (Actor *actor : render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value())) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                         pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
                         Actor::DamageMonsterFromParty(Pid(OBJECT_Sprite, pSpellSprite.Create(0, 0, 0, 0)), actor->id, Vec3f());
@@ -1754,7 +1754,7 @@ void CastSpellInfoHelpers::castSpell() {
                     // ++pSpellSprite.uType;
                     pSpellSprite.spriteId = SPRITE_SPELL_SPIRIT_TURN_UNDEAD_1;
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    for (Actor *actor : render->getActorsInViewport(4096)) {
+                    for (Actor *actor : render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value())) {
                         if (supertypeForMonsterId(actor->monsterInfo.id) == MONSTER_SUPERTYPE_UNDEAD) {
                             pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                             pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
@@ -2106,7 +2106,7 @@ void CastSpellInfoHelpers::castSpell() {
                     // ++pSpellSprite.uType;
                     pSpellSprite.spriteId = SPRITE_SPELL_MIND_MASS_FEAR_1;
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    for (Actor *actor : render->getActorsInViewport(4096)) {
+                    for (Actor *actor : render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value())) {
                         // Change: do not exit loop when first undead monster is found
                         if (supertypeForMonsterId(actor->monsterInfo.id) != MONSTER_SUPERTYPE_UNDEAD) {
                             pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
@@ -2394,7 +2394,7 @@ void CastSpellInfoHelpers::castSpell() {
                     pSpellSprite.spriteId = SPRITE_SPELL_LIGHT_DISPEL_MAGIC_1;
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     // Spell damage processing was removed because Dispel Magic does not do damage
-                    for (Actor *actor : render->getActorsInViewport(4096)) {
+                    for (Actor *actor : render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value())) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                         pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
                         pSpellSprite.Create(0, 0, 0, 0);
@@ -2484,7 +2484,7 @@ void CastSpellInfoHelpers::castSpell() {
                     // ++pSpellSprite.uType;
                     pSpellSprite.spriteId = SPRITE_SPELL_LIGHT_PRISMATIC_LIGHT_1;
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    for (Actor *actor : render->getActorsInViewport(4096)) {
+                    for (Actor *actor : render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value())) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                         pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
                         Actor::DamageMonsterFromParty(Pid(OBJECT_Sprite, pSpellSprite.Create(0, 0, 0, 0)), actor->id, Vec3f());
@@ -2842,9 +2842,7 @@ void CastSpellInfoHelpers::castSpell() {
                 case SPELL_DARK_SOULDRINKER:
                 {
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
-                    // Vanilla swept to the mouse info depth here - 25 map cells outdoors, three times the reach
-                    // of any targeted attack.
-                    std::vector<Actor*> actorsInViewport = render->getActorsInViewport(engine->config->gameplay.RangedAttackDepth.value());
+                    std::vector<Actor*> actorsInViewport = render->getActorsInViewport(engine->config->gameplay.MassSpellDepth.value());
                     for (Actor *actor : actorsInViewport) {
                         pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                         pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -880,9 +880,16 @@ void GameUI_WritePointedObjectStatusString() {
 
             auto vis = EngineIocContainer::ResolveVis();
 
-            // get_picked_object_zbuf_val contains both the pid and the depth
             Vis_PIDAndDepth pickedObject = engine->PickMouseNormal();
             mouse->uPointingObjectID = pickedObject.pid;
+            // The pick above is capped at ranged-attack reach, but monster popups reach further. Fall back to a
+            // display-only pick at popup depth so that every monster that can show a popup also gets a status bar
+            // hint. uPointingObjectID intentionally keeps the shorter reach - combat targeting reads it.
+            if (!pickedObject.pid) {
+                Vis_PIDAndDepth popupPick = engine->PickMouseInfoPopup();
+                if (popupPick.pid.type() == OBJECT_Actor)
+                    pickedObject = popupPick;
+            }
             pickedObjectID = (signed)pickedObject.pid.id();
             if (pickedObject.pid.type() == OBJECT_Sprite) {
                 if (pObjectList->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
@@ -943,20 +950,12 @@ void GameUI_WritePointedObjectStatusString() {
                 uLastPointedObjectID = Pid();
                 return;
             } else if (pickedObject.pid.type() == OBJECT_Actor) {
-                if (pickedObject.depth >= 0x2000u) {
-                    mouse->uPointingObjectID = Pid();
-                    if (uLastPointedObjectID) {
-                        engine->_statusBar->clearPermanent();
-                    }
-                    uLastPointedObjectID = Pid();
-                    return;
-                }
                 engine->_statusBar->setPermanent(pActors[pickedObjectID].GetDisplayName());
             }
-            if (!mouse->uPointingObjectID && uLastPointedObjectID) {
+            if (!pickedObject.pid && uLastPointedObjectID) {
                 engine->_statusBar->clearPermanent();
             }
-            uLastPointedObjectID = mouse->uPointingObjectID;
+            uLastPointedObjectID = pickedObject.pid;
             return;
         }
     } else if (current_screen_type == SCREEN_CHEST) {

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -22,6 +22,7 @@
 #include "Engine/Graphics/AtlasLayout.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/Sprites.h"
+#include "Engine/Graphics/Camera.h"
 #include "Engine/Graphics/Viewport.h"
 #include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Image.h"
@@ -880,16 +881,10 @@ void GameUI_WritePointedObjectStatusString() {
 
             auto vis = EngineIocContainer::ResolveVis();
 
-            Vis_PIDAndDepth pickedObject = engine->PickMouseNormal();
+            // Status bar tips share the monster popup depth, so anything close enough for a right-click popup
+            // also shows a hint.
+            Vis_PIDAndDepth pickedObject = engine->PickMouse(pCamera3D->GetMouseInfoDepth(), pX, pY, &vis_items_filter, &vis_face_filter);
             mouse->uPointingObjectID = pickedObject.pid;
-            // The pick above is capped at ranged-attack reach, but monster popups reach further. Fall back to a
-            // display-only pick at popup depth so that every monster that can show a popup also gets a status bar
-            // hint. uPointingObjectID intentionally keeps the shorter reach - combat targeting reads it.
-            if (!pickedObject.pid) {
-                Vis_PIDAndDepth popupPick = engine->PickMouseInfoPopup();
-                if (popupPick.pid.type() == OBJECT_Actor)
-                    pickedObject = popupPick;
-            }
             pickedObjectID = (signed)pickedObject.pid.id();
             if (pickedObject.pid.type() == OBJECT_Sprite) {
                 if (pObjectList->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -894,7 +894,7 @@ void GameUI_WritePointedObjectStatusString() {
                 if (!pLevelDecorations[pickedObjectID].uEventID) {
                     std::string pText;                 // ecx@79
                     if (pLevelDecorations[pickedObjectID].IsInteractive())
-                        pText = pNPCTopics[engine->_persistentVariables.decorVars[pLevelDecorations[pickedObjectID].eventVarId] + 380].pTopic; // campfire
+                        pText = pNPCTopics[engine->_persistentVariables.decorVars[pLevelDecorations[pickedObjectID].eventVarId] + 380].pTopic; // 380 is the MM7 dispatch base, see EVENT_ChangeEvent.
                     else
                         pText = pDecorationList->GetDecoration(pLevelDecorations[pickedObjectID].uDecorationDescID)->hint;
                     engine->_statusBar->setPermanent(pText);

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -845,7 +845,6 @@ void GameUI_WritePointedObjectStatusString() {
 
     // int testing;
 
-    mouse->uPointingObjectID = Pid();
     Pointi mousePos = mouse->position();
     pX = mousePos.x;
     pY = mousePos.y;
@@ -879,21 +878,15 @@ void GameUI_WritePointedObjectStatusString() {
                 return;
             }
 
-            auto vis = EngineIocContainer::ResolveVis();
-
-            // Status bar tips share the monster popup depth, so anything close enough for a right-click popup
-            // also shows a hint.
-            Vis_PIDAndDepth pickedObject = engine->PickMouse(pCamera3D->GetMouseInfoDepth(), pX, pY, &vis_items_filter, &vis_face_filter);
-            mouse->uPointingObjectID = pickedObject.pid;
+            Vis_PIDAndDepth pickedObject = engine->PickMouseForInfo();
             pickedObjectID = (signed)pickedObject.pid.id();
             if (pickedObject.pid.type() == OBJECT_Sprite) {
                 if (pObjectList->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
-                    mouse->uPointingObjectID = Pid();
                     engine->_statusBar->clearPermanent();
                     uLastPointedObjectID = Pid();
                     return;
                 }
-                if (pickedObject.depth >= 0x200u || pParty->pPickedItem.itemId != ITEM_NULL) {
+                if (pickedObject.depth >= engine->config->gameplay.MouseInteractionDepth.value() || pParty->pPickedItem.itemId != ITEM_NULL) {
                     engine->_statusBar->setPermanent(pSpriteObjects[pickedObjectID].containing_item.GetDisplayName());
                 } else {
                     engine->_statusBar->setPermanent(LSTR_GET_S, pSpriteObjects[pickedObjectID].containing_item.GetDisplayName());
@@ -913,7 +906,7 @@ void GameUI_WritePointedObjectStatusString() {
                     }
                 }  // intentional fallthrough
             } else if (pickedObject.pid.type() == OBJECT_Face) {
-                if (pickedObject.depth < 0x200u) {
+                if (pickedObject.depth < engine->config->gameplay.MouseInteractionDepth.value()) {
                     std::string newString;
                     if (uCurrentlyLoadedLevelType != LEVEL_INDOOR) {
                         v18b = pickedObject.pid.id() >> 6;
@@ -933,14 +926,10 @@ void GameUI_WritePointedObjectStatusString() {
                     }
                     if (!newString.empty()) {
                         engine->_statusBar->setPermanent(newString);
-                        if (!mouse->uPointingObjectID && uLastPointedObjectID) {
-                            engine->_statusBar->clearPermanent();
-                        }
-                        uLastPointedObjectID = mouse->uPointingObjectID;
+                        uLastPointedObjectID = pickedObject.pid;
                         return;
                     }
                 }
-                mouse->uPointingObjectID = Pid();
                 engine->_statusBar->clearPermanent();
                 uLastPointedObjectID = Pid();
                 return;
@@ -997,11 +986,9 @@ void GameUI_WritePointedObjectStatusString() {
                     // pSRZBufferLineOffsets[pY]];
                     if (pickedObjectID == 0 || pickedObjectID == -65536 ||
                         pickedObjectID >= 5000) {
-                        // if (pMouse->uPointingObjectID == 0) {
                         if (uLastPointedObjectID) {
                             engine->_statusBar->clearPermanent();
                         }
-                        //}
                         uLastPointedObjectID = Pid();
                         // return;
                     } else {
@@ -1193,7 +1180,6 @@ void GameUI_WritePointedObjectStatusString() {
         }
     }
 
-    // pMouse->uPointingObjectID = sub_46A99B(); //for software
     if (uLastPointedObjectID) {
         engine->_statusBar->clearPermanent();
     }
@@ -1750,7 +1736,6 @@ void GameUI_handleHintMessage(UIMessageType type, int param) {
             Character* character = &pParty->pCharacters[param - 1];
             engine->_statusBar->setPermanent(fmt::format("{}: {}", NameAndTitle(character->name, character->classType),
                 localization->characterConditionName(character->GetMajorConditionIdx())));
-            engine->mouse->uPointingObjectID = Pid(OBJECT_Character, (unsigned char)(8 * param - 8) | 4);
             break;
         }
 

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -22,7 +22,6 @@
 #include "Engine/Graphics/AtlasLayout.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/Sprites.h"
-#include "Engine/Graphics/Camera.h"
 #include "Engine/Graphics/Viewport.h"
 #include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Image.h"

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1807,7 +1807,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                 if ((signed int)pX <= 320) popup_window.x = pX + 30;
                 // if ( render->pRenderD3D )
 
-                Pid pointedObject = engine->PickMouseInfoPopup().pid;
+                Pid pointedObject = engine->PickMouseForInfo().pid;
                 /*else
                 pointedObject = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]];*/
                 if (pointedObject.type() == OBJECT_Actor) {

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -279,10 +279,10 @@ void Io::Mouse::UI_OnMouseLeftClick(bool isDoubleClick) {
         return;
     }
 
-    Vis_PIDAndDepth picked_object = engine->PickMouseNormal();
+    Vis_PIDAndDepth picked_object = engine->PickMouseForInteraction();
 
     ObjectType type = picked_object.pid.type();
-    if (type == OBJECT_Actor && pParty->hasActiveCharacter() && picked_object.depth < 0x200 &&
+    if (type == OBJECT_Actor && pParty->hasActiveCharacter() &&
         pParty->activeCharacter().CanAct() &&
         pParty->activeCharacter().CanSteal()) {
         engine->_messageQueue->addMessageCurrentFrame(

--- a/src/Io/Mouse.h
+++ b/src/Io/Mouse.h
@@ -39,7 +39,6 @@ class Mouse {
     void UI_OnMouseLeftClick(bool isDoubleClick);
 
 
-    Pid uPointingObjectID;
     int field_8 = 0;
     bool _arrowCursor = 0;
     int bInitialized = 0;

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1607,8 +1607,7 @@ GAME_TEST(Prs, Pr2615a) {
     Vis_PIDAndDepth object = engine->PickMouseForTargeting();
     EXPECT_EQ(object.pid, Pid(OBJECT_Decoration, 7));
     EXPECT_GT(object.depth, engine->config->gameplay.MouseInteractionDepth.value());
-    Pointi pt = mouse->position();
-    game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
+    game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
     game.tick(3);
     EXPECT_EQ(foodTape.delta(), 2);
     EXPECT_CONTAINS(statusTape, "You find 2 food");
@@ -1630,8 +1629,7 @@ GAME_TEST(Prs, Pr2615b) {
     game.castSpell(1, SPELL_EARTH_TELEKINESIS);
     game.tick(2);
     game.pointMouseAtDecoration(7);
-    Pointi pt = mouse->position();
-    game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
+    game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
     game.tick(3);
     EXPECT_EQ(foodTape.delta(), 2);
     EXPECT_CONTAINS(statusTape, "You find 2 food");
@@ -1655,9 +1653,8 @@ GAME_TEST(Prs, Pr2615c) {
         int hp = peasant->hp;
         EXPECT_GT(hp, 0);
         pParty->pCharacters[0].timeToRecovery = 0_ticks;
-        Pointi pt = mouse->position();
         game.pressKey(PlatformKey::KEY_SHIFT);
-        game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
+        game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
         game.tick(2);
         game.releaseKey(PlatformKey::KEY_SHIFT);
         game.tick(30);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1665,3 +1665,25 @@ GAME_TEST(Prs, Pr2615c) {
         EXPECT_LT(hpTape.delta(), 0); // The quick spell fired and hit.
     }
 }
+
+GAME_TEST(Prs, Pr2615d) {
+    // Telekinesis on a decoration that carries a map event - the campfire in Pr2615b is the interactive kind, this
+    // Harmondale fruit tree is the evented kind, and its event hands the player an apple. Fruit trees bear nothing
+    // in autumn and winter, and a new game starts on the 1st of January, so the calendar moves to June first.
+    game.startNewGame();
+    engine->config->debug.AllMagic.setValue(true);
+    game.teleportTo(MAP_HARMONDALE, Vec3f(-12192, 9000, 0), 0); // Decorations belong to the loaded map.
+    const LevelDecoration &tree = pLevelDecorations[559];
+    ASSERT_EQ(pDecorationList->GetDecoration(tree.uDecorationDescID)->hint, "tree");
+    ASSERT_NE(tree.uEventID, 0); // The point of this test - Pr2615b covers the eventless interactive kind.
+    game.teleportTo(MAP_HARMONDALE, tree.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
+    pParty->GetPlayingTime() += Duration::fromDays(150);
+    game.tick(2);
+    ASSERT_EQ(pParty->pPickedItem.itemId, ITEM_NULL);
+    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
+    game.tick(2);
+    game.pointMouseAtDecoration(559);
+    game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
+    game.tick(3);
+    EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_RED_APPLE); // The tree handed over an apple.
+}

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1667,7 +1667,7 @@ GAME_TEST(Prs, Pr2615c) {
 }
 
 GAME_TEST(Prs, Pr2615d) {
-    // Telekinesis on a decoration that carries a map event - the campfire in Pr2615b is the interactive kind, this
+    // Telekinesis on a decoration that carries a map event - the campfire in Pr2615c is the interactive kind, this
     // Harmondale fruit tree is the evented kind, and its event hands the player an apple. Fruit trees bear nothing
     // in autumn and winter, and a new game starts on the 1st of January, so the calendar moves to June first.
     game.startNewGame();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1591,9 +1591,9 @@ GAME_TEST(Issues, Pr2635) {
 }
 
 GAME_TEST(Prs, Pr2615a) {
-    // Clicking a decoration got a reach of exactly the mouse interaction depth after the pick rework, and vanilla
-    // extends it by the decoration's radius. This campfire is at depth 560 with radius 52, so it's clickable at the
-    // default reach of 512, and the plain interaction pick can't see it.
+    // A decoration's clickable reach extends past the mouse interaction depth by the decoration's radius, so a big
+    // one is clickable from further away than its center. This campfire is at depth 560 with radius 52, clickable
+    // at the default reach of 512.
     auto foodTape = tapes.food();
     auto statusTape = tapes.statusBar();
     game.startNewGame();
@@ -1638,8 +1638,7 @@ GAME_TEST(Prs, Pr2615b) {
 
 GAME_TEST(Prs, Pr2615c) {
     // Shift-clicking a friendly actor fires the quick spell at it on both sides of the interaction depth, as in
-    // vanilla. The out-of-reach click fallback used to consider hostile actors only, so past interaction depth the
-    // click was silently dropped.
+    // vanilla - a friendliness check in the click handler is not allowed to drop the far click.
     engine->config->debug.AllMagic.setValue(true);
     engine->config->debug.NoActors.setValue(true);
     game.startNewGame();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1614,28 +1614,6 @@ GAME_TEST(Prs, Pr2615a) {
 }
 
 GAME_TEST(Prs, Pr2615b) {
-    // In vanilla telekinesis doesn't work on decorations at all - its targeting pick skips their billboards, so
-    // the decoration branch in castSpell is dead code there, with a garbled line that crashes once reached. OE
-    // deliberately lets the pick see decorations, and this is the OE behavior being tested: telekinesis pulls an
-    // interactive decoration from beyond click reach.
-    auto foodTape = tapes.food();
-    auto statusTape = tapes.statusBar();
-    game.startNewGame();
-    engine->config->debug.AllMagic.setValue(true);
-    const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
-    ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
-    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
-    test.startTaping();
-    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
-    game.tick(2);
-    game.pointMouseAtDecoration(7);
-    game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
-    game.tick(3);
-    EXPECT_EQ(foodTape.delta(), 2);
-    EXPECT_CONTAINS(statusTape, "You find 2 food");
-}
-
-GAME_TEST(Prs, Pr2615c) {
     // Shift-clicking a friendly actor fires the quick spell at it on both sides of the interaction depth, as in
     // vanilla - a friendliness check in the click handler is not allowed to drop the far click.
     for (int depth : {300, 1200}) {
@@ -1666,6 +1644,28 @@ GAME_TEST(Prs, Pr2615c) {
     }
 }
 
+GAME_TEST(Prs, Pr2615c) {
+    // In vanilla telekinesis doesn't work on decorations at all - its targeting pick skips their billboards, so
+    // the decoration branch in castSpell is dead code there, with a garbled line that crashes once reached. OE
+    // deliberately lets the pick see decorations, and this is the OE behavior being tested: telekinesis pulls an
+    // interactive decoration from beyond click reach.
+    auto foodTape = tapes.food();
+    auto statusTape = tapes.statusBar();
+    game.startNewGame();
+    engine->config->debug.AllMagic.setValue(true);
+    const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
+    ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
+    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
+    test.startTaping();
+    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
+    game.tick(2);
+    game.pointMouseAtDecoration(7);
+    game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
+    game.tick(3);
+    EXPECT_EQ(foodTape.delta(), 2);
+    EXPECT_CONTAINS(statusTape, "You find 2 food");
+}
+
 GAME_TEST(Prs, Pr2615d) {
     // Telekinesis on a decoration that carries a map event - the campfire in Pr2615b is the interactive kind, this
     // Harmondale fruit tree is the evented kind, and its event hands the player an apple. Fruit trees bear nothing
@@ -1675,7 +1675,7 @@ GAME_TEST(Prs, Pr2615d) {
     game.teleportTo(MAP_HARMONDALE, Vec3f(-12192, 9000, 0), 0); // Decorations belong to the loaded map.
     const LevelDecoration &tree = pLevelDecorations[559];
     ASSERT_EQ(pDecorationList->GetDecoration(tree.uDecorationDescID)->hint, "tree");
-    ASSERT_NE(tree.uEventID, 0); // The point of this test - Pr2615b covers the eventless interactive kind.
+    ASSERT_NE(tree.uEventID, 0); // The point of this test - Pr2615c covers the eventless interactive kind.
     game.teleportTo(MAP_HARMONDALE, tree.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
     pParty->GetPlayingTime() += Duration::fromDays(150);
     game.tick(2);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1616,8 +1616,8 @@ GAME_TEST(Prs, Pr2615a) {
 GAME_TEST(Prs, Pr2615b) {
     // In vanilla telekinesis doesn't work on decorations at all - its targeting pick skips their billboards, so
     // the decoration branch in castSpell is dead code there, with a garbled line that crashes once reached. OE
-    // deliberately lets the pick see decorations, and this is the OE behavior being tested: telekinesis pulls a
-    // decoration from beyond click reach, evented and interactive ones alike.
+    // deliberately lets the pick see decorations, and this is the OE behavior being tested: telekinesis pulls an
+    // interactive decoration from beyond click reach.
     auto foodTape = tapes.food();
     auto statusTape = tapes.statusBar();
     game.startNewGame();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1600,7 +1600,7 @@ GAME_TEST(Prs, Pr2615a) {
     const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
     ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
     ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->uRadius, 52);
-    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(535, 0, 0), 0); // Puts it at pick depth 560.
+    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(535, 0, 0), 0); // The pick depth comes out at 560.
     test.startTaping();
     game.pointMouseAtDecoration(7);
     EXPECT_EQ(engine->PickMouseForInteraction().pid, Pid()); // Otherwise the radius allowance isn't what's tested.
@@ -1655,6 +1655,7 @@ GAME_TEST(Prs, Pr2615c) {
     engine->config->debug.AllMagic.setValue(true);
     const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
     ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
+    ASSERT_EQ(campfire.uEventID, 0); // The eventless interactive kind - Pr2615d covers the evented kind.
     game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
     test.startTaping();
     game.castSpell(1, SPELL_EARTH_TELEKINESIS);
@@ -1669,7 +1670,7 @@ GAME_TEST(Prs, Pr2615c) {
 GAME_TEST(Prs, Pr2615d) {
     // Telekinesis on a decoration that carries a map event - the campfire in Pr2615c is the interactive kind, this
     // Harmondale fruit tree is the evented kind, and its event hands the player an apple. Fruit trees bear nothing
-    // in autumn and winter, and a new game starts on the 1st of January, so the calendar moves to June first.
+    // in autumn and winter, and a new game starts on the 1st of January, so the calendar is pushed into summer first.
     game.startNewGame();
     engine->config->debug.AllMagic.setValue(true);
     game.teleportTo(MAP_HARMONDALE, Vec3f(-12192, 9000, 0), 0); // Decorations belong to the loaded map.

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1615,9 +1615,10 @@ GAME_TEST(Prs, Pr2615a) {
 }
 
 GAME_TEST(Prs, Pr2615b) {
-    // Telekinesis never worked on decorations - the pick filter skipped their billboards, so the decoration branch
-    // in castSpell was dead code, and it crashed once reached, indexing pSpriteObjects with a decoration id. The
-    // click gate also rejected interactive decorations, campfires and their kin have no event id.
+    // In vanilla telekinesis doesn't work on decorations at all - its targeting pick skips their billboards, so
+    // the decoration branch in castSpell is dead code there, with a garbled line that crashes once reached. OE
+    // deliberately lets the pick see decorations, and this is the OE behavior being tested: telekinesis pulls a
+    // decoration from beyond click reach, evented and interactive ones alike.
     auto foodTape = tapes.food();
     auto statusTape = tapes.statusBar();
     game.startNewGame();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1625,7 +1625,7 @@ GAME_TEST(Prs, Pr2615b) {
     engine->config->debug.AllMagic.setValue(true);
     const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
     ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
-    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(535, 0, 0), 0); // Puts it at pick depth 560.
+    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
     test.startTaping();
     game.castSpell(1, SPELL_EARTH_TELEKINESIS);
     game.tick(2);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1638,26 +1638,30 @@ GAME_TEST(Prs, Pr2615b) {
 GAME_TEST(Prs, Pr2615c) {
     // Shift-clicking a friendly actor fires the quick spell at it on both sides of the interaction depth, as in
     // vanilla - a friendliness check in the click handler is not allowed to drop the far click.
-    engine->config->debug.AllMagic.setValue(true);
-    engine->config->debug.NoActors.setValue(true);
-    game.startNewGame();
-    engine->config->debug.NoActors.setValue(false);
-    prepareForBattleTest();
-    pParty->pCharacters[0].uQuickSpell = SPELL_FIRE_FIRE_BOLT;
-    for (int depth : {1200, 300}) { // Far one first, so that its corpse ends up behind the near one, not in front.
+    for (int depth : {300, 1200}) {
+        test.prepareForNextTest();
+        engine->config->debug.NoActors.setValue(true);
+        engine->config->debug.AllMagic.setValue(true);
+        game.startNewGame();
+        test.startTaping();
+        prepareForBattleTest();
+        engine->config->debug.NoActors.setValue(false);
+
+        auto hpTape = actorTapes.hp(0);
         Actor *peasant = game.spawnMonster(pParty->pos + Vec3f(0, depth, 0), MONSTER_PEASANT_DWARF_FEMALE_A_A,
                                            SPAWN_DUMMY | SPAWN_FRIENDLY);
         EXPECT_EQ(peasant->GetActorsRelation(0), HOSTILITY_FRIENDLY); // Otherwise it's the hostile path that's tested.
-        game.pointMouseAtActor(peasant->id);
+        pParty->pCharacters[0].uQuickSpell = SPELL_FIRE_FIRE_BOLT;
+        game.pointMouseAtActor(0);
         EXPECT_EQ(engine->PickMouseForInteraction().pid == Pid(), depth > engine->config->gameplay.MouseInteractionDepth.value());
-        int hp = peasant->hp;
-        EXPECT_GT(hp, 0);
-        pParty->pCharacters[0].timeToRecovery = 0_ticks;
+
         game.pressKey(PlatformKey::KEY_SHIFT);
         game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
         game.tick(2);
         game.releaseKey(PlatformKey::KEY_SHIFT);
         game.tick(30);
-        EXPECT_LT(peasant->hp, hp); // The quick spell fired and hit.
+        test.stopTaping();
+
+        EXPECT_LT(hpTape.delta(), 0); // The quick spell fired and hit.
     }
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1647,9 +1647,8 @@ GAME_TEST(Prs, Pr2615c) {
     prepareForBattleTest();
     pParty->pCharacters[0].uQuickSpell = SPELL_FIRE_FIRE_BOLT;
     for (int depth : {1200, 300}) { // Far one first, so that its corpse ends up behind the near one, not in front.
-        Actor *peasant = game.spawnMonster(pParty->pos + Vec3f(0, depth, 0), MONSTER_PEASANT_DWARF_FEMALE_A_A, SPAWN_DUMMY);
-        peasant->attributes &= ~ACTOR_AGGRESSOR;
-        peasant->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
+        Actor *peasant = game.spawnMonster(pParty->pos + Vec3f(0, depth, 0), MONSTER_PEASANT_DWARF_FEMALE_A_A,
+                                           SPAWN_DUMMY | SPAWN_FRIENDLY);
         EXPECT_EQ(peasant->GetActorsRelation(0), HOSTILITY_FRIENDLY); // Otherwise it's the hostile path that's tested.
         game.pointMouseAtActor(peasant->id);
         EXPECT_EQ(engine->PickMouseForInteraction().pid == Pid(), depth > engine->config->gameplay.MouseInteractionDepth.value());

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1628,3 +1628,28 @@ GAME_TEST(Prs, Pr2615b) {
     EXPECT_EQ(foodTape.delta(), 2);
     EXPECT_CONTAINS(statusTape, "You find 2 food");
 }
+
+GAME_TEST(Prs, Pr2615c) {
+    // Shift-clicking a friendly actor between interaction reach and ranged attack depth fires the quick spell,
+    // as it does in vanilla. The out-of-reach click fallback used to consider hostile actors only, so the click
+    // was silently dropped. Within interaction reach the quick spell fired fine all along.
+    engine->config->debug.AllMagic.setValue(true);
+    game.startNewGame();
+    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12107, 4319, 96), 0); // A peasant walks about a thousand units ahead.
+    pParty->pCharacters[0].uQuickSpell = SPELL_FIRE_FIRE_BOLT;
+    game.tick();
+    game.moveMouse(240, 190);
+    game.tick();
+    Vis_PIDAndDepth object = engine->PickMouseForTargeting();
+    EXPECT_EQ(object.pid, Pid(OBJECT_Actor, 1));
+    EXPECT_TRUE(pActors[1].IsPeasant());
+    EXPECT_GT(object.depth, engine->config->gameplay.MouseInteractionDepth.value()); // Otherwise it's not the fallback.
+    int hp = pActors[1].hp;
+    EXPECT_GT(hp, 0);
+    game.pressKey(PlatformKey::KEY_SHIFT);
+    game.pressAndReleaseButton(BUTTON_LEFT, 240, 190);
+    game.tick(2);
+    game.releaseKey(PlatformKey::KEY_SHIFT);
+    game.tick(30);
+    EXPECT_LT(pActors[1].hp, hp); // The quick spell fired and hit.
+}

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1599,13 +1599,15 @@ GAME_TEST(Prs, Pr2615a) {
     game.startNewGame();
     game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12288 - 535, 2040, 0), 0); // Facing the campfire on the beach.
     test.startTaping();
-    game.moveMouse(240, 250);
-    game.tick();
+    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->hint, "campfire");
+    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->uRadius, 52);
+    game.pointMouseAtDecoration(7);
     EXPECT_EQ(engine->PickMouseForInteraction().pid, Pid()); // Otherwise the radius allowance isn't what's tested.
     Vis_PIDAndDepth object = engine->PickMouseForTargeting();
     EXPECT_EQ(object.pid, Pid(OBJECT_Decoration, 7));
     EXPECT_GT(object.depth, engine->config->gameplay.MouseInteractionDepth.value());
-    game.pressAndReleaseButton(BUTTON_LEFT, 240, 250);
+    Pointi pt = mouse->position();
+    game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
     game.tick(3);
     EXPECT_EQ(foodTape.delta(), 2);
     EXPECT_CONTAINS(statusTape, "You find 2 food");
@@ -1623,7 +1625,10 @@ GAME_TEST(Prs, Pr2615b) {
     test.startTaping();
     game.castSpell(1, SPELL_EARTH_TELEKINESIS);
     game.tick(2);
-    game.pressAndReleaseButton(BUTTON_LEFT, 240, 250);
+    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->hint, "campfire");
+    game.pointMouseAtDecoration(7);
+    Pointi pt = mouse->position();
+    game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
     game.tick(3);
     EXPECT_EQ(foodTape.delta(), 2);
     EXPECT_CONTAINS(statusTape, "You find 2 food");

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1630,26 +1630,31 @@ GAME_TEST(Prs, Pr2615b) {
 }
 
 GAME_TEST(Prs, Pr2615c) {
-    // Shift-clicking a friendly actor between interaction reach and ranged attack depth fires the quick spell,
-    // as it does in vanilla. The out-of-reach click fallback used to consider hostile actors only, so the click
-    // was silently dropped. Within interaction reach the quick spell fired fine all along.
+    // Shift-clicking a friendly actor fires the quick spell at it on both sides of the interaction depth, as in
+    // vanilla. The out-of-reach click fallback used to consider hostile actors only, so past interaction depth the
+    // click was silently dropped.
     engine->config->debug.AllMagic.setValue(true);
+    engine->config->debug.NoActors.setValue(true);
     game.startNewGame();
-    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12107, 4319, 96), 0); // A peasant walks about a thousand units ahead.
+    engine->config->debug.NoActors.setValue(false);
+    prepareForBattleTest();
     pParty->pCharacters[0].uQuickSpell = SPELL_FIRE_FIRE_BOLT;
-    game.tick();
-    game.moveMouse(240, 190);
-    game.tick();
-    Vis_PIDAndDepth object = engine->PickMouseForTargeting();
-    EXPECT_EQ(object.pid, Pid(OBJECT_Actor, 1));
-    EXPECT_TRUE(pActors[1].IsPeasant());
-    EXPECT_GT(object.depth, engine->config->gameplay.MouseInteractionDepth.value()); // Otherwise it's not the fallback.
-    int hp = pActors[1].hp;
-    EXPECT_GT(hp, 0);
-    game.pressKey(PlatformKey::KEY_SHIFT);
-    game.pressAndReleaseButton(BUTTON_LEFT, 240, 190);
-    game.tick(2);
-    game.releaseKey(PlatformKey::KEY_SHIFT);
-    game.tick(30);
-    EXPECT_LT(pActors[1].hp, hp); // The quick spell fired and hit.
+    for (int depth : {1200, 300}) { // Far one first, so that its corpse ends up behind the near one, not in front.
+        Actor *peasant = game.spawnMonster(pParty->pos + Vec3f(0, depth, 0), MONSTER_PEASANT_DWARF_FEMALE_A_A, SPAWN_DUMMY);
+        peasant->attributes &= ~ACTOR_AGGRESSOR;
+        peasant->monsterInfo.hostilityType = HOSTILITY_FRIENDLY;
+        EXPECT_EQ(peasant->GetActorsRelation(0), HOSTILITY_FRIENDLY); // Otherwise it's the hostile path that's tested.
+        game.pointMouseAtActor(peasant->id);
+        EXPECT_EQ(engine->PickMouseForInteraction().pid == Pid(), depth > engine->config->gameplay.MouseInteractionDepth.value());
+        int hp = peasant->hp;
+        EXPECT_GT(hp, 0);
+        pParty->pCharacters[0].timeToRecovery = 0_ticks;
+        Pointi pt = mouse->position();
+        game.pressKey(PlatformKey::KEY_SHIFT);
+        game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);
+        game.tick(2);
+        game.releaseKey(PlatformKey::KEY_SHIFT);
+        game.tick(30);
+        EXPECT_LT(peasant->hp, hp); // The quick spell fired and hit.
+    }
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -14,6 +14,9 @@
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Indoor.h"
+#include "Engine/Objects/Decoration.h"
+#include "Engine/Objects/DecorationList.h"
+#include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/Viewport.h"
 #include "Engine/Objects/Chest.h"
@@ -1585,4 +1588,43 @@ GAME_TEST(Issues, Pr2635) {
     game.doubleClickGuiButton("SaveMenu_Slot0");
     game.tick(2);
     EXPECT_EQ(saveLoadMenu()->keyboard_input_status, WINDOW_INPUT_IN_PROGRESS);
+}
+
+GAME_TEST(Prs, Pr2615a) {
+    // Clicking a decoration got a reach of exactly the mouse interaction depth after the pick rework, and vanilla
+    // extends it by the decoration's radius. This campfire is at depth 560 with radius 52, so it's clickable at the
+    // default reach of 512, and the plain interaction pick can't see it.
+    auto foodTape = tapes.food();
+    auto statusTape = tapes.statusBar();
+    game.startNewGame();
+    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12288 - 535, 2040, 0), 0); // Facing the campfire on the beach.
+    test.startTaping();
+    game.moveMouse(240, 250);
+    game.tick();
+    EXPECT_EQ(engine->PickMouseForInteraction().pid, Pid()); // Otherwise the radius allowance isn't what's tested.
+    Vis_PIDAndDepth object = engine->PickMouseForTargeting();
+    EXPECT_EQ(object.pid, Pid(OBJECT_Decoration, 7));
+    EXPECT_GT(object.depth, engine->config->gameplay.MouseInteractionDepth.value());
+    game.pressAndReleaseButton(BUTTON_LEFT, 240, 250);
+    game.tick(3);
+    EXPECT_EQ(foodTape.delta(), 2);
+    EXPECT_CONTAINS(statusTape, "You find 2 food");
+}
+
+GAME_TEST(Prs, Pr2615b) {
+    // Telekinesis never worked on decorations - the pick filter skipped their billboards, so the decoration branch
+    // in castSpell was dead code, and it crashed once reached, indexing pSpriteObjects with a decoration id. The
+    // click gate also rejected interactive decorations, campfires and their kin have no event id.
+    auto foodTape = tapes.food();
+    auto statusTape = tapes.statusBar();
+    game.startNewGame();
+    engine->config->debug.AllMagic.setValue(true);
+    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12288 - 535, 2040, 0), 0); // Facing the campfire on the beach.
+    test.startTaping();
+    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
+    game.tick(2);
+    game.pressAndReleaseButton(BUTTON_LEFT, 240, 250);
+    game.tick(3);
+    EXPECT_EQ(foodTape.delta(), 2);
+    EXPECT_CONTAINS(statusTape, "You find 2 food");
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1597,10 +1597,11 @@ GAME_TEST(Prs, Pr2615a) {
     auto foodTape = tapes.food();
     auto statusTape = tapes.statusBar();
     game.startNewGame();
-    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12288 - 535, 2040, 0), 0); // Facing the campfire on the beach.
+    const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
+    ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
+    ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->uRadius, 52);
+    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(535, 0, 0), 0); // Puts it at pick depth 560.
     test.startTaping();
-    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->hint, "campfire");
-    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->uRadius, 52);
     game.pointMouseAtDecoration(7);
     EXPECT_EQ(engine->PickMouseForInteraction().pid, Pid()); // Otherwise the radius allowance isn't what's tested.
     Vis_PIDAndDepth object = engine->PickMouseForTargeting();
@@ -1621,11 +1622,12 @@ GAME_TEST(Prs, Pr2615b) {
     auto statusTape = tapes.statusBar();
     game.startNewGame();
     engine->config->debug.AllMagic.setValue(true);
-    game.teleportTo(MAP_EMERALD_ISLAND, Vec3f(12288 - 535, 2040, 0), 0); // Facing the campfire on the beach.
+    const LevelDecoration &campfire = pLevelDecorations[7]; // The campfire on the beach.
+    ASSERT_EQ(pDecorationList->GetDecoration(campfire.uDecorationDescID)->hint, "campfire");
+    game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(535, 0, 0), 0); // Puts it at pick depth 560.
     test.startTaping();
     game.castSpell(1, SPELL_EARTH_TELEKINESIS);
     game.tick(2);
-    ASSERT_EQ(pDecorationList->GetDecoration(pLevelDecorations[7].uDecorationDescID)->hint, "campfire");
     game.pointMouseAtDecoration(7);
     Pointi pt = mouse->position();
     game.pressAndReleaseButton(BUTTON_LEFT, pt.x, pt.y);


### PR DESCRIPTION
Resolves `TODO(captainurist): Right now we can have popups for monsters that are not reachable with a bow, and this is OK. However, such monsters also don't get a hint displayed on mouseover. Probably should fix this?` in `Engine.cpp`.

Started as "status bar hints should reach popup depth" and became a rework of the mouse pick layer per review:

- One pick function per purpose, each owning its depth and filter: `PickMouseForInfo` (popups + status bar hints, popup depth), `PickMouseForTargeting` (attacks, targeted spells and viewport clicks, ranged attack depth), `PickMouseForInteraction` (stealing, `mouse_interaction_depth`). All three match anything, so a decoration under the cursor eats the pick - which is what the shared vanilla pick did.
- Honest filter names: `vis_items_filter` matched every billboard and is `vis_anything_filter` now, with the behaviorally identical `vis_allsprites_filter` merged in. `vis_sprite_targets_filter` turned out to have no legitimate user left and is gone - it skipped decorations, so attacks and targeted spells shot through trees, which vanilla's shared pick never did.
- The viewport click handler keeps its old shape: one pick at targeting depth, with the interaction distance checked inside the branches. The distance is the `mouse_interaction_depth` config now instead of a hard-coded 512, and the `item_id >= 1000` bounds fossil is gone - it was the size of vanilla's fixed sprite array, checked after the line had already indexed it.
- All six viewport-sweep spells (Inferno, Turn Undead, Mass Fear, Dispel Magic, Prismatic Light, Souldrinker) share a new `mass_spell_depth` config, default 4096. Five of them had it hard-coded, and vanilla's Souldrinker swept every actor within the mouse pick depth - 25 map cells outdoors, three times the reach of any targeted attack - which the config description records. The depth configs now sit next to each other in `GameConfig.h`.
- Clicked decorations keep their vanilla radius allowance - a decoration is clickable while its depth minus its radius is within interaction reach, so a big one is clickable from further away. `Pr2615a` pins it on an Emerald Island campfire that sits just past the interaction depth.
- Telekinesis works on decorations now, which it never did - the old pick filter skipped their billboards, so the decoration branch in `castSpell` was dead code, and a garbled line straight from the binary made it crash once reachable (it indexed `pSpriteObjects` with a decoration id). The branch now mirrors `DecorationInteraction`, and the click gate accepts interactive decorations alongside evented ones. `Pr2615c` pins it on the same campfire, and `Pr2615d` on an evented Harmondale fruit tree that hands over an apple. Both tests verified to fail before their fixes.
- Cast-on-click reaches friendly actors on both sides of the interaction depth, as in vanilla. `Pr2615b` pins it with spawned peasants at 300 and 1200, verified to fail before the fix.
- `Mouse::uPointingObjectID` is gone. Attacks and quick-cast spells pick their target fresh at execution time, which caps mouse combat reach at ranged attack depth, and the test controller re-queries instead of waiting a frame for the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







