### PR TITLE
Add namespace os for one-shot native file system operations

### DIFF
--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -1,7 +1,6 @@
 #include "GameStarter.h"
 
 #include <utility>
-#include <filesystem>
 #include <string>
 #include <vector>
 #include <memory>
@@ -51,6 +50,7 @@
 #include "Scripting/ScriptingSystem.h"
 
 #include "Utility/Exception.h"
+#include "Utility/System/Os.h"
 
 #include "PathResolver.h"
 
@@ -233,7 +233,7 @@ void GameStarter::resolveDataPath(Environment *environment, GameStarterOptions *
 
     for (int i = 0; i < candidates.size(); i++) {
         std::string missingFile;
-        if (!std::filesystem::exists(candidates[i].toStdPath())) {
+        if (!os::exists(candidates[i])) {
             MM_INFO("Data path #{} ('{}') doesn't exist.", i + 1, candidates[i]);
         } else if (!validateMm7Path(candidates[i], &missingFile)) {
             MM_INFO("Data path #{} ('{}') is missing file '{}'.", i + 1, candidates[i], missingFile);

--- a/src/Application/Startup/PathResolver.cpp
+++ b/src/Application/Startup/PathResolver.cpp
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <filesystem>
 
 #include "Library/Logger/Logger.h"
 #include "Library/Environment/Interface/Environment.h"

--- a/src/Application/Startup/PathResolver.cpp
+++ b/src/Application/Startup/PathResolver.cpp
@@ -75,7 +75,7 @@ static std::vector<NativePath> resolvePaths(Environment *environment, const Path
     std::vector<NativePath> result;
 
     // Otherwise we check PWD first.
-    result.push_back(NativePath::fromStdPath(std::filesystem::current_path()));
+    result.push_back(os::cwd());
 
     // Then we check paths from registry on Windows,...
     for (const char *registryKey : config.registryKeys) {

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -80,7 +80,7 @@ OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {
 
     app->parse(argc, argv, result.helpPrinted);
 
-    if (!portable && std::filesystem::exists(".portable"))
+    if (!portable && os::exists(NativePath::fromWtf8(".portable")))
         portable = true;
     if (portable && *portable) {
         if (result.userPath.isEmpty())

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -80,7 +80,7 @@ OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {
 
     app->parse(argc, argv, result.helpPrinted);
 
-    if (!portable && os::exists(NativePath::fromWtf8(".portable")))
+    if (!portable && os::exists(".portable"))
         portable = true;
     if (portable && *portable) {
         if (result.userPath.isEmpty())

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -12,6 +12,7 @@
 #include "Library/Serialization/EnumSerialization.h"
 
 #include "Utility/Exception.h"
+#include "Utility/System/Os.h"
 #include "Utility/String/Format.h"
 
 MM_DEFINE_ENUM_SERIALIZATION_FUNCTIONS(OpenEnrothOptions::Migration, CASE_INSENSITIVE, {
@@ -83,9 +84,9 @@ OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {
         portable = true;
     if (portable && *portable) {
         if (result.userPath.isEmpty())
-            result.userPath = NativePath::fromStdPath(std::filesystem::current_path());
+            result.userPath = os::cwd();
         if (result.dataPath.isEmpty())
-            result.dataPath = NativePath::fromStdPath(std::filesystem::current_path());
+            result.dataPath = os::cwd();
     }
 
     if (result.subcommand == SUBCOMMAND_RETRACE) {

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -13,7 +13,7 @@
 #include "Utility/System/Os.h"
 
 DirectoryFileSystem::DirectoryFileSystem(const NativePath &root) {
-    _root = root.absolute();
+    _root = os::absolute(root);
 }
 
 DirectoryFileSystem::~DirectoryFileSystem() = default;

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -10,6 +10,7 @@
 
 #include "Utility/Streams/FileInputStream.h"
 #include "Utility/Streams/FileOutputStream.h"
+#include "Utility/System/Os.h"
 
 DirectoryFileSystem::DirectoryFileSystem(const NativePath &root) {
     _root = root.absolute();
@@ -19,71 +20,30 @@ DirectoryFileSystem::~DirectoryFileSystem() = default;
 
 bool DirectoryFileSystem::_exists(FileSystemPathView path) const {
     assert(!path.isEmpty());
-
-    std::error_code ec;
-    return std::filesystem::exists(makeBasePath(path).toStdPath(), ec); // Returns false on error.
+    return os::exists(makeBasePath(path));
 }
 
 FileStat DirectoryFileSystem::_stat(FileSystemPathView path) const {
     assert(!path.isEmpty());
-
-    std::filesystem::path basePath = makeBasePath(path).toStdPath();
-
-    std::error_code ec;
-    std::filesystem::directory_entry entry(basePath, ec);
-    bool isRegular = entry.is_regular_file(ec);
-    bool isDirectory = !isRegular && entry.is_directory(ec);
-    if (!isRegular && !isDirectory)
-        return {}; // Return an empty stat on error or if it's not a file / directory.
-
-    std::int64_t size = 0;
-    if (isRegular) {
-        size = std::filesystem::file_size(basePath, ec);
-        if (ec)
-            return {};
-    }
-
-    FileStat result;
-    result.type = isRegular ? FILE_REGULAR : FILE_DIRECTORY;
-    result.size = size;
-    return result;}
+    return os::stat(makeBasePath(path));
+}
 
 void DirectoryFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntry> *entries) const {
-    std::filesystem::path basePath = makeBasePath(path).toStdPath();
+    NativePath basePath = makeBasePath(path);
 
     // Handle the known errors first.
-    std::error_code ec;
-    std::filesystem::directory_entry parent(basePath, ec);
-    bool isParentRegular = parent.is_regular_file(ec);
-    bool isParentDirectory = !isParentRegular && parent.is_directory(ec);
-    if (path.isEmpty() && !isParentDirectory)
+    FileType type = os::stat(basePath).type;
+    if (path.isEmpty() && type != FILE_DIRECTORY)
         return; // ls("") should always work.
-    if (isParentRegular)
+    if (type == FILE_REGULAR)
         FileSystemException::raise(this, FS_LS_FAILED_PATH_IS_FILE, path);
-    if (!isParentDirectory)
+    if (type != FILE_DIRECTORY)
         FileSystemException::raise(this, FS_LS_FAILED_PATH_DOESNT_EXIST, path);
 
-    // Then we do the regular ls and just ignore all errors. The errors we'll get here are most likely
-    // permissions-related, and we're ignoring them in stat() and exists().
-    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(basePath, ec)) {
-        // Unfortunately, std::filesystem is retarded. We can get a directory_entry here for a dir that we don't have
-        // permissions for, and which won't be stat-able. Seriously, entry.is_directory() returns true while
-        // std::filesystem::exists(entry.path()) just throws. So we need to check for that.
-        if (!std::filesystem::exists(entry.path(), ec))
-            continue;
-
-        bool isRegular = entry.is_regular_file(ec);
-        bool isDirectory = !isRegular && entry.is_directory(ec);
-        if (!isRegular && !isDirectory)
-            continue;
-
-        std::string name = entry.path().filename().string();
-        if (name.find('\\') != std::string::npos)
-            continue; // Files with '\\' in filename are not observable through this interface. Don't be a retard.
-
-        DirectoryEntry &resultEntry = entries->emplace_back();
-        resultEntry.name = std::move(name);
-        resultEntry.type = isRegular ? FILE_REGULAR : FILE_DIRECTORY;
+    for (DirectoryEntry &entry : os::ls(basePath)) {
+        if (entry.name.find('\\') != std::string::npos)
+            continue; // Files with '\\' in filename are not observable through this interface.
+        entries->push_back(std::move(entry));
     }
 }
 
@@ -95,7 +55,7 @@ Blob DirectoryFileSystem::_read(FileSystemPathView path) const {
 void DirectoryFileSystem::_write(FileSystemPathView path, const Blob &data) {
     assert(!path.isEmpty());
     NativePath basePath = makeBasePath(path);
-    std::filesystem::create_directories(basePath.toStdPath().parent_path());
+    os::mkdirs(NativePath::fromStdPath(basePath.toStdPath().parent_path()));
     FileOutputStream stream(basePath);
     stream.write(data.data(), data.size());
     stream.close();
@@ -109,13 +69,13 @@ std::unique_ptr<InputStream> DirectoryFileSystem::_openForReading(FileSystemPath
 std::unique_ptr<OutputStream> DirectoryFileSystem::_openForWriting(FileSystemPathView path) {
     assert(!path.isEmpty());
     NativePath basePath = makeBasePath(path);
-    std::filesystem::create_directories(basePath.toStdPath().parent_path());
+    os::mkdirs(NativePath::fromStdPath(basePath.toStdPath().parent_path()));
     return std::make_unique<FileOutputStream>(basePath);
 }
 
 bool DirectoryFileSystem::_remove(FileSystemPathView path) {
     assert(!path.isEmpty());
-    return std::filesystem::remove_all(makeBasePath(path).toStdPath()) > 0;
+    return os::remove(makeBasePath(path));
 }
 
 std::string DirectoryFileSystem::_displayPath(FileSystemPathView path) const {

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.cpp
@@ -1,6 +1,8 @@
 #include "DirectoryFileSystem.h"
 
 #include <cassert>
+#include <algorithm>
+#include <cstddef>
 #include <vector>
 #include <memory>
 #include <string>
@@ -40,11 +42,12 @@ void DirectoryFileSystem::_ls(FileSystemPathView path, std::vector<DirectoryEntr
     if (type != FILE_DIRECTORY)
         FileSystemException::raise(this, FS_LS_FAILED_PATH_DOESNT_EXIST, path);
 
-    for (DirectoryEntry &entry : os::ls(basePath)) {
-        if (entry.name.find('\\') != std::string::npos)
-            continue; // Files with '\\' in filename are not observable through this interface.
-        entries->push_back(std::move(entry));
-    }
+    auto oldSize = static_cast<std::ptrdiff_t>(entries->size());
+    os::ls(basePath, entries);
+
+    // Files with '\\' in filename are not observable through this interface.
+    auto isUnobservable = [] (const DirectoryEntry &entry) { return entry.name.contains('\\'); };
+    entries->erase(std::remove_if(entries->begin() + oldSize, entries->end(), isUnobservable), entries->end());
 }
 
 Blob DirectoryFileSystem::_read(FileSystemPathView path) const {
@@ -55,7 +58,7 @@ Blob DirectoryFileSystem::_read(FileSystemPathView path) const {
 void DirectoryFileSystem::_write(FileSystemPathView path, const Blob &data) {
     assert(!path.isEmpty());
     NativePath basePath = makeBasePath(path);
-    os::mkdirs(NativePath::fromStdPath(basePath.toStdPath().parent_path()));
+    os::mkdirs(basePath.parent());
     FileOutputStream stream(basePath);
     stream.write(data.data(), data.size());
     stream.close();
@@ -69,7 +72,7 @@ std::unique_ptr<InputStream> DirectoryFileSystem::_openForReading(FileSystemPath
 std::unique_ptr<OutputStream> DirectoryFileSystem::_openForWriting(FileSystemPathView path) {
     assert(!path.isEmpty());
     NativePath basePath = makeBasePath(path);
-    os::mkdirs(NativePath::fromStdPath(basePath.toStdPath().parent_path()));
+    os::mkdirs(basePath.parent());
     return std::make_unique<FileOutputStream>(basePath);
 }
 

--- a/src/Library/FileSystem/Directory/DirectoryFileSystem.h
+++ b/src/Library/FileSystem/Directory/DirectoryFileSystem.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <vector>
 #include <memory>
 #include <string>

--- a/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
@@ -8,25 +8,25 @@
 
 #include "Library/FileSystem/Directory/DirectoryFileSystem.h"
 
+#include "Utility/System/Os.h"
+
 #include "Utility/Streams/FileOutputStream.h"
 
 class TemporaryDir {
  public:
-    explicit TemporaryDir(std::string_view name): _name(name) {
-        if (std::filesystem::exists(_name))
-            std::filesystem::remove_all(_name);
-
-        std::filesystem::create_directory(name);
-        EXPECT_TRUE(std::filesystem::exists(name));
+    explicit TemporaryDir(std::string_view name): _path(NativePath::fromWtf8(name)) {
+        os::remove(_path); // Drop whatever an earlier run might have left behind.
+        os::mkdirs(_path);
+        EXPECT_TRUE(os::exists(_path));
     }
 
     ~TemporaryDir() {
-        std::filesystem::remove_all(_name);
-        EXPECT_FALSE(std::filesystem::exists(_name));
+        os::remove(_path);
+        EXPECT_FALSE(os::exists(_path));
     }
 
  private:
-    std::string _name;
+    NativePath _path;
 };
 
 UNIT_TEST(DirectoryFileSystem, LsRoot) {

--- a/src/Library/FileSystem/Interface/FileSystem.h
+++ b/src/Library/FileSystem/Interface/FileSystem.h
@@ -11,35 +11,11 @@
 #include "Utility/Memory/Blob.h"
 #include "Utility/Streams/InputStream.h"
 #include "Utility/Streams/OutputStream.h"
+#include "Utility/System/Os.h"
 
 #include "FileSystemPath.h"
 #include "FileSystemEnums.h"
 #include "FileSystemFwd.h"
-
-struct FileStat {
-    FileStat() = default;
-    FileStat(FileType type, std::int64_t size) : type(type), size(size) {}
-
-    FileType type = FILE_INVALID; // Invalid means file doesn't exist.
-    std::int64_t size = 0; // Always zero for directories.
-
-    explicit operator bool() const {
-        return type != FILE_INVALID;
-    }
-
-    friend bool operator==(const FileStat &l, const FileStat &r) = default;
-};
-
-struct DirectoryEntry {
-    DirectoryEntry() = default;
-    DirectoryEntry(std::string name, FileType type) : name(std::move(name)), type(type) {}
-
-    std::string name;
-    FileType type = FILE_INVALID; // When returned from FileSystem::ls, this one is never invalid.
-
-    // Make entries sortable. If two entries have the same name, then files go before directories.
-    friend std::strong_ordering operator<=>(const DirectoryEntry &l, const DirectoryEntry &r) = default;
-};
 
 // TODO(captainurist): I still think most of FSs should inherit from ProxyFS.
 //

--- a/src/Library/FileSystem/Interface/FileSystemEnums.h
+++ b/src/Library/FileSystem/Interface/FileSystemEnums.h
@@ -1,12 +1,5 @@
 #pragma once
 
-enum class FileType {
-    FILE_INVALID, // Returned by `AbstractFileSystem::stat` if file doesn't exist.
-    FILE_REGULAR,
-    FILE_DIRECTORY,
-};
-using enum FileType;
-
 /**
  * Naming is is `FS_<OP>_FAILED_<REASON>`.
  *

--- a/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
@@ -29,7 +29,7 @@ UNIT_TEST(LowercaseFileSystem, ExistsStatUppercase) {
 }
 
 UNIT_TEST(LowercaseFileSystem, KeepEmptyFolders) {
-    MM_AT_SCOPE_EXIT(os::remove(NativePath::fromWtf8("tmp_dir")));
+    MM_AT_SCOPE_EXIT(os::remove("tmp_dir"));
 
     DirectoryFileSystem fs0(NativePath("tmp_dir"));
     fs0.write("a/b/c.bin", Blob());

--- a/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
@@ -8,6 +8,7 @@
 #include "Library/FileSystem/Directory/DirectoryFileSystem.h"
 
 #include "Utility/ScopeGuard.h"
+#include "Utility/System/Os.h"
 
 UNIT_TEST(LowercaseFileSystem, Empty) {
     MemoryFileSystem fs0("");
@@ -28,7 +29,7 @@ UNIT_TEST(LowercaseFileSystem, ExistsStatUppercase) {
 }
 
 UNIT_TEST(LowercaseFileSystem, KeepEmptyFolders) {
-    MM_AT_SCOPE_EXIT(std::filesystem::remove_all("tmp_dir"));
+    MM_AT_SCOPE_EXIT(os::remove(NativePath::fromWtf8("tmp_dir")));
 
     DirectoryFileSystem fs0(NativePath("tmp_dir"));
     fs0.write("a/b/c.bin", Blob());

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -14,6 +14,7 @@ set(UTILITY_SOURCES
         String/Encoding.cpp
         String/Transformations.cpp
         System/NativePath.cpp
+        System/Os.cpp
         UnicodeCrt.cpp
         String/Wrap.cpp)
 
@@ -44,6 +45,7 @@ set(UTILITY_HEADERS
         Streams/OutputStream.h
         Streams/StreamBuffer.h
         System/NativePath.h
+        System/Os.h
         String/Ascii.h
         String/AsciiLiteral.h
         String/Encoding.h
@@ -93,6 +95,7 @@ if(OE_BUILD_TESTS)
             String/Tests/Ascii_ut.cpp
             String/Tests/Encoding_ut.cpp
             System/Tests/NativePath_ut.cpp
+            System/Tests/Os_ut.cpp
             String/Tests/Split_ut.cpp
             String/Tests/Join_ut.cpp
             String/Tests/Wrap_ut.cpp)

--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -11,6 +11,7 @@
 
 #include "Utility/Streams/FileInputStream.h"
 #include "Utility/Exception.h"
+#include "Utility/System/Os.h"
 
 #include "FreeDeleter.h"
 
@@ -37,7 +38,7 @@ Blob Blob::fromMalloc(const void *data, size_t size) {
 }
 
 Blob Blob::fromFile(const NativePath &path) {
-    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
+    std::string displayString = os::absolute(path).displayString(); // Absolute, so that it's still meaningful in logs.
 
     // On Mac mapping an empty file throws, so we need to provide a workaround.
     std::error_code error;

--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <memory>
 #include <utility>
-#include <filesystem>
 
 #include <mio/mmap.hpp>
 
@@ -41,9 +40,7 @@ Blob Blob::fromFile(const NativePath &path) {
     std::string displayString = os::absolute(path).displayString(); // Absolute, so that it's still meaningful in logs.
 
     // On Mac mapping an empty file throws, so we need to provide a workaround.
-    std::error_code error;
-    uintmax_t size = std::filesystem::file_size(path.toStdPath(), error);
-    if (!error && size == 0)
+    if (os::stat(path) == FileStat(FILE_REGULAR, 0))
         return Blob().withDisplayPath(displayString);
 
     // native() is a wchar_t string on Windows, so a WTF-16 name is passed as-is. Throws std::system_error if the

--- a/src/Utility/Memory/Tests/Blob_ut.cpp
+++ b/src/Utility/Memory/Tests/Blob_ut.cpp
@@ -6,6 +6,7 @@
 #include "Utility/Memory/Blob.h"
 #include "Utility/Streams/FileInputStream.h"
 #include "Utility/Streams/FileOutputStream.h"
+#include "Utility/System/Os.h"
 
 UNIT_TEST(Blob, FromFile) {
     NativePath fileName = NativePath("abcdefghijklmnopqrstuvwxyz.tmp");
@@ -88,6 +89,6 @@ UNIT_TEST(Blob, DisplayPathFromStream) {
 UNIT_TEST(Blob, ExceptionMessages) {
     NativePath fileName = NativePath("lknjdfgsbiuherqbhvdfnjkkvsdhjkweqguy.txt");
 
-    EXPECT_FALSE(std::filesystem::exists(fileName.toStdPath()));
+    EXPECT_FALSE(os::exists(fileName));
     EXPECT_THROW_MESSAGE((void) Blob::fromFile(fileName), fileName.toWtf8());
 }

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 
 #include "Utility/Exception.h"
+#include "Utility/System/Os.h"
 
 #ifdef _WINDOWS
 #   define ftello _ftelli64
@@ -25,7 +26,7 @@ FileInputStream::~FileInputStream() {
 void FileInputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
+    std::string displayString = os::absolute(path).displayString(); // Absolute, so that it's still meaningful in logs.
 
     // Wide fopen on Windows - the narrow one converts the path per the C locale.
 #ifdef _WINDOWS

--- a/src/Utility/Streams/FileInputStream.cpp
+++ b/src/Utility/Streams/FileInputStream.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <filesystem>
 
 #include "Utility/Exception.h"
 #include "Utility/System/Os.h"

--- a/src/Utility/Streams/FileOutputStream.cpp
+++ b/src/Utility/Streams/FileOutputStream.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include "Utility/Exception.h"
+#include "Utility/System/Os.h"
 
 FileOutputStream::FileOutputStream(const NativePath &path, size_t bufferSize) {
     open(path, bufferSize);
@@ -19,7 +20,7 @@ FileOutputStream::~FileOutputStream() {
 void FileOutputStream::open(const NativePath &path, size_t bufferSize) {
     assert(bufferSize > 0);
 
-    std::string displayString = path.absolute().displayString(); // Absolute, so that it's still meaningful in logs.
+    std::string displayString = os::absolute(path).displayString(); // Absolute, so that it's still meaningful in logs.
 
     // Wide fopen on Windows - the narrow one converts the path per the C locale.
 #ifdef _WINDOWS

--- a/src/Utility/Streams/FileOutputStream.cpp
+++ b/src/Utility/Streams/FileOutputStream.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <memory>
 #include <string>
-#include <filesystem>
 
 #include "Utility/Exception.h"
 #include "Utility/System/Os.h"

--- a/src/Utility/Streams/Tests/FileInputStream_ut.cpp
+++ b/src/Utility/Streams/Tests/FileInputStream_ut.cpp
@@ -32,10 +32,10 @@ UNIT_TEST(FileInputStream, Skip) {
 }
 
 UNIT_TEST(FileInputStream, ExceptionMessages) {
-    const char *fileName = "afjhrbluxnkskghelxrigjmgdhckeog.txt";
+    NativePath fileName("afjhrbluxnkskghelxrigjmgdhckeog.txt");
 
-    EXPECT_FALSE(os::exists(NativePath::fromWtf8(fileName)));
-    EXPECT_THROW_MESSAGE(FileInputStream in(NativePath::fromWtf8(fileName)), fileName);
+    EXPECT_FALSE(os::exists(fileName));
+    EXPECT_THROW_MESSAGE(FileInputStream in(fileName), fileName.toWtf8());
 }
 
 UNIT_TEST(FileInputStream, ReadUntil) {

--- a/src/Utility/Streams/Tests/FileInputStream_ut.cpp
+++ b/src/Utility/Streams/Tests/FileInputStream_ut.cpp
@@ -1,11 +1,11 @@
 #include <cstdlib>
 #include <string>
-#include <filesystem>
 
 #include "Testing/Unit/UnitTest.h"
 
 #include "Utility/Streams/FileOutputStream.h"
 #include "Utility/Streams/FileInputStream.h"
+#include "Utility/System/Os.h"
 
 UNIT_TEST(FileInputStream, Skip) {
     NativePath tmpfile = NativePath("tmp_test.txt");
@@ -34,7 +34,7 @@ UNIT_TEST(FileInputStream, Skip) {
 UNIT_TEST(FileInputStream, ExceptionMessages) {
     const char *fileName = "afjhrbluxnkskghelxrigjmgdhckeog.txt";
 
-    EXPECT_FALSE(std::filesystem::exists(fileName));
+    EXPECT_FALSE(os::exists(NativePath::fromWtf8(fileName)));
     EXPECT_THROW_MESSAGE(FileInputStream in(NativePath::fromWtf8(fileName)), fileName);
 }
 

--- a/src/Utility/System/NativePath.h
+++ b/src/Utility/System/NativePath.h
@@ -70,14 +70,6 @@ class NativePath {
     [[nodiscard]] std::string displayString() const;
 
     /**
-     * @return                          Absolute copy of this path, resolved against the current directory. An empty
-     *                                  path resolves to the current directory itself.
-     */
-    [[nodiscard]] NativePath absolute() const {
-        return fromStdPath(_path.empty() ? std::filesystem::current_path() : std::filesystem::absolute(_path));
-    }
-
-    /**
      * @param extension                 New extension, with or without the leading dot. Pass an empty string to drop
      *                                  the extension. WTF-8 on Windows, byte string on POSIX.
      * @return                          Copy of this path with the extension replaced.

--- a/src/Utility/System/NativePath.h
+++ b/src/Utility/System/NativePath.h
@@ -80,6 +80,14 @@ class NativePath {
         return fromStdPath(std::move(result));
     }
 
+    /**
+     * @return                          Parent path, or an empty path if this path has no parent. Same semantics as
+     *                                  `std::filesystem::path::parent_path`.
+     */
+    [[nodiscard]] NativePath parent() const {
+        return fromStdPath(_path.parent_path());
+    }
+
     [[nodiscard]] bool isEmpty() const {
         return _path.empty();
     }

--- a/src/Utility/System/Os.cpp
+++ b/src/Utility/System/Os.cpp
@@ -4,7 +4,10 @@
 #include <filesystem>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
+
+#include "Utility/Exception.h"
 
 bool os::exists(const NativePath &path) {
     std::error_code ec;
@@ -63,4 +66,18 @@ bool os::remove(const NativePath &path) {
 
 void os::mkdirs(const NativePath &path) {
     std::filesystem::create_directories(path.toStdPath());
+}
+
+NativePath os::cwd() {
+    return NativePath::fromStdPath(std::filesystem::current_path());
+}
+
+NativePath os::absolute(const NativePath &path) {
+    // An explicit isEmpty() check b/c libstdc++ std::filesystem::absolute chokes on an empty path.
+    std::error_code ec;
+    std::filesystem::path result =
+        path.isEmpty() ? std::filesystem::current_path(ec) : std::filesystem::absolute(path.toStdPath(), ec);
+    if (ec)
+        throw Exception("Couldn't resolve native path '{}': {}", path, ec.message());
+    return NativePath::fromStdPath(std::move(result));
 }

--- a/src/Utility/System/Os.cpp
+++ b/src/Utility/System/Os.cpp
@@ -52,7 +52,7 @@ std::vector<DirectoryEntry> os::ls(const NativePath &path) {
         if (!isRegular && !isDirectory)
             continue;
 
-        // The roundtrip through NativePath is a WTF8 conversion.
+        // The roundtrip through NativePath is a WTF-8 conversion on Windows.
         result.emplace_back(NativePath::fromStdPath(entry.path().filename()).toWtf8(),
                             isRegular ? FILE_REGULAR : FILE_DIRECTORY);
     }

--- a/src/Utility/System/Os.cpp
+++ b/src/Utility/System/Os.cpp
@@ -36,7 +36,11 @@ FileStat os::stat(const NativePath &path) {
 
 std::vector<DirectoryEntry> os::ls(const NativePath &path) {
     std::vector<DirectoryEntry> result;
+    ls(path, &result);
+    return result;
+}
 
+void os::ls(const NativePath &path, std::vector<DirectoryEntry> *entries) {
     // We just ignore all errors here. The errors we'll get are most likely permissions-related, and we're ignoring
     // them in `stat` and `exists` too.
     std::error_code ec;
@@ -53,11 +57,9 @@ std::vector<DirectoryEntry> os::ls(const NativePath &path) {
             continue;
 
         // The roundtrip through NativePath is a WTF-8 conversion on Windows.
-        result.emplace_back(NativePath::fromStdPath(entry.path().filename()).toWtf8(),
-                            isRegular ? FILE_REGULAR : FILE_DIRECTORY);
+        entries->emplace_back(NativePath::fromStdPath(entry.path().filename()).toWtf8(),
+                              isRegular ? FILE_REGULAR : FILE_DIRECTORY);
     }
-
-    return result;
 }
 
 bool os::remove(const NativePath &path) {

--- a/src/Utility/System/Os.cpp
+++ b/src/Utility/System/Os.cpp
@@ -1,0 +1,66 @@
+#include "Os.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+bool os::exists(const NativePath &path) {
+    std::error_code ec;
+    return std::filesystem::exists(path.toStdPath(), ec); // Returns false on error.
+}
+
+FileStat os::stat(const NativePath &path) {
+    const std::filesystem::path &stdPath = path.toStdPath();
+
+    std::error_code ec;
+    std::filesystem::directory_entry entry(stdPath, ec);
+    bool isRegular = entry.is_regular_file(ec);
+    bool isDirectory = !isRegular && entry.is_directory(ec);
+    if (!isRegular && !isDirectory)
+        return {}; // Return an empty stat on error or if it's not a file / directory.
+
+    std::int64_t size = 0;
+    if (isRegular) {
+        size = std::filesystem::file_size(stdPath, ec);
+        if (ec)
+            return {};
+    }
+
+    return FileStat(isRegular ? FILE_REGULAR : FILE_DIRECTORY, size);
+}
+
+std::vector<DirectoryEntry> os::ls(const NativePath &path) {
+    std::vector<DirectoryEntry> result;
+
+    // We just ignore all errors here. The errors we'll get are most likely permissions-related, and we're ignoring
+    // them in `stat` and `exists` too.
+    std::error_code ec;
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(path.toStdPath(), ec)) {
+        // Unfortunately, std::filesystem is broken here. We can get a directory_entry for a dir that we don't have
+        // permissions for, and which won't be stat-able. Seriously, entry.is_directory() returns true while
+        // std::filesystem::exists(entry.path()) just throws. So we need to check for that.
+        if (!std::filesystem::exists(entry.path(), ec))
+            continue;
+
+        bool isRegular = entry.is_regular_file(ec);
+        bool isDirectory = !isRegular && entry.is_directory(ec);
+        if (!isRegular && !isDirectory)
+            continue;
+
+        // The roundtrip through NativePath is a WTF8 conversion.
+        result.emplace_back(NativePath::fromStdPath(entry.path().filename()).toWtf8(),
+                            isRegular ? FILE_REGULAR : FILE_DIRECTORY);
+    }
+
+    return result;
+}
+
+bool os::remove(const NativePath &path) {
+    return std::filesystem::remove_all(path.toStdPath()) > 0;
+}
+
+void os::mkdirs(const NativePath &path) {
+    std::filesystem::create_directories(path.toStdPath());
+}

--- a/src/Utility/System/Os.h
+++ b/src/Utility/System/Os.h
@@ -80,4 +80,17 @@ bool remove(const NativePath &path);
  */
 void mkdirs(const NativePath &path);
 
+/**
+ * @return                              Current working directory.
+ */
+[[nodiscard]] NativePath cwd();
+
+/**
+ * @param path                          Path to resolve.
+ * @return                              Absolute copy of `path`, resolved against the current directory. An empty path
+ *                                      resolves to the current directory itself.
+ * @throws Exception                    If the path couldn't be resolved.
+ */
+[[nodiscard]] NativePath absolute(const NativePath &path);
+
 } // namespace os

--- a/src/Utility/System/Os.h
+++ b/src/Utility/System/Os.h
@@ -59,7 +59,8 @@ namespace os {
  * entries that can't be stat'ed, so the result is always in sync with what `stat` returns.
  *
  * @param path                          Path to a directory to list.
- * @return                              Directory entries, with WTF8-encoded names, in unspecified order.
+ * @return                              Directory entries, in unspecified order. Names are WTF-8 on Windows, byte
+ *                                      strings on POSIX.
  */
 [[nodiscard]] std::vector<DirectoryEntry> ls(const NativePath &path);
 

--- a/src/Utility/System/Os.h
+++ b/src/Utility/System/Os.h
@@ -60,15 +60,18 @@ namespace os {
 [[nodiscard]] inline FileStat stat(AsciiLiteral path) { return stat(NativePath(path)); }
 
 /**
- * Lists a directory. Never throws - returns an empty vector if `path` doesn't exist or isn't a directory, and skips
- * entries that can't be stat'ed, so the result is always in sync with what `stat` returns.
+ * Lists a directory. Never throws - lists nothing if `path` doesn't exist or isn't a directory, and skips entries
+ * that can't be stat'ed, so the result is always in sync with what `stat` returns.
  *
  * @param path                          Path to a directory to list.
+ * @param[out] entries                  Vector to append the entries to.
  * @return                              Directory entries, in unspecified order. Names are WTF-8 on Windows, byte
  *                                      strings on POSIX.
  */
 [[nodiscard]] std::vector<DirectoryEntry> ls(const NativePath &path);
 [[nodiscard]] inline std::vector<DirectoryEntry> ls(AsciiLiteral path) { return ls(NativePath(path)); }
+void ls(const NativePath &path, std::vector<DirectoryEntry> *entries);
+inline void ls(AsciiLiteral path, std::vector<DirectoryEntry> *entries) { ls(NativePath(path), entries); }
 
 /**
  * Removes the file or directory at `path`. A directory is removed with everything that's in it.

--- a/src/Utility/System/Os.h
+++ b/src/Utility/System/Os.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Utility/System/NativePath.h"
+
+enum class FileType {
+    FILE_INVALID, // Returned by `stat` calls if file doesn't exist.
+    FILE_REGULAR,
+    FILE_DIRECTORY,
+};
+using enum FileType;
+
+struct FileStat {
+    FileStat() = default;
+    FileStat(FileType type, std::int64_t size) : type(type), size(size) {}
+
+    FileType type = FILE_INVALID; // Invalid means file doesn't exist.
+    std::int64_t size = 0; // Always zero for directories.
+
+    explicit operator bool() const {
+        return type != FILE_INVALID;
+    }
+
+    friend bool operator==(const FileStat &l, const FileStat &r) = default;
+};
+
+struct DirectoryEntry {
+    DirectoryEntry() = default;
+    DirectoryEntry(std::string name, FileType type) : name(std::move(name)), type(type) {}
+
+    std::string name;
+    FileType type = FILE_INVALID; // Never invalid when returned from `ls` calls.
+
+    // Make entries sortable. If two entries have the same name, then files go before directories.
+    friend std::strong_ordering operator<=>(const DirectoryEntry &l, const DirectoryEntry &r) = default;
+};
+
+namespace os {
+
+/**
+ * @param path                          Path to check. Never throws, returns `false` on errors.
+ * @return                              Whether `path` exists.
+ */
+[[nodiscard]] bool exists(const NativePath &path);
+
+/**
+ * @param path                          Path to stat. Never throws.
+ * @return                              Stats for `path`, or an empty `FileStat` on errors, or if `path` is neither
+ *                                      a file nor a directory.
+ */
+[[nodiscard]] FileStat stat(const NativePath &path);
+
+/**
+ * Lists a directory. Never throws - returns an empty vector if `path` doesn't exist or isn't a directory, and skips
+ * entries that can't be stat'ed, so the result is always in sync with what `stat` returns.
+ *
+ * @param path                          Path to a directory to list.
+ * @return                              Directory entries, with WTF8-encoded names, in unspecified order.
+ */
+[[nodiscard]] std::vector<DirectoryEntry> ls(const NativePath &path);
+
+/**
+ * Removes the file or directory at `path`. A directory is removed with everything that's in it.
+ *
+ * @param path                          Path to remove.
+ * @return                              Whether anything was removed.
+ * @throws std::runtime_error           On errors, e.g. missing permissions.
+ */
+bool remove(const NativePath &path);
+
+/**
+ * Creates the directory at `path`, along with all missing parents. Does nothing if it already exists.
+ *
+ * @param path                          Path to the directory to create.
+ * @throws std::runtime_error           On errors.
+ */
+void mkdirs(const NativePath &path);
+
+} // namespace os

--- a/src/Utility/System/Os.h
+++ b/src/Utility/System/Os.h
@@ -41,11 +41,15 @@ struct DirectoryEntry {
 
 namespace os {
 
+// Path-taking functions below also have an `AsciiLiteral` overload - C++ allows a single user-defined conversion,
+// so a string literal passed as an argument wouldn't otherwise reach `NativePath`'s literal constructor.
+
 /**
  * @param path                          Path to check. Never throws, returns `false` on errors.
  * @return                              Whether `path` exists.
  */
 [[nodiscard]] bool exists(const NativePath &path);
+[[nodiscard]] inline bool exists(AsciiLiteral path) { return exists(NativePath(path)); }
 
 /**
  * @param path                          Path to stat. Never throws.
@@ -53,6 +57,7 @@ namespace os {
  *                                      a file nor a directory.
  */
 [[nodiscard]] FileStat stat(const NativePath &path);
+[[nodiscard]] inline FileStat stat(AsciiLiteral path) { return stat(NativePath(path)); }
 
 /**
  * Lists a directory. Never throws - returns an empty vector if `path` doesn't exist or isn't a directory, and skips
@@ -63,6 +68,7 @@ namespace os {
  *                                      strings on POSIX.
  */
 [[nodiscard]] std::vector<DirectoryEntry> ls(const NativePath &path);
+[[nodiscard]] inline std::vector<DirectoryEntry> ls(AsciiLiteral path) { return ls(NativePath(path)); }
 
 /**
  * Removes the file or directory at `path`. A directory is removed with everything that's in it.
@@ -72,6 +78,7 @@ namespace os {
  * @throws std::runtime_error           On errors, e.g. missing permissions.
  */
 bool remove(const NativePath &path);
+inline bool remove(AsciiLiteral path) { return remove(NativePath(path)); }
 
 /**
  * Creates the directory at `path`, along with all missing parents. Does nothing if it already exists.
@@ -80,6 +87,7 @@ bool remove(const NativePath &path);
  * @throws std::runtime_error           On errors.
  */
 void mkdirs(const NativePath &path);
+inline void mkdirs(AsciiLiteral path) { mkdirs(NativePath(path)); }
 
 /**
  * @return                              Current working directory.
@@ -93,5 +101,6 @@ void mkdirs(const NativePath &path);
  * @throws Exception                    If the path couldn't be resolved.
  */
 [[nodiscard]] NativePath absolute(const NativePath &path);
+[[nodiscard]] inline NativePath absolute(AsciiLiteral path) { return absolute(NativePath(path)); }
 
 } // namespace os

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -47,17 +47,26 @@ UNIT_TEST(NativePath, DisplayString) {
 }
 
 #ifndef _WINDOWS
-UNIT_TEST(NativePath, InvalidUtf8FileNames) {
-    // File names on Linux are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is
+UNIT_TEST(NativePath, InvalidUtf8RoundTrip) {
+    // File names on POSIX are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is
     // an incomplete UTF-8 sequence, "\xFF" can't appear in UTF-8 at all.
-    for (std::string_view name : {"tmp_lol\xD0kek.txt", "tmp_lol\xFFkek.txt", "tmp_trailing\xD0"}) {
-        NativePath path = NativePath::fromWtf8(name);
-        EXPECT_EQ(path.toWtf8(), name);
+    for (std::string_view name : {"lol\xD0kek.txt", "lol\xFFkek.txt", "trailing\xD0"})
+        EXPECT_EQ(NativePath::fromWtf8(name).toWtf8(), name);
+}
+#endif
 
-        // APFS rejects such names, and so do APFS-backed mounts in a dev container, so we skip instead of asserting.
+#if !defined(_WINDOWS) && !defined(__APPLE__)
+UNIT_TEST(NativePath, InvalidUtf8FileNames) {
+    // A name with invalid UTF-8 in it is not just convertible, but is also usable to actually open a file. Not on
+    // APFS though - it only takes file names that are valid UTF-8, thus no MacOS here. And we write into the temp
+    // dir b/c the build dir can be on an APFS-backed mount in a dev container.
+    NativePath tmpDir = NativePath::fromStdPath(std::filesystem::temp_directory_path());
+
+    for (std::string_view name : {"tmp_lol\xD0kek.txt", "tmp_lol\xFFkek.txt", "tmp_trailing\xD0"}) {
+        NativePath path = tmpDir / NativePath::fromWtf8(name);
+
         std::ofstream stream(path.toStdPath());
-        if (!stream.is_open())
-            GTEST_SKIP() << "File system rejected an invalid UTF-8 name.";
+        ASSERT_TRUE(stream.is_open()) << name;
         stream << "lol";
         stream.close();
 

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -45,11 +45,6 @@ UNIT_TEST(NativePath, DisplayString) {
     EXPECT_EQ(display.find("\xed\xb0\x80"), std::string::npos);
 }
 
-UNIT_TEST(NativePath, Absolute) {
-    EXPECT_EQ(NativePath().absolute().toStdPath(), std::filesystem::current_path());
-    EXPECT_EQ(NativePath("a").absolute().toStdPath(), std::filesystem::current_path() / "a");
-}
-
 #ifndef _WINDOWS
 UNIT_TEST(NativePath, InvalidUtf8FileNames) {
     // File names on Linux are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -6,6 +6,7 @@
 #include "Testing/Unit/UnitTest.h"
 
 #include "Utility/System/NativePath.h"
+#include "Utility/System/Os.h"
 
 UNIT_TEST(NativePath, Wtf8RoundTrip) {
     // The conversion goes through wchar_t on Windows, so WTF-8 has to survive, unpaired surrogates included.
@@ -60,8 +61,8 @@ UNIT_TEST(NativePath, InvalidUtf8FileNames) {
         stream << "lol";
         stream.close();
 
-        EXPECT_TRUE(std::filesystem::exists(path.toStdPath())) << name;
-        EXPECT_TRUE(std::filesystem::remove(path.toStdPath())) << name;
+        EXPECT_TRUE(os::exists(path)) << name;
+        EXPECT_TRUE(os::remove(path)) << name;
     }
 }
 #endif

--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -35,6 +35,12 @@ UNIT_TEST(NativePath, WithExtension) {
     EXPECT_EQ(NativePath("a/b.json").withExtension("").toWtf8(), "a/b");
 }
 
+UNIT_TEST(NativePath, Parent) {
+    EXPECT_EQ(NativePath("a/b/c.txt").parent(), NativePath("a/b"));
+    EXPECT_EQ(NativePath("c.txt").parent(), NativePath()); // No parent means an empty path.
+    EXPECT_EQ(NativePath().parent(), NativePath());
+}
+
 UNIT_TEST(NativePath, DisplayString) {
     EXPECT_EQ(NativePath::fromWtf8("a/b/\xd0\xbb\xd0\xbe\xd0\xbb.txt").displayString(), "a/b/\xd0\xbb\xd0\xbe\xd0\xbb.txt");
 

--- a/src/Utility/System/Tests/Os_ut.cpp
+++ b/src/Utility/System/Tests/Os_ut.cpp
@@ -11,27 +11,27 @@
 UNIT_TEST(Os, CwdAbsolute) {
     EXPECT_EQ(os::cwd().toStdPath(), std::filesystem::current_path());
     EXPECT_EQ(os::absolute(NativePath()), os::cwd()); // An empty path resolves to the cwd itself.
-    EXPECT_EQ(os::absolute(NativePath::fromWtf8("a")), os::cwd() / NativePath::fromWtf8("a"));
+    EXPECT_EQ(os::absolute("a"), os::cwd() / NativePath("a"));
 }
 
 UNIT_TEST(Os, ExistsStat) {
     ScopedTestFile tmp("tmp_os_test.txt", "lol");
 
-    EXPECT_TRUE(os::exists(NativePath::fromWtf8("tmp_os_test.txt")));
-    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_test.txt")), FileStat(FILE_REGULAR, 3));
+    EXPECT_TRUE(os::exists("tmp_os_test.txt"));
+    EXPECT_EQ(os::stat("tmp_os_test.txt"), FileStat(FILE_REGULAR, 3));
 
-    EXPECT_FALSE(os::exists(NativePath::fromWtf8("tmp_os_doesnt_exist")));
-    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_doesnt_exist")), FileStat());
+    EXPECT_FALSE(os::exists("tmp_os_doesnt_exist"));
+    EXPECT_EQ(os::stat("tmp_os_doesnt_exist"), FileStat());
 }
 
 UNIT_TEST(Os, LsRemoveMkdirs) {
-    MM_AT_SCOPE_EXIT(os::remove(NativePath::fromWtf8("tmp_os_dir")));
+    MM_AT_SCOPE_EXIT(os::remove("tmp_os_dir"));
 
-    os::mkdirs(NativePath::fromWtf8("tmp_os_dir/a/b"));
-    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_dir/a/b")).type, FILE_DIRECTORY);
+    os::mkdirs("tmp_os_dir/a/b");
+    EXPECT_EQ(os::stat("tmp_os_dir/a/b").type, FILE_DIRECTORY);
 
     ScopedTestFile tmp("tmp_os_dir/1.txt", "");
-    std::vector<DirectoryEntry> entries = os::ls(NativePath::fromWtf8("tmp_os_dir"));
+    std::vector<DirectoryEntry> entries = os::ls("tmp_os_dir");
     std::ranges::sort(entries); // ls doesn't promise any particular order.
     EXPECT_EQ(entries, std::vector<DirectoryEntry>({
         {"1.txt", FILE_REGULAR},
@@ -39,10 +39,20 @@ UNIT_TEST(Os, LsRemoveMkdirs) {
     }));
 
     // ls never throws, not for a path that doesn't exist, and not for a file either.
-    EXPECT_TRUE(os::ls(NativePath::fromWtf8("tmp_os_doesnt_exist")).empty());
-    EXPECT_TRUE(os::ls(NativePath::fromWtf8("tmp_os_dir/1.txt")).empty());
+    EXPECT_TRUE(os::ls("tmp_os_doesnt_exist").empty());
+    EXPECT_TRUE(os::ls("tmp_os_dir/1.txt").empty());
 
-    EXPECT_TRUE(os::remove(NativePath::fromWtf8("tmp_os_dir")));
-    EXPECT_FALSE(os::remove(NativePath::fromWtf8("tmp_os_dir"))); // Nothing left to remove.
-    EXPECT_FALSE(os::exists(NativePath::fromWtf8("tmp_os_dir")));
+    EXPECT_TRUE(os::remove("tmp_os_dir"));
+    EXPECT_FALSE(os::remove("tmp_os_dir")); // Nothing left to remove.
+    EXPECT_FALSE(os::exists("tmp_os_dir"));
+}
+
+UNIT_TEST(Os, AsciiLiterals) {
+    // Every os function has an AsciiLiteral overload. Without them these calls don't compile - reaching a NativePath
+    // parameter from a literal needs two user-defined conversions, and C++ allows only one.
+    ScopedTestFile tmp("tmp_os_literal.txt", "lol");
+
+    EXPECT_TRUE(os::exists("tmp_os_literal.txt"));
+    EXPECT_EQ(os::stat("tmp_os_literal.txt"), FileStat(FILE_REGULAR, 3));
+    EXPECT_EQ(os::absolute("tmp_os_literal.txt"), os::cwd() / NativePath("tmp_os_literal.txt"));
 }

--- a/src/Utility/System/Tests/Os_ut.cpp
+++ b/src/Utility/System/Tests/Os_ut.cpp
@@ -1,0 +1,41 @@
+#include <algorithm>
+#include <vector>
+
+#include "Testing/Unit/UnitTest.h"
+
+#include "Utility/ScopeGuard.h"
+
+#include "Utility/System/Os.h"
+
+UNIT_TEST(Os, ExistsStat) {
+    ScopedTestFile tmp("tmp_os_test.txt", "lol");
+
+    EXPECT_TRUE(os::exists(NativePath::fromWtf8("tmp_os_test.txt")));
+    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_test.txt")), FileStat(FILE_REGULAR, 3));
+
+    EXPECT_FALSE(os::exists(NativePath::fromWtf8("tmp_os_doesnt_exist")));
+    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_doesnt_exist")), FileStat());
+}
+
+UNIT_TEST(Os, LsRemoveMkdirs) {
+    MM_AT_SCOPE_EXIT(os::remove(NativePath::fromWtf8("tmp_os_dir")));
+
+    os::mkdirs(NativePath::fromWtf8("tmp_os_dir/a/b"));
+    EXPECT_EQ(os::stat(NativePath::fromWtf8("tmp_os_dir/a/b")).type, FILE_DIRECTORY);
+
+    ScopedTestFile tmp("tmp_os_dir/1.txt", "");
+    std::vector<DirectoryEntry> entries = os::ls(NativePath::fromWtf8("tmp_os_dir"));
+    std::ranges::sort(entries); // ls doesn't promise any particular order.
+    EXPECT_EQ(entries, std::vector<DirectoryEntry>({
+        {"1.txt", FILE_REGULAR},
+        {"a", FILE_DIRECTORY}
+    }));
+
+    // ls never throws, not for a path that doesn't exist, and not for a file either.
+    EXPECT_TRUE(os::ls(NativePath::fromWtf8("tmp_os_doesnt_exist")).empty());
+    EXPECT_TRUE(os::ls(NativePath::fromWtf8("tmp_os_dir/1.txt")).empty());
+
+    EXPECT_TRUE(os::remove(NativePath::fromWtf8("tmp_os_dir")));
+    EXPECT_FALSE(os::remove(NativePath::fromWtf8("tmp_os_dir"))); // Nothing left to remove.
+    EXPECT_FALSE(os::exists(NativePath::fromWtf8("tmp_os_dir")));
+}

--- a/src/Utility/System/Tests/Os_ut.cpp
+++ b/src/Utility/System/Tests/Os_ut.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <filesystem>
 #include <vector>
 
 #include "Testing/Unit/UnitTest.h"
@@ -6,6 +7,12 @@
 #include "Utility/ScopeGuard.h"
 
 #include "Utility/System/Os.h"
+
+UNIT_TEST(Os, CwdAbsolute) {
+    EXPECT_EQ(os::cwd().toStdPath(), std::filesystem::current_path());
+    EXPECT_EQ(os::absolute(NativePath()), os::cwd()); // An empty path resolves to the cwd itself.
+    EXPECT_EQ(os::absolute(NativePath::fromWtf8("a")), os::cwd() / NativePath::fromWtf8("a"));
+}
 
 UNIT_TEST(Os, ExistsStat) {
     ScopedTestFile tmp("tmp_os_test.txt", "lol");

--- a/test/Bin/RetraceTest/RetraceTestMain.cpp
+++ b/test/Bin/RetraceTest/RetraceTestMain.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -10,7 +9,7 @@
 #include "Library/StackTrace/StackTraceOnCrash.h"
 
 #include "Utility/String/Format.h"
-#include "Utility/System/NativePath.h"
+#include "Utility/System/Os.h"
 #include "Utility/UnicodeCrt.h"
 
 #include "RetraceTest.h"
@@ -24,16 +23,18 @@ int platformMain(int argc, char **argv) {
         if (opts.helpPrinted)
             return 1;
 
-        std::vector<NativePath> tracePaths;
-        for (const auto &entry : std::filesystem::directory_iterator(opts.testPath.toStdPath()))
-            if (entry.path().extension() == ".json")
-                tracePaths.push_back(NativePath::fromStdPath(entry.path()));
-        std::ranges::sort(tracePaths);
+        std::vector<std::string> traceNames;
+        for (const DirectoryEntry &entry : os::ls(opts.testPath))
+            if (entry.name.ends_with(".json"))
+                traceNames.push_back(entry.name);
+        std::ranges::sort(traceNames);
 
-        for (const NativePath &tracePath : tracePaths)
-            testing::RegisterTest("Retrace", tracePath.toStdPath().stem().string().c_str(),
+        for (const std::string &traceName : traceNames)
+            testing::RegisterTest("Retrace", traceName.substr(0, traceName.size() - 5).c_str(), // Minus ".json".
                                   nullptr, nullptr, __FILE__, __LINE__,
-                                  [tracePath] { return new RetraceTest(tracePath); });
+                                  [tracePath = opts.testPath / NativePath::fromWtf8(traceName)] {
+                                      return new RetraceTest(tracePath);
+                                  });
 
         testing::InitGoogleTest(&argc, argv);
         if (opts.listRequested)

--- a/test/Bin/RetraceTest/RetraceTestMain.cpp
+++ b/test/Bin/RetraceTest/RetraceTestMain.cpp
@@ -23,16 +23,16 @@ int platformMain(int argc, char **argv) {
         if (opts.helpPrinted)
             return 1;
 
-        std::vector<std::string> traceNames;
+        std::vector<NativePath> traceNames;
         for (const DirectoryEntry &entry : os::ls(opts.testPath))
             if (entry.name.ends_with(".json"))
-                traceNames.push_back(entry.name);
+                traceNames.push_back(NativePath::fromWtf8(entry.name));
         std::ranges::sort(traceNames);
 
-        for (const std::string &traceName : traceNames)
-            testing::RegisterTest("Retrace", traceName.substr(0, traceName.size() - 5).c_str(), // Minus ".json".
+        for (const NativePath &traceName : traceNames)
+            testing::RegisterTest("Retrace", traceName.withExtension("").toWtf8().c_str(),
                                   nullptr, nullptr, __FILE__, __LINE__,
-                                  [tracePath = opts.testPath / NativePath::fromWtf8(traceName)] {
+                                  [tracePath = opts.testPath / traceName] {
                                       return new RetraceTest(tracePath);
                                   });
 

--- a/test/Testing/Extensions/ScopedTestFile.cpp
+++ b/test/Testing/Extensions/ScopedTestFile.cpp
@@ -1,8 +1,7 @@
 #include "ScopedTestFile.h"
 
-#include <filesystem>
-
 #include "Utility/Streams/FileOutputStream.h"
+#include "Utility/System/Os.h"
 
 ScopedTestFile::ScopedTestFile(const NativePath &path, std::string_view contents) : _path(path) {
     FileOutputStream stream(_path);
@@ -11,6 +10,7 @@ ScopedTestFile::ScopedTestFile(const NativePath &path, std::string_view contents
 }
 
 ScopedTestFile::~ScopedTestFile() {
-    std::error_code ec;
-    std::filesystem::remove(_path.toStdPath(), ec);
+    try {
+        os::remove(_path);
+    } catch (...) {} // Cleanup errors shouldn't throw out of a dtor.
 }

--- a/test/Testing/Extensions/ScopedTestFileSlot.cpp
+++ b/test/Testing/Extensions/ScopedTestFileSlot.cpp
@@ -1,13 +1,13 @@
 #include "ScopedTestFileSlot.h"
 
-#include <filesystem>
+#include "Utility/System/Os.h"
 
 ScopedTestFileSlot::ScopedTestFileSlot(const NativePath &path) : _path(path) {
-    std::error_code ec;
-    std::filesystem::remove(_path.toStdPath(), ec);
+    os::remove(_path); // Drop whatever an earlier run might have left behind.
 }
 
 ScopedTestFileSlot::~ScopedTestFileSlot() {
-    std::error_code ec;
-    std::filesystem::remove(_path.toStdPath(), ec);
+    try {
+        os::remove(_path);
+    } catch (...) {} // Cleanup errors shouldn't throw out of a dtor.
 }


### PR DESCRIPTION
os::exists / stat / ls / remove / mkdirs take NativePath, and thus don't depend on the C locale. FileType, FileStat & DirectoryEntry moved into Utility/System/Os.h so that both os and FileSystem can return them. DirectoryFileSystem is now implemented on top of the os functions, so that the permission handling semantics live in one place.

This is also important as part of the upcoming refactoring to get rid of exceptions in the codebase.