### PR TITLE
Drop the dead Arcomage message types

### DIFF
--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -880,10 +880,6 @@ void ArcomageGame::Loop() {
             pArcomageGame->_frameLimiter.tick(pArcomageGame->_targetFPS);
 
             ArcomageGame::MsgLoop(20, &v10);
-            if (v10.am_input_type == ARCO_MSG_KEYDOWN) {
-                if (v10.field_4) break;
-                continue;
-            }
             if ((v10.am_input_type == ARCO_MSG_PLAYCARD) || (v10.am_input_type == ARCO_MSG_DISCARD)) break;
             if (v10.am_input_type == ARCO_MSG_ESCAPE) break;
 
@@ -1187,13 +1183,6 @@ char PlayerTurn(int player_num) {
         if (pArcomageGame->_forceExit) break_loop = true;
         ArcomageGame::MsgLoop(0, &get_message);
         switch (get_message.am_input_type) {
-            case ARCO_MSG_FORCEQUIT:
-                if (get_message.field_4 == 129 && get_message.am_input_key == PlatformKey::KEY_ESCAPE) { // TODO(pskelton): was 1 - what was this meant to do? Check for dual key press??
-                    num_actions_left = 0;
-                    break_loop = true;
-                    pArcomageGame->_forceExit = 1;
-                }
-                break;
             case ARCO_MSG_ESCAPE:
                 if (pArcomageGame->_checkExit == 1) {
                     pArcomageGame->_gameOver = 1;

--- a/src/Arcomage/Arcomage.h
+++ b/src/Arcomage/Arcomage.h
@@ -134,17 +134,8 @@ struct ArcomagePlayer {
     Pointi card_shift[10] {};
 };
 
-// TODO(pskelton): cleanup unused
 enum class ArcomageMessageType {
     ARCO_MSG_NULL,
-
-    ARCO_MSG_KEYDOWN,
-    ARCO_MSG_FORCEQUIT,
-    ARCO_MSG_LM_UP,
-    ARCO_MSG_RM_UP,
-    ARCO_MSG_LM_DOWN,
-    ARCO_MSG_RM_DOWN,
-    ARCO_MSG_SWITCH_FULLSCREEN, // Not used in Arcomage
 
     ARCO_MSG_ESCAPE,
     ARCO_MSG_PLAYCARD,
@@ -157,7 +148,6 @@ using enum ArcomageMessageType;
 struct ArcomageGame_InputMSG {
     ArcomageMessageType am_input_type{ ARCO_MSG_NULL };
     PlatformKey am_input_key{ PlatformKey::KEY_NONE };
-    int field_4 = 0; // unsused
 };
 
 class GUIFont;


### PR DESCRIPTION
Resolves `TODO(pskelton): cleanup unused` on `enum class ArcomageMessageType`, and swallows the `TODO(pskelton): was 1 - what was this meant to do?` in the process.

- `ARCO_MSG_LM_UP/RM_UP/LM_DOWN/RM_DOWN/SWITCH_FULLSCREEN` - zero references.
- `ARCO_MSG_KEYDOWN` / `ARCO_MSG_FORCEQUIT` - one consumer branch each, no producer anywhere: `MsgLoop` only ever yields what `onKeyPress` / `OnMouseClick` set, and those produce only NULL/ESCAPE/PLAYCARD/DISCARD/LEFT/RIGHT. Both unreachable branches deleted with their enumerators. The double-Escape exit still sets `_forceExit` via the surviving ESCAPE case.
- `ArcomageGame_InputMSG::field_4` - never written, both always-false reads lived in the deleted branches.

Renumbering the enum is safe - it appears nowhere outside `src/Arcomage/`, is never cast to or from int, isn't serialized, and traces replay platform key events, not these values (review verified all of this, plus that the arcomage trace tests cover the adjacent ESCAPE flow).

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
