### PR TITLE
Turn CullFaceToCameraFrustum into a pure predicate

### DIFF
--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -72,18 +72,16 @@ void Camera3D::do_draw_debug_line_sw(RenderVertexSoft *pLineBegin,
                                             RenderVertexSoft *pLineEnd,
                                             Color sEndDiffuse32,
                                             float z_stuff) {
-    RenderVertexSoft a1[20];
-    RenderVertexSoft pVertices[20];
+    RenderVertexSoft a1[2];
 
-    int uOutNumVertices = 2;
     a1[0].vWorldPosition = pLineBegin->vWorldPosition;
     a1[1].vWorldPosition = pLineEnd->vWorldPosition;
-    if (CullFaceToCameraFrustum(a1, &uOutNumVertices, pVertices, FRUSTUM_PLANE_COUNT) != 1 || uOutNumVertices >= 2) {
-        ViewTransform(pVertices, 2);
-        Project(pVertices, 2, 0);
+    if (IsFaceInCameraFrustum(a1, 2)) {
+        ViewTransform(a1, 2);
+        Project(a1, 2, 0);
 
         render->BeginLines2D();
-        render->RasterLine2D(pVertices[0].vWorldViewProj.toInt(), pVertices[1].vWorldViewProj.toInt(),
+        render->RasterLine2D(a1[0].vWorldViewProj.toInt(), a1[1].vWorldViewProj.toInt(),
                              sStartDiffuse32, sEndDiffuse32);
         render->EndLines2D();
     }
@@ -168,19 +166,13 @@ void Camera3D::BuildViewFrustum() {
     FrustumPlanes[3].w = glm::dot(glm::vec3(FrustumPlanes[3]), vCameraPos);
 }
 
-// TODO(pskelton): does this func need to copy verts or could it be eliminated
-//----- (00437285) --------------------------------------------------------
-bool Camera3D::CullFaceToCameraFrustum(RenderVertexSoft *pInVertices,
-                                       int *pOutNumVertices,
-                                       RenderVertexSoft *pVertices,
-                                       int NumFrustumPlanes) {
-    if (NumFrustumPlanes <= 0) return false;
-    if (*pOutNumVertices <= 0) return false;
+bool Camera3D::IsFaceInCameraFrustum(const RenderVertexSoft *pInVertices, int uNumVertices) const {
+    if (uNumVertices <= 0) return false;
 
     bool inside = false;
-    for (int p = 0; p < NumFrustumPlanes; p++) {
+    for (int p = 0; p < 4; p++) {
         inside = false;
-        for (int v = 0; v < *pOutNumVertices; v++) {
+        for (int v = 0; v < uNumVertices; v++) {
             float pLinelength1 = pInVertices[v].vWorldPosition.x * FrustumPlanes[p].x +
                                   pInVertices[v].vWorldPosition.y * FrustumPlanes[p].y +
                                   pInVertices[v].vWorldPosition.z * FrustumPlanes[p].z;
@@ -193,19 +185,7 @@ bool Camera3D::CullFaceToCameraFrustum(RenderVertexSoft *pInVertices,
         if (inside == false) break;
     }
 
-    if (inside == false) {
-        *pOutNumVertices = 0;
-        return false;
-    } else {
-        // copy in vcerts
-        memcpy(pVertices, pInVertices, sizeof(RenderVertexSoft) * *pOutNumVertices);
-        // return true
-        return true;
-    }
-
-    assert(false);
-
-    return false;
+    return inside;
 }
 
 // used for culling to supplied portal frustums

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -23,10 +23,14 @@ struct Camera3D {
                  bool fit_into_viewport = false);
     Vec2f FitToViewport(const Vec2f& projPos) const;
 
-    bool CullFaceToCameraFrustum(RenderVertexSoft *pInVertices,
-        int *pOutNumVertices,
-        RenderVertexSoft *pVertices,
-        int NumFrustumPlanes);
+    /**
+     * @param pInVertices               Face vertices in world space.
+     * @param uNumVertices              Vertex count.
+     * @return                          Whether the face is approximately inside the camera frustum. Each plane is
+     *                                  tested independently, so a face outside a frustum corner can still pass.
+     * @offset 0x437285
+     */
+    bool IsFaceInCameraFrustum(const RenderVertexSoft *pInVertices, int uNumVertices) const;
 
     bool CullFaceToFrustum(RenderVertexSoft *inVerts,
         unsigned int *pOutNumVertices,


### PR DESCRIPTION
Resolves `TODO(pskelton): does this func need to copy verts or could it be eliminated` on `Camera3D::CullFaceToCameraFrustum`.

The answer: the copy served nothing. The function is now a const predicate `IsFaceInCameraFrustum(verts, count)` with the plane test verbatim - the in-out vertex count, the memcpy into the caller's buffer, the plane-count parameter (always 4) and the dead code after return are gone.

Untangling the single caller exposed a vanilla-era bug: `do_draw_debug_line_sw`'s condition `cull != 1 || count >= 2` was a tautology - it drew on both cull outcomes, and on the reject path it drew from the never-written output buffer, producing a degenerate zero-length line at the projection of the world origin (`RenderVertexSoft` zero-initializes, so bogus rather than UB). The caller now transforms its own endpoints, and offscreen debug lines are skipped. Debug-only rendering path (collision cylinders, portal and decal outlines), unobservable in headless tests.

Known adjacent conflict: #2619 touches the deleted call site - whichever merges second needs a trivial rebase, and the predicate's internal literal 4 should become `FRUSTUM_PLANE_COUNT` once both land.

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
