### PR TITLE
Environment strings are WTF8, not UTF8

### DIFF
--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -8,8 +8,8 @@
 /**
  * Base class akin to `Platform` that provides an abstraction for the process's environment.
  *
- * Strings accepted by and returned from methods of this class are WTF8-encoded on Windows. On POSIX they are just
- * byte strings that are passed through as-is - POSIX doesn't guarantee UTF8 in paths, or anywhere else.
+ * Strings accepted by and returned from methods of this class are WTF-8 encoded on Windows. On POSIX they are just
+ * byte strings that are passed through as-is - POSIX doesn't guarantee UTF-8 in paths, or anywhere else.
  *
  * Why is this class not a part of `Platform`? Mainly for the following reasons:
  * - `Platform` handles an unrelated domain (UI and window management). Using a `NullPlatform` while still relying on
@@ -30,9 +30,9 @@ class Environment {
     /**
      * Windows-only function for querying the registry. Always returns an empty string on non-Windows systems.
      *
-     * @param path                      Registry path to query. WTF8-encoded.
+     * @param path                      Registry path to query. WTF-8 encoded.
      * @return                          Value at the given path, or an empty string in case of an error.
-     *                                  WTF8-encoded.
+     *                                  WTF-8 encoded.
      */
     [[nodiscard]] virtual std::string queryRegistry(const std::string &path) const = 0;
 
@@ -40,34 +40,32 @@ class Environment {
      * Accessor for various system paths.
      *
      * @param path                      Path to get.
-     * @return                          Requested path, or an empty string in case of an error. WTF8-encoded on
-     *                                  Windows, byte string on POSIX.
+     * @return                          Requested path, or an empty string in case of an error. WTF-8 on Windows,
+     *                                  byte string on POSIX.
      */
     [[nodiscard]] virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
      * Same as `std::getenv`.
      *
-     * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
+     * Note that on Windows `std::getenv` doesn't switch to UTF-8 even if `UnicodeCrt` is used
      * (aka `std::setlocale(LC_ALL, ".UTF-8")`).
      *
      * Returns an empty string for non-existent environment variables, and thus doesn't distinguish between empty and
      * non-existent values (and you shouldn't, either).
      *
-     * @param key                       Name of the environment variable to query. WTF8-encoded on Windows, byte
-     *                                  string on POSIX.
-     * @return                          Value of the environment variable. WTF8-encoded on Windows, byte string on
-     *                                  POSIX.
+     * @param key                       Name of the environment variable to query. WTF-8 on Windows, byte string
+     *                                  on POSIX.
+     * @return                          Value of the environment variable. WTF-8 on Windows, byte string on POSIX.
      */
     [[nodiscard]] virtual std::string getenv(const std::string &key) const = 0;
 
     /**
      * Same as POSIX `setenv(key, value, 1)`.
      *
-     * @param key                       Name of the environment variable to set. WTF8-encoded on Windows, byte
-     *                                  string on POSIX.
-     * @param value                     Value of the environment variable. WTF8-encoded on Windows, byte string on
+     * @param key                       Name of the environment variable to set. WTF-8 on Windows, byte string on
      *                                  POSIX.
+     * @param value                     Value of the environment variable. WTF-8 on Windows, byte string on POSIX.
      */
     virtual void setenv(const std::string &key, const std::string &value) const = 0;
 };

--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -8,9 +8,8 @@
 /**
  * Base class akin to `Platform` that provides an abstraction for the process's environment.
  *
- * Strings accepted by and returned from methods of this class are WTF8-encoded on Windows - the underlying wide
- * strings are converted to and from WTF8. On POSIX they are just byte strings that are passed through as-is - POSIX
- * doesn't guarantee UTF8 in paths, or anywhere else.
+ * Strings accepted by and returned from methods of this class are WTF8-encoded on Windows. On POSIX they are just
+ * byte strings that are passed through as-is - POSIX doesn't guarantee UTF8 in paths, or anywhere else.
  *
  * Why is this class not a part of `Platform`? Mainly for the following reasons:
  * - `Platform` handles an unrelated domain (UI and window management). Using a `NullPlatform` while still relying on
@@ -31,9 +30,9 @@ class Environment {
     /**
      * Windows-only function for querying the registry. Always returns an empty string on non-Windows systems.
      *
-     * @param path                      Registry path to query, WTF8-encoded on Windows.
-     * @return                          Value at the given path, WTF8-encoded on Windows, or an empty string in case
-     *                                  of an error.
+     * @param path                      Registry path to query. WTF8-encoded.
+     * @return                          Value at the given path, or an empty string in case of an error.
+     *                                  WTF8-encoded.
      */
     [[nodiscard]] virtual std::string queryRegistry(const std::string &path) const = 0;
 
@@ -41,12 +40,13 @@ class Environment {
      * Accessor for various system paths.
      *
      * @param path                      Path to get.
-     * @return                          Path, WTF8-encoded on Windows, or an empty string in case of an error.
+     * @return                          Requested path, or an empty string in case of an error. WTF8-encoded on
+     *                                  Windows, byte string on POSIX.
      */
     [[nodiscard]] virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
-     * Same as `std::getenv`, but takes & returns WTF8-encoded keys and values on Windows.
+     * Same as `std::getenv`, but doesn't depend on the C locale.
      *
      * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
      * (aka `std::setlocale(LC_ALL, ".UTF-8")`).
@@ -54,16 +54,20 @@ class Environment {
      * Returns an empty string for non-existent environment variables, and thus doesn't distinguish between empty and
      * non-existent values (and you shouldn't, either).
      *
-     * @param key                       Name of the environment variable to query, WTF8-encoded on Windows.
-     * @return                          Value of the environment variable, WTF8-encoded on Windows.
+     * @param key                       Name of the environment variable to query. WTF8-encoded on Windows, byte
+     *                                  string on POSIX.
+     * @return                          Value of the environment variable. WTF8-encoded on Windows, byte string on
+     *                                  POSIX.
      */
     [[nodiscard]] virtual std::string getenv(const std::string &key) const = 0;
 
     /**
-     * Same as POSIX `setenv(key, value, 1)`. Takes WTF8-encoded keys and values on Windows.
+     * Same as POSIX `setenv(key, value, 1)`.
      *
-     * @param key                       Name of the environment variable to set, WTF8-encoded on Windows.
-     * @param value                     Value of the environment variable, WTF8-encoded on Windows.
+     * @param key                       Name of the environment variable to set. WTF8-encoded on Windows, byte
+     *                                  string on POSIX.
+     * @param value                     Value of the environment variable. WTF8-encoded on Windows, byte string on
+     *                                  POSIX.
      */
     virtual void setenv(const std::string &key, const std::string &value) const = 0;
 };

--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -46,7 +46,7 @@ class Environment {
     [[nodiscard]] virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
-     * Same as `std::getenv`, but doesn't depend on the C locale.
+     * Same as `std::getenv`.
      *
      * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
      * (aka `std::setlocale(LC_ALL, ".UTF-8")`).

--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -8,9 +8,9 @@
 /**
  * Base class akin to `Platform` that provides an abstraction for the process's environment.
  *
- * All strings accepted by and returned from methods of this class are WTF8-encoded, in the same sense as in
- * `NativePath` - on Windows the underlying wide strings are converted to and from WTF8, and on POSIX systems
- * the bytes are passed through as-is.
+ * Strings accepted by and returned from methods of this class are WTF8-encoded on Windows - the underlying wide
+ * strings are converted to and from WTF8. On POSIX they are just byte strings that are passed through as-is - POSIX
+ * doesn't guarantee UTF8 in paths, or anywhere else.
  *
  * Why is this class not a part of `Platform`? Mainly for the following reasons:
  * - `Platform` handles an unrelated domain (UI and window management). Using a `NullPlatform` while still relying on
@@ -31,8 +31,9 @@ class Environment {
     /**
      * Windows-only function for querying the registry. Always returns an empty string on non-Windows systems.
      *
-     * @param path                      WTF8-encoded registry path to query.
-     * @return                          WTF8-encoded value at the given path, or an empty string in case of an error.
+     * @param path                      Registry path to query, WTF8-encoded on Windows.
+     * @return                          Value at the given path, WTF8-encoded on Windows, or an empty string in case
+     *                                  of an error.
      */
     [[nodiscard]] virtual std::string queryRegistry(const std::string &path) const = 0;
 
@@ -40,12 +41,12 @@ class Environment {
      * Accessor for various system paths.
      *
      * @param path                      Path to get.
-     * @return                          WTF8-encoded path, or an empty string in case of an error.
+     * @return                          Path, WTF8-encoded on Windows, or an empty string in case of an error.
      */
     [[nodiscard]] virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
-     * Same as `std::getenv`, but takes & returns WTF8-encoded keys and values on all platforms.
+     * Same as `std::getenv`, but takes & returns WTF8-encoded keys and values on Windows.
      *
      * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
      * (aka `std::setlocale(LC_ALL, ".UTF-8")`).
@@ -53,16 +54,16 @@ class Environment {
      * Returns an empty string for non-existent environment variables, and thus doesn't distinguish between empty and
      * non-existent values (and you shouldn't, either).
      *
-     * @param key                       WTF8-encoded name of the environment variable to query.
-     * @return                          WTF8-encoded value of the environment variable.
+     * @param key                       Name of the environment variable to query, WTF8-encoded on Windows.
+     * @return                          Value of the environment variable, WTF8-encoded on Windows.
      */
     [[nodiscard]] virtual std::string getenv(const std::string &key) const = 0;
 
     /**
-     * Same as POSIX `setenv(key, value, 1)`. Takes WTF8-encoded keys and values on all platforms.
+     * Same as POSIX `setenv(key, value, 1)`. Takes WTF8-encoded keys and values on Windows.
      *
-     * @param key                       WTF8-encoded name of the environment variable to set.
-     * @param value                     WTF8-encoded value of the environment variable.
+     * @param key                       Name of the environment variable to set, WTF8-encoded on Windows.
+     * @param value                     Value of the environment variable, WTF8-encoded on Windows.
      */
     virtual void setenv(const std::string &key, const std::string &value) const = 0;
 };

--- a/src/Library/Environment/Interface/Environment.h
+++ b/src/Library/Environment/Interface/Environment.h
@@ -8,7 +8,9 @@
 /**
  * Base class akin to `Platform` that provides an abstraction for the process's environment.
  *
- * All strings accepted by and returned from methods of this class are UTF8-encoded.
+ * All strings accepted by and returned from methods of this class are WTF8-encoded, in the same sense as in
+ * `NativePath` - on Windows the underlying wide strings are converted to and from WTF8, and on POSIX systems
+ * the bytes are passed through as-is.
  *
  * Why is this class not a part of `Platform`? Mainly for the following reasons:
  * - `Platform` handles an unrelated domain (UI and window management). Using a `NullPlatform` while still relying on
@@ -29,8 +31,8 @@ class Environment {
     /**
      * Windows-only function for querying the registry. Always returns an empty string on non-Windows systems.
      *
-     * @param path                      UTF8-encoded registry path to query.
-     * @return                          UTF8-encoded value at the given path, or an empty string in case of an error.
+     * @param path                      WTF8-encoded registry path to query.
+     * @return                          WTF8-encoded value at the given path, or an empty string in case of an error.
      */
     [[nodiscard]] virtual std::string queryRegistry(const std::string &path) const = 0;
 
@@ -38,12 +40,12 @@ class Environment {
      * Accessor for various system paths.
      *
      * @param path                      Path to get.
-     * @return                          UTF8-encoded path, or an empty string in case of an error.
+     * @return                          WTF8-encoded path, or an empty string in case of an error.
      */
     [[nodiscard]] virtual std::string path(EnvironmentPath path) const = 0;
 
     /**
-     * Same as `std::getenv`, but takes & returns UTF8-encoded keys and values on all platforms.
+     * Same as `std::getenv`, but takes & returns WTF8-encoded keys and values on all platforms.
      *
      * Note that on Windows `std::getenv` doesn't switch to UTF8 even if `UnicodeCrt` is used
      * (aka `std::setlocale(LC_ALL, ".UTF-8")`).
@@ -51,16 +53,16 @@ class Environment {
      * Returns an empty string for non-existent environment variables, and thus doesn't distinguish between empty and
      * non-existent values (and you shouldn't, either).
      *
-     * @param key                       UTF8-encoded name of the environment variable to query.
-     * @return                          UTF8-encoded value of the environment variable.
+     * @param key                       WTF8-encoded name of the environment variable to query.
+     * @return                          WTF8-encoded value of the environment variable.
      */
     [[nodiscard]] virtual std::string getenv(const std::string &key) const = 0;
 
     /**
-     * Same as POSIX `setenv(key, value, 1)`. Takes UTF8-encoded keys and values on all platforms.
+     * Same as POSIX `setenv(key, value, 1)`. Takes WTF8-encoded keys and values on all platforms.
      *
-     * @param key                       UTF8-encoded name of the environment variable to set.
-     * @param value                     UTF8-encoded value of the environment variable.
+     * @param key                       WTF8-encoded name of the environment variable to set.
+     * @param value                     WTF8-encoded value of the environment variable.
      */
     virtual void setenv(const std::string &key, const std::string &value) const = 0;
 };

--- a/src/Library/Environment/Win/WinEnvironment.cpp
+++ b/src/Library/Environment/Win/WinEnvironment.cpp
@@ -81,7 +81,7 @@ static std::wstring OS_GetAppStringRecursive(HKEY parent_key, const wchar_t *pat
 }
 
 std::string WinEnvironment::queryRegistry(const std::string &path) const {
-    return txt::wideToUtf8(OS_GetAppStringRecursive(NULL, txt::utf8ToWide(path).c_str(), 0));
+    return txt::wideToWtf8(OS_GetAppStringRecursive(NULL, txt::wtf8ToWide(path).c_str(), 0));
 }
 
 std::string WinEnvironment::path(EnvironmentPath path) const {
@@ -98,21 +98,21 @@ std::string WinEnvironment::path(EnvironmentPath path) const {
         if (status != S_OK || path == nullptr)
             return {};
 
-        return txt::wideToUtf8(path);
+        return txt::wideToWtf8(path);
     } else {
         return {};
     }
 }
 
 std::string WinEnvironment::getenv(const std::string &key) const {
-    const wchar_t *result = _wgetenv(txt::utf8ToWide(key).c_str());
+    const wchar_t *result = _wgetenv(txt::wtf8ToWide(key).c_str());
     if (result)
-        return txt::wideToUtf8(result);
+        return txt::wideToWtf8(result);
     return {};
 }
 
 void WinEnvironment::setenv(const std::string &key, const std::string &value) const {
-    _wputenv_s(txt::utf8ToWide(key).c_str(), txt::utf8ToWide(value).c_str()); // Errors are ignored.
+    _wputenv_s(txt::wtf8ToWide(key).c_str(), txt::wtf8ToWide(value).c_str()); // Errors are ignored.
 }
 
 std::unique_ptr<Environment> Environment::createStandardEnvironment() {

--- a/src/Library/Platform/Interface/Platform.h
+++ b/src/Library/Platform/Interface/Platform.h
@@ -134,7 +134,7 @@ class Platform {
  * Entrypoint for the program that uses the platform lib. Function definition should be provided in user code.
  *
  * @param argc                          Total number of arguments passed.
- * @param argv                          Program arguments. WTF8-encoded on Windows, byte strings on POSIX.
+ * @param argv                          Program arguments. WTF-8 on Windows, byte strings on POSIX.
  * @return                              Program return code.
  */
 int platformMain(int argc, char **argv);

--- a/src/Library/Platform/Interface/Platform.h
+++ b/src/Library/Platform/Interface/Platform.h
@@ -134,8 +134,7 @@ class Platform {
  * Entrypoint for the program that uses the platform lib. Function definition should be provided in user code.
  *
  * @param argc                          Total number of arguments passed.
- * @param argv                          WTF8-encoded program arguments. Note that you're getting WTF8 on ALL platforms,
- *                                      including Windows.
+ * @param argv                          Program arguments. WTF8-encoded on Windows, byte strings on POSIX.
  * @return                              Program return code.
  */
 int platformMain(int argc, char **argv);

--- a/src/Library/Platform/Interface/Platform.h
+++ b/src/Library/Platform/Interface/Platform.h
@@ -134,7 +134,7 @@ class Platform {
  * Entrypoint for the program that uses the platform lib. Function definition should be provided in user code.
  *
  * @param argc                          Total number of arguments passed.
- * @param argv                          UTF8-encoded program arguments. Note that you're getting UTF8 on ALL platforms,
+ * @param argv                          WTF8-encoded program arguments. Note that you're getting WTF8 on ALL platforms,
  *                                      including Windows.
  * @return                              Program return code.
  */


### PR DESCRIPTION
Registry values, environment variables & system paths on Windows can contain unpaired surrogates - wideToUtf8 would replace those with U+FFFD, producing a path that can't be opened. Note that all of these end up in NativePath objects, and NativePath is WTF8 inside.

Also fixed the platformMain doc - argv has been WTF8 since #2593.