### PR TITLE
Spell UTF-8 and WTF-8, with hyphens

### DIFF
--- a/src/Library/FileSystem/Interface/FileSystem.h
+++ b/src/Library/FileSystem/Interface/FileSystem.h
@@ -54,7 +54,7 @@ struct DirectoryEntry {
 /**
  * File system interface.
  *
- * All user-facing methods take paths as UTF8-encoded `std::string_view`s, and users are expected to just use
+ * All user-facing methods take paths as UTF-8 encoded `std::string_view`s, and users are expected to just use
  * `std::string`s to store paths.
  *
  * Paths are normalized internally, and then processed by the implementation in a derived class. Both `".."` and `"."`

--- a/src/Utility/Memory/Blob.cpp
+++ b/src/Utility/Memory/Blob.cpp
@@ -45,7 +45,7 @@ Blob Blob::fromFile(const NativePath &path) {
     if (!error && size == 0)
         return Blob().withDisplayPath(pathString);
 
-    // native() is a wchar_t string on Windows, so a WTF16 name is passed as-is. Throws std::system_error if the
+    // native() is a wchar_t string on Windows, so a WTF-16 name is passed as-is. Throws std::system_error if the
     // file doesn't exist.
     std::shared_ptr<mio::mmap_source> mmap;
     try {

--- a/src/Utility/UnicodeCrt.cpp
+++ b/src/Utility/UnicodeCrt.cpp
@@ -32,7 +32,7 @@ UnicodeCrt::UnicodeCrt(int &argc, char **&argv) {
     // Convert command line first.
     //
     // Note on SDL interop. SDL runs basically the same code before calling into SDL_main, and thus if we get here from
-    // platformMain, argc and argv are already UTF8-encoded. However, SDL doesn't add/remove arguments, so it's safe to
+    // platformMain, argc and argv are already UTF-8 encoded. However, SDL doesn't add/remove arguments, so it's safe to
     // run the same code again.
     //
     _storage = detail::parseCommandLine(GetCommandLineW());
@@ -42,11 +42,11 @@ UnicodeCrt::UnicodeCrt(int &argc, char **&argv) {
     argc = static_cast<int>(_storage.size());
     argv = _argv.data();
 
-    // Switch to UTF8 for CRT functions. Without this, std::filesystem won't be able to process UTF8 paths.
+    // Switch to UTF-8 for CRT functions. Without this, std::filesystem won't be able to process UTF-8 paths.
     if (std::setlocale(LC_ALL, ".UTF-8") == nullptr)
         throw Exception("Could not change system locale to UTF-8");
 
-    // Also use UTF8 for console io.
+    // Also use UTF-8 for console io.
     if (SetConsoleCP(CP_UTF8) == 0)
         throw Exception("Could not set console input codepage to UTF-8");
     if (SetConsoleOutputCP(CP_UTF8) == 0)
@@ -66,7 +66,7 @@ std::vector<std::string> detail::parseCommandLine(const wchar_t *commandLine) {
 
     std::vector<std::string> result;
     for (int i = 0; i < argc; i++)
-        result.push_back(txt::wideToWtf8(argvw[i])); // WTF8, so that paths with unpaired surrogates survive.
+        result.push_back(txt::wideToWtf8(argvw[i])); // WTF-8, so that paths with unpaired surrogates survive.
     return result;
 }
 #endif


### PR DESCRIPTION
That's how Wikipedia & the standards spell it. Identifiers are left alone, so std::text_encoding::UTF8 stays as it is.