### PR TITLE
Name CircusPrises and Unknown1 in evt debug strings

### DIFF
--- a/src/Engine/Evt/EvtInstruction.cpp
+++ b/src/Engine/Evt/EvtInstruction.cpp
@@ -308,7 +308,7 @@ static std::string getVariableSetStr(EvtVariable type, int value) {
         case VAR_HiredNPCHasSpeciality:
             return fmt::format("NPCProfession({})", value);
         case VAR_CircusPrises:
-            return fmt::format("[{}], {}", (int)type, value); // TODO
+            return fmt::format("ERROR: CircusPrises, {}", value);
         case VAR_NumSkillPoints:
             return fmt::format("SkillPoints, {}", value);
         case VAR_MonthIs:
@@ -316,7 +316,7 @@ static std::string getVariableSetStr(EvtVariable type, int value) {
         case VAR_ReputationInCurrentLocation:
             return fmt::format("LocationReputation, {}", value);
         case VAR_Unknown1:
-            return fmt::format("[{}], {}", (int)type, value); // TODO
+            return fmt::format("ERROR: Unknown1, {}", value);
         case VAR_GoldInBank:
             return fmt::format("GoldInBank, {}", value);
         case VAR_NumDeaths:
@@ -631,7 +631,7 @@ static std::string getVariableCompareStr(EvtVariable type, int value) {
         case VAR_HiredNPCHasSpeciality:
             return fmt::format("NPCProfession({})", value);
         case VAR_CircusPrises:
-            return fmt::format("[{}] ? {}", (int)type, value); // TODO
+            return fmt::format("CircusPrises >= {}", value);
         case VAR_NumSkillPoints:
             return fmt::format("SkillPoints >= {}", value);
         case VAR_MonthIs:
@@ -639,7 +639,7 @@ static std::string getVariableCompareStr(EvtVariable type, int value) {
         case VAR_ReputationInCurrentLocation:
             return fmt::format("LocationReputation >= {}", value);
         case VAR_Unknown1:
-            return fmt::format("[{}] ? {}", (int)type, value); // TODO
+            return fmt::format("Unknown1 == {}", value);
         case VAR_GoldInBank:
             return fmt::format("GoldInBank >= {}", value);
         case VAR_NumDeaths:


### PR DESCRIPTION
Resolves the four placeholder TODOs in `getVariableSetStr` / `getVariableCompareStr` where `VAR_CircusPrises` and `VAR_Unknown1` rendered as raw `[{type}], {value}`.

The strings now follow the interpreter's actual semantics, verified against `Character::CompareVariable`:
- `CircusPrises >= {}` - the comparison is `>=` (Character.cpp:3907).
- `Unknown1 == {}` - equality on the location alert status, per the explicit "yes, equality, not >=" comment (Character.cpp:3936).
- Set side gets `ERROR: CircusPrises, {}` / `ERROR: Unknown1, {}`, matching the `ERROR: MonthIs` convention - neither variable is handled in `SetVariable`, `AddVariable` or `SubtractVariable`.

These strings only feed `EvtProgram::dump` trace logging, so no behavior change.

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
