### PR TITLE
displayPath always returns valid UTF8

### DIFF
--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -119,7 +119,7 @@ bool DirectoryFileSystem::_remove(FileSystemPathView path) {
 }
 
 std::string DirectoryFileSystem::_displayPath(FileSystemPathView path) const {
-    return makeBasePath(path).toWtf8();
+    return makeBasePath(path).displayString();
 }
 
 NativePath DirectoryFileSystem::makeBasePath(FileSystemPathView path) const {

--- a/src/Library/FileSystem/Embedded/EmbeddedFileSystem.cpp
+++ b/src/Library/FileSystem/Embedded/EmbeddedFileSystem.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "Utility/Streams/MemoryInputStream.h"
+#include "Utility/String/Encoding.h"
 #include "Utility/String/Join.h"
 
 EmbeddedFileSystem::EmbeddedFileSystem(cmrc::embedded_filesystem base, std::string_view displayName) : _base(base), _displayName(displayName) {}
@@ -44,5 +45,5 @@ std::unique_ptr<InputStream> EmbeddedFileSystem::_openForReading(FileSystemPathV
 }
 
 std::string EmbeddedFileSystem::_displayPath(FileSystemPathView path) const {
-    return join(_displayName, "://", path.string());
+    return join(_displayName, "://", txt::encodedToUtf8(path.string(), ENCODING_UTF8)); // Replaces invalid UTF8.
 }

--- a/src/Library/FileSystem/Interface/FileSystem.h
+++ b/src/Library/FileSystem/Interface/FileSystem.h
@@ -147,7 +147,8 @@ class FileSystem {
     /**
      * @param path                      Path inside this file system. The passed path is not required to exist.
      * @return                          A path string that's suitable to be displayed to the user. E.g. an absolute path
-     *                                  on the underlying OS file system.
+     *                                  on the underlying OS file system. Always valid UTF-8, with everything that's
+     *                                  not valid UTF-8 replaced with U+FFFD, so it might not map back to a real path.
      */
     [[nodiscard]] std::string displayPath(std::string_view path) const;
     [[nodiscard]] std::string displayPath(FileSystemPathView path) const;

--- a/src/Library/FileSystem/Masking/MaskingFileSystem.cpp
+++ b/src/Library/FileSystem/Masking/MaskingFileSystem.cpp
@@ -6,6 +6,7 @@
 
 #include "Library/FileSystem/Interface/FileSystemException.h"
 
+#include "Utility/String/Encoding.h"
 #include "Utility/String/Join.h"
 
 MaskingFileSystem::MaskingFileSystem(FileSystem *base) : ProxyFileSystem(base) {}
@@ -117,6 +118,6 @@ bool MaskingFileSystem::_remove(FileSystemPathView path) {
 
 std::string MaskingFileSystem::_displayPath(FileSystemPathView path) const {
     if (isMasked(path))
-        return join("masked://", path.string());
+        return join("masked://", txt::encodedToUtf8(path.string(), ENCODING_UTF8)); // Replaces invalid UTF8.
     return ProxyFileSystem::_displayPath(path);
 }

--- a/src/Library/FileSystem/Memory/MemoryFileSystem.cpp
+++ b/src/Library/FileSystem/Memory/MemoryFileSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "Library/FileSystem/Interface/FileSystemException.h"
 
+#include "Utility/String/Encoding.h"
 #include "Utility/String/Join.h"
 
 #include "MemoryFileSystemInputStream.h"
@@ -79,7 +80,7 @@ bool MemoryFileSystem::_remove(FileSystemPathView path) {
 }
 
 std::string MemoryFileSystem::_displayPath(FileSystemPathView path) const {
-    return join(_displayName, "://", path.string());
+    return join(_displayName, "://", txt::encodedToUtf8(path.string(), ENCODING_UTF8)); // Replaces invalid UTF8.
 }
 
 const MemoryFileSystem::Node *MemoryFileSystem::nodeForReading(FileSystemPathView path) const {

--- a/src/Library/FileSystem/Memory/Tests/MemoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Memory/Tests/MemoryFileSystem_ut.cpp
@@ -1,4 +1,5 @@
 #include <ranges>
+#include <string>
 #include <utility>
 #include <memory>
 #include <vector>
@@ -199,6 +200,18 @@ UNIT_TEST(MemoryFileSystem, Overwrite) {
     output->close();
 
     EXPECT_EQ(fs.read("a").str(), "A");
+}
+
+UNIT_TEST(MemoryFileSystem, DisplayPathInvalidUtf8) {
+    // displayPath guarantees valid UTF-8, and file names can be arbitrary bytes, e.g. when round-tripped through
+    // an ls of a DirectoryFileSystem on POSIX.
+    MemoryFileSystem fs("mem");
+
+    std::string display = fs.displayPath("lol\xD0kek"); // "\xD0" starts an incomplete UTF-8 sequence.
+    EXPECT_TRUE(display.starts_with("mem://lol"));
+    EXPECT_TRUE(display.ends_with("kek"));
+    EXPECT_NE(display.find("\xEF\xBF\xBD"), std::string::npos); // U+FFFD.
+    EXPECT_EQ(display.find('\xD0'), std::string::npos);
 }
 
 UNIT_TEST(MemoryFileSystem, DisplayPath) {

--- a/src/Library/FileSystem/Mounting/MountingFileSystem.cpp
+++ b/src/Library/FileSystem/Mounting/MountingFileSystem.cpp
@@ -8,6 +8,7 @@
 
 #include "Library/FileSystem/Interface/FileSystemException.h"
 
+#include "Utility/String/Encoding.h"
 #include "Utility/String/Join.h"
 
 MountingFileSystem::MountingFileSystem(std::string_view displayName) : _displayName(displayName) {}
@@ -124,7 +125,7 @@ bool MountingFileSystem::_remove(FileSystemPathView path) {
 
 std::string MountingFileSystem::_displayPath(FileSystemPathView path) const {
     // TODO(captainurist): this is not symmetric with that's done in read / openForReading / openForWriting.
-    return join(_displayName, "://", path.string());
+    return join(_displayName, "://", txt::encodedToUtf8(path.string(), ENCODING_UTF8)); // Replaces invalid UTF8.
 }
 
 MountingFileSystem::WalkResult MountingFileSystem::walk(FileSystemPathView path) {

--- a/src/Library/FileSystem/Null/NullFileSystem.cpp
+++ b/src/Library/FileSystem/Null/NullFileSystem.cpp
@@ -6,6 +6,7 @@
 
 #include "Library/FileSystem/Interface/FileSystemException.h"
 
+#include "Utility/String/Encoding.h"
 #include "Utility/String/Join.h"
 
 bool NullFileSystem::_exists(FileSystemPathView path) const {
@@ -33,7 +34,7 @@ std::unique_ptr<InputStream> NullFileSystem::_openForReading(FileSystemPathView 
 }
 
 std::string NullFileSystem::_displayPath(FileSystemPathView path) const {
-    return join("null://", path.string());
+    return join("null://", txt::encodedToUtf8(path.string(), ENCODING_UTF8)); // Replaces invalid UTF8.
 }
 
 [[noreturn]] void NullFileSystem::reportReadError(FileSystemPathView path) const {

--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -37,13 +37,13 @@ Blob Blob::fromMalloc(const void *data, size_t size) {
 }
 
 Blob Blob::fromFile(const NativePath &path) {
-    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
+    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
 
     // On Mac mapping an empty file throws, so we need to provide a workaround.
     std::error_code error;
     uintmax_t size = std::filesystem::file_size(path.toStdPath(), error);
     if (!error && size == 0)
-        return Blob().withDisplayPath(pathString);
+        return Blob().withDisplayPath(displayString);
 
     // native() is a wchar_t string on Windows, so a WTF16 name is passed as-is. Throws std::system_error if the
     // file doesn't exist.
@@ -52,14 +52,14 @@ Blob Blob::fromFile(const NativePath &path) {
         mmap = std::make_shared<mio::mmap_source>(path.toStdPath().native());
     } catch (const std::system_error &e) {
         // mio doesn't fill in the path component for std::system_error, so we need to do this ourselves.
-        throw std::system_error(e.code(), pathString);
+        throw std::system_error(e.code(), displayString);
     }
 
     Blob result;
     result._data = mmap->data();
     result._size = mmap->size();
     result._state = std::move(mmap);
-    result._displayPath = std::move(pathString);
+    result._displayPath = std::move(displayString);
     return result;
 }
 

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -25,7 +25,7 @@ FileInputStream::~FileInputStream() {
 void FileInputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
+    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
 
     // Wide fopen on Windows - the narrow one converts the path per the C locale.
 #ifdef _WINDOWS
@@ -34,23 +34,23 @@ void FileInputStream::open(const NativePath &path, size_t bufferSize) {
     _file = fopen(path.toStdPath().c_str(), "rb");
 #endif
     if (!_file)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
 
     // Disable libc buffering, we manage our own buffer.
     if (setvbuf(_file, nullptr, _IONBF, 0) != 0)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
 
     // Compute file size at open time.
     if (fseeko(_file, 0, SEEK_END) != 0)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
     int64_t fileEnd = ftello(_file);
     if (fileEnd == -1)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
     if (fseeko(_file, 0, SEEK_SET) != 0)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
 
     _bufSize = bufferSize;
-    base_type::open({}, fileEnd, pathString);
+    base_type::open({}, fileEnd, displayString);
 }
 
 size_t FileInputStream::_underflow(void *data, size_t size, Buffer *buffer) {

--- a/src/Utility/Streams/FileOutputStream.cpp
+++ b/src/Utility/Streams/FileOutputStream.cpp
@@ -19,7 +19,7 @@ FileOutputStream::~FileOutputStream() {
 void FileOutputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string pathString = path.absolute().toWtf8(); // Display path. Absolute, so that it's still meaningful in logs.
+    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
 
     // Wide fopen on Windows - the narrow one converts the path per the C locale.
 #ifdef _WINDOWS
@@ -28,14 +28,14 @@ void FileOutputStream::open(const NativePath &path, size_t bufferSize) {
     _file = fopen(path.toStdPath().c_str(), "wb");
 #endif
     if (!_file)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
 
     // Disable libc buffering, we manage our own buffer.
     if (setvbuf(_file, nullptr, _IONBF, 0) != 0)
-        Exception::throwFromErrno(pathString);
+        Exception::throwFromErrno(displayString);
 
     _bufSize = bufferSize;
-    base_type::open({}, pathString);
+    base_type::open({}, displayString);
 }
 
 void FileOutputStream::_overflow(Buffer *buffer, const void *data, size_t size) {

--- a/src/Utility/System/NativePath.cpp
+++ b/src/Utility/System/NativePath.cpp
@@ -19,3 +19,7 @@ std::string NativePath::toWtf8() const {
     return _path.generic_string();
 #endif
 }
+
+std::string NativePath::displayString() const {
+    return txt::encodedToUtf8(toWtf8(), ENCODING_UTF8); // UTF8 to UTF8 conversion replaces all the invalid parts.
+}

--- a/src/Utility/System/NativePath.h
+++ b/src/Utility/System/NativePath.h
@@ -45,6 +45,13 @@ class NativePath {
     }
 
     /**
+     * @return                          This path as a valid UTF-8 string for displaying to the user, with everything
+     *                                  that's not valid UTF-8 replaced with U+FFFD. Unlike the string returned by
+     *                                  `toWtf8`, it might not round-trip back into the same path.
+     */
+    [[nodiscard]] std::string displayString() const;
+
+    /**
      * @return                          Absolute copy of this path, resolved against the current directory. An empty
      *                                  path resolves to the current directory itself.
      */

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -28,6 +28,17 @@ UNIT_TEST(NativePath, WithExtension) {
     EXPECT_EQ(NativePath::fromWtf8("a/b.json").withExtension("").toWtf8(), "a/b");
 }
 
+UNIT_TEST(NativePath, DisplayString) {
+    EXPECT_EQ(NativePath::fromWtf8("a/b/\xd0\xbb\xd0\xbe\xd0\xbb.txt").displayString(), "a/b/\xd0\xbb\xd0\xbe\xd0\xbb.txt");
+
+    // WTF-8-encoded surrogates are not valid UTF-8, so they have to come out as replacement characters.
+    std::string display = NativePath::fromWtf8("lol\xed\xb0\x80kek.txt").displayString();
+    EXPECT_TRUE(display.starts_with("lol"));
+    EXPECT_TRUE(display.ends_with("kek.txt"));
+    EXPECT_NE(display.find("\xEF\xBF\xBD"), std::string::npos); // U+FFFD.
+    EXPECT_EQ(display.find("\xed\xb0\x80"), std::string::npos);
+}
+
 UNIT_TEST(NativePath, Absolute) {
     EXPECT_EQ(NativePath().absolute().toStdPath(), std::filesystem::current_path());
     EXPECT_EQ(NativePath::fromWtf8("a").absolute().toStdPath(), std::filesystem::current_path() / "a");


### PR DESCRIPTION
File names are arbitrary byte strings on POSIX, and can hold unpaired surrogates on Windows, so the strings we get out of the file systems are not necessarily valid UTF8. Display paths go into logs & UI, so they are now sanitized - everything that's not valid UTF8 becomes U+FFFD.

NativePath::displayString does this for native paths, and the file systems that build display paths from path components sanitize them directly.