### PR TITLE
Encapsulate monster tier arithmetic in SummonMinion

### DIFF
--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2376,7 +2376,7 @@ std::string Actor::GetDisplayName() const {
 //----- (0044FD29) --------------------------------------------------------
 void Actor::SummonMinion(int summonerId) {
     uint8_t extraSummonLevel;  // al@1
-    MonsterId summonMonsterBaseType;         // esi@1
+    MonsterId summonMonsterId;         // esi@1
     int v5;                            // edx@2
     int v7;                            // edi@10
     MonsterInfo *v9;                   // ebx@10
@@ -2408,34 +2408,34 @@ void Actor::SummonMinion(int summonerId) {
 
     extraSummonLevel = this->monsterInfo.specialAbilityDamageDiceRolls;
     // TODO(captainurist): drop the cast here, store the data properly.
-    summonMonsterBaseType = static_cast<MonsterId>(this->monsterInfo.field_3C_some_special_attack);
+    summonMonsterId = static_cast<MonsterId>(this->monsterInfo.field_3C_some_special_attack);
+
+    MonsterTier summonTier = MONSTER_TIER_A;
     if (extraSummonLevel) {
-        if (extraSummonLevel >= 1 && extraSummonLevel <= 3) {
-            // TODO(captainurist): encapsulate monster level arithmetic properly.
-            summonMonsterBaseType = static_cast<MonsterId>(std::to_underlying(summonMonsterBaseType) + extraSummonLevel - 1);
-        }
+        if (extraSummonLevel >= 1 && extraSummonLevel <= 3)
+            summonTier = static_cast<MonsterTier>(extraSummonLevel - 1);
     } else {
         v5 = grng->random(100);
-        // TODO(captainurist): encapsulate monster level arithmetic properly.
         if (v5 >= 90)
-            summonMonsterBaseType = static_cast<MonsterId>(std::to_underlying(summonMonsterBaseType) + 2);
+            summonTier = MONSTER_TIER_C;
         else if (v5 >= 60)
-            summonMonsterBaseType = static_cast<MonsterId>(std::to_underlying(summonMonsterBaseType) + 1);
+            summonTier = MONSTER_TIER_B;
     }
+    summonMonsterId = monsterIdForMonsterTypeAndTier(monsterTypeForMonsterId(summonMonsterId), summonTier);
     Actor *actor = AllocateActor();
     if (!actor)
         return;
 
-    v9 = &pMonsterStats->infos[summonMonsterBaseType];
+    v9 = &pMonsterStats->infos[summonMonsterId];
     actor->hp = v9->hp;
     actor->monsterInfo = *v9;
-    actor->monsterId = summonMonsterBaseType;
-    actor->radius = pMonsterList->monsters[summonMonsterBaseType].monsterRadius;
-    actor->height = pMonsterList->monsters[summonMonsterBaseType].monsterHeight;
+    actor->monsterId = summonMonsterId;
+    actor->radius = pMonsterList->monsters[summonMonsterId].monsterRadius;
+    actor->height = pMonsterList->monsters[summonMonsterId].monsterHeight;
     actor->monsterInfo.goldDiceRolls = 0;
     actor->monsterInfo.treasureType = RANDOM_ITEM_ANY;
     actor->monsterInfo.exp = 0;
-    actor->moveSpeed = pMonsterList->monsters[summonMonsterBaseType].movementSpeed;
+    actor->moveSpeed = pMonsterList->monsters[summonMonsterId].movementSpeed;
 
     actor->initialPosition.x = v15;
     actor->initialPosition.y = v17;

--- a/src/Engine/Objects/MonsterEnumFunctions.h
+++ b/src/Engine/Objects/MonsterEnumFunctions.h
@@ -74,6 +74,10 @@ inline MonsterTier monsterTierForMonsterId(MonsterId monsterId) {
     return static_cast<MonsterTier>((std::to_underlying(monsterId) - std::to_underlying(MONSTER_FIRST)) % 3);
 }
 
+inline MonsterId monsterIdForMonsterTypeAndTier(MonsterType monsterType, MonsterTier tier) {
+    return static_cast<MonsterId>((std::to_underlying(monsterType) - 1) * 3 + 1 + std::to_underlying(tier));
+}
+
 
 //
 // MonsterSupertype

--- a/src/Engine/Objects/Tests/MonsterEnumFunctions_ut.cpp
+++ b/src/Engine/Objects/Tests/MonsterEnumFunctions_ut.cpp
@@ -13,3 +13,14 @@ GAME_TEST(MonsterEnumFunctions, MonsterTierForMonsterId) {
     EXPECT_EQ(monsterTierForMonsterId(MONSTER_GHOST_B), MONSTER_TIER_B);
     EXPECT_EQ(monsterTierForMonsterId(MONSTER_GHOST_C), MONSTER_TIER_C);
 }
+
+GAME_TEST(MonsterEnumFunctions, MonsterIdForMonsterTypeAndTier) {
+    // Spot checks.
+    EXPECT_EQ(monsterIdForMonsterTypeAndTier(MONSTER_TYPE_ANGEL, MONSTER_TIER_A), MONSTER_ANGEL_A);
+    EXPECT_EQ(monsterIdForMonsterTypeAndTier(MONSTER_TYPE_ANGEL, MONSTER_TIER_C), MONSTER_ANGEL_C);
+    EXPECT_EQ(monsterIdForMonsterTypeAndTier(MONSTER_TYPE_GHOST, MONSTER_TIER_B), MONSTER_GHOST_B);
+
+    // Splitting any monster id into type and tier and reassembling must give the same id back.
+    for (MonsterId id : allMonsters())
+        EXPECT_EQ(monsterIdForMonsterTypeAndTier(monsterTypeForMonsterId(id), monsterTierForMonsterId(id)), id);
+}


### PR DESCRIPTION
Resolves the two "encapsulate monster level arithmetic properly" TODOs in `Actor::SummonMinion`.

Adds `monsterIdForMonsterTypeAndTier(MonsterType, MonsterTier)` to `MonsterEnumFunctions.h`, mirroring the formulas of its neighbors, with a round-trip unit test over all monster ids. `SummonMinion` now computes a `MonsterTier` per branch (fixed from `extraSummonLevel`, or the 60/30/10 roll) and assembles the summon id once. The local `summonMonsterBaseType` is renamed to `summonMonsterId` since it holds the final adjusted id.

For well-formed data this is a pure refactor - base summon ids are tier A by construction (`GetBaseMonsterId` at parse time), the round-trip is the identity, and the `grng` draw pattern is unchanged, so no traces are affected. The only observable difference is with malformed saves: a non-base id in `field_3C` previously offset across into the next monster group, now it normalizes to its own group first.

The neighboring `field_3C_some_special_attack` "store the data properly" TODO is intentionally left - that one is a union-type split (summon id vs damage type) with snapshot implications, a separate change.

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
