### PR TITLE
Drop the write only BSPModel seen flag

### DIFF
--- a/src/Engine/Graphics/BSPModel.h
+++ b/src/Engine/Graphics/BSPModel.h
@@ -9,7 +9,6 @@
 class BSPModel {
  public:
     int index = 0;
-    int32_t field_40 = 0; // visibility flag TODO(pskelton): use for map tooltip checking or remove
     Vec3f position {};
     BBoxi boundingBox = {0, 0, 0, 0, 0, 0};
     Vec3f boundingCenter {};

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -2281,7 +2281,6 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
         for (BSPModel &model : pOutdoor->pBModels) {
             //int reachable;
             //if (IsBModelVisible(&model, &reachable)) {
-            model.field_40 |= 1;
             if (!model.faces.empty()) {
                 for (BLVFace &face : model.faces) {
                     if (!face.Invisible()) {
@@ -2470,7 +2469,6 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
             bool reachable;
             if (IsBModelVisible(&model, 256, &reachable)) {
                 //if (model.index == 35) continue;
-                model.field_40 |= 1;
                 if (!model.faces.empty()) {
                     for (BLVFace &face : model.faces) {
                         if (!face.Invisible()) {

--- a/src/Engine/Snapshots/CompositeSnapshots.cpp
+++ b/src/Engine/Snapshots/CompositeSnapshots.cpp
@@ -429,7 +429,6 @@ void reconstruct(std::tuple<const BSPModelData_MM7 &, const BSPModelExtras_MM7 &
     const auto &[srcData, srcExtras] = src;
 
     // dst->index is set externally.
-    dst->field_40 = srcData.field_40;
     dst->position = srcData.position.toFloat();
     dst->boundingBox.x1 = srcData.minX;
     dst->boundingBox.y1 = srcData.minY;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1207,7 +1207,8 @@ struct BSPModelData_MM7 {
                                     // remnant of the mapping software that was used by NWC. Not used by the engine.
     std::array<char, 32> modelName2; // Sometimes different from the first model name, mainly for boats and chests.
                                      // Why? No idea.
-    int32_t field_40;
+    int32_t visibilityFlagsUnused; // Was a runtime visibility flag, the renderer set bit 0 on every model it
+                                   // drew. Zero in all shipped map data, and OE doesn't read it.
     uint32_t numVertices;
     Pointer_MM7 vertices;
     uint32_t numFaces;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1207,7 +1207,7 @@ struct BSPModelData_MM7 {
                                     // remnant of the mapping software that was used by NWC. Not used by the engine.
     std::array<char, 32> modelName2; // Sometimes different from the first model name, mainly for boats and chests.
                                      // Why? No idea.
-    int32_t visibilityFlagsUnused; // Was a runtime visibility flag, the renderer set bit 0 on every model it
+    int32_t visibilityFlagsUnused; // Was a runtime visibility flag, the renderer set it to 1 on every model it
                                    // drew. Zero in all shipped map data, and OE doesn't read it.
     uint32_t numVertices;
     Pointer_MM7 vertices;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1207,8 +1207,8 @@ struct BSPModelData_MM7 {
                                     // remnant of the mapping software that was used by NWC. Not used by the engine.
     std::array<char, 32> modelName2; // Sometimes different from the first model name, mainly for boats and chests.
                                      // Why? No idea.
-    int32_t visibilityFlagsUnused; // Was a runtime visibility flag, the renderer set it to 1 on every model it
-                                   // drew. Zero in all shipped map data, and OE doesn't read it.
+    int32_t wasSeenUnused; // The renderer set this to 1 when it drew the model, and nothing cleared it or read
+                           // it back. Zero in all shipped map data.
     uint32_t numVertices;
     Pointer_MM7 vertices;
     uint32_t numFaces;


### PR DESCRIPTION
Resolves `visibility flag TODO(pskelton): use for map tooltip checking or remove` on `BSPModel::field_40` - by removing.

The audit: the flag is loaded from static ODM geometry, OR'd with 1 by the renderer when a model is drawn, and read by nothing. Review traced it back to the original decompile - even vanilla's `Odbuild.cpp` only ever wrote it, zero reads project-wide, in every renderer that ever existed.

The decisive point against the "use for tooltips" option: it lives in the static geometry, not the save delta (outdoor model data is never written back to saves), so the seen-marks evaporate on every reload - tooltip gating would need new persistence machinery regardless. The map book already gates building hints on the *persisted* fog-of-war cell reveal, and the indoor analogue (`_visible_outlines`) is properly persisted through the BLV delta, which underlines that this flag was just dead weight. The wire field stays in `BSPModelData_MM7` for layout (`static_assert(sizeof == 188)` untouched), renamed to `wasSeenUnused` and commented with what the renderer did to it.

Review observation for a future pass: `ODMRenderParams::field_40` looks similarly write-only.

Local battery: 394 unit tests, 356/356 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

