### PR TITLE
Animate face textures on the anim timer

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -202,9 +202,7 @@ void IndoorLocation::Draw() {
 //----- (004AE5BA) --------------------------------------------------------
 GraphicsImage *BLVFace::GetTexture() const {
     if (this->IsAnimated())
-        // TODO(captainurist): using gameTimer here is weird. This means that e.g. cleric in the haunted mansion is
-        //                     not animated in turn-based mode. Use the anim timer?
-        return pTextureFrameTable->animationFrame(this->animationId, gameTimer->time());
+        return pTextureFrameTable->animationFrame(this->animationId, animTimer->time());
     else
         return this->texture;
 }


### PR DESCRIPTION
Resolves `TODO(captainurist): using gameTimer here is weird...` in `BLVFace::GetTexture` - per the TODO's own suggestion, animated face frames now come from `animTimer`.

Effects: animated walls and model faces (haunted mansion cleric ghost, torches, waterfalls) keep animating in turn-based mode. The waterfall split - flow scrolling animated in TB while frame animation froze - is gone.

**Deliberate vanilla deviation**: vanilla drove face frames from the event timer (0x4AE5BA via `textureFrameTableTimer`) and froze them in turn-based mode - while inconsistently switching its indoor *decoration* animation to the misc timer there. Review verified the full caller inventory (frame selection is rendering-only, atlas init walks all frames from 0, the door UV path reads only frame dimensions, save deltas mask `FACE_ANIMATED` out), that `animTimer` runs in a strict superset of `gameTimer`'s states (so nothing that animated before freezes now, dialogues still pause both), and that `animationFrame` is modulo-safe for the never-reset anim clock.

Local battery: 382 unit tests, 351/351 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
