### PR TITLE
Replace backward-cpp with cpptrace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,9 +61,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libpipewire-0.3-dev \
   xvfb \
   mesa-utils \
-  libdwarf-dev \
-  libelf-dev \
-  libdw-dev \
   ccache \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -167,11 +167,13 @@ jobs:
             sudo apt-get install -y gcc-multilib g++-multilib lld libgmp-dev libmpfr-dev libmpc-dev libisl-dev flex bison
             if [ "${{env.MATRIX_ARCHITECTURE}}" = "x86" ]; then
               sudo apt-get install -y libglu1-mesa-dev:i386
-              sudo apt-get install -y libdwarf-dev:i386 libelf-dev:i386
+              # Luajit generates its interpreter with minilua, which luajit-cmake builds as a separate host
+              # tool only when cross-compiling. An -m32 build isn't cross-compiling, so minilua is built
+              # 32-bit as well, and the libm it links against has to be 32-bit too.
+              sudo apt-get install -y libc6-dev:i386
             fi
             if [ "${{env.MATRIX_ARCHITECTURE}}" = "x86_64" ]; then
               sudo apt-get install -y libglu1-mesa-dev
-              sudo apt-get install -y libdwarf-dev libelf-dev
             fi
 
       # gcc-15 from source, cached. ubuntu-24.04 ships gcc-13 which is too old for our C++23 usage,

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,9 +42,6 @@
 [submodule "thirdparty/inifile_cpp"]
 	path = thirdparty/inifile_cpp
 	url = https://github.com/Rookfighter/inifile-cpp.git
-[submodule "thirdparty/backward_cpp"]
-	path = thirdparty/backward_cpp
-	url = https://github.com/OpenEnroth/backward-cpp.git
 [submodule "thirdparty/small_vector"]
 	path = thirdparty/small_vector
 	url = https://github.com/gharveymn/small_vector.git
@@ -69,3 +66,6 @@
 [submodule "thirdparty/ztd_text"]
 	path = thirdparty/ztd_text
 	url = https://github.com/captainurist/ztd_text.git
+[submodule "thirdparty/cpptrace"]
+	path = thirdparty/cpptrace
+	url = https://github.com/jeremy-rifkin/cpptrace.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Cla
     string(REPLACE " -g " " -g -Og " CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
     string(REPLACE " -g " " -g -Og " CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 
+    # Keep frame pointers. Clang drops them at -O2 on x86, and then nothing can walk a stack through code that
+    # has no unwind info - jit traces, the luajit interpreter, a call through a bad pointer.
+    add_compile_options(-fno-omit-frame-pointer)
+
     # Detect available linkers.
     check_linker_flag(CXX "-fuse-ld=mold" COMPILER_RT_HAS_FUSE_LD_MOLD_FLAG)
     check_linker_flag(CXX "-fuse-ld=lld" COMPILER_RT_HAS_FUSE_LD_LLD_FLAG)

--- a/HACKING.md
+++ b/HACKING.md
@@ -96,6 +96,8 @@ Code formatting:
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.
 * Use `virtual` prefix for all virtual functions, even when `override` is also present.
+* When an `#else` or `#endif` is far enough from its `#if` that the two don't fit on screen together, repeat the condition there verbatim, e.g. `#endif // _WIN32`. In an `#elif` chain, repeat the condition of the last `#elif`.
+* Indent after the `#` inside a conditional, e.g. `#   define MM_FOO 1`, when the block is compact enough to read as preprocessor logic. A conditional wrapping ordinary code is left at column zero.
 
 Language features:
 * We use C++23. Prefer modern alternatives where appropriate, e.g. `contains()` instead of `find() != end()`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -96,7 +96,7 @@ Code formatting:
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.
 * Use `virtual` prefix for all virtual functions, even when `override` is also present.
-* When an `#else` or `#endif` is far enough from its `#if` that the two don't fit on screen together, repeat the condition there verbatim, e.g. `#endif // _WIN32`. In an `#elif` chain, repeat the condition of the last `#elif`.
+* When an `#else` or `#endif` is far enough from its `#if` that the two don't fit on screen together, repeat the condition there verbatim, e.g. `#endif // _WINDOWS`. In an `#elif` chain, repeat the condition of the last `#elif`.
 * Indent after the `#` inside a conditional, e.g. `#   define MM_FOO 1`, when the block is compact enough to read as preprocessor logic. A conditional wrapping ordinary code is left at column zero.
 
 Language features:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ packages on your computer (e.g. on "atomic"/"immutable" distributions like Bazzi
 The loose executable is better if you want direct access to the binary (e.g. for development), or need full
 control over install location. Requires Ubuntu 24.04 or a distribution with compatible system libraries.
 
-1. Install required libraries: `sudo apt-get install libdwarf1 libelf++* libgl1` (Ubuntu 24.04).
+1. Install required libraries: `sudo apt-get install libgl1` (Ubuntu 24.04).
    For other distributions, check your package manager for equivalent packages.
 2. Download a prebuilt [release](https://github.com/OpenEnroth/OpenEnroth/releases) and unzip it.
 3. Copy the game data (`ANIMS`, `DATA`, `MUSIC` and `SOUNDS`) next to the `OpenEnroth` executable.

--- a/distribution/linux/flatpak/dev.io.github.openenroth.openenroth.yml
+++ b/distribution/linux/flatpak/dev.io.github.openenroth.openenroth.yml
@@ -32,15 +32,6 @@ add-extensions:
     autodelete: false
 
 modules:
-  - name: libdwarf
-    buildsystem: cmake-ninja
-    builddir: true
-    sources:
-      - type: git
-        url: https://github.com/davea42/libdwarf-code/
-        tag: v0.11.0
-        commit: 285d9d34f3e9f56cc1c487d0055f6dc54a9c54a1
-
   - name: sdl3
     buildsystem: cmake-ninja
     builddir: true

--- a/distribution/linux/flatpak/io.github.openenroth.openenroth.yml
+++ b/distribution/linux/flatpak/io.github.openenroth.openenroth.yml
@@ -32,15 +32,6 @@ add-extensions:
     autodelete: false
 
 modules:
-  - name: libdwarf
-    buildsystem: cmake-ninja
-    builddir: true
-    sources:
-      - type: git
-        url: https://github.com/davea42/libdwarf-code/
-        tag: v0.11.0
-        commit: 285d9d34f3e9f56cc1c487d0055f6dc54a9c54a1
-
   - name: sdl3
     buildsystem: cmake-ninja
     builddir: true

--- a/src/Bin/OpenEnroth/OpenEnroth.cpp
+++ b/src/Bin/OpenEnroth/OpenEnroth.cpp
@@ -123,9 +123,20 @@ int runOpenEnroth(const OpenEnrothOptions &options) {
     return 0;
 }
 
+#ifdef _WINDOWS
+static void waitForAnyKey() {
+    printf("[Press any key to close this window]");
+    getchar();
+}
+#endif
+
 int openEnrothMain(int argc, char **argv) {
     try {
+#ifdef _WINDOWS
+        StackTraceOnCrash st(&waitForAnyKey);
+#else
         StackTraceOnCrash st;
+#endif
         UnicodeCrt _(argc, argv);
         OpenEnrothOptions options = OpenEnrothOptions::parse(argc, argv);
         if (options.helpPrinted)
@@ -147,12 +158,8 @@ int platformMain(int argc, char **argv) {
     int result = openEnrothMain(argc, argv);
 
 #ifdef _WINDOWS
-    // SDL on Windows creates a separate console window, and we want to be able to actually read the error message
-    // before that window closes.
-    if (result != 0) {
-        printf("[Press any key to close this window]");
-        getchar();
-    }
+    if (result != 0)
+        waitForAnyKey();
 #elif __ANDROID__
     // TODO: on android without this it won't close application properly until it finishes music track?!
     // Something is not closing and preventing proper teardown?

--- a/src/Library/StackTrace/CMakeLists.txt
+++ b/src/Library/StackTrace/CMakeLists.txt
@@ -12,7 +12,24 @@ add_library(library_stack_trace STATIC ${LIBRARY_STACK_TRACE_SOURCES} ${LIBRARY_
 target_link_libraries(library_stack_trace PUBLIC utility)
 target_check_style(library_stack_trace)
 
-# backward-cpp doesn't support Android...
+# cpptrace doesn't support Android...
 if (NOT OE_BUILD_PLATFORM STREQUAL "android")
-    target_link_libraries(library_stack_trace PRIVATE Backward::Backward)
+    target_link_libraries(library_stack_trace PRIVATE cpptrace::cpptrace)
 endif ()
+
+# The crash handler walks the stack with StackWalk64.
+if (OE_BUILD_PLATFORM STREQUAL "windows")
+    target_link_libraries(library_stack_trace PRIVATE dbghelp)
+endif ()
+
+if(OE_BUILD_TESTS)
+    set(TEST_LIBRARY_STACK_TRACE_SOURCES
+            Tests/StackTrace_ut.cpp)
+
+    add_library(test_library_stack_trace OBJECT ${TEST_LIBRARY_STACK_TRACE_SOURCES})
+    target_link_libraries(test_library_stack_trace PUBLIC testing_unit library_stack_trace)
+
+    target_check_style(test_library_stack_trace)
+
+    target_link_libraries(OpenEnroth_UnitTest PUBLIC test_library_stack_trace)
+endif()

--- a/src/Library/StackTrace/StackTrace.cpp
+++ b/src/Library/StackTrace/StackTrace.cpp
@@ -1,31 +1,28 @@
 #include "StackTrace.h"
 
 #include <cstdio>
+#include <string>
 
 #ifndef __ANDROID__
-#   include <backward.hpp>
+#   include <cpptrace/cpptrace.hpp>
 #endif
 
 #include "Utility/String/Format.h"
 
 #ifdef __ANDROID__
 
-void printStackTrace(FILE *stream) {
-    fmt::println(stream, "Stack traces not supported on Android...");
+std::string stackTraceToString() {
+    return "Stack traces not supported on Android...";
 }
 
 #else
 
-void printStackTrace(FILE *stream) {
-    backward::StackTrace trace;
-    trace.load_here(32);
-    backward::TraceResolver resolver;
-    resolver.load_stacktrace(trace);
-
-    for (size_t i = 0; i < trace.size(); i++) {
-        backward::ResolvedTrace frame = resolver.resolve(trace[i]);
-        fmt::println(stream, "#{: <2} {}", frame.idx, frame.object_function);
-    }
+std::string stackTraceToString() {
+    return cpptrace::generate_trace(0, detail::MAX_TRACE_DEPTH).to_string();
 }
 
 #endif
+
+void printStackTrace(FILE *stream) {
+    fmt::println(stream, "{}", stackTraceToString());
+}

--- a/src/Library/StackTrace/StackTrace.h
+++ b/src/Library/StackTrace/StackTrace.h
@@ -1,5 +1,26 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdio>
+#include <string>
 
+namespace detail {
+/**
+ * Deep enough for any call stack worth reading, shallow enough that a runaway recursion prints a trace instead
+ * of megabytes of one.
+ */
+constexpr std::size_t MAX_TRACE_DEPTH = 128;
+} // namespace detail
+
+/**
+ * @return                              Stack trace starting at this function, one frame per line. On
+ *                                      platforms with no stack trace support, returns a message saying so.
+ */
+std::string stackTraceToString();
+
+/**
+ * Prints what `stackTraceToString` returns into the provided stream.
+ *
+ * @param stream                        Stream to print into.
+ */
 void printStackTrace(FILE *stream);

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -1,19 +1,487 @@
 #include "StackTraceOnCrash.h"
 
-#include <memory>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #ifndef __ANDROID__
-#   include <backward.hpp>
+#   include <cpptrace/cpptrace.hpp>
 #endif
+
+#ifdef _WINDOWS
+#   include <windows.h> // NOLINT: not a C system header.
+#   include <dbghelp.h> // NOLINT: not a C system header.
+#   include <csignal>
+#   include <exception>
+#   include <mutex>
+#elif !defined(__ANDROID__)
+#   include <unistd.h> // NOLINT: not a C++ system header.
+#   include <sys/ucontext.h> // NOLINT: not a C++ system header.
+#   ifdef __APPLE__
+#       include <libunwind.h> // NOLINT: not a C++ system header.
+#   else
+#       include <unwind.h> // NOLINT: not a C++ system header.
+#   endif
+#   include <csignal>
+#   include <cstring>
+#endif
+
+#include "Library/StackTrace/StackTrace.h"
+
+#include "Utility/String/Format.h"
 
 #ifdef __ANDROID__
 
-StackTraceOnCrash::StackTraceOnCrash() = default;
+StackTraceOnCrash::StackTraceOnCrash(void (*)()) {}
 
 #else
 
-StackTraceOnCrash::StackTraceOnCrash() {
-    _private = std::make_shared<backward::SignalHandling>();
+// Set by whichever handler runs first. Handlers chain into each other - terminate calls abort, and a crash
+// inside a handler re-enters it - and one trace is what's actually useful.
+static std::atomic_flag crashHandled = ATOMIC_FLAG_INIT;
+
+static void (*crashCallback)() = nullptr;
+
+static void runCrashCallback() {
+    if (crashCallback)
+        crashCallback();
 }
 
+static void printCrashHeader(std::string_view reason) {
+    // Flushed on its own because building the trace can hang, and then this is all anyone sees.
+    fmt::println(stderr, "\nCrashed because of {}", reason);
+    std::fflush(stderr);
+}
+
+static void printTrace(std::string_view trace) {
+    fmt::println(stderr, "{}", trace);
+    std::fflush(stderr);
+}
+
+static void warmUpCpptrace() {
+    (void) cpptrace::generate_trace(0, 1).to_string();
+}
+
+static void printCrashTrace(std::string_view reason) {
+    printCrashHeader(reason);
+    printTrace(stackTraceToString());
+}
+
+#ifdef _WINDOWS
+
+namespace cpptrace {
+inline namespace v1 {
+namespace detail {
+/**
+ * Cpptrace serializes its own dbghelp calls behind this lock - dbghelp is single-threaded. Declared rather
+ * than included, because it lives in cpptrace's internals - a signature change there becomes a link error
+ * here, which is the failure mode we want.
+ *
+ * @return                              The dbghelp lock.
+ */
+std::unique_lock<std::recursive_mutex> get_dbghelp_lock();
+} // namespace detail
+} // namespace v1
+} // namespace cpptrace
+
+/**
+ * Walks the stack the exception was raised on, rather than the one the filter is running on. Cpptrace only
+ * ever captures the latter, and getting from there back to the fault means crossing ntdll's dispatcher, which
+ * has no frame pointers to follow - 64-bit manages it on unwind data, 32-bit doesn't get across at all.
+ * Seeding the walk with the faulting context skips that problem instead of solving it.
+ *
+ * @param crashContext                  Register state the exception was raised with.
+ * @param exceptionAddress              Address the exception was raised at.
+ * @return                              Stack trace starting at the faulting frame, one frame per line.
+ */
+static std::string traceFromContext(const CONTEXT &crashContext, const void *exceptionAddress) {
+    CONTEXT context = crashContext; // StackWalk64 walks by mutating it.
+
+    std::unique_lock<std::recursive_mutex> lock = cpptrace::detail::get_dbghelp_lock();
+
+    // The module lookup below, StackWalk64 and the symbol callbacks all need the symbol handler initialized
+    // for the handle they're passed, and cpptrace initializes a duplicate of it rather than this one. Failure
+    // means it was already initialized, which is just as good.
+    SymInitialize(GetCurrentProcess(), nullptr, TRUE);
+
+    // A call through a bad pointer faults at the bad address, where there's nothing to walk from. The call
+    // pushed its return address first though, so pop it back into the pc and carry on from the caller. A bad
+    // address is one no module was loaded at.
+    bool popped = SymGetModuleBase64(GetCurrentProcess(), reinterpret_cast<DWORD64>(exceptionAddress)) == 0;
+    if (popped) {
+#if defined(_M_IX86)
+        context.Eip = *reinterpret_cast<const DWORD *>(context.Esp);
+        context.Esp += sizeof(DWORD);
+#elif defined(_M_X64)
+        context.Rip = *reinterpret_cast<const DWORD64 *>(context.Rsp);
+        context.Rsp += sizeof(DWORD64);
 #endif
+    }
+
+    STACKFRAME64 frame = {};
+    frame.AddrPC.Mode = AddrModeFlat;
+    frame.AddrFrame.Mode = AddrModeFlat;
+    frame.AddrStack.Mode = AddrModeFlat;
+#if defined(_M_IX86)
+    DWORD machineType = IMAGE_FILE_MACHINE_I386;
+    frame.AddrPC.Offset = context.Eip;
+    frame.AddrFrame.Offset = context.Ebp;
+    frame.AddrStack.Offset = context.Esp;
+#elif defined(_M_X64)
+    DWORD machineType = IMAGE_FILE_MACHINE_AMD64;
+    frame.AddrPC.Offset = context.Rip;
+    frame.AddrFrame.Offset = context.Rsp;
+    frame.AddrStack.Offset = context.Rsp;
+#else
+#   error "Unsupported windows architecture."
+#endif
+
+    cpptrace::raw_trace raw;
+    while (raw.frames.size() < detail::MAX_TRACE_DEPTH &&
+           StackWalk64(machineType, GetCurrentProcess(), GetCurrentThread(), &frame,
+                       machineType == IMAGE_FILE_MACHINE_I386 ? nullptr : &context, nullptr,
+                       SymFunctionTableAccess64, SymGetModuleBase64, nullptr) &&
+           frame.AddrPC.Offset != 0) {
+        // Cpptrace resolves call sites, and a return address points one past the call. The first frame is
+        // the faulting instruction itself, so it's exact as is - unless it was popped above, then it's a
+        // return address like the rest.
+        cpptrace::frame_ptr pc = static_cast<cpptrace::frame_ptr>(frame.AddrPC.Offset);
+        raw.frames.push_back(raw.frames.empty() && !popped ? pc : pc - 1);
+    }
+    lock.unlock();
+
+    return raw.resolve().to_string();
+}
+
+/**
+ * Structured exceptions are what access violations, illegal instructions and division by zero arrive as.
+ * Signals cover none of those on windows.
+ *
+ * @param exceptionInfo                 Exception record and register state of the crash.
+ * @return                              Always `EXCEPTION_CONTINUE_SEARCH`, so that the crash proceeds.
+ */
+static LONG WINAPI onStructuredException(EXCEPTION_POINTERS *exceptionInfo) {
+    if (!crashHandled.test_and_set()) {
+        char reason[128];
+        std::snprintf(reason, sizeof(reason), "exception %#lx at %p",
+                      exceptionInfo->ExceptionRecord->ExceptionCode, exceptionInfo->ExceptionRecord->ExceptionAddress);
+        printCrashHeader(reason);
+        printTrace(traceFromContext(*exceptionInfo->ContextRecord, exceptionInfo->ExceptionRecord->ExceptionAddress));
+        runCrashCallback();
+    }
+
+    // Continuing the search hands the exception to windows error reporting, which is what writes the crash
+    // dump, and to any attached debugger.
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+static void onAbort(int signal) {
+    if (!crashHandled.test_and_set()) {
+        printCrashTrace("abort()");
+        runCrashCallback();
+    }
+    // Returning is fine here, abort() goes on to terminate the process.
+}
+
+static void onTerminate() {
+    if (!crashHandled.test_and_set()) {
+        printCrashTrace("std::terminate()");
+        runCrashCallback();
+    }
+    std::abort(); // Ends the process, as returning from a terminate handler is undefined behavior.
+}
+
+static void __cdecl onPureCall() {
+    if (!crashHandled.test_and_set()) {
+        printCrashTrace("pure virtual function call");
+        runCrashCallback();
+    }
+    std::abort(); // Ends the process, as a pure virtual call leaves nothing sane to continue with.
+}
+
+static void __cdecl onInvalidParameter(const wchar_t *expression, const wchar_t *function, const wchar_t *file,
+                                       unsigned int line, uintptr_t reserved) {
+    if (!crashHandled.test_and_set()) {
+        printCrashTrace("invalid parameter passed to a CRT function");
+        runCrashCallback();
+    }
+    std::abort(); // Ends the process, as the CRT was handed garbage and can't carry on.
+}
+
+static void installHandlers() {
+    SetUnhandledExceptionFilter(&onStructuredException);
+
+    // A stack overflow dispatches its exception on the stack that just ran out, and symbolizing needs tens of
+    // kilobytes, so ask windows to keep some committed for exception dispatch. Per-thread, like the posix
+    // alternate stack.
+    ULONG stackGuarantee = 128 * 1024;
+    SetThreadStackGuarantee(&stackGuarantee);
+
+    // Drop the CRT's own abort message, we print a trace instead. _CALL_REPORTFAULT is left alone so that
+    // abort() still gets a crash dump out of windows error reporting, the way a structured exception does.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
+    std::signal(SIGABRT, &onAbort);
+
+    std::set_terminate(&onTerminate);
+    _set_purecall_handler(&onPureCall);
+    _set_invalid_parameter_handler(&onInvalidParameter);
+}
+
+#else // _WINDOWS
+
+static const int handledSignals[] = {
+    SIGABRT, // abort().
+    SIGBUS, // Bad memory access.
+    SIGFPE, // Floating point exception.
+    SIGILL, // Illegal instruction.
+    SIGQUIT, // Quit from keyboard.
+    SIGSEGV, // Invalid memory reference.
+    SIGSYS, // Bad argument to routine.
+    SIGTRAP, // Trace/breakpoint trap.
+    SIGXCPU, // CPU time limit exceeded.
+    SIGXFSZ, // File size limit exceeded.
+};
+
+#ifdef __APPLE__
+
+/**
+ * Fills a libunwind context from the register state a signal was delivered with. Libunwind keeps its own
+ * layout rather than the kernel's, so this is a register-by-register copy.
+ *
+ * @param crashContext                  Register state the signal was delivered with.
+ * @param[out] context                  Libunwind context to walk from.
+ */
+static void fillUnwindContext(const ucontext_t &crashContext, unw_context_t *context) {
+    std::memset(context, 0, sizeof(*context));
+    uint64_t *regs = reinterpret_cast<uint64_t *>(context);
+    const auto &ss = crashContext.uc_mcontext->__ss;
+#if defined(__aarch64__)
+    for (int i = 0; i < 29; i++) // x0-x28.
+        regs[i] = ss.__x[i];
+    regs[29] = ss.__fp;
+    regs[30] = ss.__lr;
+    regs[31] = ss.__sp;
+    regs[32] = ss.__pc;
+#elif defined(__x86_64__)
+    const uint64_t order[] = {ss.__rax, ss.__rbx, ss.__rcx, ss.__rdx, ss.__rdi, ss.__rsi, ss.__rbp, ss.__rsp,
+                              ss.__r8, ss.__r9, ss.__r10, ss.__r11, ss.__r12, ss.__r13, ss.__r14, ss.__r15,
+                              ss.__rip};
+    std::memcpy(regs, order, sizeof(order));
+#else
+#   error "Unsupported apple architecture."
+#endif
+}
+
+/**
+ * Walks the stack the signal interrupted, from the register state the crash left behind. The system unwinder
+ * drops the frame a signal fired in when it walks across the trampoline from inside the handler, so the walk
+ * is seeded with that frame's registers instead and never crosses the trampoline at all.
+ *
+ * A call through a bad pointer faults at the bad address, where there's nothing to walk from. The call pushed
+ * its return address first though, so the pc is set back into that call and the walk carries on from there.
+ *
+ * @param crashContext                  Register state the signal was delivered with.
+ * @param faultAddress                  Address the signal was about, `si_addr`.
+ * @return                              Stack trace starting at the faulting frame, one frame per line.
+ */
+static std::string traceFromContext(const ucontext_t &crashContext, const void *faultAddress) {
+    unw_context_t context;
+    fillUnwindContext(crashContext, &context);
+
+    // The patch goes into the context before the cursor exists. Setting the pc on a cursor doesn't make it
+    // re-read the unwind info, and the walk would stop after one frame.
+    uint64_t *regs = reinterpret_cast<uint64_t *>(&context);
+#if defined(__aarch64__)
+    uint64_t &pc = regs[32];
+    if (pc == reinterpret_cast<uint64_t>(faultAddress))
+        pc = regs[30] - 1; // Back into the call that jumped here.
+#else
+    uint64_t &pc = regs[16];
+    if (pc == reinterpret_cast<uint64_t>(faultAddress)) {
+        pc = *reinterpret_cast<const uint64_t *>(regs[7]) - 1; // Return address is at [rsp].
+        regs[7] += sizeof(uint64_t); // And it's been popped.
+    }
+#endif
+
+    unw_cursor_t cursor;
+    unw_init_local(&cursor, &context);
+
+    cpptrace::raw_trace raw;
+    unw_word_t ip;
+    do {
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        // The first frame is the instruction itself, every later one is a return address one past its call.
+        raw.frames.push_back(raw.frames.empty() ? ip : ip - 1);
+    } while (raw.frames.size() < detail::MAX_TRACE_DEPTH && unw_step(&cursor) > 0);
+
+    return raw.resolve().to_string();
+}
+
+#else // __APPLE__
+
+struct dwarf_eh_bases {
+    void *tbase, *dbase, *func;
+};
+extern "C" const void *_Unwind_Find_FDE(const void *pc, struct dwarf_eh_bases *bases); // Mirrors libgcc's own declaration, names and all.
+
+/**
+ * @param crashContext                  Register state the signal was delivered with.
+ * @return                              Program counter the signal was delivered at.
+ */
+static uintptr_t faultingProgramCounter(const ucontext_t &crashContext) {
+#if defined(__aarch64__)
+    return crashContext.uc_mcontext.pc;
+#elif defined(__x86_64__)
+    return crashContext.uc_mcontext.gregs[REG_RIP];
+#elif defined(__i386__)
+    return crashContext.uc_mcontext.gregs[REG_EIP];
+#elif defined(__arm__)
+    return crashContext.uc_mcontext.arm_pc;
+#else
+#   error "Unsupported posix architecture."
+#endif
+}
+
+/**
+ * Walks the frame pointer chain from the register state a signal was delivered with. This is for a call
+ * through a bad pointer, which faults at the bad address where the unwinder has nothing to go on. The call
+ * pushed its return address first, and the frame pointer still points at the caller's frame, so both are
+ * there to be read - which is why frame pointers are kept on every build.
+ *
+ * @param crashContext                  Register state the signal was delivered with.
+ * @return                              Frames starting with the call that jumped to the bad address.
+ */
+static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &crashContext) {
+    std::vector<cpptrace::frame_ptr> frames;
+#if defined(__aarch64__)
+    uintptr_t returnAddress = crashContext.uc_mcontext.regs[30]; // lr
+    uintptr_t fp = crashContext.uc_mcontext.regs[29];
+#elif defined(__x86_64__)
+    uintptr_t sp = crashContext.uc_mcontext.gregs[REG_RSP];
+    uintptr_t returnAddress = *reinterpret_cast<const uintptr_t *>(sp); // The call pushed it.
+    uintptr_t fp = crashContext.uc_mcontext.gregs[REG_RBP];
+#elif defined(__i386__)
+    uintptr_t sp = crashContext.uc_mcontext.gregs[REG_ESP];
+    uintptr_t returnAddress = *reinterpret_cast<const uintptr_t *>(sp);
+    uintptr_t fp = crashContext.uc_mcontext.gregs[REG_EBP];
+#elif defined(__arm__)
+    uintptr_t returnAddress = crashContext.uc_mcontext.arm_lr;
+    uintptr_t fp = crashContext.uc_mcontext.arm_fp;
+#endif
+    frames.push_back(returnAddress - 1); // Back into the call that jumped.
+    while (fp != 0 && frames.size() < detail::MAX_TRACE_DEPTH) {
+        const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp); // [fp] = caller's fp, [fp + 1] = return.
+        if (frame[1] == 0)
+            break;
+        frames.push_back(frame[1] - 1);
+        fp = frame[0];
+    }
+    return frames;
+}
+
+/**
+ * Walks the stack from inside the handler, then trims it back to the frame the signal interrupted. The libgcc
+ * unwinder crosses the signal trampoline on its own and marks the interrupted frame as the one where the pc
+ * is the faulting instruction rather than a return address, so that mark is where the trace starts.
+ *
+ * A call through a bad pointer is the one case the unwinder can't handle - there's no unwind info at the bad
+ * address, so it stops there - and for that the frame pointer chain is walked by hand instead.
+ *
+ * @param crashContext                  Register state the signal was delivered with.
+ * @return                              Stack trace starting at the faulting frame, one frame per line.
+ */
+static std::string traceFromContext(const ucontext_t &crashContext) {
+    cpptrace::raw_trace raw;
+
+    dwarf_eh_bases bases;
+    if (!_Unwind_Find_FDE(reinterpret_cast<const void *>(faultingProgramCounter(crashContext)), &bases)) {
+        raw.frames = walkFramePointers(crashContext);
+        return raw.resolve().to_string();
+    }
+
+    struct Walk {
+        std::vector<cpptrace::frame_ptr> frames;
+        bool reachedFault = false;
+    } walk;
+    _Unwind_Backtrace([](struct _Unwind_Context *context, void *arg) {
+        Walk &walk = *static_cast<Walk *>(arg);
+        int isFault = 0;
+        uintptr_t ip = _Unwind_GetIPInfo(context, &isFault);
+        if (isFault)
+            walk.reachedFault = true;
+        if (!walk.reachedFault)
+            return _URC_NO_REASON; // Still inside the handler.
+        walk.frames.push_back(isFault ? ip : ip - 1);
+        return walk.frames.size() < detail::MAX_TRACE_DEPTH ? _URC_NO_REASON : _URC_END_OF_STACK;
+    }, &walk);
+
+    raw.frames = std::move(walk.frames);
+    return raw.resolve().to_string();
+}
+
+#endif // __APPLE__
+
+static void onSignal(int signal, siginfo_t *info, void *context) {
+    // Only the first crash prints. A second thread raising a different signal while this one symbolizes
+    // would interleave with it, so it skips to the raise below instead - exiting here would cost the core
+    // dump. A second thread raising the same signal never gets here, SA_RESETHAND already put the default
+    // handler back, so the kernel kills the process and whatever was printed so far is all there is.
+    if (!crashHandled.test_and_set()) {
+        char reason[128];
+        std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
+        printCrashHeader(reason);
+#ifdef __APPLE__
+        printTrace(traceFromContext(*static_cast<ucontext_t *>(context), info->si_addr));
+#else
+        printTrace(traceFromContext(*static_cast<ucontext_t *>(context)));
+#endif
+        runCrashCallback();
+    }
+
+    // Die of the original signal, so that a core dump still happens and whoever launched the process sees it
+    // was killed by a SIGSEGV. SA_RESETHAND put the default handler back before we were called, so raising it
+    // here is what actually kills us.
+    std::raise(info->si_signo);
+    _exit(EXIT_FAILURE);
+}
+
+static void installHandlers() {
+    // The handler runs on its own stack so that it also works when the crash is stack exhaustion. Symbolizing
+    // a trace measures at 17kb, well past SIGSTKSZ, and the rest is margin for the platforms that weren't
+    // measured. This is bss, so the pages past what's touched never get committed.
+    static char alternateStack[1024 * 1024];
+
+    stack_t stack;
+    stack.ss_sp = alternateStack;
+    stack.ss_size = sizeof(alternateStack);
+    stack.ss_flags = 0;
+    sigaltstack(&stack, nullptr);
+
+    for (int signal : handledSignals) {
+        struct sigaction action;
+        std::memset(&action, 0, sizeof(action));
+        action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
+        sigfillset(&action.sa_mask);
+        sigdelset(&action.sa_mask, signal);
+        action.sa_sigaction = &onSignal;
+        sigaction(signal, &action, nullptr);
+    }
+}
+
+#endif // _WINDOWS
+
+StackTraceOnCrash::StackTraceOnCrash(void (*callback)()) {
+    crashCallback = callback;
+
+    // Symbols resolve lazily, so the first trace is the one that opens debug info and allocates. Better done
+    // here than inside a handler, with the process already broken.
+    warmUpCpptrace();
+    installHandlers();
+}
+
+#endif // __ANDROID__

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -111,8 +111,9 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
     SymInitialize(GetCurrentProcess(), nullptr, TRUE);
 
     // A call through a bad pointer faults at the bad address, where there's nothing to walk from. The call
-    // pushed its return address first though, so pop it back into the pc, backed into the call so the unwind
-    // data lookup lands in the caller. A bad address is one no module was loaded at.
+    // pushed its return address first though, so pop it into the pc, minus one - a return address points one
+    // past the call, and the unwind data lookup has to land inside the caller, not one past it. A bad
+    // address is one no module was loaded at.
     if (SymGetModuleBase64(GetCurrentProcess(), reinterpret_cast<DWORD64>(exceptionAddress)) == 0) {
 #if defined(_M_IX86)
         context.Eip = *reinterpret_cast<const DWORD *>(context.Esp) - 1;
@@ -148,8 +149,8 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
                        SymFunctionTableAccess64, SymGetModuleBase64, nullptr) &&
            frame.AddrPC.Offset != 0) {
         // Cpptrace resolves call sites, and a return address points one past the call. The first frame is
-        // exact as is - the faulting instruction itself, or a popped return address already backed into its
-        // call above.
+        // exact as is - the faulting instruction itself, or the popped return address that already got its
+        // minus one above.
         cpptrace::frame_ptr pc = static_cast<cpptrace::frame_ptr>(frame.AddrPC.Offset);
         raw.frames.push_back(raw.frames.empty() ? pc : pc - 1);
     }
@@ -299,7 +300,7 @@ static std::string traceFromContext(const ucontext_t &crashContext, const void *
 #if defined(__aarch64__)
     uint64_t &pc = regs[32];
     if (pc == reinterpret_cast<uint64_t>(faultAddress))
-        pc = regs[30] - 1; // Back into the call that jumped here.
+        pc = regs[30] - 1; // Minus one, so the pc points into the call, not one past it.
 #else
     uint64_t &pc = regs[16];
     if (pc == reinterpret_cast<uint64_t>(faultAddress)) {
@@ -373,7 +374,7 @@ static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &cras
     uintptr_t returnAddress = crashContext.uc_mcontext.arm_lr;
     uintptr_t fp = crashContext.uc_mcontext.arm_fp;
 #endif
-    frames.push_back(returnAddress - 1); // Back into the call that jumped.
+    frames.push_back(returnAddress - 1); // Minus one, so it points into the call, not one past it.
     while (fp != 0 && frames.size() < detail::MAX_TRACE_DEPTH) {
         const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp); // [fp] = caller's fp, [fp + 1] = return.
         if (frame[1] == 0)

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -106,7 +106,8 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
 
     // The module lookup below, StackWalk64 and the symbol callbacks all need the symbol handler initialized
     // for the handle they're passed, and cpptrace initializes a duplicate of it rather than this one. Failure
-    // means it was already initialized, which is just as good.
+    // means it was already initialized, which is just as good. Done at crash time rather than at install so
+    // the module list is current - a dll loaded since then must not read as a bad call target.
     SymInitialize(GetCurrentProcess(), nullptr, TRUE);
 
     // A call through a bad pointer faults at the bad address, where there's nothing to walk from. The call

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -110,15 +110,14 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
     SymInitialize(GetCurrentProcess(), nullptr, TRUE);
 
     // A call through a bad pointer faults at the bad address, where there's nothing to walk from. The call
-    // pushed its return address first though, so pop it back into the pc and carry on from the caller. A bad
-    // address is one no module was loaded at.
-    bool popped = SymGetModuleBase64(GetCurrentProcess(), reinterpret_cast<DWORD64>(exceptionAddress)) == 0;
-    if (popped) {
+    // pushed its return address first though, so pop it back into the pc, backed into the call so the unwind
+    // data lookup lands in the caller. A bad address is one no module was loaded at.
+    if (SymGetModuleBase64(GetCurrentProcess(), reinterpret_cast<DWORD64>(exceptionAddress)) == 0) {
 #if defined(_M_IX86)
-        context.Eip = *reinterpret_cast<const DWORD *>(context.Esp);
+        context.Eip = *reinterpret_cast<const DWORD *>(context.Esp) - 1;
         context.Esp += sizeof(DWORD);
 #elif defined(_M_X64)
-        context.Rip = *reinterpret_cast<const DWORD64 *>(context.Rsp);
+        context.Rip = *reinterpret_cast<const DWORD64 *>(context.Rsp) - 1;
         context.Rsp += sizeof(DWORD64);
 #endif
     }
@@ -148,10 +147,10 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
                        SymFunctionTableAccess64, SymGetModuleBase64, nullptr) &&
            frame.AddrPC.Offset != 0) {
         // Cpptrace resolves call sites, and a return address points one past the call. The first frame is
-        // the faulting instruction itself, so it's exact as is - unless it was popped above, then it's a
-        // return address like the rest.
+        // exact as is - the faulting instruction itself, or a popped return address already backed into its
+        // call above.
         cpptrace::frame_ptr pc = static_cast<cpptrace::frame_ptr>(frame.AddrPC.Offset);
-        raw.frames.push_back(raw.frames.empty() && !popped ? pc : pc - 1);
+        raw.frames.push_back(raw.frames.empty() ? pc : pc - 1);
     }
     lock.unlock();
 

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -1,11 +1,23 @@
 #pragma once
 
-#include <memory>
-
+/**
+ * Installs crash handlers that dump a stack trace to stderr, then let the crash proceed so that the OS still
+ * produces a core dump or a crash report. The handlers are never uninstalled, the process is dying anyway.
+ *
+ * Construct one in `main` before anything else can crash. The handlers need stack of their own for when the
+ * crash is stack exhaustion - an alternate signal stack on posix, a committed stack guarantee on windows -
+ * and both are per-thread, so only the thread that constructs this gets one. On a worker thread the handlers
+ * are left to run on whatever stack remains. The handlers themselves are process-wide.
+ *
+ * The handlers are not async-signal-safe, and can't be - symbolizing a trace allocates, reads files and takes
+ * locks, so a crash while another thread holds one of those hangs the process instead of killing it. Crashing
+ * inside the allocator does the same.
+ */
 class StackTraceOnCrash {
  public:
-    StackTraceOnCrash();
-
- private:
-    std::shared_ptr<void> _private;
+    /**
+     * @param callback                  Called after the crash trace is printed, right before the process
+     *                                  dies. For holding a console window open until a key is pressed.
+     */
+    explicit StackTraceOnCrash(void (*callback)() = nullptr);
 };

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -17,7 +17,7 @@ class StackTraceOnCrash {
  public:
     /**
      * @param callback                  Called after the crash trace is printed, right before the process
-     *                                  dies. For holding a console window open until a key is pressed.
+     *                                  dies.
      */
     explicit StackTraceOnCrash(void (*callback)() = nullptr);
 };

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -75,7 +75,6 @@ struct StackTracePureCallDerived : StackTracePureCallBase {
     virtual void callPure() override {}
 };
 
-// Not static because windows drops private symbols from a stripped pdb.
 MM_NOINLINE void stackTracePureCallFunction() {
     StackTracePureCallDerived derived;
 }

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -115,7 +115,8 @@ MM_NOINLINE int stackTraceOverflowFunction(int depth) {
     volatile char pad[1024]; // Big frames run out of stack fast.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1); // Using the pad keeps the recursion from being folded into a loop.
+    pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.
+    return pad[0] + pad[1023];
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -19,7 +19,7 @@
 // On windows dedicated CRT hooks print the reasons asserted below. On posix there are no hooks - abort and
 // terminate arrive as SIGABRT with the abort machinery in the output, and a pure call is a plain crash - so
 // the posix side of each check probes for that instead. Mac needs its own spellings - its abort frame prints
-// with no name, and libc++abi says terminating rather than terminate.
+// with no name, and libc++abi says "terminating" rather than "terminate".
 #ifdef _WINDOWS
 constexpr bool isWindows = true;
 #else

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -68,7 +68,9 @@ struct StackTracePureCallBase {
     MM_NOINLINE void callPureIndirectly() {
         // An extra hop the compiler can't fold away. Inlined into the constructor, the call site would have a
         // known dynamic type, and the call devirtualizes into a direct one to a function with no body.
+        volatile int keepFrame = 0;
         callPure();
+        keepFrame = 1; // Or the call is in tail position, becomes a jump, and this frame is gone from the trace.
     }
 };
 struct StackTracePureCallDerived : StackTracePureCallBase {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -126,8 +126,6 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
 }
 
 UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
-    // The crash path is the one that matters, and it's the one that breaks silently - a handler that traces
-    // the wrong thread, or traces nothing at all, still exits with the right signal.
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -162,9 +162,10 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
 }
 
 UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
-    // Guards against detecting a bad call target by comparing the pc to si_addr. On x86-64 a jump to a
-    // non-canonical address is a general protection fault with si_addr reported as zero, so that comparison
-    // only ever passed the null call, where the two happen to be equal.
+    // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
+    // to walk from the caller instead. Recognizing it by comparing the pc to si_addr was a bug - on x86-64 a
+    // jump to a non-canonical address is a general protection fault, which reports si_addr as zero, so the
+    // comparison held only for a null call, where both sides are zero.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -211,7 +211,7 @@ UNIT_TEST(StackTrace, AbortIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceAbortFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : "abort"),
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : "Crashed because of Abort"), // "Aborted" on glibc, "Abort trap" on mac.
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
@@ -221,7 +221,7 @@ UNIT_TEST(StackTrace, TerminateIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceTerminateFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : "terminate"),
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : "terminat"), // Chopped, it's "terminating" on mac and "terminate called" on glibc.
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -163,9 +163,7 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
 
 UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
-    // to walk from the caller instead. Recognizing it by comparing the pc to si_addr was a bug - on x86-64 a
-    // jump to a non-canonical address is a general protection fault, which reports si_addr as zero, so the
-    // comparison held only for a null call, where both sides are zero.
+    // to walk from the caller instead.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -111,18 +111,11 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-/**
- * Overflows the stack. The pad makes each frame big enough to get there fast, and feeding it into the return
- * value keeps the recursion from being folded into a loop.
- *
- * @param depth                         Recursion depth, start at zero.
- * @return                              Never returns, the stack runs out first.
- */
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
-    volatile char pad[1024];
+    volatile char pad[1024]; // Big frames run out of stack fast.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1); // Using the pad keeps the recursion from being folded into a loop.
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -18,11 +18,17 @@
 
 // On windows dedicated CRT hooks print the reasons asserted below. On posix there are no hooks - abort and
 // terminate arrive as SIGABRT with the abort machinery in the output, and a pure call is a plain crash - so
-// the posix side of each check probes for that instead.
+// the posix side of each check probes for that instead. Mac needs its own spellings - its abort frame prints
+// with no name, and libc++abi says terminating rather than terminate.
 #ifdef _WINDOWS
 constexpr bool isWindows = true;
 #else
 constexpr bool isWindows = false;
+#endif
+#ifdef __APPLE__
+constexpr bool isMac = true;
+#else
+constexpr bool isMac = false;
 #endif
 
 /**
@@ -211,7 +217,7 @@ UNIT_TEST(StackTrace, AbortIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceAbortFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : "Crashed because of Abort"), // "Aborted" on glibc, "Abort trap" on mac.
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : isMac ? "Abort trap" : "abort"),
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
@@ -221,7 +227,7 @@ UNIT_TEST(StackTrace, TerminateIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceTerminateFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : "terminat"), // Chopped, it's "terminating" on mac and "terminate called" on glibc.
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : isMac ? "terminating" : "terminate"),
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -1,0 +1,250 @@
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <string>
+#include <thread>
+
+#include "Testing/Unit/UnitTest.h"
+
+#include "Library/StackTrace/StackTrace.h"
+#include "Library/StackTrace/StackTraceOnCrash.h"
+
+#include "Utility/Attributes.h"
+#include "Utility/String/Format.h"
+#include "Utility/String/Split.h"
+
+#ifndef __ANDROID__ // Stack traces are not supported on android.
+
+// On windows dedicated CRT hooks print the reasons asserted below. On posix there are no hooks - abort and
+// terminate arrive as SIGABRT with the abort machinery in the output, and a pure call is a plain crash - so
+// the posix side of each check probes for that instead.
+#ifdef _WINDOWS
+constexpr bool isWindows = true;
+#else
+constexpr bool isWindows = false;
+#endif
+
+/**
+ * Matches when the frame numbered `index` names `function`. The regexes gtest's own death test matchers take
+ * aren't portable - gtest picks between two engines with different grammars depending on the platform - so
+ * this walks the lines instead.
+ */
+MATCHER_P2(HasFrame, index, function, "") {
+    std::string prefix = fmt::format("#{} ", index);
+    for (std::string_view line : split(std::string_view(arg)).by('\n'))
+        if (line.starts_with(prefix) && line.contains(function))
+            return true;
+    return false;
+}
+
+MM_NOINLINE std::string stackTraceMarkerFunction() {
+    std::string trace = stackTraceToString();
+
+    // Deriving the result from the trace keeps the call above out of tail position. Clang tail-calls it at
+    // -O2 otherwise, and then this frame, which is the one the test looks for, isn't in the trace at all.
+    return trace.empty() ? std::string() : trace;
+}
+
+MM_NOINLINE int stackTraceCrashingFunction() {
+    // Volatile pointer, not pointer to volatile, or the compiler knows it's null and traps instead of
+    // faulting. The read feeds the return value because a store on its own is dead code that some compilers
+    // drop, and then nothing crashes at all.
+    int *volatile nowhere = nullptr;
+    *nowhere = 1;
+    return *nowhere;
+}
+
+struct StackTracePureCallBase {
+    StackTracePureCallBase() { callPureIndirectly(); }
+    virtual void callPure() = 0;
+
+    MM_NOINLINE void callPureIndirectly() {
+        // An extra hop the compiler can't fold away. Inlined into the constructor, the call site would have a
+        // known dynamic type, and the call devirtualizes into a direct one to a function with no body.
+        callPure();
+    }
+};
+struct StackTracePureCallDerived : StackTracePureCallBase {
+    virtual void callPure() override {}
+};
+
+// Not static because windows drops private symbols from a stripped pdb.
+MM_NOINLINE void stackTracePureCallFunction() {
+    StackTracePureCallDerived derived;
+}
+
+MM_NOINLINE void stackTraceTerminateFunction() {
+    volatile int keepFrame = 0;
+    std::terminate();
+    keepFrame = 1; // Or the noreturn call becomes a jump, and this frame is gone before the handler runs.
+}
+
+MM_NOINLINE void stackTraceAbortFunction() {
+    volatile int keepFrame = 0;
+    std::abort();
+    keepFrame = 1; // Or the noreturn call becomes a jump, and this frame is gone before the handler runs.
+}
+
+#ifdef _WINDOWS
+MM_NOINLINE void stackTraceInvalidParameterFunction() {
+    volatile int keepFrame = 0;
+    std::printf(nullptr); // Null format string is the canonical way to trip the invalid parameter handler.
+    keepFrame = 1; // Or the call is in tail position, becomes a jump, and this frame is gone from the trace.
+}
+#endif // _WINDOWS
+
+MM_NOINLINE int stackTraceNullCallFunction() {
+    int (*volatile nowhere)() = nullptr; // Volatile, or the compiler sees the target and emits a trap instead.
+    volatile int result = nowhere(); // Using the result keeps this out of tail position, which keeps the frame.
+    return result + 1;
+}
+
+MM_NOINLINE int stackTraceBadTargetCallFunction() {
+    int (*volatile nowhere)() = reinterpret_cast<int (*)()>(static_cast<uintptr_t>(0xdeadbeefdeadULL));
+    volatile int result = nowhere(); // Using the result keeps this out of tail position, which keeps the frame.
+    return result + 1;
+}
+
+/**
+ * Overflows the stack. The pad makes each frame big enough to get there fast, and feeding it into the return
+ * value keeps the recursion from being folded into a loop.
+ *
+ * @param depth                         Recursion depth, start at zero.
+ * @return                              Never returns, the stack runs out first.
+ */
+MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+}
+
+UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
+    std::string trace = stackTraceMarkerFunction();
+
+    EXPECT_THAT(trace, HasFrame(1, "stackTraceMarkerFunction"));
+    EXPECT_CONTAINS(trace, "main");
+}
+
+UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
+    // The crash path is the one that matters, and it's the one that breaks silently - a handler that traces
+    // the wrong thread, or traces nothing at all, still exits with the right signal.
+    EXPECT_DEATH({
+        // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
+        // exception filter, so on windows ours would never see the access violation below.
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceCrashingFunction();
+    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
+}
+
+UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
+    // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
+    // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        std::thread(stackTraceCrashingFunction).join();
+    // A worker's stack ends at the thread entry, so main being absent is what says we traced the thread that
+    // crashed rather than the one that installed the handlers.
+    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
+}
+
+UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
+    // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
+    // return address first though, and walking on from that names the function that made the call and
+    // everything above it.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceNullCallFunction();
+    }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
+}
+
+UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
+    // Guards against detecting a bad call target by comparing the pc to si_addr. On x86-64 a jump to a
+    // non-canonical address is a general protection fault with si_addr reported as zero, so that comparison
+    // only ever passed the null call, where the two happen to be equal.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceBadTargetCallFunction();
+    }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
+}
+
+UNIT_TEST(StackTrace, StackOverflowIsTraced) {
+    // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
+    // faults on the exhausted stack and the crash prints nothing at all.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceOverflowFunction(0);
+    }, HasFrame(0, "stackTraceOverflowFunction"));
+}
+
+UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
+    // The callback is what holds a console window open after a crash, so it has to fire after the trace is
+    // printed. Matching on order and not just presence is what guards that.
+    auto callbackAfterTrace = testing::Truly([](const std::string &output) {
+        size_t tracePos = output.find("stackTraceCrashingFunction");
+        size_t callbackPos = output.find("crash callback ran");
+        return tracePos != std::string::npos && callbackPos != std::string::npos && tracePos < callbackPos;
+    });
+
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler([] { std::fputs("crash callback ran", stderr); });
+        stackTraceCrashingFunction();
+    }, callbackAfterTrace);
+}
+
+UNIT_TEST(StackTrace, AbortIsTraced) {
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceAbortFunction();
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : "abort"),
+                      testing::HasSubstr("stackTraceAbortFunction")));
+}
+
+UNIT_TEST(StackTrace, TerminateIsTraced) {
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceTerminateFunction();
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : "terminate"),
+                      testing::HasSubstr("stackTraceTerminateFunction")));
+}
+
+UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTracePureCallFunction();
+    }, testing::AllOf(testing::HasSubstr(isWindows ? "pure virtual function call" : "callPureIndirectly"),
+                      testing::HasSubstr("stackTracePureCallFunction")));
+}
+
+#ifdef _WINDOWS
+UNIT_TEST(StackTrace, InvalidParameterIsTraced) {
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceInvalidParameterFunction();
+    }, testing::AllOf(testing::HasSubstr("invalid parameter passed to a CRT function"),
+                      testing::HasSubstr("stackTraceInvalidParameterFunction")));
+}
+#endif // _WINDOWS
+
+#endif // !__ANDROID__

--- a/src/Utility/Attributes.h
+++ b/src/Utility/Attributes.h
@@ -1,0 +1,13 @@
+#pragma once
+
+/**
+ * @def MM_NOINLINE
+ *
+ * Prevents the compiler from inlining a function. Note that a function that's not inlined is also a function
+ * that shows up as its own frame in a stack trace.
+ */
+#ifdef _MSC_VER
+#   define MM_NOINLINE __declspec(noinline)
+#else
+#   define MM_NOINLINE [[gnu::noinline]]
+#endif

--- a/src/Utility/Attributes.h
+++ b/src/Utility/Attributes.h
@@ -3,8 +3,7 @@
 /**
  * @def MM_NOINLINE
  *
- * Prevents the compiler from inlining a function. Note that a function that's not inlined is also a function
- * that shows up as its own frame in a stack trace.
+ * Prevents the compiler from inlining a function.
  */
 #ifdef _MSC_VER
 #   define MM_NOINLINE __declspec(noinline)

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -18,6 +18,7 @@ set(UTILITY_SOURCES
         String/Wrap.cpp)
 
 set(UTILITY_HEADERS
+        Attributes.h
         Exception.h
         Flags.h
         Hash.h

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -65,10 +65,10 @@ endif()
 # cpptrace, it clones libdwarf with FetchContent at configure time. The options below are libdwarf's and
 # cpptrace's, and they only take effect thanks to the CMP0077 default set at the top of this file.
 if(NOT OE_BUILD_PLATFORM STREQUAL "android")
-    # Cpptrace picks execinfo on macos, which starts its traces two frames in and returns nothing at all from
-    # a signal handler in optimized builds. The built-in unwinder is what the C++ runtime unwinds with - libgcc
-    # on linux, the system libunwind on macos - so it's as accurate as the platform gets, and it's already
-    # linked. Windows is left alone because it wants dbghelp.
+    # Cpptrace picks execinfo on macos, which starts its traces two frames in, and that breaks the
+    # stackTraceToString contract of starting at the caller. The built-in unwinder is what the C++ runtime
+    # unwinds with - libgcc on linux, the system libunwind on macos - and it's already linked. Windows is
+    # left alone because it wants dbghelp.
     if(NOT OE_BUILD_PLATFORM STREQUAL "windows")
         set(CPPTRACE_UNWIND_WITH_UNWIND ON)
     endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -65,6 +65,13 @@ endif()
 # cpptrace, it clones libdwarf with FetchContent at configure time. The options below are libdwarf's and
 # cpptrace's, and they only take effect thanks to the CMP0077 default set at the top of this file.
 if(NOT OE_BUILD_PLATFORM STREQUAL "android")
+    # Cpptrace picks execinfo on macos, which starts traces two frames in - a trace taken inside
+    # stackTraceToString opens at its caller's caller, and FunctionNamesAreResolved fails exactly that way.
+    # The built-in unwinder is what the C++ runtime unwinds with - libgcc on linux, the system libunwind on
+    # macos - and it's already linked. Windows is left alone because it wants dbghelp.
+    if(NOT OE_BUILD_PLATFORM STREQUAL "windows")
+        set(CPPTRACE_UNWIND_WITH_UNWIND ON)
+    endif()
     set(ENABLE_DECOMPRESSION OFF) # We don't emit compressed debug sections, and libdwarf can't export its zlib dep.
     set(CPPTRACE_USE_EXTERNAL_ZSTD ON) # Only used for decompression, so this just stops cpptrace downloading it.
     set(CPPTRACE_DISABLE_CXX_20_MODULES ON) # Nothing imports cpptrace, and module scanning needs a ninja generator.

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -65,13 +65,6 @@ endif()
 # cpptrace, it clones libdwarf with FetchContent at configure time. The options below are libdwarf's and
 # cpptrace's, and they only take effect thanks to the CMP0077 default set at the top of this file.
 if(NOT OE_BUILD_PLATFORM STREQUAL "android")
-    # Cpptrace picks execinfo on macos, which starts its traces two frames in, and that breaks the
-    # stackTraceToString contract of starting at the caller. The built-in unwinder is what the C++ runtime
-    # unwinds with - libgcc on linux, the system libunwind on macos - and it's already linked. Windows is
-    # left alone because it wants dbghelp.
-    if(NOT OE_BUILD_PLATFORM STREQUAL "windows")
-        set(CPPTRACE_UNWIND_WITH_UNWIND ON)
-    endif()
     set(ENABLE_DECOMPRESSION OFF) # We don't emit compressed debug sections, and libdwarf can't export its zlib dep.
     set(CPPTRACE_USE_EXTERNAL_ZSTD ON) # Only used for decompression, so this just stops cpptrace downloading it.
     set(CPPTRACE_DISABLE_CXX_20_MODULES ON) # Nothing imports cpptrace, and module scanning needs a ninja generator.

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -62,15 +62,20 @@ if(OE_BUILD_TESTS)
     add_subdirectory(googletest EXCLUDE_FROM_ALL)
 endif()
 
-# backward
+# cpptrace, it clones libdwarf with FetchContent at configure time. The options below are libdwarf's and
+# cpptrace's, and they only take effect thanks to the CMP0077 default set at the top of this file.
 if(NOT OE_BUILD_PLATFORM STREQUAL "android")
-    add_subdirectory(backward_cpp EXCLUDE_FROM_ALL)
-    if (OE_BUILD_PLATFORM STREQUAL "linux" AND NOT OE_USE_DUMMY_DEPENDENCIES)
-        string(FIND "${BACKWARD_DEFINITIONS}" "BACKWARD_HAS_DWARF=1" DWARF_POS)
-        if (${DWARF_POS} EQUAL -1)
-            message(WARNING "libdwarf is required for backward-cpp on linux.")
-        endif()
+    # Cpptrace picks execinfo on macos, which starts its traces two frames in and returns nothing at all from
+    # a signal handler in optimized builds. The built-in unwinder is what the C++ runtime unwinds with - libgcc
+    # on linux, the system libunwind on macos - so it's as accurate as the platform gets, and it's already
+    # linked. Windows is left alone because it wants dbghelp.
+    if(NOT OE_BUILD_PLATFORM STREQUAL "windows")
+        set(CPPTRACE_UNWIND_WITH_UNWIND ON)
     endif()
+    set(ENABLE_DECOMPRESSION OFF) # We don't emit compressed debug sections, and libdwarf can't export its zlib dep.
+    set(CPPTRACE_USE_EXTERNAL_ZSTD ON) # Only used for decompression, so this just stops cpptrace downloading it.
+    set(CPPTRACE_DISABLE_CXX_20_MODULES ON) # Nothing imports cpptrace, and module scanning needs a ninja generator.
+    add_subdirectory(cpptrace EXCLUDE_FROM_ALL)
 endif()
 
 # generator


### PR DESCRIPTION
TLDR backward-cpp is not maintained and we had problems with it b/c it depends on libdwarf that's 5 or so years old, and fails to link with a newer libdwarf. This prevents us from moving to Ubuntu 26.04 builders.