### PR TITLE
Link libstdc++ and libgcc statically on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,15 @@ if(OE_DISTRIBUTION_BUILD)
     add_compile_definitions(OE_DISTRIBUTION_BUILD)
 endif()
 
+# We build with a newer gcc than most distros ship, so a binary that links libstdc++ dynamically fails to start
+# on the machines it was built for with a "version GLIBCXX_x.y.z not found". Link the C++ runtime in instead.
+# This is deliberately not restricted to distribution builds - a dev build that behaves differently from the
+# shipped one is how this class of bug goes unnoticed. The link options are global rather than per target so
+# that the test binaries link the same way the game does.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_link_options(-static-libstdc++ -static-libgcc)
+endif()
+
 if(OE_USE_PREBUILT_DEPENDENCIES AND OE_USE_DUMMY_DEPENDENCIES)
     message(FATAL_ERROR "Only one of OE_USE_PREBUILT_DEPENDENCIES and OE_USE_DUMMY_DEPENDENCIES must be set.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,15 +42,6 @@ if(OE_DISTRIBUTION_BUILD)
     add_compile_definitions(OE_DISTRIBUTION_BUILD)
 endif()
 
-# We build with a newer gcc than most distros ship, so a binary that links libstdc++ dynamically fails to start
-# on the machines it was built for with a "version GLIBCXX_x.y.z not found". Link the C++ runtime in instead.
-# This is deliberately not restricted to distribution builds - a dev build that behaves differently from the
-# shipped one is how this class of bug goes unnoticed. The link options are global rather than per target so
-# that the test binaries link the same way the game does.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_link_options(-static-libstdc++ -static-libgcc)
-endif()
-
 if(OE_USE_PREBUILT_DEPENDENCIES AND OE_USE_DUMMY_DEPENDENCIES)
     message(FATAL_ERROR "Only one of OE_USE_PREBUILT_DEPENDENCIES and OE_USE_DUMMY_DEPENDENCIES must be set.")
 endif()
@@ -153,6 +144,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Cla
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>) # Enable assertions in libstdc++.
+    add_link_options(-static-libstdc++ -static-libgcc) # We build with a newer gcc than our target distros ship.
 elseif((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     add_compile_definitions($<$<CONFIG:Debug>:_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG>) # Enable assertions in libcxx.
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))


### PR DESCRIPTION
We build with a newer gcc than most distros ship, so a dynamically linked binary can fail to start on the very machines it targets with a "version GLIBCXX_x.y.z not found". Linking the C++ runtime in removes that failure mode.

The options are global rather than per target so the test binaries link the way the game does, which means CI tests what ships.