### PR TITLE
Pin every Ubuntu CI job to ubuntu-24.04

### DIFF
--- a/.github/workflows/build_data_cache.yml
+++ b/.github/workflows/build_data_cache.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_data_cache:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   advanceNightlyTag:
     name: Advance Nightly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tagName: ${{steps.outputReleaseTag.outputs.tagName }}
     steps:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   generate_documentation:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux_flatpak.yml
+++ b/.github/workflows/linux_flatpak.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build_flatpak_bundle:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
       options: --privileged

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   check_shaders:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   check_style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Every Ubuntu job now names `ubuntu-24.04` explicitly - no `ubuntu-22.04`, no `ubuntu-latest`.

`build_all` was already on 24.04. Four jobs were left behind on 22.04 - `check_shaders`, `check_style`, `generate_documentation` and `build_data_cache`. Nothing pinned them there, they just predate the 24.04 image. None of them needs anything 22.04-specific:

* `check_shaders` installs `glslang-tools` from apt.
* `check_style` builds lua-language-server from source and runs cpplint - it installs no compiler, so it takes whatever the image ships, and 24.04 ships a newer one than 22.04 did.
* `generate_documentation` downloads a prebuilt doxygen binary.
* `build_data_cache` only checks out and caches the data repo.

The other two were on `ubuntu-latest`, which resolves to 24.04 today, so pinning them changes nothing right now - it just stops the image from moving underneath us when GitHub advances the alias. `build_flatpak_bundle` does its work inside a `freedesktop-24.08` container anyway, and `advanceNightlyTag` only runs a github-script step.
