### PR TITLE
Drop the event cancellation flag

### DIFF
--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -35,6 +35,8 @@
 #include "GUI/UI/UITransition.h"
 #include "GUI/UI/UIStatusBar.h"
 
+bool cancelEventProcessing = false;
+
 /**
  * @offset 0x4465DF
  */
@@ -587,7 +589,7 @@ bool EvtInterpreter::executeRegular(int startStep) {
 
     _who = !pParty->hasActiveCharacter() ? CHOOSE_RANDOM : CHOOSE_ACTIVE;
 
-    while (step != -1 && dword_5B65C4_cancelEventProcessing == 0) {
+    while (step != -1 && !cancelEventProcessing) {
         step = executeOneEvent(step, false);
     }
 

--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -35,8 +35,6 @@
 #include "GUI/UI/UITransition.h"
 #include "GUI/UI/UIStatusBar.h"
 
-bool cancelEventProcessing = false;
-
 /**
  * @offset 0x4465DF
  */
@@ -318,13 +316,15 @@ int EvtInterpreter::executeOneEvent(int step, bool isNpc) {
                 ItemId itemId = static_cast<ItemId>(ir.data.variable_descr.value);
                 for (Character &character : pParty->pCharacters) {
                     if (pParty->pPickedItem.itemId == itemId || character.inventory.find(itemId)) {
-                        character.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value);
+                        if (!character.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value))
+                            _cancelled = true;
                         break;  // Only take one item.
                     }
                 }
             } else {
                 for (Character &character : iterateCharacters(_who, grng))
-                    character.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value);
+                    if (!character.SubtractVariable(ir.data.variable_descr.type, ir.data.variable_descr.value))
+                        _cancelled = true;
             }
             break;
         case EVENT_Set:
@@ -589,7 +589,7 @@ bool EvtInterpreter::executeRegular(int startStep) {
 
     _who = !pParty->hasActiveCharacter() ? CHOOSE_RANDOM : CHOOSE_ACTIVE;
 
-    while (step != -1 && !cancelEventProcessing) {
+    while (step != -1 && !_cancelled) {
         step = executeOneEvent(step, false);
     }
 

--- a/src/Engine/Evt/EvtInterpreter.h
+++ b/src/Engine/Evt/EvtInterpreter.h
@@ -8,9 +8,6 @@
 
 #include "Library/Geometry/Vec.h"
 
-// Set from inside a running event script to abort it, e.g. when the script tries to take more gold than the party has.
-extern bool cancelEventProcessing;
-
 // EvtInterpreter
 class EvtInterpreter {
  public:
@@ -31,6 +28,7 @@ class EvtInterpreter {
      bool _canShowOption = true;
      bool _readyToExit = false;
      bool _mapExitTriggered = false;
+     bool _cancelled = false; // Set when a script asks for more than the party has, e.g. gold, and aborts it.
      EvtTargetCharacter _who = CHOOSE_PARTY;
 };
 

--- a/src/Engine/Evt/EvtInterpreter.h
+++ b/src/Engine/Evt/EvtInterpreter.h
@@ -8,6 +8,9 @@
 
 #include "Library/Geometry/Vec.h"
 
+// Set from inside a running event script to abort it, e.g. when the script tries to take more gold than the party has.
+extern bool cancelEventProcessing;
+
 // EvtInterpreter
 class EvtInterpreter {
  public:

--- a/src/Engine/Evt/Processor.cpp
+++ b/src/Engine/Evt/Processor.cpp
@@ -151,8 +151,6 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
         return;
     }
 
-    cancelEventProcessing = false;
-
     EvtInterpreter interpreter;
     MM_TRACE("Executing regular event starting from step {}", startStep);
     if (activeLevelDecoration) {

--- a/src/Engine/Evt/Processor.cpp
+++ b/src/Engine/Evt/Processor.cpp
@@ -151,7 +151,7 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
         return;
     }
 
-    dword_5B65C4_cancelEventProcessing = 0; // TODO: rename and contain in this module or better remove it altogether
+    cancelEventProcessing = false;
 
     EvtInterpreter interpreter;
     MM_TRACE("Executing regular event starting from step {}", startStep);

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -40,7 +40,6 @@
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Conditions.h"
 #include "Engine/Evt/EvtEnumFunctions.h"
-#include "Engine/Evt/EvtInterpreter.h"
 
 #include "Io/Mouse.h"
 
@@ -5156,75 +5155,73 @@ void Character::AddSkillByEvent(Skill skill, uint16_t addSkillValue) {
 }
 
 //----- (0044B9C4) --------------------------------------------------------
-void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
+bool Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
     LocationInfo *locationHeader;  // eax@90
     int randGold;
     int randFood;
 
     if (VarNum >= VAR_MapPersistentVariable_0 && VarNum <= VAR_MapPersistentVariable_74) {
         engine->_persistentVariables.mapVars[std::to_underlying(VarNum) - std::to_underlying(VAR_MapPersistentVariable_0)] -= pValue;
-        return;
+        return true;
     }
     if (VarNum >= VAR_MapPersistentDecorVariable_0 && VarNum <= VAR_MapPersistentDecorVariable_24) {
         engine->_persistentVariables.decorVars[std::to_underlying(VarNum) - std::to_underlying(VAR_MapPersistentDecorVariable_0)] -= pValue;
-        return;
+        return true;
     }
 
     switch (VarNum) {
         case VAR_CurrentHP:
             receiveDamage((signed int)pValue, DAMAGE_PHYSICAL);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_CurrentSP:
             this->mana = std::max(this->mana - pValue, 0);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_ACModifier:
             this->sACModifier -= (uint8_t)pValue;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_BaseLevel:
             this->uLevel -= (uint8_t)pValue;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_LevelModifier:
             this->sLevelModifier -= (uint8_t)pValue;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Age:
             this->sAgeModifier -= (int16_t)pValue;
-            return;
+            return true;
         case VAR_Award:
             this->_achievedAwardsBits.reset(static_cast<AwardId>(pValue));
-            return;
+            return true;
         case VAR_Experience:
             this->experience -= pValue;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_QBits_QuestsDone:
             // TODO(captainurist): quest bit is coming from a script, do range checking here.
             pParty->_questBits.reset(static_cast<QuestBit>(pValue));
             this->playReaction(SPEECH_AWARD_GOT);
-            return;
+            return true;
         case VAR_PlayerItemInHands:
             for (InventoryEntry entry : inventory.entries()) {
                 if (entry->itemId == static_cast<ItemId>(pValue)) {
                     inventory.take(entry);
-                    return;
+                    return true;
                 }
             }
             if (pParty->pPickedItem.itemId == static_cast<ItemId>(pValue)) {
                 pParty->takeHoldingItem();
-                return;
+                return true;
             }
-            return;
+            return true;
         case VAR_FixedGold:
-            if (pValue > pParty->GetGold()) {
-                cancelEventProcessing = true;
-                return;
-            }
+            if (pValue > pParty->GetGold())
+                return false;
             pParty->TakeGold(pValue);
-            return;
+            return true;
         case VAR_RandomGold:
             randGold = grng->random(pValue) + 1;
             if (randGold > pParty->GetGold())
@@ -5232,11 +5229,11 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             pParty->TakeGold(randGold);
             engine->_statusBar->setEvent(LSTR_YOU_LOSE_LU_GOLD, randGold);
             GameUI_DrawFoodAndGold();
-            return;
+            return true;
         case VAR_FixedFood:
             pParty->TakeFood(pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_RandomFood:
             randFood = grng->random(pValue) + 1;
             if (randFood > pParty->GetFood())
@@ -5245,373 +5242,373 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             engine->_statusBar->setEvent(LSTR_YOU_LOSE_LU_FOOD, randFood);
             GameUI_DrawFoodAndGold();
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_MightBonus:
         case VAR_ActualMight:
             this->_statBonuses[ATTRIBUTE_MIGHT] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_IntellectBonus:
         case VAR_ActualIntellect:
             this->_statBonuses[ATTRIBUTE_INTELLIGENCE] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_PersonalityBonus:
         case VAR_ActualPersonality:
             this->_statBonuses[ATTRIBUTE_PERSONALITY] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_EnduranceBonus:
         case VAR_ActualEndurance:
             this->_statBonuses[ATTRIBUTE_ENDURANCE] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_SpeedBonus:
         case VAR_ActualSpeed:
             this->_statBonuses[ATTRIBUTE_SPEED] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_AccuracyBonus:
         case VAR_ActualAccuracy:
             this->_statBonuses[ATTRIBUTE_ACCURACY] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_LuckBonus:
         case VAR_ActualLuck:
             this->_statBonuses[ATTRIBUTE_LUCK] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_BaseMight:
             this->_stats[ATTRIBUTE_MIGHT] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BaseIntellect:
             this->_stats[ATTRIBUTE_INTELLIGENCE] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BasePersonality:
             this->_stats[ATTRIBUTE_PERSONALITY] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BaseEndurance:
             this->_stats[ATTRIBUTE_ENDURANCE] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BaseSpeed:
             this->_stats[ATTRIBUTE_SPEED] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BaseAccuracy:
             this->_stats[ATTRIBUTE_ACCURACY] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BaseLuck:
             this->_stats[ATTRIBUTE_LUCK] -= (uint16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_FireResistance:
             this->sResFireBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_AirResistance:
             this->sResAirBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_WaterResistance:
             this->sResWaterBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_EarthResistance:
             this->sResEarthBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_SpiritResistance:
             this->sResSpiritBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_MindResistance:
             this->sResMindBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_BodyResistance:
             this->sResBodyBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_LightResistance:
             this->sResLightBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_DarkResistance:
             this->sResDarkBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_MagicResistance:
             this->sResMagicBase -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_FireResistanceBonus:
             this->sResFireBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_AirResistanceBonus:
             this->sResAirBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BASE_INC);
-            return;
+            return true;
         case VAR_WaterResistanceBonus:
             this->sResWaterBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_EarthResistanceBonus:
             this->sResEarthBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_SpiritResistanceBonus:
             this->sResSpiritBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_MindResistanceBonus:
             this->sResMindBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_BodyResistanceBonus:
             this->sResBodyBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_LightResistanceBonus:
             this->sResLightBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_DarkResistanceBonus:
             this->sResDarkBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_MagicResistanceBonus:
             this->sResMagicBonus -= (int16_t)pValue;
             this->PlayAwardSound_AnimSubtract_Face(SPEECH_STAT_BONUS_INC);
-            return;
+            return true;
         case VAR_StaffSkill:
             SubtractSkillByEvent(SKILL_STAFF, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_SwordSkill:
             SubtractSkillByEvent(SKILL_SWORD, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DaggerSkill:
             SubtractSkillByEvent(SKILL_DAGGER, pValue);;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_AxeSkill:
             SubtractSkillByEvent(SKILL_AXE, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_SpearSkill:
             SubtractSkillByEvent(SKILL_BOW, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_BowSkill:
             SubtractSkillByEvent(SKILL_BOW, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_MaceSkill:
             SubtractSkillByEvent(SKILL_MACE, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_BlasterSkill:
             SubtractSkillByEvent(SKILL_BLASTER, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_ShieldSkill:
             SubtractSkillByEvent(SKILL_SHIELD, pValue);;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_LeatherSkill:
             SubtractSkillByEvent(SKILL_LEATHER, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_SkillChain:
             SubtractSkillByEvent(SKILL_CHAIN, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_PlateSkill:
             SubtractSkillByEvent(SKILL_PLATE, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_FireSkill:
             SubtractSkillByEvent(SKILL_FIRE, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_AirSkill:
             SubtractSkillByEvent(SKILL_AIR, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_WaterSkill:
             SubtractSkillByEvent(SKILL_WATER, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_EarthSkill:
             SubtractSkillByEvent(SKILL_EARTH, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_SpiritSkill:
             SubtractSkillByEvent(SKILL_SPIRIT, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_MindSkill:
             SubtractSkillByEvent(SKILL_MIND, pValue);;
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_BodySkill:
             SubtractSkillByEvent(SKILL_BODY, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_LightSkill:
             SubtractSkillByEvent(SKILL_LIGHT, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DarkSkill:
             SubtractSkillByEvent(SKILL_DARK, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_IdentifyItemSkill:
             SubtractSkillByEvent(SKILL_ITEM_ID, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_MerchantSkill:
             SubtractSkillByEvent(SKILL_MERCHANT, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_RepairSkill:
             SubtractSkillByEvent(SKILL_REPAIR, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_BodybuildingSkill:
             SubtractSkillByEvent(SKILL_BODYBUILDING, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_MeditationSkill:
             SubtractSkillByEvent(SKILL_MEDITATION, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_PerceptionSkill:
             SubtractSkillByEvent(SKILL_PERCEPTION, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DiplomacySkill:
             SubtractSkillByEvent(SKILL_DIPLOMACY, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_ThieverySkill:
             MM_ERROR("Thieving unsupported");
-            return;
+            return true;
         case VAR_DisarmTrapSkill:
             SubtractSkillByEvent(SKILL_TRAP_DISARM, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DodgeSkill:
             SubtractSkillByEvent(SKILL_DODGE, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_UnarmedSkill:
             SubtractSkillByEvent(SKILL_UNARMED, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_IdentifyMonsterSkill:
             SubtractSkillByEvent(SKILL_MONSTER_ID, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_ArmsmasterSkill:
             SubtractSkillByEvent(SKILL_ARMSMASTER, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_StealingSkill:
             SubtractSkillByEvent(SKILL_STEALING, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_AlchemySkill:
             SubtractSkillByEvent(SKILL_ALCHEMY, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_LearningSkill:
             SubtractSkillByEvent(SKILL_LEARNING, pValue);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Cursed:
             this->conditions.reset(CONDITION_CURSED);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Weak:
             this->conditions.reset(CONDITION_WEAK);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Asleep:
             this->conditions.reset(CONDITION_SLEEP);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Afraid:
             this->conditions.reset(CONDITION_FEAR);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Drunk:
             this->conditions.reset(CONDITION_DRUNK);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Insane:
             this->conditions.reset(CONDITION_INSANE);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_PoisonedGreen:
             this->conditions.reset(CONDITION_POISON_WEAK);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DiseasedGreen:
             this->conditions.reset(CONDITION_DISEASE_WEAK);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_PoisonedYellow:
             this->conditions.reset(CONDITION_POISON_MEDIUM);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DiseasedYellow:
             this->conditions.reset(CONDITION_DISEASE_MEDIUM);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_PoisonedRed:
             this->conditions.reset(CONDITION_POISON_SEVERE);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_DiseasedRed:
             this->conditions.reset(CONDITION_DISEASE_SEVERE);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Paralyzed:
             this->conditions.reset(CONDITION_PARALYZED);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Unconsious:
             this->conditions.reset(CONDITION_UNCONSCIOUS);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Dead:
             this->conditions.reset(CONDITION_DEAD);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Stoned:
             this->conditions.reset(CONDITION_PETRIFIED);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_Eradicated:
             this->conditions.reset(CONDITION_ERADICATED);
             PlayAwardSound_AnimSubtract();
-            return;
+            return true;
         case VAR_AutoNotes:
             // TODO(Nik-RE-dev): decreasing 1 seems wrong, also bits indexing was changed
             assert(false);
             //pParty->_autonoteBits.reset(pValue - 1);
-            return;
+            return true;
         case VAR_PlayerBits:
             _characterEventBits.reset(pValue);
-            return;
+            return true;
         case VAR_NPCs2:
             if (getNPCType(speakingNpcId) == NPC_TYPE_QUEST && speakingNpcId == pValue) {
                 npcIdToDismissAfterDialogue = pValue;
@@ -5621,7 +5618,7 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
                 pNPCStats->pNPCData[(int)pValue].flags &= ~NPC_HIRED;
                 pParty->CountHirelings();
             }
-            return;
+            return true;
         case VAR_HiredNPCHasSpeciality:
             for (int i = 0; i < pNPCStats->uNumNewNPCs; i++) {
                 if (pNPCStats->pNPCData[i].profession == (NpcProfession)pValue) {
@@ -5636,50 +5633,48 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             }
             pParty->hirelingScrollPosition = 0;
             pParty->CountHirelings();
-            return;
+            return true;
         case VAR_NumSkillPoints:
             if (pValue <= this->uSkillPoints) {
                 this->uSkillPoints -= pValue;
             } else {
                 this->uSkillPoints = 0;
             }
-            return;
+            return true;
         case VAR_ReputationInCurrentLocation:
             locationHeader = &currentLocationInfo();
             locationHeader->reputation -= pValue;
             if (locationHeader->reputation < -10000)
                 locationHeader->reputation = -10000;
-            return;
+            return true;
         case VAR_GoldInBank:
-            if (pValue <= pParty->uNumGoldInBank) {
-                pParty->uNumGoldInBank -= pValue;
-            } else {
-                cancelEventProcessing = true;
-            }
-            return;
+            if (pValue > pParty->uNumGoldInBank)
+                return false;
+            pParty->uNumGoldInBank -= pValue;
+            return true;
         case VAR_NumDeaths:
             pParty->uNumDeaths -= pValue;
-            return;
+            return true;
         case VAR_NumBounties:
             pParty->uNumBountiesCollected -= pValue;
-            return;
+            return true;
         case VAR_PrisonTerms:
             pParty->uNumPrisonTerms -= pValue;
-            return;
+            return true;
         case VAR_ArenaWinsPage:
             pParty->uNumArenaWins[ARENA_LEVEL_PAGE] -= pValue;
-            return;
+            return true;
         case VAR_ArenaWinsSquire:
             pParty->uNumArenaWins[ARENA_LEVEL_SQUIRE] -= pValue;
-            return;
+            return true;
         case VAR_ArenaWinsKnight:
             pParty->uNumArenaWins[ARENA_LEVEL_KNIGHT] -= pValue;
-            return;
+            return true;
         case VAR_ArenaWinsLord:
             pParty->uNumArenaWins[ARENA_LEVEL_LORD] -= pValue;
-            return;
+            return true;
         default:
-            return;
+            return true;
     }
 }
 

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -40,6 +40,7 @@
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Conditions.h"
 #include "Engine/Evt/EvtEnumFunctions.h"
+#include "Engine/Evt/EvtInterpreter.h"
 
 #include "Io/Mouse.h"
 
@@ -5219,7 +5220,7 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             return;
         case VAR_FixedGold:
             if (pValue > pParty->GetGold()) {
-                dword_5B65C4_cancelEventProcessing = 1;
+                cancelEventProcessing = true;
                 return;
             }
             pParty->TakeGold(pValue);
@@ -5653,7 +5654,7 @@ void Character::SubtractVariable(EvtVariable VarNum, signed int pValue) {
             if (pValue <= pParty->uNumGoldInBank) {
                 pParty->uNumGoldInBank -= pValue;
             } else {
-                dword_5B65C4_cancelEventProcessing = 1;
+                cancelEventProcessing = true;
             }
             return;
         case VAR_NumDeaths:

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -74,13 +74,22 @@ class Character {
 
     bool matchesAttackPreference(MonsterAttackPreference preference) const;
 
+    // TODO(captainurist): evt script semantics, belongs in the Evt module. The callers outside it all go through
+    //                     VAR_Award or VAR_PlayerItemInHands and need their own entry points first.
     void SetVariable(EvtVariable var, signed int a3);
+
+    // TODO(captainurist): evt script semantics, belongs in the Evt module, see SetVariable.
     void AddVariable(EvtVariable var, signed int val);
+
     /**
+     * TODO(captainurist): evt script semantics, belongs in the Evt module. Only the interpreter calls this one.
+     *
      * @return                          False if the subtraction could not be performed, e.g. the party doesn't have
      *                                  enough gold. A script that hits this is aborted.
      */
     [[nodiscard]] bool SubtractVariable(EvtVariable VarNum, signed int pValue);
+
+    // TODO(captainurist): evt script semantics, belongs in the Evt module. Only the interpreter calls this one.
     bool CompareVariable(EvtVariable VarNum, signed int pValue);
 
     /**

--- a/src/Engine/Objects/Character.h
+++ b/src/Engine/Objects/Character.h
@@ -76,7 +76,11 @@ class Character {
 
     void SetVariable(EvtVariable var, signed int a3);
     void AddVariable(EvtVariable var, signed int val);
-    void SubtractVariable(EvtVariable VarNum, signed int pValue);
+    /**
+     * @return                          False if the subtraction could not be performed, e.g. the party doesn't have
+     *                                  enough gold. A script that hits this is aborted.
+     */
+    [[nodiscard]] bool SubtractVariable(EvtVariable VarNum, signed int pValue);
     bool CompareVariable(EvtVariable VarNum, signed int pValue);
 
     /**

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2412,7 +2412,6 @@ unsigned int uIconIdx_WaterWalk;
 
 int uCurrentHouse_Animation;
 std::string branchless_dialogue_str;
-int dword_5B65C4_cancelEventProcessing;
 int npcIdToDismissAfterDialogue;
 // std::array<char, 777> byte_5C3427;
 

--- a/src/Engine/mm7_data.h
+++ b/src/Engine/mm7_data.h
@@ -84,7 +84,6 @@ extern int uCurrentHouse_Animation;
 
 extern std::string branchless_dialogue_str;
 
-extern int dword_5B65C4_cancelEventProcessing;
 extern int npcIdToDismissAfterDialogue;
 extern int bDialogueUI_InitializeActor_NPC_ID;
 


### PR DESCRIPTION
Resolves `TODO: rename and contain in this module or better remove it altogether` on `dword_5B65C4_cancelEventProcessing` - by removing it altogether.

The flag was cross-module communication: `Character::SubtractVariable` set it when an event script tried to take more on-hand or bank gold than the party has, the `EvtInterpreter::executeRegular` step loop aborted on it, and `eventProcessor` reset it.

Per review, the flag is gone rather than renamed. Those two spots are the only ones that ever cancelled a script and both mean the same thing - the party cannot pay - so `SubtractVariable` reports it instead:

```cpp
/**
 * @return                          False if the subtraction could not be performed, e.g. the party doesn't have
 *                                  enough gold. A script that hits this is aborted.
 */
[[nodiscard]] bool SubtractVariable(EvtVariable VarNum, signed int pValue);
```

The interpreter owns the cancellation as a `_cancelled` member. That drops the global, the reset in `eventProcessor`, and the `Objects` to `Evt` include. `[[nodiscard]]` keeps it honest - both call sites are in the interpreter. The pre-existing asymmetry where `executeNpcDialogue` ignores cancellation is preserved. One incidental fix: the old global was reset at the top of `eventProcessor`, so a nested event run cleared an outer cancellation, which a member cannot.

Also per review, each of the four evt variable methods now carries a TODO saying it belongs in the `Evt` module. `SubtractVariable` and `CompareVariable` are called only by the interpreter and can move as soon as someone picks it up. `SetVariable` and `AddVariable` have callers in `NPCTopics.cpp`, `UIPopup.cpp`, `UIHouses.cpp`, `Houses/TownHall.cpp` and `Game.cpp` that go through `VAR_Award` or `VAR_PlayerItemInHands`, and those need their own entry points first.

Local battery: 394 unit tests, 356/356 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)