### PR TITLE
Use NativePath in GameStarterOptions & path resolution

### DIFF
--- a/src/Application/Startup/FileSystemStarter.cpp
+++ b/src/Application/Startup/FileSystemStarter.cpp
@@ -21,23 +21,23 @@ FileSystemStarter::~FileSystemStarter() {
     dfs = nullptr;
 }
 
-void FileSystemStarter::initUserFs(bool ramFs, std::string_view path) {
+void FileSystemStarter::initUserFs(bool ramFs, const NativePath &path) {
     assert(ufs == nullptr);
 
     if (ramFs) {
         _userFs = std::make_unique<MemoryFileSystem>("ramfs");
     } else {
-        _userFs = std::make_unique<DirectoryFileSystem>(NativePath::fromWtf8(path));
+        _userFs = std::make_unique<DirectoryFileSystem>(path);
     }
 
     ufs = _userFs.get();
 }
 
-void FileSystemStarter::initDataFs(std::string_view path, bool pathOverridesBuiltIn) {
+void FileSystemStarter::initDataFs(const NativePath &path, bool pathOverridesBuiltIn) {
     assert(dfs == nullptr);
 
     _dataEmbeddedFs = std::make_unique<EmbeddedFileSystem>(cmrc::openenroth::get_filesystem(), "embedded");
-    _dataDirFs = std::make_unique<DirectoryFileSystem>(NativePath::fromWtf8(path));
+    _dataDirFs = std::make_unique<DirectoryFileSystem>(path);
     _dataDirLowercaseFs = std::make_unique<LowercaseFileSystem>(_dataDirFs.get());
 
     std::vector<const FileSystem *> baseFileSystems = {_dataDirLowercaseFs.get(), _dataEmbeddedFs.get()};

--- a/src/Application/Startup/FileSystemStarter.h
+++ b/src/Application/Startup/FileSystemStarter.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <string_view>
+
+#include "Utility/System/NativePath.h"
 
 class FileSystem;
 
@@ -10,8 +11,8 @@ class FileSystemStarter {
     FileSystemStarter();
     ~FileSystemStarter();
 
-    void initUserFs(bool ramFs, std::string_view path);
-    void initDataFs(std::string_view path, bool pathOverridesBuiltIn);
+    void initUserFs(bool ramFs, const NativePath &path);
+    void initDataFs(const NativePath &path, bool pathOverridesBuiltIn);
 
  private:
     std::unique_ptr<FileSystem> _userFs;

--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -218,13 +218,13 @@ GameStarter::~GameStarter() {
 }
 
 void GameStarter::resolveUserPath(Environment *environment, GameStarterOptions *options) {
-    if (options->userPath.empty())
+    if (options->userPath.isEmpty())
         options->userPath = resolveMm7UserPath(environment);
 }
 
 void GameStarter::resolveDataPath(Environment *environment, GameStarterOptions *options) {
-    std::vector<std::string> candidates;
-    if (!options->dataPath.empty()) {
+    std::vector<NativePath> candidates;
+    if (!options->dataPath.isEmpty()) {
         candidates.push_back(options->dataPath);
     } else {
         candidates = resolveMm7Paths(environment);
@@ -233,7 +233,7 @@ void GameStarter::resolveDataPath(Environment *environment, GameStarterOptions *
 
     for (int i = 0; i < candidates.size(); i++) {
         std::string missingFile;
-        if (!std::filesystem::exists(candidates[i])) {
+        if (!std::filesystem::exists(candidates[i].toStdPath())) {
             MM_INFO("Data path #{} ('{}') doesn't exist.", i + 1, candidates[i]);
         } else if (!validateMm7Path(candidates[i], &missingFile)) {
             MM_INFO("Data path #{} ('{}') is missing file '{}'.", i + 1, candidates[i], missingFile);
@@ -245,11 +245,11 @@ void GameStarter::resolveDataPath(Environment *environment, GameStarterOptions *
     }
 
     // Just use the last data path if all paths are invalid. We'll throw later.
-    if (options->dataPath.empty())
+    if (options->dataPath.isEmpty())
         options->dataPath = candidates.back();
 }
 
-void GameStarter::failOnInvalidPath(std::string_view dataPath, Platform *platform) {
+void GameStarter::failOnInvalidPath(const NativePath &dataPath, Platform *platform) {
     std::string missingFile;
     if (validateMm7Path(dataPath, &missingFile))
         return;

--- a/src/Application/Startup/GameStarter.h
+++ b/src/Application/Startup/GameStarter.h
@@ -47,7 +47,7 @@ class GameStarter {
 
     static void resolveUserPath(Environment *environment, GameStarterOptions *options);
     static void resolveDataPath(Environment *environment, GameStarterOptions *options);
-    static void failOnInvalidPath(std::string_view dataPath, Platform *platform);
+    static void failOnInvalidPath(const NativePath &dataPath, Platform *platform);
     static void migrateSaves();
 
  private:

--- a/src/Application/Startup/GameStarterOptions.h
+++ b/src/Application/Startup/GameStarterOptions.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <string>
 #include <optional>
 
 #include "Library/Logger/LogEnums.h"
 
+#include "Utility/System/NativePath.h"
+
 struct GameStarterOptions {
-    std::string dataPath; // Path to game data. TODO(captainurist): Should be a NativePath.
-    std::string userPath; // Path to user data. TODO(captainurist): Should be a NativePath.
+    NativePath dataPath; // Path to game data.
+    NativePath userPath; // Path to user data.
     std::optional<LogLevel> logLevel; // Override log level.
     bool ramFsUserData = false; // Use in-memory file system for user data, don't read/write config & saves
                                 // from/to disk. This also means that default config will be used.

--- a/src/Application/Startup/PathResolver.cpp
+++ b/src/Application/Startup/PathResolver.cpp
@@ -64,25 +64,25 @@ static const PathResolutionConfig mm8Config = {
     }
 };
 
-static std::vector<std::string> resolvePaths(Environment *environment, const PathResolutionConfig &config) {
+static std::vector<NativePath> resolvePaths(Environment *environment, const PathResolutionConfig &config) {
     // If we have a path override then it'll be the only path we'll check.
     std::string envPath = environment->getenv(config.overrideEnvKey);
     if (!envPath.empty()) {
         MM_INFO("Path override provided, '{}={}'.", config.overrideEnvKey, envPath);
-        return {envPath};
+        return {NativePath::fromWtf8(envPath)};
     }
 
-    std::vector<std::string> result;
+    std::vector<NativePath> result;
 
     // Otherwise we check PWD first.
-    result.push_back(std::filesystem::current_path().generic_string());
+    result.push_back(NativePath::fromStdPath(std::filesystem::current_path()));
 
     // Then we check paths from registry on Windows,...
     for (const char *registryKey : config.registryKeys) {
         if (registryKey) {
             std::string registryPath = environment->queryRegistry(registryKey);
             if (!registryPath.empty())
-                result.push_back(registryPath);
+                result.push_back(NativePath::fromWtf8(registryPath));
         }
     }
 
@@ -90,10 +90,10 @@ static std::vector<std::string> resolvePaths(Environment *environment, const Pat
     // ...Android storage paths on Android,...
     std::string externalPath = environment->path(PATH_ANDROID_STORAGE_EXTERNAL);
     if (!externalPath.empty())
-        result.push_back(externalPath);
+        result.push_back(NativePath::fromWtf8(externalPath));
     std::string internalPath = environment->path(PATH_ANDROID_STORAGE_INTERNAL);
     if (!internalPath.empty())
-        result.push_back(internalPath);
+        result.push_back(NativePath::fromWtf8(internalPath));
     // TODO(captainurist): need a mechanism to show user-visible errors. Commenting out for now.
     //if (ANDROID && result.empty())
     //    platform->showMessageBox("Device currently unsupported", "Your device doesn't have any storage so it is unsupported!");
@@ -103,26 +103,26 @@ static std::vector<std::string> resolvePaths(Environment *environment, const Pat
     // ...or Library/Application Support in home on macOS.
     std::string home = environment->path(PATH_HOME);
     if (!home.empty())
-        result.push_back(home + "/Library/Application Support/OpenEnroth");
+        result.push_back(NativePath::fromWtf8(home + "/Library/Application Support/OpenEnroth"));
 #endif
 
     return result;
 }
 
-std::vector<std::string> resolveMm6Paths(Environment *environment) {
+std::vector<NativePath> resolveMm6Paths(Environment *environment) {
     return resolvePaths(environment, mm6Config);
 }
 
-std::vector<std::string> resolveMm7Paths(Environment *environment) {
+std::vector<NativePath> resolveMm7Paths(Environment *environment) {
     return resolvePaths(environment, mm7Config);
 }
 
-std::vector<std::string> resolveMm8Paths(Environment *environment) {
+std::vector<NativePath> resolveMm8Paths(Environment *environment) {
     return resolvePaths(environment, mm8Config);
 }
 
-bool validateMm7Path(std::string_view dataPath, std::string *missingFile) {
-    DirectoryFileSystem dirFs(NativePath::fromWtf8(dataPath));
+bool validateMm7Path(const NativePath &dataPath, std::string *missingFile) {
+    DirectoryFileSystem dirFs(dataPath);
     LowercaseFileSystem lowerFs(&dirFs);
 
     for (std::string_view entry : globalValidateList) {
@@ -135,15 +135,15 @@ bool validateMm7Path(std::string_view dataPath, std::string *missingFile) {
     return true;
 }
 
-std::string resolveMm7UserPath(Environment *environment) {
+NativePath resolveMm7UserPath(Environment *environment) {
 #ifdef _WINDOWS
     std::string savedGames = environment->path(PATH_WINDOWS_SAVED_GAMES);
     if (savedGames.empty())
         return {}; // Shouldn't really happen.
-    return fmt::format("{}/OpenEnroth", savedGames);
+    return NativePath::fromWtf8(fmt::format("{}/OpenEnroth", savedGames));
 #elif __ANDROID__
-    return fmt::format("{}/.openenroth", environment->path(PATH_ANDROID_STORAGE_INTERNAL));
+    return NativePath::fromWtf8(fmt::format("{}/.openenroth", environment->path(PATH_ANDROID_STORAGE_INTERNAL)));
 #else // Mac & linux
-    return fmt::format("{}/.openenroth", environment->path(PATH_HOME));
+    return NativePath::fromWtf8(fmt::format("{}/.openenroth", environment->path(PATH_HOME)));
 #endif
 }

--- a/src/Application/Startup/PathResolver.h
+++ b/src/Application/Startup/PathResolver.h
@@ -3,16 +3,18 @@
 #include <string>
 #include <vector>
 
+#include "Utility/System/NativePath.h"
+
 class Environment;
 
 constexpr char mm6PathOverrideKey[] = "OPENENROTH_MM6_PATH";
 constexpr char mm7PathOverrideKey[] = "OPENENROTH_MM7_PATH";
 constexpr char mm8PathOverrideKey[] = "OPENENROTH_MM8_PATH";
 
-std::vector<std::string> resolveMm6Paths(Environment *environment);
-std::vector<std::string> resolveMm7Paths(Environment *environment);
-std::vector<std::string> resolveMm8Paths(Environment *environment);
+std::vector<NativePath> resolveMm6Paths(Environment *environment);
+std::vector<NativePath> resolveMm7Paths(Environment *environment);
+std::vector<NativePath> resolveMm8Paths(Environment *environment);
 
-bool validateMm7Path(std::string_view dataPath, std::string *missingFile);
+bool validateMm7Path(const NativePath &dataPath, std::string *missingFile);
 
-std::string resolveMm7UserPath(Environment *environment);
+NativePath resolveMm7UserPath(Environment *environment);

--- a/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
+++ b/src/Bin/OpenEnroth/OpenEnrothOptions.cpp
@@ -82,10 +82,10 @@ OpenEnrothOptions OpenEnrothOptions::parse(int argc, char **argv) {
     if (!portable && std::filesystem::exists(".portable"))
         portable = true;
     if (portable && *portable) {
-        if (result.userPath.empty())
-            result.userPath = std::filesystem::current_path().generic_string();
-        if (result.dataPath.empty())
-            result.dataPath = std::filesystem::current_path().generic_string();
+        if (result.userPath.isEmpty())
+            result.userPath = NativePath::fromStdPath(std::filesystem::current_path());
+        if (result.dataPath.isEmpty())
+            result.dataPath = NativePath::fromStdPath(std::filesystem::current_path());
     }
 
     if (result.subcommand == SUBCOMMAND_RETRACE) {


### PR DESCRIPTION
dataPath & userPath are now NativePath, and so is everything in PathResolver - the resolve functions return NativePath objects. initUserFs / initDataFs / validateMm7Path / failOnInvalidPath take NativePath too.