### PR TITLE
Let windows end the text input they started

### DIFF
--- a/src/GUI/UI/UIBranchlessDialogue.cpp
+++ b/src/GUI/UI/UIBranchlessDialogue.cpp
@@ -28,7 +28,7 @@ GUIWindow_BranchlessDialogue::GUIWindow_BranchlessDialogue(EvtOpcode event) : GU
 
 GUIWindow_BranchlessDialogue::~GUIWindow_BranchlessDialogue() {
     current_screen_type = prev_screen_type;
-    keyboardInputHandler->EndTextInput();
+    keyboardInputHandler->EndTextInput(this);
 }
 
 void GUIWindow_BranchlessDialogue::Update() {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -294,7 +294,6 @@ static constexpr IndexedArray<const char *, HOUSE_TYPE_WEAPON_SHOP, HOUSE_TYPE_M
 bool enterHouse(HouseId uHouseID) {
     engine->_statusBar->clearAll();
     engine->_messageQueue->clear();
-    keyboardInputHandler->EndTextInput();
 
     if (uHouseID == HOUSE_THRONEROOM_WIN_GOOD || uHouseID == HOUSE_THRONEROOM_WIN_EVIL) {
         engine->_messageQueue->addMessageCurrentFrame(UIMSG_ShowGameOverWindow, 0, 0);
@@ -557,7 +556,6 @@ void selectProprietorDialogueOption(DialogueId option) {
 
 bool houseDialogPressEscape() {
     engine->_messageQueue->clear();
-    keyboardInputHandler->EndTextInput();
     activeLevelDecoration = nullptr;
     current_npc_text.clear();
     pParty->placeHeldItemInInventoryOrDrop();
@@ -1078,6 +1076,8 @@ void GUIWindow_House::Update() {
 }
 
 GUIWindow_House::~GUIWindow_House() {
+    keyboardInputHandler->EndTextInput(this); // Banks and town halls ask for a gold amount.
+
     for (HouseNpcDesc &desc : houseNpcs) {
         if (desc.icon) {
             desc.icon->release();

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -124,6 +124,10 @@ GUIWindow_SaveLoad::GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei d
     : GUIWindow(type, position, dimensions)
 {}
 
+GUIWindow_SaveLoad::~GUIWindow_SaveLoad() {
+    keyboardInputHandler->EndTextInput(this); // Save slots are renamed in place.
+}
+
 void GUIWindow_SaveLoad::preselectSlot(std::string_view fileName) {
     auto pos = std::ranges::find(_slots, fileName, &SavegameSlot::fileName);
     if (pos == _slots.end())

--- a/src/GUI/UI/UISaveLoad.h
+++ b/src/GUI/UI/UISaveLoad.h
@@ -19,6 +19,7 @@ struct SavegameSlot {
 class GUIWindow_SaveLoad : public GUIWindow {
  public:
     GUIWindow_SaveLoad(WindowType type, Pointi position, Sizei dimensions);
+    virtual ~GUIWindow_SaveLoad();
 
     /**
      * @return                      Slots shown in this menu, in display order.

--- a/src/Io/KeyboardInputHandler.cpp
+++ b/src/Io/KeyboardInputHandler.cpp
@@ -403,6 +403,11 @@ void Io::KeyboardInputHandler::EndTextInput() {
     inputType = TextInputType::None;
 }
 
+void Io::KeyboardInputHandler::EndTextInput(GUIWindow *window) {
+    if (this->window == window)
+        EndTextInput();
+}
+
 //----- (00459ED1) --------------------------------------------------------
 void Io::KeyboardInputHandler::SetWindowInputStatus(WindowInputStatus status) {
     inputType = TextInputType::None;

--- a/src/Io/KeyboardInputHandler.h
+++ b/src/Io/KeyboardInputHandler.h
@@ -49,6 +49,17 @@ class KeyboardInputHandler {
     bool ProcessTextInput(PlatformKey key, int c);
     void EndTextInput();
 
+    /**
+     * Ends text input, but only if it was started for the passed window. Windows that start text input call
+     * this as they go away, so that the handler is never left pointing at a dead window.
+     *
+     * Passing the window matters. A window that's closing might not be the one the player is typing into, and
+     * ending someone else's input session would drop the text they'd entered.
+     *
+     * @param window                    Window that's going away.
+     */
+    void EndTextInput(GUIWindow *window);
+
     const std::string &GetTextInput() const;
     void SetTextInput(std::string_view text);
 


### PR DESCRIPTION
`KeyboardInputHandler` keeps the raw `GUIWindow *` that `StartTextInput` was handed, and nothing dropped it when that window died.

Five windows start text input. Only `GUIWindow_BranchlessDialogue` ended it in its destructor. `GUIWindow_Save`, `GUIWindow_Load`, `GUIWindow_Bank` and `GUIWindow_TownHall` did not, so closing any of them left the handler pointing at freed memory, and the next `EndTextInput` wrote the input status through that pointer.

AddressSanitizer catches it as a heap-use-after-free:

```
WRITE of size 4
    #0 Io::KeyboardInputHandler::EndTextInput()   KeyboardInputHandler.cpp:398
    #1 enterHouse(HouseId)                        UIHouses.cpp:297
    #2 EvtInterpreter::executeOneEvent(int, bool) EvtInterpreter.cpp:168
    ...
```

The lifetime spans tests. A save window starts input in one test, is destroyed at the start of the next, and the stale write lands several tests later when the party enters a house. Running that last test on its own shows nothing.

### The fix

`enterHouse` and `houseDialogPressEscape` both opened by calling `EndTextInput`, which is what masked this for so long. Neither of them knows who started the input, and they only helped when the player happened to walk into a house afterwards. Both calls are gone.

Cleanup now sits in the destructor of the window that owns the session, placed on the shared bases so that subclasses cannot forget it:

- `~GUIWindow_House` covers banks and town halls, which ask for a gold amount
- `~GUIWindow_SaveLoad` covers save and load, which rename slots in place
- `~GUIWindow_BranchlessDialogue` already did this

The new `EndTextInput(GUIWindow *)` overload ends the session only when the passed window owns it. A bare `EndTextInput()` in a destructor would end whichever session happened to be active, discarding text the player had typed into a different window.

### Verification

There is no sanitizer coverage in CI, so this was checked locally against an ASan build.

- Before: the game tests abort partway through with the trace above.
- After: 356/356 game tests and 395/395 unit tests pass clean.

A temporary probe in `~GUIWindow`, reporting any window destroyed while it still held text input, fired 4 times before the change and never after.

### No test

The bug writes `WINDOW_INPUT_NONE`, which is zero, into freed memory. Nothing reads it back and nothing crashes, so a behavioural test passes identically with and without the fix. What would actually catch this class of bug is ASan in CI, which does not exist today and is a separate change.
