### PR TITLE
Move GetFacetOrientation into stru314

### DIFF
--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ENGINE_SOURCES
         TeleportPoint.cpp
         mm7_data.cpp
         mm7text_ru.cpp
+        stru314.cpp
         Seasons.cpp)
 
 set(ENGINE_HEADERS

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -57,52 +57,6 @@ Vec3f Camera3D::ViewTransform(const Vec3f* pos) const {
     return Vec3f(camtovert.x, camtovert.y, camtovert.z);
 }
 
-//----- (00436932) --------------------------------------------------------
-// TODO(captainurist): function belongs to stru314
-void Camera3D::GetFacetOrientation(const Vec3f &normal, Vec3f *outU, Vec3f *outV) {
-    if (fabsf(normal.z) < 1e-6f) {
-        // Vertical wall.
-        outV->x = -normal.y;
-        outV->y = normal.x;
-        outV->z = 0.0;
-
-        outU->x = 0.0;
-        outU->y = 0.0;
-        outU->z = 1.0f;
-    } else if (fabsf(normal.x) < 1e-6f && fabsf(normal.y) < 1e-6f) {
-        // Floor.
-        outV->x = 1.0;
-        outV->y = 0.0;
-        outV->z = 0.0;
-
-        outU->x = 0.0;
-        outU->y = 1.0;
-        outU->z = 0.0;
-    } else {
-        // Other.
-        if (fabs(normal.z) < 0.70811361) {
-            outV->x = -normal.y;
-            outV->y = normal.x;
-            outV->z = 0.0;
-            outV->normalize();
-
-            outU->x = 0.0;
-            outU->y = 0.0;
-            outU->z = 1.0;
-        } else {
-            outV->x = 1.0;
-            outV->y = 0.0;
-            outV->z = 0.0;
-
-            outU->x = 0.0;
-            outU->y = 1.0;
-            outU->z = 0.0;
-        }
-    }
-}
-
-
-
 //----- (00438258) --------------------------------------------------------
 bool Camera3D::is_face_faced_to_camera(BLVFace *pFace) {
     return pFace->facePlane.dist +

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -47,7 +47,6 @@ struct Camera3D {
                                RenderVertexSoft *pLineEnd,
                                Color sEndDiffuse32, float z_stuff);
     bool is_face_faced_to_camera(BLVFace *pFace);
-    static void GetFacetOrientation(const Vec3f &normal, Vec3f *outU, Vec3f *outV);
 
     void CullByNearClip(RenderVertexSoft *pverts, unsigned int *unumverts);
     void CullByFarClip(RenderVertexSoft *pverts, unsigned int *unumverts);

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -68,7 +68,7 @@ char DecalBuilder::BuildAndApplyDecals(int light_level, LocationFlags locationFl
     static stru314 static_FacePlane;
     static_FacePlane.Normal = FacePlane.normal;
     static_FacePlane.dist = FacePlane.dist;
-    Camera3D::GetFacetOrientation(static_FacePlane.Normal, &static_FacePlane.field_10, &static_FacePlane.field_1C);
+    static_FacePlane.computeBasis();
 
     if (this->uNumSplatsThisFace > 0) {
         for (int i = 0; i < this->uNumSplatsThisFace; ++i) {

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -439,7 +439,7 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
 
 //----- (00498A41) --------------------------------------------------------
 std::pair<Vec3f, Vec3f> BLVFace::textureUV() const {
-    // TODO(captainurist): code looks very similar to Camera3D::GetFacetOrientation
+    // TODO(captainurist): code looks very similar to stru314::computeBasis
     Vec3f u;
     Vec3f v;
 

--- a/src/Engine/Graphics/PortalFunctions.cpp
+++ b/src/Engine/Graphics/PortalFunctions.cpp
@@ -166,7 +166,7 @@ bool CalcFaceBounding(const BLVFace *pFace, RenderVertexSoft *pFaceLimits,
 
     float var_28;
     float var_24;
-    // TODO(captainurist): code looks very similar to Camera3D::GetFacetOrientation
+    // TODO(captainurist): code looks very similar to stru314::computeBasis
     switch (pFace->polygonType) {
         case POLYGON_VerticalWall:
             a1.x = -pFace->facePlane.normal.y;  // направление полигона

--- a/src/Engine/stru314.cpp
+++ b/src/Engine/stru314.cpp
@@ -1,0 +1,48 @@
+#include "Engine/stru314.h"
+
+#include <cmath>
+
+void stru314::computeBasis() {
+    Vec3f *outU = &field_10;
+    Vec3f *outV = &field_1C;
+    const Vec3f &normal = Normal;
+    if (fabsf(normal.z) < 1e-6f) {
+        // Vertical wall.
+        outV->x = -normal.y;
+        outV->y = normal.x;
+        outV->z = 0.0;
+
+        outU->x = 0.0;
+        outU->y = 0.0;
+        outU->z = 1.0f;
+    } else if (fabsf(normal.x) < 1e-6f && fabsf(normal.y) < 1e-6f) {
+        // Floor.
+        outV->x = 1.0;
+        outV->y = 0.0;
+        outV->z = 0.0;
+
+        outU->x = 0.0;
+        outU->y = 1.0;
+        outU->z = 0.0;
+    } else {
+        // Other.
+        if (fabs(normal.z) < 0.70811361) {
+            outV->x = -normal.y;
+            outV->y = normal.x;
+            outV->z = 0.0;
+            outV->normalize();
+
+            outU->x = 0.0;
+            outU->y = 0.0;
+            outU->z = 1.0;
+        } else {
+            outV->x = 1.0;
+            outV->y = 0.0;
+            outV->z = 0.0;
+
+            outU->x = 0.0;
+            outU->y = 1.0;
+            outU->z = 0.0;
+        }
+    }
+}

--- a/src/Engine/stru314.h
+++ b/src/Engine/stru314.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Library/Geometry/Vec.h"
+
 struct stru314 {  // facet normals face / wall / celings
     //----- (00489B60) --------------------------------------------------------
     stru314() {
@@ -20,6 +22,13 @@ struct stru314 {  // facet normals face / wall / celings
 
     //----- (00489B96) --------------------------------------------------------
     inline ~stru314() {}
+
+    /**
+     * Computes the facet-local u and v axes from `Normal` and stores them in `field_10` and `field_1C`.
+     *
+     * @offset 0x436932
+     */
+    void computeBasis();
 
     Vec3f Normal;
     Vec3f field_10; // For decal application: u vector, perpendicular to Normal

--- a/src/Engine/stru314.h
+++ b/src/Engine/stru314.h
@@ -2,6 +2,8 @@
 
 #include "Library/Geometry/Vec.h"
 
+// TODO(captainurist): this is a facet plane plus a decal basis - rename the struct and its field_* members
+//                     accordingly.
 struct stru314 {  // facet normals face / wall / celings
     //----- (00489B60) --------------------------------------------------------
     stru314() {


### PR DESCRIPTION
Resolves `TODO(captainurist): function belongs to stru314` on `Camera3D::GetFacetOrientation`.

The static helper becomes `stru314::computeBasis()` - it computes the facet-local u and v axes from `Normal` into `field_10`/`field_1C`, which is exactly what the single caller (`DecalBuilder::BuildAndApplyDecals`) used it for. The body moves verbatim into a new `stru314.cpp` (review diffed it mechanically - byte-identical, and the aliasing topology at the call site is unchanged since the old call already pointed all three arguments into the same struct). `stru314.h` gains the `Vec.h` include it always needed, and the vanilla offset moves into an `@offset` doxygen tag per HACKING.md.

The two "code looks very similar" comments in `Indoor.cpp` and `PortalFunctions.cpp` now reference the new symbol - consolidating those three implementations remains a separate TODO.

Per review, the struct also carries a TODO to rename it and its `field_*` members properly - it is a facet plane plus a decal basis.

Local battery: 394 unit tests, 356/356 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)