### PR TITLE
ViewInterface::skip takes a predicate

### DIFF
--- a/src/Utility/Tests/View_ut.cpp
+++ b/src/Utility/Tests/View_ut.cpp
@@ -200,3 +200,17 @@ UNIT_TEST(View, ExplicitConversion) {
     view(v).to(&r);
     EXPECT_EQ(r, std::vector<std::string>({"a", "b", "c"}));
 }
+
+UNIT_TEST(View, SkipByPredicate) {
+    struct Item {
+        int value = 0;
+        bool isBad() const { return value < 0; }
+    };
+    std::vector<Item> items{{1}, {-1}, {2}, {-2}, {3}};
+
+    std::vector<int> result;
+    for (const Item &item : view(items).skip(&Item::isBad))
+        result.push_back(item.value);
+
+    EXPECT_EQ(result, (std::vector<int>{1, 2, 3}));
+}

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 #include <functional>
 #include <ranges>
 #include <string>
@@ -21,6 +22,14 @@ inline constexpr bool is_initializer_list_v = is_initializer_list<T>::value;
 
 template<class Container, class Element>
 concept Emplaceable = requires (Container &c, Element &e) { c.emplace_back(e); } || requires (Container &c, Element &e) { c.emplace(e); };
+
+template<class Range, class T>
+concept ComparableWithElement = requires (std::ranges::range_reference_t<Range> element, const T &value) {
+    element != value;
+};
+
+template<class Range, class T>
+concept PredicateOnElement = std::invocable<T, std::ranges::range_reference_t<Range>>;
 
 template<class Range>
 class ViewWrapper;
@@ -92,7 +101,7 @@ class ResizeView {
  * CRTP mixin that provides a fluent range API on top of `std::ranges::view_interface`.
  *
  * Any class that inherits `ViewInterface<Derived>` and provides `begin()`/`end()` gets:
- * - `drop(n)`, `take(n)`, `skip(value)`, `replace(from, to)`, `resize(n, value)`, `zip(other)` — chainable range transformations.
+ * - `drop(n)`, `take(n)`, `skip(value or predicate)`, `replace(from, to)`, `resize(n, value)`, `zip(other)` — chainable range transformations.
  * - `to(&container)` — populate an existing container. For dynamic containers (`std::vector`, `std::set`, ...)
  *   the container is cleared and refilled. For `std::array<T, N>` the first N elements are written, extras are
  *   dropped, and the tail (if the range yielded fewer than N elements) is reset to default-constructed `T()`.
@@ -118,18 +127,23 @@ class ViewInterface : public std::ranges::view_interface<Derived> {
     }
 
     /**
-     * Drops the elements that are equal to `value`, or, if `value` is callable on an element, the elements it
-     * returns `true` for. The latter form takes member functions, e.g. `skip(&Item::isBad)`.
-     *
-     * @param value                     Value to drop, or a predicate selecting the elements to drop.
+     * @param value                     Value to drop.
      */
-    [[nodiscard]] auto skip(auto value) {
-        return detail::ViewWrapper(std::views::filter(derived(), [value] (const auto &e) {
-            if constexpr (std::invocable<decltype(value), const decltype(e) &>) {
-                return !std::invoke(value, e);
-            } else {
-                return e != value;
-            }
+    [[nodiscard]] auto skip(auto value) requires detail::ComparableWithElement<Derived, decltype(value)> {
+        return detail::ViewWrapper(std::views::filter(derived(), [value = std::move(value)] (auto &&element) {
+            return element != value;
+        }));
+    }
+
+    /**
+     * Same as above, but drops the elements that `predicate` returns `true` for. Takes member functions, so
+     * `skip(&Item::isBad)` works.
+     *
+     * @param predicate                 Predicate selecting the elements to drop.
+     */
+    [[nodiscard]] auto skip(auto predicate) requires detail::PredicateOnElement<Derived, decltype(predicate)> {
+        return detail::ViewWrapper(std::views::filter(derived(), [predicate = std::move(predicate)] (auto &&element) {
+            return !std::invoke(predicate, element);
         }));
     }
 

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <ranges>
 #include <string>
 #include <type_traits>
@@ -116,8 +117,20 @@ class ViewInterface : public std::ranges::view_interface<Derived> {
         return detail::ViewWrapper(std::views::take(derived(), n));
     }
 
+    /**
+     * Drops the elements that are equal to `value`, or, if `value` is callable on an element, the elements it
+     * returns `true` for. The latter form takes member functions, e.g. `skip(&Item::isBad)`.
+     *
+     * @param value                     Value to drop, or a predicate selecting the elements to drop.
+     */
     [[nodiscard]] auto skip(auto value) {
-        return detail::ViewWrapper(std::views::filter(derived(), [value] (const auto &e) { return e != value; }));
+        return detail::ViewWrapper(std::views::filter(derived(), [value] (const auto &e) {
+            if constexpr (std::invocable<decltype(value), const decltype(e) &>) {
+                return !std::invoke(value, e);
+            } else {
+                return e != value;
+            }
+        }));
     }
 
     [[nodiscard]] auto replace(auto from, auto to) {

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -24,9 +24,7 @@ template<class Container, class Element>
 concept Emplaceable = requires (Container &c, Element &e) { c.emplace_back(e); } || requires (Container &c, Element &e) { c.emplace(e); };
 
 template<class Range, class T>
-concept ComparableWithElement = requires (std::ranges::range_reference_t<Range> element, const T &value) {
-    element != value;
-};
+concept ComparableWithElement = requires (std::ranges::range_reference_t<Range> e, const T &v) { e != v; };
 
 template<class Range, class T>
 concept PredicateOnElement = std::invocable<T, std::ranges::range_reference_t<Range>>;


### PR DESCRIPTION
`skip(value)` drops the elements equal to `value`, which is no help when the condition isn't equality to anything. It now also accepts anything callable on an element, member functions included:

```cpp
for (const Item &item : view(items).skip(&Item::isBad))
```

The value form is unchanged - the two are told apart with `std::invocable`, so a predicate is only treated as one if it can actually be called on an element.

Split out of #2610, which needs it to drop the empty rows of a table.
