### PR TITLE
Document the Human Needed label in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,3 +13,5 @@ Comments in production code should say how the present code works, and only wher
 Comments in tests are the opposite. State the bug that the test guards against, otherwise it's unclear why the test exists, and someone will eventually delete it as redundant.
 
 When you do write about a past bug, spell out that it *was* a bug and name it. "We used to keep the old buffer" reads like a reasonable choice that happened to change. "This used to be a heap buffer overflow" doesn't.
+
+Put the `🤖 Human Needed` label on every pull request you open, once its CI is green. The label means a human has to look at the PR, and it's the only label you may ever add or remove - every other label belongs to the humans. Don't add it to a pull request that already carries any other label, a PR that a human has already triaged is in their pipeline anyway. Take the label off while you're working on review comments, and put it back when the ball is with the humans again.


### PR DESCRIPTION
Writes down the rules for the `🤖 Human Needed` label so an agent working in this repo applies it consistently:

- Put it on every PR the agent opens, once CI is green.
- It's the only label an agent may add or remove, every other label belongs to the humans.
- Don't add it to a PR that already carries another label - a PR a human has triaged is in their pipeline already, and the marker is just noise there.
- Take it off while working on review comments, put it back when the ball returns to the humans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
