### PR TITLE
Make CollideOutdoorWithModels respect ignore_ethereal

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -462,7 +462,7 @@ void CollideOutdoorWithModels(bool ignore_ethereal) {
             if (!collision_state.bbox.intersects(mface.boundingBox))
                 continue;
 
-            if (mface.Ethereal() || mface.isPortal()) // TODO: this doesn't respect ignore_ethereal parameter
+            if (mface.isPortal())
                 continue;
 
             Pid pid = Pid::odmFace(model.index, mface.faceId);


### PR DESCRIPTION
Resolves `TODO: this doesn't respect ignore_ethereal parameter` in `CollideOutdoorWithModels` - by making it respect the parameter.

The outer loop skipped every ethereal face before `CollideBodyWithFace` ever ran, so the `ignore_ethereal` it forwarded could not matter. That pre-filter is gone, and nothing replaces it in the loop on purpose: the flag is already checked once, in `CollideSphereWithFace`, and every sphere test that `CollideBodyWithFace` runs goes through it. `CollideIndoorWithGeometry` relies on that same check instead of filtering up front, so the two paths now read the same way. Party and actors pass `true` and keep walking through ethereal faces. Sprite objects pass `false`, so arrows, spells and dropped items now collide with ethereal model faces outdoors, as they do indoors.

This is a deliberate deviation from vanilla, where the outdoor loop at 0x0046E889 skipped ethereal faces unconditionally. It's not small on paper - a probe across all 13 outdoor maps counted 2471 ethereal model faces, 4.4% of 56347 - but it's the behavior the flag was written to express, and it's what the indoor path has done all along. No game test trace desynced, so nothing recorded so far has a projectile meeting an ethereal outdoor face.

Local battery: 408 unit tests, 360/360 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
