### PR TITLE
Consider all containing faces in GetSector

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -48,6 +48,7 @@
 #include "Library/Logger/Logger.h"
 #include "Library/LodFormats/LodFormats.h"
 
+#include "Utility/SmallVector.h"
 #include "Utility/String/Ascii.h"
 #include "Utility/Math/TrigLut.h"
 #include "Utility/Exception.h"
@@ -337,17 +338,13 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
         return 0;
     }
 
-     // holds faces the coords are above
-    int FoundFaceStore[5] = { 0 };
-    int NumFoundFaceStore = 0;
+    gch::small_vector<uint16_t, 16> foundFaces; // Faces the coords are above.
     int backupboundingsector = 0;
     std::optional<int> foundSector;
     bool singleSectorFound = false;
 
     // loop through sectors
     for (unsigned i = 1; i < sectors.size(); ++i) {
-        if (NumFoundFaceStore >= 5) break;
-
         BLVSector *pSector = &sectors[i];
 
         if (!pSector->boundingBox.intersectsCuboid(Vec3f(sX, sY, sZ), Vec3f(5, 5, 64)))
@@ -373,22 +370,19 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
 
             // add found faces into store
             if (pFace->Contains(Vec3f(sX, sY, 0), MODEL_INDOOR, engine->config->debug.FloorChecksEps.value(), FACE_XY_PLANE))
-                FoundFaceStore[NumFoundFaceStore++] = faceId;
-
-            if (NumFoundFaceStore >= 5)
-                break; // TODO(captainurist): we do get here sometimes (e.g. in dragon cave), increase limit?
+                foundFaces.push_back(faceId);
         }
     }
 
     // only one face found
-    if (NumFoundFaceStore == 1)
-        return this->faces[FoundFaceStore[0]].sectorId;
+    if (foundFaces.size() == 1)
+        return this->faces[foundFaces[0]].sectorId;
 
     // only one sector found
     if (singleSectorFound) return *foundSector;
 
     // No face found - outside of level
-    if (!NumFoundFaceStore) {
+    if (foundFaces.empty()) {
         if (!backupboundingsector) {
             MM_WARNING("GetSector fail: {}, {}, {}", sX, sY, sZ);
             return 0;
@@ -401,23 +395,23 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
     // when multiple possibilities are found - cycle through and use the closer one to party
     int pSectorID = 0, backupID = 0;
     int MinZDist = INT32_MAX, backupDist = INT32_MAX;
-    if (NumFoundFaceStore > 0) {
+    if (!foundFaces.empty()) {
         int CalcZDist = MinZDist;
-        for (int s = 0; s < NumFoundFaceStore; ++s) {
+        for (uint16_t faceId : foundFaces) {
             // calc distance between this face and party
-            if (this->faces[FoundFaceStore[s]].polygonType == POLYGON_Floor)
-                CalcZDist = sZ - this->vertices[this->faces[FoundFaceStore[s]].vertexIds[0]].z;
-            if (this->faces[FoundFaceStore[s]].polygonType == POLYGON_InBetweenFloorAndWall) {
-                CalcZDist = sZ - this->faces[FoundFaceStore[s]].zCalc.calculate(sX, sY);
+            if (this->faces[faceId].polygonType == POLYGON_Floor)
+                CalcZDist = sZ - this->vertices[this->faces[faceId].vertexIds[0]].z;
+            if (this->faces[faceId].polygonType == POLYGON_InBetweenFloorAndWall) {
+                CalcZDist = sZ - this->faces[faceId].zCalc.calculate(sX, sY);
             }
 
             // use this face if its smaller than the current min - prefer faces below party
             if (CalcZDist < MinZDist) {
                 if (CalcZDist >= 0) {
-                    pSectorID = this->faces[FoundFaceStore[s]].sectorId;
+                    pSectorID = this->faces[faceId].sectorId;
                     MinZDist = CalcZDist;
                 } else {
-                    backupID = this->faces[FoundFaceStore[s]].sectorId;
+                    backupID = this->faces[faceId].sectorId;
                     backupDist = std::abs(CalcZDist);
                 }
             }
@@ -426,7 +420,7 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
         if (pSectorID == 0) {
             if (backupID == 0) {
                 assert(false); // doesnt choose - so default to first - SHOULDNT GET HERE
-                pSectorID = this->faces[FoundFaceStore[0]].sectorId;
+                pSectorID = this->faces[foundFaces[0]].sectorId;
             } else {
                 // there is a face above the party to use
                 pSectorID = backupID;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -338,7 +338,7 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
         return 0;
     }
 
-    gch::small_vector<uint16_t, 16> foundFaces; // Faces the coords are above.
+    gch::small_vector<uint16_t, 32> foundFaces; // Floor faces whose horizontal projection contains the point.
     int backupboundingsector = 0;
     std::optional<int> foundSector;
     bool singleSectorFound = false;
@@ -395,36 +395,36 @@ int IndoorLocation::GetSector(float sX, float sY, float sZ) {
     // when multiple possibilities are found - cycle through and use the closer one to party
     int pSectorID = 0, backupID = 0;
     int MinZDist = INT32_MAX, backupDist = INT32_MAX;
-    if (!foundFaces.empty()) {
-        int CalcZDist = MinZDist;
-        for (uint16_t faceId : foundFaces) {
-            // calc distance between this face and party
-            if (this->faces[faceId].polygonType == POLYGON_Floor)
-                CalcZDist = sZ - this->vertices[this->faces[faceId].vertexIds[0]].z;
-            if (this->faces[faceId].polygonType == POLYGON_InBetweenFloorAndWall) {
-                CalcZDist = sZ - this->faces[faceId].zCalc.calculate(sX, sY);
-            }
-
-            // use this face if its smaller than the current min - prefer faces below party
-            if (CalcZDist < MinZDist) {
-                if (CalcZDist >= 0) {
-                    pSectorID = this->faces[faceId].sectorId;
-                    MinZDist = CalcZDist;
-                } else {
-                    backupID = this->faces[faceId].sectorId;
-                    backupDist = std::abs(CalcZDist);
-                }
-            }
+    int CalcZDist = MinZDist;
+    for (uint16_t faceId : foundFaces) {
+        // calc distance between this face and party
+        if (this->faces[faceId].polygonType == POLYGON_Floor)
+            CalcZDist = sZ - this->vertices[this->faces[faceId].vertexIds[0]].z;
+        if (this->faces[faceId].polygonType == POLYGON_InBetweenFloorAndWall) {
+            CalcZDist = sZ - this->faces[faceId].zCalc.calculate(sX, sY);
         }
 
-        if (pSectorID == 0) {
-            if (backupID == 0) {
-                assert(false); // doesnt choose - so default to first - SHOULDNT GET HERE
-                pSectorID = this->faces[foundFaces[0]].sectorId;
+        // use this face if its smaller than the current min - prefer faces below party
+        if (CalcZDist < MinZDist) {
+            if (CalcZDist >= 0) {
+                pSectorID = this->faces[faceId].sectorId;
+                MinZDist = CalcZDist;
             } else {
-                // there is a face above the party to use
-                pSectorID = backupID;
+                backupID = this->faces[faceId].sectorId;
+                backupDist = std::abs(CalcZDist);
             }
+        }
+    }
+
+    if (pSectorID == 0) {
+        if (backupID == 0) {
+            // TODO(captainurist): asserts are on in release builds, so the line below is unreachable. Work out
+            //                     whether every face can really be above the party here, and drop it if not.
+            assert(false); // doesnt choose - so default to first - SHOULDNT GET HERE
+            pSectorID = this->faces[foundFaces[0]].sectorId;
+        } else {
+            // there is a face above the party to use
+            pSectorID = backupID;
         }
     }
 

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1490,3 +1490,13 @@ GAME_TEST(Issues, Issue2636) {
                                         "and the ability to put that strength where it counts.  Characters with a "
                                         "high might statistic do more damage in combat.");
 }
+
+GAME_TEST(Prs, Pr2626) {
+    // GetSector used to stop looking after 5 candidate floor faces, so where more floors than that stack up it
+    // could miss the one the party is standing on. This spot in Colony Zod has 16 of them, and the truncated
+    // search answered sector 9 instead of 23.
+    game.startNewGame();
+    game.teleportTo(MAP_COLONY_ZOD, Vec3f(-1849, 6726, 934), 0);
+    game.tick(2);
+    EXPECT_EQ(pIndoor->GetSector(-1849, 6726.5f, 934), 23);
+}


### PR DESCRIPTION
Resolves `TODO(captainurist): we do get here sometimes (e.g. in dragon cave), increase limit?` in `IndoorLocation::GetSector`.

The candidate store was a fixed `int[5]` with two early breaks - one mid-face-loop, one that stopped the whole sector scan. On maps with more than five stacked floor faces above one XY spot, later candidates were silently dropped, and since the outer break could also stop before examining the *correct* sector entirely, the party could get assigned a sector whose floor is nowhere near it.

Now a `gch::small_vector<uint16_t, 32>` with no caps - every containing face is considered. The selection rule (nearest floor below, negative distances as backup) is byte-identical, so with up to five candidates the behavior is exactly as before, which the trace suite confirms (no desyncs). Review traced the `singleSectorFound` bookkeeping change through concrete scenarios: the only behavioral difference is the intended one - the sector containing the actually-nearest floor now wins where the cap used to hide it.

**Where the worst spots are.** Every indoor MM7 map was deserialized and reconstructed, then `GetSector` run at every floor face vertex and bounding box centre, with the collected face count recorded:

| candidate points | worst count | where |
|---|---|---|
| face vertices, so points on a floor boundary | 19 | The Lincoln at (4471, -1216) |
| face bounding box centres | 16 | Colony Zod at (-1849, 6726.5) |

So the inline capacity is 32 rather than 16, which was exactly on the line. It only ever cost a heap allocation, since `small_vector` grows, but there is no reason to spill on shipped maps.

The same scan, run with the old truncating search alongside the new one, located a spot where the two disagree and is not on a face boundary, which is the test:

```cpp
GAME_TEST(Prs, Pr2626) {
    // GetSector used to stop looking after 5 candidate floor faces, so where more floors than that stack up it
    // could miss the one the party is standing on. This spot in Colony Zod has 16 of them, and the truncated
    // search answered sector 9 instead of 23.
    game.startNewGame();
    game.teleportTo(MAP_COLONY_ZOD, Vec3f(-1849, 6726, 934), 0);
    game.tick(2);
    EXPECT_EQ(pIndoor->GetSector(-1849, 6726.5f, 934), 23);
}
```

Verified red with the 5 face cap restored, where it returns 9.

Also per review: the store's comment now says what it holds (faces whose horizontal projection contains the point, which is not the same as faces the point is above), the redundant `!foundFaces.empty()` check after the early return is gone, and the unreachable line after `assert(false)` carries a TODO to work out whether it can be deleted.

Local battery: 394 unit tests, 357/357 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)