### PR TITLE
Drop the unused HouseData fields

### DIFF
--- a/src/Engine/Data/HouseData.h
+++ b/src/Engine/Data/HouseData.h
@@ -7,20 +7,13 @@
 #include "Engine/MapEnums.h"
 #include "Engine/PartyEnums.h"
 
-// TODO(captainurist): drop everything that's not used here.
 struct HouseData {
     HouseType uType = HOUSE_TYPE_INVALID;
     uint16_t uAnimationID = 0;
     std::string name;
     std::string pProprieterName;
-    std::string pEnterText;
     std::string pProprieterTitle;
-    int16_t field_14 = 0;
-    int16_t _state = 0;
-    int16_t _rep = 0;
-    int16_t _per = 0;
     int16_t generation_interval_days = 0;
-    int16_t field_1E = 0;
     float fPriceMultiplier = 0; // shop price multiplier
     float flt_24 = 0; // skills price multiplier
     uint16_t uOpenTime = 0;
@@ -28,5 +21,4 @@ struct HouseData {
     int16_t uExitPicID = 0;
     MapId uExitMapID = MAP_INVALID;
     QuestBit _quest_bit = QBIT_INVALID;
-    int16_t field_32 = 0;
 };

--- a/src/Engine/Tables/HouseTable.cpp
+++ b/src/Engine/Tables/HouseTable.cpp
@@ -26,10 +26,10 @@ void initializeHouses(const Blob &houses) {
     //  5: "Name"               - house name                                                (localized)
     //  6: "Proprietor Name"                                                                (localized)
     //  7: "Proprietor Title"                                                               (localized)
-    //  8: "Picture"            - always 0                                                  (not used)
-    //  9: "State"              - always 0                                                  (not used)
-    // 10: "Rep"                - always 0, reputation?                                     (not used)
-    // 11: "Per"                - always 0                                                  (not used)
+    //  8: "Picture"            - always 0                                                  (not used in MM7)
+    //  9: "State"              - always 0                                                  (not used in MM7)
+    // 10: "Rep"                - always 0, reputation?                                     (not used in MM7)
+    // 11: "Per"                - always 0                                                  (not used in MM7)
     // 12: "Val"                - shop price multiplier, float
     // 13: "A"                  - skill/spell price multiplier, float
     // 14: "B"                  - always empty
@@ -42,7 +42,7 @@ void initializeHouses(const Blob &houses) {
     // 20: "Pic"                - exit picture id                                           (not used in MM7)
     // 21: "Map"                - exit map id                                               (not used in MM7)
     // 22: "Restrictions"       - exit gating quest bit                                     (not used in MM7)
-    // 23: "Text"               - exit text                                                 (not used)
+    // 23: "Text"               - exit text                                                 (not used in MM7)
     static const std::map<std::string, HouseType, ascii::NoCaseLess> houseTypeMap = {
         {"Weapon Shop", HOUSE_TYPE_WEAPON_SHOP},
         {"Armor Shop", HOUSE_TYPE_ARMOR_SHOP},

--- a/src/Engine/Tables/HouseTable.cpp
+++ b/src/Engine/Tables/HouseTable.cpp
@@ -26,10 +26,10 @@ void initializeHouses(const Blob &houses) {
     //  5: "Name"               - house name                                                (localized)
     //  6: "Proprietor Name"                                                                (localized)
     //  7: "Proprietor Title"                                                               (localized)
-    //  8: "Picture"            - always 0
-    //  9: "State"              - always 0
-    // 10: "Rep"                - always 0, reputation?
-    // 11: "Per"                - always 0
+    //  8: "Picture"            - always 0                                                  (not used)
+    //  9: "State"              - always 0                                                  (not used)
+    // 10: "Rep"                - always 0, reputation?                                     (not used)
+    // 11: "Per"                - always 0                                                  (not used)
     // 12: "Val"                - shop price multiplier, float
     // 13: "A"                  - skill/spell price multiplier, float
     // 14: "B"                  - always empty
@@ -42,7 +42,7 @@ void initializeHouses(const Blob &houses) {
     // 20: "Pic"                - exit picture id                                           (not used in MM7)
     // 21: "Map"                - exit map id                                               (not used in MM7)
     // 22: "Restrictions"       - exit gating quest bit                                     (not used in MM7)
-    // 23: "Text"               - exit text                                                 (not used in MM7)
+    // 23: "Text"               - exit text                                                 (not used)
     static const std::map<std::string, HouseType, ascii::NoCaseLess> houseTypeMap = {
         {"Weapon Shop", HOUSE_TYPE_WEAPON_SHOP},
         {"Armor Shop", HOUSE_TYPE_ARMOR_SHOP},
@@ -83,10 +83,6 @@ void initializeHouses(const Blob &houses) {
         houseTable[houseId].name = unquote(tokens[5]);
         houseTable[houseId].pProprieterName = unquote(tokens[6]);
         houseTable[houseId].pProprieterTitle = unquote(tokens[7]);
-        houseTable[houseId].field_14 = fromString<int>(tokens[8]);
-        houseTable[houseId]._state = fromString<int>(tokens[9]);
-        houseTable[houseId]._rep = fromString<int>(tokens[10]);
-        houseTable[houseId]._per = fromString<int>(tokens[11]);
         houseTable[houseId].fPriceMultiplier = fromString<float>(tokens[12]);
         houseTable[houseId].flt_24 = fromString<float>(tokens[13]);
         houseTable[houseId].generation_interval_days = fromString<int>(tokens[15]);
@@ -95,6 +91,5 @@ void initializeHouses(const Blob &houses) {
         houseTable[houseId].uExitPicID = fromString<int>(tokens[20]);
         houseTable[houseId].uExitMapID = static_cast<MapId>(fromString<int>(tokens[21]));
         houseTable[houseId]._quest_bit = static_cast<QuestBit>(fromString<int>(tokens[22]));
-        houseTable[houseId].pEnterText = unquote(tokens[23]);
     }
 }


### PR DESCRIPTION
Resolves `TODO(captainurist): drop everything that's not used here.` on `struct HouseData`.

Seven fields dropped - `pEnterText`, `field_14`, `_state`, `_rep`, `_per`, `field_1E`, `field_32` - each either never referenced at all or only written by the 2devents.txt parser and never read (audited across src/, tests, scripts and CodeGen, which consumes only `uType` and `name`). Their five parser lines go too. Token indices are absolute into the 24-column split, so the remaining assignments are unaffected.

Review double-checked the inverse too: every remaining field has a real read, so the struct is now exactly the used set. HouseData is never serialized - the table is re-parsed from game data each launch, so saves and traces are unaffected.

**The annotations stay scoped to MM7**, per review. I first widened the format comment's `(not used in MM7)` tags to a bare `(not used)` and that was wrong - MM6 populates two of those columns, column 8 in 311 rows and column 23 in 41. Reverted, and columns 9 to 11 keep the MM7 wording too rather than claiming something the MM8 data I have cannot back.

What MM6 does with them, for whoever picks up MM6 support. Columns 20 to 23 are one feature, not four fields - the first header row groups them as `Other Exits`, `Questbit` and `Enter`, and they describe a second exit out of a house dialogue, labelled with column 23, which is the string `Enter` in all 41 rows that use it. Those rows are all house types MM7 does not have: 33 `Dungeon Ent` pointing at a map id, 6 `Castle Entrance` pointing at *another row of this same table* (`2D 154` from Castle Ironfist at id 153, matching the MM6 scripts decoded on #2599), plus the City Council and the Oracle. Column 22 holds a quest bit, or free text, or one of six negative values on six houses that all exit to map 47, the Free Haven Sewer - and those index `std::array<int, 6> teleportX` in the dead branch at `Game.cpp:830`, which answers its `what's going on here?` TODO. Column 8 is a separate picture column holding names like `Poor House` and `2nd floor`.

Worth knowing: none of these can be read by the parser we have, with or without this PR. `fromString<int>` throws on a non-number, and MM6 has `Poor House` in column 8, `Dungeon` in 20, `2D 154` in 21 and `Need Key` in 22. The fields would have to be re-typed rather than restored, which is another reason not to leave them sitting there as ints.

Local battery: 394 unit tests, 356/356 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)