### PR TITLE
Fix button hotkeys posting their message twice

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1102,7 +1102,6 @@ void Game::processQueuedMessages() {
                 pParty->activeCharacter().playReaction(SPEECH_CANT_REST_HERE);
                 continue;
             case UIMSG_Rest8Hour:
-                engine->_messageQueue->clear(); // TODO: sometimes it is called twice, prevent that for now and investigate why later
                 if (currentRestType != REST_NONE) {
                     engine->_statusBar->setEvent(LSTR_YOU_ARE_ALREADY_RESTING);
                     pAudioPlayer->playUISound(SOUND_error);

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -432,7 +432,7 @@ void GameWindowHandler::OnToggleWindowMode() {
 }
 
 void GameWindowHandler::handleKeyPress(PlatformKey key, PlatformModifiers mods, bool isAutoRepeat) {
-    OnChar(key, -1);
+    bool hotkeyHandled = OnChar(key, -1);
 
     if (!isAutoRepeat) {
         // Do not use autorepeat for game actions, only for text input
@@ -441,7 +441,9 @@ void GameWindowHandler::handleKeyPress(PlatformKey key, PlatformModifiers mods, 
 
     char c = PlatformKeyToChar(key, mods);
 
-    if (c != 0)
+    // Skip the char call when a button hotkey already consumed the key, both calls fall through to
+    // GUI_HandleHotkey and the button message would be posted twice.
+    if (c != 0 && !hotkeyHandled)
         OnChar(key, c);
 }
 

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -28,6 +28,8 @@ GUICredits::GUICredits() : GUIWindow(WINDOW_Credits, {0, 0}, render->GetRenderDi
     _fontQuick->DrawCreditsEntry(_fontCChar.get(), 0, creditsRect.h, creditsRect.w, height, colorTable.CornFlowerBlue, colorTable.Primrose, colorTable.Black, text, &credits);
     _creditsTexture = GraphicsImage::Create(std::move(credits));
 
+    // TODO(captainurist): binding this button to INPUT_ACTION_ESCAPE posts UIMSG_Escape twice per Esc press, once
+    //                     through the button hotkey path and once through OnKey's hardcoded Esc handling.
     CreateButton({0, 0}, {0, 0}, BUTTON_TYPE_NORMAL, 0, UIMSG_Escape, 0, INPUT_ACTION_ESCAPE);
 }
 

--- a/src/GUI/UI/UICredits.cpp
+++ b/src/GUI/UI/UICredits.cpp
@@ -27,10 +27,6 @@ GUICredits::GUICredits() : GUIWindow(WINDOW_Credits, {0, 0}, render->GetRenderDi
     RgbaImage credits = RgbaImage::solid(Color(), creditsRect.w, height);
     _fontQuick->DrawCreditsEntry(_fontCChar.get(), 0, creditsRect.h, creditsRect.w, height, colorTable.CornFlowerBlue, colorTable.Primrose, colorTable.Black, text, &credits);
     _creditsTexture = GraphicsImage::Create(std::move(credits));
-
-    // TODO(captainurist): binding this button to INPUT_ACTION_ESCAPE posts UIMSG_Escape twice per Esc press, once
-    //                     through the button hotkey path and once through OnKey's hardcoded Esc handling.
-    CreateButton({0, 0}, {0, 0}, BUTTON_TYPE_NORMAL, 0, UIMSG_Escape, 0, INPUT_ACTION_ESCAPE);
 }
 
 GUICredits::~GUICredits() {

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1490,3 +1490,21 @@ GAME_TEST(Issues, Issue2636) {
                                         "and the ability to put that strength where it counts.  Characters with a "
                                         "high might statistic do more damage in combat.");
 }
+
+GAME_TEST(Issues, Pr2632) {
+    // Pressing a button hotkey used to post the button's message twice, once for the raw key and once for the
+    // printable character that the key produces.
+    engine->config->debug.NoActors.setValue(true);
+    game.startNewGame();
+
+    auto msgTape = tapes.uiMessages();
+    test.startTaping();
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_R); // Open the rest menu.
+    game.tick(2);
+    ASSERT_EQ(current_screen_type, SCREEN_REST);
+    game.pressAndReleaseKey(PlatformKey::KEY_H); // Hotkey of the rest menu's wait-one-hour button.
+    game.tick(2);
+
+    EXPECT_EQ(std::ranges::count(msgTape.flatten(), UIMSG_Wait1Hour), 1);
+}

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1490,21 +1490,3 @@ GAME_TEST(Issues, Issue2636) {
                                         "and the ability to put that strength where it counts.  Characters with a "
                                         "high might statistic do more damage in combat.");
 }
-
-GAME_TEST(Issues, Pr2632) {
-    // Pressing a button hotkey used to post the button's message twice, once for the raw key and once for the
-    // printable character that the key produces.
-    engine->config->debug.NoActors.setValue(true);
-    game.startNewGame();
-
-    auto msgTape = tapes.uiMessages();
-    test.startTaping();
-    game.tick(2);
-    game.pressAndReleaseKey(PlatformKey::KEY_R); // Open the rest menu.
-    game.tick(2);
-    ASSERT_EQ(current_screen_type, SCREEN_REST);
-    game.pressAndReleaseKey(PlatformKey::KEY_H); // Hotkey of the rest menu's wait-one-hour button.
-    game.tick(2);
-
-    EXPECT_EQ(std::ranges::count(msgTape.flatten(), UIMSG_Wait1Hour), 1);
-}


### PR DESCRIPTION
Resolves `TODO: sometimes it is called twice, prevent that for now and investigate why later` on the `UIMSG_Rest8Hour` queue clear - by finding the why.

`handleKeyPress` runs `OnChar` twice (raw-key pass, then printable-char pass for text input), and with no text field active **both** passes fall through to `GUI_HandleHotkey`, so any button hotkey bound to a printable key posted its message twice per press. Review traced this to the 2022 platform rework (67d1c52f81e) - it's an OE artifact, not vanilla, and the `clear()` band-aid was added later (0e1867b2a7c) to hide it.

Fix: `OnChar` already returns whether a hotkey button consumed the key - the char pass is now skipped in that case. Review verified all input classes: text input unaffected (`ProcessTextInput` swallows every key while a field is active, so hotkeys never fired during typing anyway), special keys and gamepad never double-fired, key-binding mode unaffected, and `OnKey` can't activate text input between the two calls.

With the root cause gone, the Rest8Hour handler's `clear()` goes too - it was wiping every other same-frame queued message. The `You are already resting` guard keeps the one remaining theoretical duplicate (click-then-key in a single frame) harmless.

**Did the duplicate affect gameplay?** No. `PlatformKeyToChar` only produces a character for letters and digits, and every handler reachable from a button hotkey on one of those either clears the message queue as its first act, which drops the duplicate before it is processed, or is idempotent. The three rest-menu wait handlers do process the duplicate, but they assign `remainingRestTime` rather than adding to it, so the only trace is a second button press animation. The real cost of the bug is the other way round - there are 21 `_messageQueue->clear()` calls in `Game.cpp`, the book and panel toggles genuinely need theirs today (without it the duplicate would open a book and immediately post the `UIMSG_Escape` that closes it), and each one wipes every unrelated message queued in the same frame. Removing the cause is what lets them go, one at a time.

Also per review, the credits screen's redundant Esc button is gone. `OnKey` posts `UIMSG_Escape` for the Esc key on every window and `CreditsState::update` transitions on the first one it sees, so the zero sized button that window created for `INPUT_ACTION_ESCAPE` was only ever a second source of the same message.

No test, per review discussion.

Local battery: 394 unit tests, 356/356 game tests (traces drive keys through this exact path), style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)