### PR TITLE
Turn the Arcomage C arrays into std::array

### DIFF
--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -95,8 +95,8 @@ constexpr auto SIG_MEMFREE = 0x78787878;  // memory free;
 
 ArcomageGame *pArcomageGame = new ArcomageGame;
 
-ArcomagePlayer am_Players[2];
-AcromageCardOnTable shown_cards[10];
+std::array<ArcomagePlayer, 2> am_Players;
+std::array<AcromageCardOnTable, 10> shown_cards;
 std::array<am_effects_struct, 10> am_effects_array;
 
 ArcomageDeck playDeck;
@@ -346,8 +346,8 @@ int explosion_effect_struct::IsEffectActive() {
 
 int new_explosion_effect(Pointi *startXY, int effect_value) {
     // find first empty effect slot
-    signed int arr_slot = 0;
-    for (arr_slot = 0; arr_slot < std::ssize(am_effects_array); arr_slot++) {
+    size_t arr_slot = 0;
+    for (arr_slot = 0; arr_slot < am_effects_array.size(); arr_slot++) {
         if (am_effects_array[arr_slot].have_effect) {
             if (am_effects_array[arr_slot].explosion_eff->IsEffectActive() == 0) {
                 am_effects_array[arr_slot].have_effect = 0;
@@ -356,7 +356,7 @@ int new_explosion_effect(Pointi *startXY, int effect_value) {
         } else {
             break;
         }
-        if (arr_slot == std::ssize(am_effects_array) - 1) return 2;
+        if (arr_slot == am_effects_array.size() - 1) return 2;
     }
 
     // set slot active and effect colour
@@ -383,7 +383,7 @@ int new_explosion_effect(Pointi *startXY, int effect_value) {
     am_effects_array[arr_slot].eff_params.unused_acc_1 = 8.0;
     am_effects_array[arr_slot].eff_params.min_lifespan = 5;
     am_effects_array[arr_slot].eff_params.max_lifespan = 15;
-    am_effects_array[arr_slot].eff_params.sparks_array = &am_effects_array[arr_slot].effect_sparks[0];
+    am_effects_array[arr_slot].eff_params.sparks_array = am_effects_array[arr_slot].effect_sparks.data();
 
     // fill explosion struct
     explosion_effect_struct *explos = am_effects_array[arr_slot].explosion_eff;
@@ -416,7 +416,7 @@ void DrawSparks() {
             if (!am_effects_array[i].effect_sign) rgb_pixel_color = colorTable.Red;
 
             // draw sparks
-            for (size_t j = 0; j < std::size(am_effects_array[i].effect_sparks); ++j) {
+            for (size_t j = 0; j < am_effects_array[i].effect_sparks.size(); ++j) {
                 if (am_effects_array[i].effect_sparks[j].spark_remaining_life > 0) {
                     // check limits - TODO(pskelton): hardcoded 640x480 screen bounds
                     if (am_effects_array[i].effect_sparks[j].spark_position.x >= 0 && am_effects_array[i].effect_sparks[j].spark_position.y >= 0) {

--- a/src/Arcomage/Arcomage.cpp
+++ b/src/Arcomage/Arcomage.cpp
@@ -1,6 +1,7 @@
 #include "Arcomage.h"
 
 #include <algorithm>
+#include <array>
 #include <string>
 
 #include "Engine/EngineGlobals.h"
@@ -96,7 +97,7 @@ ArcomageGame *pArcomageGame = new ArcomageGame;
 
 ArcomagePlayer am_Players[2];
 AcromageCardOnTable shown_cards[10];
-am_effects_struct am_effects_array[10];
+std::array<am_effects_struct, 10> am_effects_array;
 
 ArcomageDeck playDeck;
 ArcomageDeck deckMaster;
@@ -346,7 +347,7 @@ int explosion_effect_struct::IsEffectActive() {
 int new_explosion_effect(Pointi *startXY, int effect_value) {
     // find first empty effect slot
     signed int arr_slot = 0;
-    for (arr_slot = 0; arr_slot < 10; arr_slot++) {
+    for (arr_slot = 0; arr_slot < std::ssize(am_effects_array); arr_slot++) {
         if (am_effects_array[arr_slot].have_effect) {
             if (am_effects_array[arr_slot].explosion_eff->IsEffectActive() == 0) {
                 am_effects_array[arr_slot].have_effect = 0;
@@ -355,7 +356,7 @@ int new_explosion_effect(Pointi *startXY, int effect_value) {
         } else {
             break;
         }
-        if (arr_slot == 9) return 2;
+        if (arr_slot == std::ssize(am_effects_array) - 1) return 2;
     }
 
     // set slot active and effect colour
@@ -405,20 +406,19 @@ int new_explosion_effect(Pointi *startXY, int effect_value) {
     return 0;
 }
 
-// TODO(pskelton): Hardcoded limit checks need changing
 void DrawSparks() {
     Color rgb_pixel_color;
 
-    for (int i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < am_effects_array.size(); ++i) {
         if (am_effects_array[i].have_effect && (am_effects_array[i].explosion_eff->IsEffectActive() == 2)) {
             // set the pixel color
             rgb_pixel_color = colorTable.Green;
             if (!am_effects_array[i].effect_sign) rgb_pixel_color = colorTable.Red;
 
             // draw sparks
-            for (int j = 0; j < 150; ++j) {
+            for (size_t j = 0; j < std::size(am_effects_array[i].effect_sparks); ++j) {
                 if (am_effects_array[i].effect_sparks[j].spark_remaining_life > 0) {
-                    // check limits
+                    // check limits - TODO(pskelton): hardcoded 640x480 screen bounds
                     if (am_effects_array[i].effect_sparks[j].spark_position.x >= 0 && am_effects_array[i].effect_sparks[j].spark_position.y >= 0) {
                         if (am_effects_array[i].effect_sparks[j].spark_position.x <= 639 && am_effects_array[i].effect_sparks[j].spark_position.y <= 479) {
                             if (j % 2) {
@@ -949,7 +949,7 @@ void ArcomageGame::Loop() {
         }
     }
 
-    for (int i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < am_effects_array.size(); ++i) {
         am_effects_array[i].explosion_eff->Clear(1, 1);
         am_effects_array[i].explosion_eff->Free();
     }
@@ -1324,7 +1324,7 @@ void DrawGameUI(int animation_stage) {
         current_card_slot_index = DrawCardsRectangles(current_player_num);
 
     // update explosion effects
-    for (int i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < am_effects_array.size(); ++i) {
         if (am_effects_array[i].have_effect) am_effects_array[i].explosion_eff->UpdateEffect();
     }
     DrawSparks();
@@ -2885,7 +2885,7 @@ void ArcomageGame::PrepareArcomage() {
     }
 
     // create new explosion effect struct array
-    for (int i = 0; i < 10; ++i)
+    for (size_t i = 0; i < am_effects_array.size(); ++i)
         am_effects_array[i].explosion_eff = explosion_effect_struct::New();
 
     // load in start condtions and create initial deck and deal

--- a/src/Arcomage/Arcomage.h
+++ b/src/Arcomage/Arcomage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <string>
 
 #include "Engine/Graphics/FrameLimiter.h"
@@ -276,5 +277,5 @@ struct am_effects_struct {
     char _pad_3 = 0;
     effect_params_struct eff_params {};
     explosion_effect_struct *explosion_eff = nullptr;
-    spark_point_struct effect_sparks[150] {};
+    std::array<spark_point_struct, 150> effect_sparks {};
 };


### PR DESCRIPTION
Resolves `TODO(pskelton): Hardcoded limit checks need changing` on `DrawSparks`.

`am_effects_array` becomes a `std::array`, and all five loops over it - allocation in `PrepareArcomage`, teardown, per-frame update, the free-slot search in `new_explosion_effect`, and the spark drawing - take their bounds from the container. The slot search's all-slots-busy check keeps its exact vanilla control flow (review verified the loop still can't exit past the last index). Zero-init parity between the old static C arrays and the new global `std::array`s was verified via the NSDMIs.

Per review, the rest of the file's C arrays went the same way. `am_Players`, `shown_cards` and `am_effects_struct::effect_sparks` are `std::array` now, so the spark sub-loop uses `.size()` rather than `std::size` and `eff_params.sparks_array` takes `.data()`. Nothing outside `Arcomage.cpp` touches those three and nothing relied on decay, so it was a straight swap. The slot search indexes with `size_t` off `size()`.

Deliberately left, per review discussion: the 639/479 spark clip keeps its values under a narrowed TODO (the whole minigame draws in a fixed 640x480 coordinate space, so naming just those two literals is noise), the vanilla effect parameter values (`spark_array_size = 150`, the `10 * effect_value > 150` cap), and the card-hand 10s inside `ArcomagePlayer`, `cards_at_hand` and `card_shift`, which sit under their own make-it-a-vector TODO and are indexed by card slot rather than iterated.

Local battery: 394 unit tests, 356/356 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)