### PR TITLE
Answer the treasure level TODO on the respawning maps

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -570,10 +570,9 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
     setNPCNamesOnLoad();
     engine->_461103_load_level_sub();
     if (engine->_currentLoadedMapId == MAP_BREEDING_ZONE || engine->_currentLoadedMapId == MAP_WALLS_OF_MIST) {
-        // spawning grounds & walls of mist - no loot & exp from monsters
-
+        // Monsters here give no exp and no gold, and their typed loot is replaced with untyped random
+        // items. Item drops themselves stay. treasureDropChance and treasureLevel are untouched.
         for (Actor &actor : pActors) {
-            // TODO(captainurist): shouldn't we also set uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID?
             actor.monsterInfo.treasureType = RANDOM_ITEM_ANY;
             actor.monsterInfo.goldDiceRolls = 0;
             actor.monsterInfo.exp = 0;


### PR DESCRIPTION
Resolves `TODO(captainurist): shouldn't we also set uTreasureLevel = ITEM_TREASURE_LEVEL_INVALID?` in the Breeding Zone / Walls of Mist block - by answering no and fixing the comment that prompted the question.

The old comment claimed "no loot & exp from monsters", but the block never suppressed item drops - only exp, gold, and the loot's *type*. That's not an oversight:

- The block is an unmodified vanilla decompilation (git -L shows renames only since the 2016 import, offset 00464866).
- The identical three-field nerf (type=ANY, gold dice=0, exp=0, treasureLevel untouched) is the engine's standard "free monster" idiom, used verbatim for summoned minions and spawned monsters.
- Data check (monsters.txt / mapstats.txt out of events.lod): Walls of Mist spawns Djinni/Genie/Efreet with untyped 30% L4-L6 drops - setting treasureLevel invalid would delete the classic WoM item farming, a real gameplay deviation. On the Breeding Zone the question is moot, none of its spawn families have a valid treasureLevel.
- Setting it would also shift grng draws in LootActor and desync traces, for zero gameplay win.

Note for the triage index: the todos.md entry for this TODO concluded "yes" - it took the old wrong comment at face value.

Comment-only change. Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
