### PR TITLE
Make the frustum plane count a global constant

### DIFF
--- a/src/Engine/Graphics/BspRenderer.cpp
+++ b/src/Engine/Graphics/BspRenderer.cpp
@@ -276,7 +276,7 @@ void BspRenderer::AddBSPFaces(const int node_id, const int initialBSPNodeId) {
 
 
 void BspRenderer_ViewportNode::SetFrustumToCamera() {
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < FRUSTUM_PLANE_COUNT; i++) {
         ViewportNodeFrustum[i].normal.x = pCamera3D->FrustumPlanes[i].x;
         ViewportNodeFrustum[i].normal.y = pCamera3D->FrustumPlanes[i].y;
         ViewportNodeFrustum[i].normal.z = pCamera3D->FrustumPlanes[i].z;

--- a/src/Engine/Graphics/BspRenderer.h
+++ b/src/Engine/Graphics/BspRenderer.h
@@ -12,7 +12,7 @@ struct BspRenderer_ViewportNode {
     int uSectorID = 0;  // sector that this node shows
     int uFaceID = 0;  // face id of the portal through which we're seeing this node
     int parentNodeId = 0;
-    std::array<Planef, 4> ViewportNodeFrustum = {{}};  // frustum planes of portal
+    std::array<Planef, FRUSTUM_PLANE_COUNT> ViewportNodeFrustum = {{}};  // frustum planes of portal
 
  private:
     void SetFrustumToCamera();

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -78,7 +78,7 @@ void Camera3D::do_draw_debug_line_sw(RenderVertexSoft *pLineBegin,
     int uOutNumVertices = 2;
     a1[0].vWorldPosition = pLineBegin->vWorldPosition;
     a1[1].vWorldPosition = pLineEnd->vWorldPosition;
-    if (CullFaceToCameraFrustum(a1, &uOutNumVertices, pVertices, 4) != 1 || uOutNumVertices >= 2) {
+    if (CullFaceToCameraFrustum(a1, &uOutNumVertices, pVertices, FRUSTUM_PLANE_COUNT) != 1 || uOutNumVertices >= 2) {
         ViewTransform(pVertices, 2);
         Project(pVertices, 2, 0);
 
@@ -249,7 +249,6 @@ bool Camera3D::ClipFaceToFrustum(RenderVertexSoft *pInVertices,
     unsigned int *pOutNumVertices,
     RenderVertexSoft *pVertices,
     const Planef *CameraFrustrum) {
-    // NumFrustumPlanes usually 4 - top, bottom, left, right - near and far done elsewhere
     // DebugLines 0 or 1 - 1 when debug lines
 
     RenderVertexSoft *v14;  // eax@8
@@ -258,9 +257,6 @@ bool Camera3D::ClipFaceToFrustum(RenderVertexSoft *pInVertices,
     // int v18; // [sp+48h] [bp-Ch]@5
     bool VertsAdjusted = false;  // [sp+53h] [bp-1h]@5
     // bool a6a; // [sp+70h] [bp+1Ch]@5
-
-    // TODO(yoctozepto): just have this as a global constant instead of random vars/4 around
-    const int NumFrustumPlanes = 4;
 
     // v17 = 0.0;
     // thisa = engine->pStru9Instance;
@@ -275,7 +271,7 @@ bool Camera3D::ClipFaceToFrustum(RenderVertexSoft *pInVertices,
     // v13 = (char *)&a4->y;
 
     // while ( 1 )
-    for (unsigned i = 0; i < NumFrustumPlanes; ++i) {  // cycle through left,right, top, bottom planes
+    for (unsigned i = 0; i < FRUSTUM_PLANE_COUNT; ++i) {  // cycle through left,right, top, bottom planes
         if (i % 2) {
             v14 = pInVertices;
             v15 = sr_vertices_50D9D8;
@@ -284,7 +280,7 @@ bool Camera3D::ClipFaceToFrustum(RenderVertexSoft *pInVertices,
             v14 = sr_vertices_50D9D8;
         }
 
-        if (i == NumFrustumPlanes - 1) v14 = pVertices;
+        if (i == FRUSTUM_PLANE_COUNT - 1) v14 = pVertices;
 
         ClippingFunctions::ClipVertsToFrustumPlane(
             v15, *pOutNumVertices, v14, pOutNumVertices, &CameraFrustrum[i].normal, -CameraFrustrum[i].dist,
@@ -297,8 +293,6 @@ bool Camera3D::ClipFaceToFrustum(RenderVertexSoft *pInVertices,
         }
         // result = a6a;
         // v13 += 24;
-        // if (++i >= FrustumPlanes)
-        //
     }
     return VertsAdjusted;
 }

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -10,6 +10,8 @@
 
 struct BLVFace;
 
+constexpr int FRUSTUM_PLANE_COUNT = 4;  // Left, right, top and bottom. Near and far are handled separately.
+
 struct Camera3D {
     Vec3f ViewTransform(const Vec3f* pos) const;
     void ViewTransform(RenderVertexSoft *vertex, int uNumVertices) const;
@@ -55,7 +57,7 @@ struct Camera3D {
 
     glm::mat3x3 ViewMatrix = {};
     // using w comp of vec4 for dotdist
-    std::array<glm::vec4, 6> FrustumPlanes = {{}};
+    std::array<glm::vec4, FRUSTUM_PLANE_COUNT> FrustumPlanes = {{}};
 
     // field of view in vertical direction in degrees for GL
     float fov_y_deg = 0;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -324,7 +324,7 @@ bool IsSphereInFrustum(Vec3f center, float radius, Planef *frustum) {
     // center must be within all four of the camera frustum planes to be visible
     Vec3f planenormal;
     float planedist = 0;
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < FRUSTUM_PLANE_COUNT; i++) {
         if (frustum) {
             planenormal = frustum[i].normal;
             planedist = -frustum[i].dist;


### PR DESCRIPTION
Resolves `TODO(yoctozepto): just have this as a global constant instead of random vars/4 around` in `Camera3D::ClipFaceToFrustum`.

`FRUSTUM_PLANE_COUNT = 4` (left, right, top, bottom - near and far are handled separately) now lives in `Camera.h` and replaces the local const in `ClipFaceToFrustum`, the literal in the `CullFaceToCameraFrustum` call, the loop bounds in `IsSphereInFrustum` and `SetFrustumToCamera`, and both array sizes - `Camera3D::FrustumPlanes` shrinks from 6 to 4 in the process, since only indices 0-3 were ever written or read and the camera is never serialized, sized or range-iterated (verified by review).

Observation from review, left untouched: `Camera3D::CullFaceToFrustum` has zero callers - a candidate for a separate dead-code PR.

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
