### PR TITLE
Add the X11/Wayland dev headers to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ninja-build \
   mold \
   libgl-dev \
+  libx11-dev \
+  libxext-dev \
+  libxrandr-dev \
+  libxcursor-dev \
+  libxi-dev \
+  libxfixes-dev \
+  libwayland-dev \
+  libxkbcommon-dev \
   xvfb \
   mesa-utils \
   libdwarf-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc-15 \
   g++-15 \
   ninja-build \
+  pkg-config \
   mold \
   libgl-dev \
   libx11-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,6 +56,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libxfixes-dev \
   libwayland-dev \
   libxkbcommon-dev \
+  libasound2-dev \
+  libpulse-dev \
+  libpipewire-0.3-dev \
   xvfb \
   mesa-utils \
   libdwarf-dev \


### PR DESCRIPTION
The bazel build compiles SDL3 from source, and its configure hard-errors without these headers. The cmake build never needed them - it consumed a prebuilt SDL. This is the same list the bazel CI legs install.