### PR TITLE
Use real double clicks in the save and load menus

### DIFF
--- a/src/Application/GameMenu.cpp
+++ b/src/Application/GameMenu.cpp
@@ -125,7 +125,7 @@ void Menu::EventLoop() {
                 new OnSaveLoad({241, 302}, {106, 42}, pBtnLoadSlot);
                 continue;
             case UIMSG_SelectLoadSlot:
-                saveLoadMenu()->slotClicked(param);
+                saveLoadMenu()->slotClicked(param, param2);
                 continue;
             case UIMSG_LoadGame:
                 if (saveLoadMenu()->hasSelectedSlot()) {

--- a/src/Application/GameStates/LoadSlotState.cpp
+++ b/src/Application/GameStates/LoadSlotState.cpp
@@ -36,7 +36,7 @@ FsmAction LoadSlotState::update() {
             return FsmAction::transition("slotConfirmed");
         }
         case UIMSG_SelectLoadSlot: {
-            _uiLoadSaveSlot->slotClicked(param1);
+            _uiLoadSaveSlot->slotClicked(param1, param2);
             break;
         }
         case UIMSG_SaveLoadBtn: {

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -472,7 +472,7 @@ bool GameWindowHandler::mousePressEvent(const PlatformMouseEvent *event) {
         if (event->isDoubleClick) {
             OnMouseLeftDoubleClick(position);
         } else {
-            OnMouseLeftClick(position);
+            OnMouseLeftClick(position, false);
         }
     } else if (event->button == BUTTON_RIGHT) {
         if (event->isDoubleClick) {

--- a/src/Application/GameWindowHandler.cpp
+++ b/src/Application/GameWindowHandler.cpp
@@ -181,7 +181,7 @@ bool GameWindowHandler::OnChar(PlatformKey key, int c) {
     return false;
 }
 
-void GameWindowHandler::OnMouseLeftClick(Pointi position) {
+void GameWindowHandler::OnMouseLeftClick(Pointi position, bool isDoubleClick) {
     if (pArcomageGame->_gameInProgress) {
         ArcomageGame::OnMouseClick(0, true);
     } else {
@@ -198,7 +198,7 @@ void GameWindowHandler::OnMouseLeftClick(Pointi position) {
                               &vis_decoration_noevent_filter, &vis_door_filter);
         }
 
-        mouse->UI_OnMouseLeftClick();
+        mouse->UI_OnMouseLeftClick(isDoubleClick);
     }
 }
 
@@ -256,7 +256,7 @@ void GameWindowHandler::OnMouseLeftDoubleClick(Pointi position) {
     if (pArcomageGame->_gameInProgress) {
         pArcomageGame->OnMouseClick(0, true);
     } else {
-        OnMouseLeftClick(position);
+        OnMouseLeftClick(position, true);
     }
 }
 

--- a/src/Application/GameWindowHandler.h
+++ b/src/Application/GameWindowHandler.h
@@ -30,7 +30,7 @@ class GameWindowHandler : public PlatformEventFilter, private PlatformApplicatio
  private:
     friend class PlatformIntrospection;
 
-    void OnMouseLeftClick(Pointi position);
+    void OnMouseLeftClick(Pointi position, bool isDoubleClick = false);
     void OnMouseRightClick(Pointi position);
     void OnMouseLeftUp();
     void OnMouseRightUp();

--- a/src/Application/GameWindowHandler.h
+++ b/src/Application/GameWindowHandler.h
@@ -30,7 +30,7 @@ class GameWindowHandler : public PlatformEventFilter, private PlatformApplicatio
  private:
     friend class PlatformIntrospection;
 
-    void OnMouseLeftClick(Pointi position, bool isDoubleClick = false);
+    void OnMouseLeftClick(Pointi position, bool isDoubleClick);
     void OnMouseRightClick(Pointi position);
     void OnMouseLeftUp();
     void OnMouseRightUp();

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -107,25 +107,29 @@ void EngineController::releaseKey(PlatformKey key) {
     postEvent(std::move(event));
 }
 
-void EngineController::pressButton(PlatformMouseButton button, int x, int y) {
+void EngineController::postMouseButtonEvent(PlatformEventType type, PlatformMouseButton button, int x, int y,
+                                            bool isDoubleClick) {
     std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
-    event->type = EVENT_MOUSE_BUTTON_PRESS;
+    event->type = type;
     event->window = ::application->window();
     event->button = button;
+    if (type == EVENT_MOUSE_BUTTON_RELEASE)
+        event->buttons = button;
     event->pos = render->MapToPresent({ x, y });
-    event->isDoubleClick = false;
+    event->isDoubleClick = isDoubleClick;
     postEvent(std::move(event));
 }
 
+void EngineController::pressButton(PlatformMouseButton button, int x, int y) {
+    postMouseButtonEvent(EVENT_MOUSE_BUTTON_PRESS, button, x, y, false);
+}
+
+void EngineController::pressButtonDoubleClick(PlatformMouseButton button, int x, int y) {
+    postMouseButtonEvent(EVENT_MOUSE_BUTTON_PRESS, button, x, y, true);
+}
+
 void EngineController::releaseButton(PlatformMouseButton button, int x, int y) {
-    std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
-    event->type = EVENT_MOUSE_BUTTON_RELEASE;
-    event->window = ::application->window();
-    event->button = button;
-    event->buttons = button;
-    event->pos = render->MapToPresent({ x, y });
-    event->isDoubleClick = false;
-    postEvent(std::move(event));
+    postMouseButtonEvent(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
 }
 
 void EngineController::moveMouse(int x, int y) {
@@ -153,6 +157,15 @@ void EngineController::pressGuiButton(std::string_view buttonId) {
     GUIButton *button = existingButton(buttonId);
     Pointi center = button->rect.center();
     pressAndReleaseButton(BUTTON_LEFT, center.x, center.y);
+}
+
+void EngineController::doubleClickGuiButton(std::string_view buttonId) {
+    GUIButton *button = existingButton(buttonId);
+    Pointi center = button->rect.center();
+    pressAndReleaseButton(BUTTON_LEFT, center.x, center.y); // The platform sends the 1st click as an ordinary one.
+    tick(1); // A click clears the message queue, so the 1st one needs a frame of its own to be seen.
+    pressButtonDoubleClick(BUTTON_LEFT, center.x, center.y);
+    releaseButton(BUTTON_LEFT, center.x, center.y);
 }
 
 void EngineController::goToGame() {

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -146,7 +146,12 @@ void EngineController::doubleClickGuiButton(std::string_view buttonId) {
     GUIButton *button = existingButton(buttonId);
     Pointi center = button->rect.center();
     pressAndReleaseButton(BUTTON_LEFT, center.x, center.y); // The platform sends the 1st click as an ordinary one.
-    tick(1); // A click clears the message queue, so the 1st one needs a frame of its own to be seen.
+
+    // Clicking a button clears the message queue before posting into it, and the queue is only drained once a
+    // frame. Without a frame in between, the 2nd click would wipe the 1st one's message before anything reads
+    // it, and only the double click would ever arrive.
+    tick(1);
+
     pressButton(BUTTON_LEFT, center.x, center.y, true);
     releaseButton(BUTTON_LEFT, center.x, center.y);
 }

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -109,6 +109,8 @@ void EngineController::releaseKey(PlatformKey key) {
 
 void EngineController::postMouseButtonEvent(PlatformEventType type, PlatformMouseButton button, int x, int y,
                                             bool isDoubleClick) {
+    assert(type == EVENT_MOUSE_BUTTON_PRESS || type == EVENT_MOUSE_BUTTON_RELEASE);
+
     std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
     event->type = type;
     event->window = ::application->window();

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -107,7 +107,7 @@ void EngineController::releaseKey(PlatformKey key) {
     postEvent(std::move(event));
 }
 
-void EngineController::postMouseButtonEvent(PlatformEventType type, PlatformMouseButton button, int x, int y,
+void EngineController::pressOrReleaseButton(PlatformEventType type, PlatformMouseButton button, int x, int y,
                                             bool isDoubleClick) {
     assert(type == EVENT_MOUSE_BUTTON_PRESS || type == EVENT_MOUSE_BUTTON_RELEASE);
 
@@ -122,16 +122,12 @@ void EngineController::postMouseButtonEvent(PlatformEventType type, PlatformMous
     postEvent(std::move(event));
 }
 
-void EngineController::pressButton(PlatformMouseButton button, int x, int y) {
-    postMouseButtonEvent(EVENT_MOUSE_BUTTON_PRESS, button, x, y, false);
-}
-
-void EngineController::pressButtonDoubleClick(PlatformMouseButton button, int x, int y) {
-    postMouseButtonEvent(EVENT_MOUSE_BUTTON_PRESS, button, x, y, true);
+void EngineController::pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick) {
+    pressOrReleaseButton(EVENT_MOUSE_BUTTON_PRESS, button, x, y, isDoubleClick);
 }
 
 void EngineController::releaseButton(PlatformMouseButton button, int x, int y) {
-    postMouseButtonEvent(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
+    pressOrReleaseButton(EVENT_MOUSE_BUTTON_RELEASE, button, x, y, false);
 }
 
 void EngineController::moveMouse(int x, int y) {
@@ -151,7 +147,7 @@ void EngineController::pressAndReleaseKey(PlatformKey key) {
 }
 
 void EngineController::pressAndReleaseButton(PlatformMouseButton button, int x, int y) {
-    pressButton(button, x, y);
+    pressButton(button, x, y, false);
     releaseButton(button, x, y);
 }
 
@@ -166,7 +162,7 @@ void EngineController::doubleClickGuiButton(std::string_view buttonId) {
     Pointi center = button->rect.center();
     pressAndReleaseButton(BUTTON_LEFT, center.x, center.y); // The platform sends the 1st click as an ordinary one.
     tick(1); // A click clears the message queue, so the 1st one needs a frame of its own to be seen.
-    pressButtonDoubleClick(BUTTON_LEFT, center.x, center.y);
+    pressButton(BUTTON_LEFT, center.x, center.y, true);
     releaseButton(BUTTON_LEFT, center.x, center.y);
 }
 

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -107,21 +107,6 @@ void EngineController::releaseKey(PlatformKey key) {
     postEvent(std::move(event));
 }
 
-void EngineController::pressOrReleaseButton(PlatformEventType type, PlatformMouseButton button, int x, int y,
-                                            bool isDoubleClick) {
-    assert(type == EVENT_MOUSE_BUTTON_PRESS || type == EVENT_MOUSE_BUTTON_RELEASE);
-
-    std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
-    event->type = type;
-    event->window = ::application->window();
-    event->button = button;
-    if (type == EVENT_MOUSE_BUTTON_RELEASE)
-        event->buttons = button;
-    event->pos = render->MapToPresent({ x, y });
-    event->isDoubleClick = isDoubleClick;
-    postEvent(std::move(event));
-}
-
 void EngineController::pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick) {
     pressOrReleaseButton(EVENT_MOUSE_BUTTON_PRESS, button, x, y, isDoubleClick);
 }
@@ -445,6 +430,21 @@ void EngineController::goToGameOrMainMenu() {
     // If game is starting up - wait for main menu to appear.
     while (GetCurrentMenuID() == MENU_MAIN && lWindowList.empty())
         ticker.tick();
+}
+
+void EngineController::pressOrReleaseButton(PlatformEventType type, PlatformMouseButton button, int x, int y,
+                                            bool isDoubleClick) {
+    assert(type == EVENT_MOUSE_BUTTON_PRESS || type == EVENT_MOUSE_BUTTON_RELEASE);
+
+    std::unique_ptr<PlatformMouseEvent> event = std::make_unique<PlatformMouseEvent>();
+    event->type = type;
+    event->window = ::application->window();
+    event->button = button;
+    if (type == EVENT_MOUSE_BUTTON_RELEASE)
+        event->buttons = button;
+    event->pos = render->MapToPresent({ x, y });
+    event->isDoubleClick = isDoubleClick;
+    postEvent(std::move(event));
 }
 
 GUIButton *EngineController::existingButton(std::string_view buttonId) {

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -132,7 +132,7 @@ void EngineController::pressAndReleaseKey(PlatformKey key) {
 }
 
 void EngineController::pressAndReleaseButton(PlatformMouseButton button, int x, int y) {
-    pressButton(button, x, y, false);
+    pressButton(button, x, y);
     releaseButton(button, x, y);
 }
 

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -145,13 +145,8 @@ void EngineController::pressGuiButton(std::string_view buttonId) {
 void EngineController::doubleClickGuiButton(std::string_view buttonId) {
     GUIButton *button = existingButton(buttonId);
     Pointi center = button->rect.center();
-    pressAndReleaseButton(BUTTON_LEFT, center.x, center.y); // The platform sends the 1st click as an ordinary one.
-
-    // Clicking a button clears the message queue before posting into it, and the queue is only drained once a
-    // frame. Without a frame in between, the 2nd click would wipe the 1st one's message before anything reads
-    // it, and only the double click would ever arrive.
+    pressAndReleaseButton(BUTTON_LEFT, center.x, center.y);
     tick(1);
-
     pressButton(BUTTON_LEFT, center.x, center.y, true);
     releaseButton(BUTTON_LEFT, center.x, center.y);
 }

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -56,8 +56,7 @@ class EngineController {
     void pressKey(PlatformKey key);
     void pressAutoRepeatedKey(PlatformKey key);
     void releaseKey(PlatformKey key);
-    void pressButton(PlatformMouseButton button, int x, int y);
-    void pressButtonDoubleClick(PlatformMouseButton button, int x, int y);
+    void pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick);
     void releaseButton(PlatformMouseButton button, int x, int y);
     void moveMouse(int x, int y);
 
@@ -165,7 +164,7 @@ class EngineController {
  private:
     void goToGameOrMainMenu();
 
-    void postMouseButtonEvent(PlatformEventType type, PlatformMouseButton button, int x, int y, bool isDoubleClick);
+    void pressOrReleaseButton(PlatformEventType type, PlatformMouseButton button, int x, int y, bool isDoubleClick);
 
     GUIButton *existingButton(std::string_view buttonId);
 

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -57,6 +57,7 @@ class EngineController {
     void pressAutoRepeatedKey(PlatformKey key);
     void releaseKey(PlatformKey key);
     void pressButton(PlatformMouseButton button, int x, int y);
+    void pressButtonDoubleClick(PlatformMouseButton button, int x, int y);
     void releaseButton(PlatformMouseButton button, int x, int y);
     void moveMouse(int x, int y);
 
@@ -70,6 +71,14 @@ class EngineController {
      * @throws Exception                If the button with the provided id doesn't exist.
      */
     void pressGuiButton(std::string_view buttonId);
+
+    /**
+     * Clicks a GUI button twice, the second click carrying the double click flag the platform would set.
+     *
+     * @param buttonId                  Id of the button to click.
+     * @throws Exception                If the button with the provided id doesn't exist.
+     */
+    void doubleClickGuiButton(std::string_view buttonId);
 
     /**
      * Closes all menus and goes to the game screen. Will fail if main menu is currently open.
@@ -155,6 +164,8 @@ class EngineController {
 
  private:
     void goToGameOrMainMenu();
+
+    void postMouseButtonEvent(PlatformEventType type, PlatformMouseButton button, int x, int y, bool isDoubleClick);
 
     GUIButton *existingButton(std::string_view buttonId);
 

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -56,7 +56,7 @@ class EngineController {
     void pressKey(PlatformKey key);
     void pressAutoRepeatedKey(PlatformKey key);
     void releaseKey(PlatformKey key);
-    void pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick);
+    void pressButton(PlatformMouseButton button, int x, int y, bool isDoubleClick = false);
     void releaseButton(PlatformMouseButton button, int x, int y);
     void moveMouse(int x, int y);
 

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -277,7 +277,7 @@ void GUIWindow_Save::Update() {
     drawSaveLoad();
 }
 
-void GUIWindow_Save::slotClicked(int slotIndex) {
+void GUIWindow_Save::slotClicked(int slotIndex, bool isDoubleClick) {
     if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
     int slot = _scrollPosition + slotIndex;
@@ -358,17 +358,16 @@ void GUIWindow_Load::Update() {
     drawSaveLoad();
 }
 
-void GUIWindow_Load::slotClicked(int slotIndex) {
+void GUIWindow_Load::slotClicked(int slotIndex, bool isDoubleClick) {
     if (keyboard_input_status == WINDOW_INPUT_IN_PROGRESS)
         keyboardInputHandler->EndTextInput();
     int slot = _scrollPosition + slotIndex;
     if (slot >= std::ssize(_slots))
         return; // Clicked below the last save.
-    if (!_loadSlotClicked || _selectedSlot != slot) {
-        _selectedSlot = slot;
-        _loadSlotClicked = true;
-    } else {
+    if (isDoubleClick && _selectedSlot == slot) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
+    } else {
+        _selectedSlot = slot;
     }
 }
 

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -283,12 +283,11 @@ void GUIWindow_Save::slotClicked(int slotIndex, bool isDoubleClick) {
     int slot = _scrollPosition + slotIndex;
     if (slot >= std::ssize(_slots))
         return; // Clicked below the last slot.
-    if (isDoubleClick && _selectedSlot == slot) {
+    _selectedSlot = slot;
+    if (isDoubleClick) {
         keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
-        if (!_slots[slot].fileName.empty())
-            keyboardInputHandler->SetTextInput(_slots[slot].header.name);
-    } else {
-        _selectedSlot = slot;
+        if (!selectedSlot().fileName.empty())
+            keyboardInputHandler->SetTextInput(selectedSlot().header.name);
     }
 }
 
@@ -364,11 +363,9 @@ void GUIWindow_Load::slotClicked(int slotIndex, bool isDoubleClick) {
     int slot = _scrollPosition + slotIndex;
     if (slot >= std::ssize(_slots))
         return; // Clicked below the last save.
-    if (isDoubleClick && _selectedSlot == slot) {
+    _selectedSlot = slot;
+    if (isDoubleClick)
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
-    } else {
-        _selectedSlot = slot;
-    }
 }
 
 void GUIWindow_Load::loadButtonPressed() {

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -283,12 +283,12 @@ void GUIWindow_Save::slotClicked(int slotIndex, bool isDoubleClick) {
     int slot = _scrollPosition + slotIndex;
     if (slot >= std::ssize(_slots))
         return; // Clicked below the last slot.
-    if (_selectedSlot != slot) {
-        _selectedSlot = slot;
-    } else {
+    if (isDoubleClick && _selectedSlot == slot) {
         keyboardInputHandler->StartTextInput(TextInputType::Text, 19, this);
         if (!_slots[slot].fileName.empty())
             keyboardInputHandler->SetTextInput(_slots[slot].header.name);
+    } else {
+        _selectedSlot = slot;
     }
 }
 

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -46,8 +46,8 @@ class GUIWindow_SaveLoad : public GUIWindow {
     }
 
     /**
-     * Handles a click on one of the visible slot rows. First click selects the slot, a repeat click starts
-     * renaming in the save menu, and a double click loads in the load menu.
+     * Handles a click on one of the visible slot rows. A single click selects the slot, and a double click on
+     * the selected slot acts on it - loading it in the load menu, renaming it in the save menu.
      *
      * @param slotIndex             Index of the clicked row in the visible part of the list, in [0, 7).
      * @param isDoubleClick         Whether this click is the second click of a double click.

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -46,11 +46,13 @@ class GUIWindow_SaveLoad : public GUIWindow {
     }
 
     /**
-     * Handles a click on one of the visible slot rows. First click selects the slot, second click acts on it.
+     * Handles a click on one of the visible slot rows. First click selects the slot, a repeat click starts
+     * renaming in the save menu, and a double click loads in the load menu.
      *
      * @param slotIndex             Index of the clicked row in the visible part of the list, in [0, 7).
+     * @param isDoubleClick         Whether this click is the second click of a double click.
      */
-    virtual void slotClicked(int slotIndex) = 0;
+    virtual void slotClicked(int slotIndex, bool isDoubleClick) = 0;
 
     void scrollUp();
     void scrollDown();
@@ -72,7 +74,7 @@ class GUIWindow_Save : public GUIWindow_SaveLoad {
 
     virtual void Update() override;
 
-    virtual void slotClicked(int slotIndex) override;
+    virtual void slotClicked(int slotIndex, bool isDoubleClick) override;
 
  protected:
     GraphicsImage *saveload_ui_save_up = nullptr;
@@ -87,7 +89,7 @@ class GUIWindow_Load : public GUIWindow_SaveLoad {
 
     virtual void Update() override;
 
-    virtual void slotClicked(int slotIndex) override;
+    virtual void slotClicked(int slotIndex, bool isDoubleClick) override;
     void loadButtonPressed();
     void downArrowPressed();
     void upArrowPressed();
@@ -95,8 +97,6 @@ class GUIWindow_Load : public GUIWindow_SaveLoad {
     void quickLoad();
 
  protected:
-    // TODO(Nik-RE-dev): drop variable and load game only on double click.
-    bool _loadSlotClicked = false;
     GraphicsImage *main_menu_background = nullptr;
 
     GraphicsImage *saveload_ui_load_up = nullptr;

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -208,7 +208,7 @@ void Io::Mouse::DrawPickedItem() {
     }
 }
 
-void Io::Mouse::UI_OnMouseLeftClick() {
+void Io::Mouse::UI_OnMouseLeftClick(bool isDoubleClick) {
     if (current_screen_type == SCREEN_VIDEO || isHoldingMouseRightButton())
         return;
 
@@ -243,7 +243,9 @@ void Io::Mouse::UI_OnMouseLeftClick() {
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
                             engine->_messageQueue->clear();
-                            engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);
+                            // Load menu slots load on double click, everything else ignores the click multiplicity.
+                            engine->_messageQueue->addMessageCurrentFrame(
+                                control->msg, control->msg_param, control->msg == UIMSG_SelectLoadSlot ? isDoubleClick : 0);
                             return;
                         }
                         continue;

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -243,9 +243,8 @@ void Io::Mouse::UI_OnMouseLeftClick(bool isDoubleClick) {
                         if (control->Contains(x, y)) {
                             control->field_2C_is_pushed = true;
                             engine->_messageQueue->clear();
-                            // Load menu slots load on double click, everything else ignores the click multiplicity.
                             engine->_messageQueue->addMessageCurrentFrame(
-                                control->msg, control->msg_param, control->msg == UIMSG_SelectLoadSlot ? isDoubleClick : 0);
+                                control->msg, control->msg_param, isDoubleClick);
                             return;
                         }
                         continue;

--- a/src/Io/Mouse.h
+++ b/src/Io/Mouse.h
@@ -36,7 +36,7 @@ class Mouse {
     void DrawCursor();
     void DrawPickedItem();
 
-    void UI_OnMouseLeftClick();
+    void UI_OnMouseLeftClick(bool isDoubleClick);
 
 
     Pid uPointingObjectID;

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -320,7 +320,7 @@ GAME_TEST(Issues, Issue624) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.doubleClickGuiButton("SaveMenu_Slot0"); // Double click starts the name input.
     game.tick(1);
 
     for (int i = 0; i < 5; i++) {
@@ -351,7 +351,7 @@ GAME_TEST(Issues, Issue626) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(10);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.doubleClickGuiButton("SaveMenu_Slot0"); // Double click starts the name input.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_0);
     game.tick(2);
@@ -535,7 +535,7 @@ GAME_TEST(Issues, Issue689) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(10);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.doubleClickGuiButton("SaveMenu_Slot0"); // Double click starts the name input.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_0);
     game.tick(2);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1046,7 +1046,7 @@ GAME_TEST(Issues, Issue2452) {
 
     // Sweep through skill list Y positions and verify at most one tooltip per frame.
     for (int y = 40; y < 200; y++) {
-        game.pressButton(BUTTON_RIGHT, 100, y, false);
+        game.pressButton(BUTTON_RIGHT, 100, y);
         game.tick(1);
         game.releaseButton(BUTTON_RIGHT, 100, y);
         game.tick(1);
@@ -1480,7 +1480,7 @@ GAME_TEST(Issues, Issue2636) {
     game.pressAndReleaseKey(PlatformKey::KEY_C); // Switch to the stats tab.
     game.tick(2);
     EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
-    game.pressButton(BUTTON_RIGHT, 100, 60, false); // Right-click hold over the Might row shows its tooltip.
+    game.pressButton(BUTTON_RIGHT, 100, 60); // Right-click hold over the Might row shows its tooltip.
     game.tick(2);
     game.releaseButton(BUTTON_RIGHT, 100, 60);
     game.tick(1);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1531,7 +1531,6 @@ GAME_TEST(Prs, Pr2599) {
 GAME_TEST(Issues, Pr2635) {
     // Loading a save and opening the save name editor take a real double click on a slot, and are not
     // triggered by two ordinary clicks on it.
-    ufs->remove("saves");
     game.startNewGame();
     game.tick(2);
 

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1529,9 +1529,8 @@ GAME_TEST(Prs, Pr2599) {
 }
 
 GAME_TEST(Issues, Pr2635) {
-    // The load menu opens with a row already selected, and clicking that row used to load it. The first click
-    // changed nothing on screen because the row was selected already, so the second one loaded a save the
-    // player had only been looking at. Acting on a slot now takes a real double click.
+    // Loading a save and opening the save name editor take a real double click on a slot, and are not
+    // triggered by two ordinary clicks on it.
     ufs->remove("saves");
     game.startNewGame();
     game.tick(2);
@@ -1564,7 +1563,7 @@ GAME_TEST(Issues, Pr2635) {
     EXPECT_EQ(current_screen_type, SCREEN_LOADGAME);
     game.pressGuiButton("LoadMenu_Slot0");
     game.tick(2);
-    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME); // This is the click that used to load the save.
+    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME);
 
     // A double click on it loads.
     game.doubleClickGuiButton("LoadMenu_Slot0");

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1046,7 +1046,7 @@ GAME_TEST(Issues, Issue2452) {
 
     // Sweep through skill list Y positions and verify at most one tooltip per frame.
     for (int y = 40; y < 200; y++) {
-        game.pressButton(BUTTON_RIGHT, 100, y);
+        game.pressButton(BUTTON_RIGHT, 100, y, false);
         game.tick(1);
         game.releaseButton(BUTTON_RIGHT, 100, y);
         game.tick(1);
@@ -1480,7 +1480,7 @@ GAME_TEST(Issues, Issue2636) {
     game.pressAndReleaseKey(PlatformKey::KEY_C); // Switch to the stats tab.
     game.tick(2);
     EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
-    game.pressButton(BUTTON_RIGHT, 100, 60); // Right-click hold over the Might row shows its tooltip.
+    game.pressButton(BUTTON_RIGHT, 100, 60, false); // Right-click hold over the Might row shows its tooltip.
     game.tick(2);
     game.releaseButton(BUTTON_RIGHT, 100, 60);
     game.tick(1);
@@ -1529,13 +1529,14 @@ GAME_TEST(Prs, Pr2599) {
 }
 
 GAME_TEST(Issues, Pr2635) {
-    // Save and load slots used to act on the second of two clicks at any speed, so a slow double click on a
-    // load slot loaded a save the player had only meant to select.
+    // The load menu opens with a row already selected, and clicking that row used to load it. The first click
+    // changed nothing on screen because the row was selected already, so the second one loaded a save the
+    // player had only been looking at. Acting on a slot now takes a real double click.
     ufs->remove("saves");
     game.startNewGame();
     game.tick(2);
 
-    // Make a save to load back later.
+    // Save something to load back.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
@@ -1548,7 +1549,31 @@ GAME_TEST(Issues, Pr2635) {
     game.tick(10);
     ASSERT_TRUE(ufs->exists("saves/save000.mm7"));
 
-    // Clicking the selected save slot twice slowly only selects it, the name input stays closed.
+    // Open the load menu and check a row really is selected before anything is clicked.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_LoadGame");
+    game.tick(3);
+    ASSERT_EQ(current_screen_type, SCREEN_LOADGAME);
+    ASSERT_TRUE(saveLoadMenu()->hasSelectedSlot()); // A row is selected before the player clicks anything...
+    ASSERT_EQ(saveLoadMenu()->selectedSlot().fileName, "save000.mm7"); // ...and it's the one Slot0 points at.
+
+    // Clicking the already selected row does nothing, however many times it's clicked slowly.
+    game.pressGuiButton("LoadMenu_Slot0");
+    game.tick(2);
+    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME);
+    game.pressGuiButton("LoadMenu_Slot0");
+    game.tick(2);
+    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME); // This is the click that used to load the save.
+
+    // A double click on it loads.
+    game.doubleClickGuiButton("LoadMenu_Slot0");
+    game.tick(2);
+    game.skipLoadingScreen();
+    game.tick(2);
+    EXPECT_EQ(current_screen_type, SCREEN_GAME);
+
+    // Same rule in the save menu - two slow clicks don't open the name input, a double click does.
     game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
@@ -1559,36 +1584,7 @@ GAME_TEST(Issues, Pr2635) {
     game.tick(2);
     EXPECT_NE(saveLoadMenu()->keyboard_input_status, WINDOW_INPUT_IN_PROGRESS);
 
-    // A double click opens it.
     game.doubleClickGuiButton("SaveMenu_Slot0");
     game.tick(2);
     EXPECT_EQ(saveLoadMenu()->keyboard_input_status, WINDOW_INPUT_IN_PROGRESS);
-
-    // Make a second save so the load menu has a slot that isn't the preselected one. The name input from the
-    // double click above is still open.
-    game.pressAndReleaseKey(PlatformKey::KEY_B);
-    game.tick(2);
-    game.pressGuiButton("SaveMenu_Save");
-    game.tick(10);
-    ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave plus our two.
-
-    // Same in the load menu - two slow clicks select without loading, a double click loads. Slot 1 is not the
-    // preselected slot, so this also pins that the first of the two clicks is the one doing the selecting.
-    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
-    game.tick(2);
-    game.pressGuiButton("GameMenu_LoadGame");
-    game.tick(3);
-    game.pressGuiButton("LoadMenu_Slot1");
-    game.tick(2);
-    game.pressGuiButton("LoadMenu_Slot1");
-    game.tick(2);
-    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME); // Still in the menu, nothing was loaded.
-
-    game.pressGuiButton("LoadMenu_Slot0"); // Move the selection away, so the double click has to do the selecting.
-    game.tick(2);
-    game.doubleClickGuiButton("LoadMenu_Slot1");
-    game.tick(2);
-    game.skipLoadingScreen();
-    game.tick(2);
-    EXPECT_EQ(current_screen_type, SCREEN_GAME); // The double click selected and loaded the save.
 }

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1073,7 +1073,7 @@ GAME_TEST(Issues, Issue2453) {
     game.tick(2);
     game.pressGuiButton("GameMenu_SaveGame");
     game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot0");
+    game.doubleClickGuiButton("SaveMenu_Slot0"); // Double click starts the name input.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_0);
     game.tick(2);
@@ -1404,9 +1404,7 @@ GAME_TEST(Issues, Issue2551b) {
     ASSERT_EQ(saveMenu->slots().size(), 1); // ...which is not shown in the save menu, so it's just the new save slot.
 
     // And the menu is still fully functional.
-    game.pressGuiButton("SaveMenu_Slot0"); // Select the new save slot...
-    game.tick(2);
-    game.pressGuiButton("SaveMenu_Slot0"); // ...and click it again to start the name input.
+    game.doubleClickGuiButton("SaveMenu_Slot0"); // Double click the new save slot to start the name input.
     game.tick(2);
     game.pressAndReleaseKey(PlatformKey::KEY_A);
     game.tick(2);
@@ -1528,4 +1526,69 @@ GAME_TEST(Prs, Pr2599) {
     EXPECT_EQ(pParty->pos.y, -21526);
     EXPECT_EQ(pParty->_viewYaw, 1536);
     EXPECT_EQ(pParty->_viewPitch, 0);
+}
+
+GAME_TEST(Issues, Pr2635) {
+    // Save and load slots used to act on the second of two clicks at any speed, so a slow double click on a
+    // load slot loaded a save the player had only meant to select.
+    ufs->remove("saves");
+    game.startNewGame();
+    game.tick(2);
+
+    // Make a save to load back later.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    game.doubleClickGuiButton("SaveMenu_Slot0");
+    game.tick(2);
+    game.pressAndReleaseKey(PlatformKey::KEY_A);
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(10);
+    ASSERT_TRUE(ufs->exists("saves/save000.mm7"));
+
+    // Clicking the selected save slot twice slowly only selects it, the name input stays closed.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_SaveGame");
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Slot0");
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Slot0");
+    game.tick(2);
+    EXPECT_NE(saveLoadMenu()->keyboard_input_status, WINDOW_INPUT_IN_PROGRESS);
+
+    // A double click opens it.
+    game.doubleClickGuiButton("SaveMenu_Slot0");
+    game.tick(2);
+    EXPECT_EQ(saveLoadMenu()->keyboard_input_status, WINDOW_INPUT_IN_PROGRESS);
+
+    // Make a second save so the load menu has a slot that isn't the preselected one. The name input from the
+    // double click above is still open.
+    game.pressAndReleaseKey(PlatformKey::KEY_B);
+    game.tick(2);
+    game.pressGuiButton("SaveMenu_Save");
+    game.tick(10);
+    ASSERT_EQ(ufs->ls("saves").size(), 3); // Autosave plus our two.
+
+    // Same in the load menu - two slow clicks select without loading, a double click loads. Slot 1 is not the
+    // preselected slot, so this also pins that the first of the two clicks is the one doing the selecting.
+    game.pressAndReleaseKey(PlatformKey::KEY_ESCAPE);
+    game.tick(2);
+    game.pressGuiButton("GameMenu_LoadGame");
+    game.tick(3);
+    game.pressGuiButton("LoadMenu_Slot1");
+    game.tick(2);
+    game.pressGuiButton("LoadMenu_Slot1");
+    game.tick(2);
+    EXPECT_EQ(current_screen_type, SCREEN_LOADGAME); // Still in the menu, nothing was loaded.
+
+    game.pressGuiButton("LoadMenu_Slot0"); // Move the selection away, so the double click has to do the selecting.
+    game.tick(2);
+    game.doubleClickGuiButton("LoadMenu_Slot1");
+    game.tick(2);
+    game.skipLoadingScreen();
+    game.tick(2);
+    EXPECT_EQ(current_screen_type, SCREEN_GAME); // The double click selected and loaded the save.
 }


### PR DESCRIPTION
Resolves `TODO(Nik-RE-dev): drop variable and load game only on double click` on `isLoadSlotClicked` - which existed in two independent copies (a GameMenu static and a GUIWindow_Load member), emulating second-click-loads with no time window.

The platform's double-click signal now flows through the click dispatch: `OnMouseLeftClick(pos, isDoubleClick)` → `UI_OnMouseLeftClick(bool)` → posted as the button message's `param2`. Both consumers of the slot message (main-menu GameMenu handler, in-game LoadSlotState → `slotSelected`) branch on it, and both flag copies are gone.

**Deliberate vanilla deviation**, per the TODO's intent: vanilla loaded on any second click of the same slot regardless of timing (review traced the logic to the decompile-era `dword_6BE138`). Now a single click selects, and loading takes a real double-click or the Load button.

Review rounds changed three things beyond the original scope.

- The save menu gets the same treatment. Its rename editor used to open on a second click of the already selected row, which is the same unintuitive behaviour in the other dialog, and now takes a double click.
- Both handlers select the clicked row on every click and act only on the double click:

  ```cpp
  _selectedSlot = slot;
  if (isDoubleClick)
      engine->_messageQueue->addMessageCurrentFrame(UIMSG_LoadGame, 0, 0);
  ```

  The `_selectedSlot == slot` guard that first shipped here was a leftover from vanilla's condition. Dropping it means the action always targets the row that was clicked - `UIMSG_LoadGame` and `UIMSG_SaveGame` both act on the *selected* slot, so a double click whose two halves land on adjacent rows used to be able to act on the previously selected one.
- `param2` now carries the click kind for every button message rather than only `UIMSG_SelectLoadSlot`.

`EngineController` grew the helpers the test needs: `pressButton`/`releaseButton` take an `isDoubleClick` flag defaulting to false, share a private `pressOrReleaseButton`, and `doubleClickGuiButton` drives a real double click (the two presses need a frame between them, because a click clears the message queue and the synthetic event pump drains everything in one go).

The test walks the actual complaint - the load menu opens with a row already selected, clicking that row slowly does nothing however often, a double click loads it, and the save menu behaves the same way for its name editor.

Local battery: 394 unit tests, 357/357 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)