### PR TITLE
Enforce a 200 column line limit

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
-filter=-readability/casting,-legal/copyright,-runtime/printf,-runtime/references,-runtime/threadsafe_fn,-runtime/int,-whitespace/line_length,-readability/fn_size,-readability/todo,-runtime/string,-whitespace/parens,-whitespace/comments,-build/c++11,-build/header_guard,-readability/inheritance,-build/c++17
+filter=-readability/casting,-legal/copyright,-runtime/printf,-runtime/references,-runtime/threadsafe_fn,-runtime/int,-readability/fn_size,-readability/todo,-runtime/string,-whitespace/parens,-whitespace/comments,-build/c++11,-build/header_guard,-readability/inheritance,-build/c++17
 exclude_files=(build|lib|out|thirdparty)/*
-linelength=120
+linelength=200

--- a/HACKING.md
+++ b/HACKING.md
@@ -90,7 +90,7 @@ Naming:
 * Exceptions to the rules above are STL-compatible interfaces, which should follow STL naming rules. So it's `value_type` for iterator value type, and `push_back` for a method that's adding an element to a container.
 
 Code formatting:
-* Lines are 120 columns wide. This applies to all file types, not just C++. Don't wrap at 80! The hard limit that `check_style` enforces is 200 columns, and it's there for the cases where squeezing the code into 120 would make it uglier or harder to read. Don't contort the code to stay within 120, let the line run longer instead.
+* Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -90,7 +90,8 @@ Naming:
 * Exceptions to the rules above are STL-compatible interfaces, which should follow STL naming rules. So it's `value_type` for iterator value type, and `push_back` for a method that's adding an element to a container.
 
 Code formatting:
-* Lines are 120 columns wide. This applies to comments, and to all file types, not just C++. Don't wrap at 80!
+* Lines are 120 columns wide. This applies to all file types, not just C++. Don't wrap at 80! The hard limit that `check_style` enforces is 200 columns, and it's there for the cases where squeezing the code into 120 would make it uglier or harder to read. Don't contort the code to stay within 120, let the line run longer instead.
+* Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/src/Engine/Data/SoundEnums.h
+++ b/src/Engine/Data/SoundEnums.h
@@ -172,7 +172,9 @@ enum class MusicId {
     MUSIC_ENDGAME_DUNGEON = 16,                  // The Dragon Caves, Thunderfist Mountain, The Titans' Stronghold, Tunnels to Eeofol.
     MUSIC_ERATHIA = 17,
     MUSIC_TULAREAN_FOREST = 18,
-    MUSIC_CASTLE_HARMONDALE = 19,                // Lord Markham's Manor, The Bandit Caves, Castle Harmondale, Fort Riverstride, The School of Sorcery, Stone City, The Mercenary Guild, William Setag's Tower, The Strange Temple, The Small House.
+    // Lord Markham's Manor, The Bandit Caves, Castle Harmondale, Fort Riverstride, The School of Sorcery, Stone City,
+    // The Mercenary Guild, William Setag's Tower, The Strange Temple, The Small House.
+    MUSIC_CASTLE_HARMONDALE = 19,
     MUSIC_EMERALD_ISLAND = 20,
 
     MUSIC_MAIN_MENU = MUSIC_CASTLE_GRYPHONHEART_CASTLE_NAVAN,

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -273,7 +273,9 @@ void Engine::DrawGUI() {
             int uFaceID;
             int sector_id = pBLVRenderParams->uPartySectorID;
             float floor_level = BLV_GetFloorLevel(pParty->pos/* + Vec3f(0,0,40) */, sector_id, &uFaceID);
-            floor_level_str = fmt::format("BLV_GetFloorLevel: {}   face_id {}\nNodes: {}, Faces: {} ({}), Sectors: {}\n", floor_level, uFaceID, pBspRenderer->num_nodes, pBspRenderer->num_faces, pBLVRenderParams->uNumFacesRenderedThisFrame, pBspRenderer->uNumVisibleNotEmptySectors);
+            floor_level_str = fmt::format("BLV_GetFloorLevel: {}   face_id {}\nNodes: {}, Faces: {} ({}), Sectors: {}\n",
+                                          floor_level, uFaceID, pBspRenderer->num_nodes, pBspRenderer->num_faces,
+                                          pBLVRenderParams->uNumFacesRenderedThisFrame, pBspRenderer->uNumVisibleNotEmptySectors);
         } else if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR) {
             bool on_water = false;
             int floor_face_id;

--- a/src/Engine/Evt/EvtInstruction.cpp
+++ b/src/Engine/Evt/EvtInstruction.cpp
@@ -686,7 +686,10 @@ std::string EvtInstruction::toString() const {
         case EVENT_LocationName:
             return fmt::format("{}: LocationName", step);
         case EVENT_MoveToMap:
-            return fmt::format("{}: MoveToMap(({}, {}, {}), {}, {}, {}, {}, {}, \"{}\")", step, data.move_map_descr.x, data.move_map_descr.y, data.move_map_descr.z, data.move_map_descr.yaw, data.move_map_descr.pitch, data.move_map_descr.zspeed, std::to_underlying(data.move_map_descr.house_id), data.move_map_descr.exit_pic_id, str);
+            return fmt::format("{}: MoveToMap(({}, {}, {}), {}, {}, {}, {}, {}, \"{}\")", step,
+                               data.move_map_descr.x, data.move_map_descr.y, data.move_map_descr.z,
+                               data.move_map_descr.yaw, data.move_map_descr.pitch, data.move_map_descr.zspeed,
+                               std::to_underlying(data.move_map_descr.house_id), data.move_map_descr.exit_pic_id, str);
         case EVENT_OpenChest:
             return fmt::format("{}: OpenChest({})", step, data.chest_id);
         case EVENT_ShowFace:
@@ -712,9 +715,16 @@ std::string EvtInstruction::toString() const {
         case EVENT_Set:
             return fmt::format("{}: Set({})", step, getVariableSetStr(data.variable_descr.type, data.variable_descr.value));
         case EVENT_SummonMonsters:
-            return fmt::format("{}: SummonMonsters({}, {}, {}, ({}, {}, {}), {}, {})", step, data.monster_descr.type, data.monster_descr.level, data.monster_descr.count, data.monster_descr.x, data.monster_descr.y, data.monster_descr.z, data.monster_descr.group, data.monster_descr.name_id);
+            return fmt::format("{}: SummonMonsters({}, {}, {}, ({}, {}, {}), {}, {})", step,
+                               data.monster_descr.type, data.monster_descr.level, data.monster_descr.count,
+                               data.monster_descr.x, data.monster_descr.y, data.monster_descr.z,
+                               data.monster_descr.group, data.monster_descr.name_id);
         case EVENT_CastSpell:
-            return fmt::format("{}: CastSpell({}, {}, {}, ({}, {}, {}), ({}, {}, {}))", step, std::to_underlying(data.spell_descr.spell_id), std::to_underlying(data.spell_descr.spell_mastery), data.spell_descr.spell_level, data.spell_descr.fromx, data.spell_descr.fromy, data.spell_descr.fromz, data.spell_descr.tox, data.spell_descr.toy, data.spell_descr.toz);
+            return fmt::format("{}: CastSpell({}, {}, {}, ({}, {}, {}), ({}, {}, {}))", step,
+                               std::to_underlying(data.spell_descr.spell_id),
+                               std::to_underlying(data.spell_descr.spell_mastery), data.spell_descr.spell_level,
+                               data.spell_descr.fromx, data.spell_descr.fromy, data.spell_descr.fromz,
+                               data.spell_descr.tox, data.spell_descr.toy, data.spell_descr.toz);
         case EVENT_SpeakNPC:
             return fmt::format("{}: SpeakNPC({})", step, data.npc_descr.npc_id);
         case EVENT_SetFacesBit:
@@ -747,13 +757,19 @@ std::string EvtInstruction::toString() const {
                 return fmt::format("{}: ShowMessage({})", step, data.text_id);
             }
         case EVENT_OnTimer:
-            return fmt::format("{}: OnTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step, data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly, data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute, data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
+            return fmt::format("{}: OnTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step,
+                               data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly,
+                               data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute,
+                               data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
         case EVENT_ToggleIndoorLight:
             return fmt::format("{}: ToggleIndoorLight({}, {})", step, data.light_descr.light_id, data.light_descr.is_enable);
         case EVENT_PressAnyKey:
             return fmt::format("{}: PressAnyKey()", step);
         case EVENT_SummonItem:
-            return fmt::format("{}: SummonItem({}, ({}, {}, {}), {}, {}, {})", step, std::to_underlying(data.summon_item_descr.sprite), data.summon_item_descr.x, data.summon_item_descr.y, data.summon_item_descr.z, data.summon_item_descr.speed, data.summon_item_descr.count, data.summon_item_descr.random_rotate);
+            return fmt::format("{}: SummonItem({}, ({}, {}, {}), {}, {}, {})", step,
+                               std::to_underlying(data.summon_item_descr.sprite),
+                               data.summon_item_descr.x, data.summon_item_descr.y, data.summon_item_descr.z,
+                               data.summon_item_descr.speed, data.summon_item_descr.count, data.summon_item_descr.random_rotate);
         case EVENT_ForPartyMember:
             return fmt::format("{}: ForPartyMember({})", step, std::to_underlying(who));
         case EVENT_Jmp:
@@ -761,17 +777,26 @@ std::string EvtInstruction::toString() const {
         case EVENT_OnMapReload:
             return fmt::format("{}: OnMapReload", step);
         case EVENT_OnLongTimer:
-            return fmt::format("{}: OnLongTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step, data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly, data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute, data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
+            return fmt::format("{}: OnLongTimer(Year({}), Month({}), Week({}), Day({}hr, {}min, {}sec), {})", step,
+                               data.timer_descr.is_yearly, data.timer_descr.is_monthly, data.timer_descr.is_weekly,
+                               data.timer_descr.daily_start_hour, data.timer_descr.daily_start_minute,
+                               data.timer_descr.daily_start_second, data.timer_descr.alt_halfmin_interval);
         case EVENT_SetNPCTopic:
             return fmt::format("{}: SetNPCTopic({}, {}, {})", step, data.npc_topic_descr.npc_id, data.npc_topic_descr.index, data.npc_topic_descr.event_id);
         case EVENT_MoveNPC:
             return fmt::format("{}: MoveNPC({}, {})", step, data.npc_move_descr.npc_id, std::to_underlying(data.npc_move_descr.location_id));
         case EVENT_GiveItem:
-            return fmt::format("{}: GiveItem({}, {}, {})", step, std::to_underlying(data.give_item_descr.treasure_level), std::to_underlying(data.give_item_descr.treasure_type), std::to_underlying(data.give_item_descr.item_id));
+            return fmt::format("{}: GiveItem({}, {}, {})", step,
+                               std::to_underlying(data.give_item_descr.treasure_level),
+                               std::to_underlying(data.give_item_descr.treasure_type),
+                               std::to_underlying(data.give_item_descr.item_id));
         case EVENT_ChangeEvent:
             return fmt::format("{}: ChangeEvent({})", step, data.event_id);
         case EVENT_CheckSkill:
-             return fmt::format("{}: CheckSkill({}, {}, {}) -> {}", step, std::to_underlying(data.check_skill_descr.skill_type), std::to_underlying(data.check_skill_descr.skill_mastery), data.check_skill_descr.skill_level, target_step);
+             return fmt::format("{}: CheckSkill({}, {}, {}) -> {}", step,
+                                std::to_underlying(data.check_skill_descr.skill_type),
+                                std::to_underlying(data.check_skill_descr.skill_mastery),
+                                data.check_skill_descr.skill_level, target_step);
         case EVENT_OnCanShowDialogItemCmp:
             return fmt::format("{}: OnCanShowDialogItemCmp({}) -> {}", step, getVariableCompareStr(data.variable_descr.type, data.variable_descr.value), target_step);
         case EVENT_EndCanShowDialogItem:

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -468,7 +468,7 @@ IndexedArray<std::array<PortraitId, 5>, SPEECH_FIRST, SPEECH_LAST> portraitVaria
     {SPEECH_LAST_MAN_STANDING,   {PORTRAIT_48,             PORTRAIT_INVALID,           PORTRAIT_INVALID,        PORTRAIT_INVALID,      PORTRAIT_INVALID}},
     {SPEECH_NOT_ENOUGH_FOOD,     {PORTRAIT_48,             PORTRAIT_INVALID,           PORTRAIT_INVALID,        PORTRAIT_INVALID,      PORTRAIT_INVALID}},
     {SPEECH_DEATH_BLOW,          {PORTRAIT_INVALID,        PORTRAIT_INVALID,           PORTRAIT_INVALID,        PORTRAIT_INVALID,      PORTRAIT_INVALID}},
-    {SPEECH_110,                 {PORTRAIT_INVALID,        PORTRAIT_INVALID,           PORTRAIT_INVALID,        PORTRAIT_INVALID,      PORTRAIT_INVALID}}, // Initially this entry was not present in array.
+    {SPEECH_110,                 {PORTRAIT_INVALID,        PORTRAIT_INVALID,           PORTRAIT_INVALID,        PORTRAIT_INVALID,      PORTRAIT_INVALID}}, // Not in the original game's table.
 }};
 
 std::array<int16_t, 4> pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing = {{34, 149, 264, 379}};

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -313,7 +313,9 @@ std::string MakeDateTimeString(Duration time) {
 //----- (004B1854) --------------------------------------------------------
 void GUIWindow::DrawShops_next_generation_time_string(Duration time, Recti frameRect) {
     auto str = MakeDateTimeString(time);
-    DrawTitleText(assets->pFontArrus.get(), 0, (212 - assets->pFontArrus->CalcTextHeight(str, frameRect.w, 0)) / 2 + 101, colorTable.PaleCanary, localization->str(LSTR_PLEASE_TRY_BACK_IN) + str, 3, frameRect);
+    DrawTitleText(assets->pFontArrus.get(), 0,
+                  (212 - assets->pFontArrus->CalcTextHeight(str, frameRect.w, 0)) / 2 + 101, colorTable.PaleCanary,
+                  localization->str(LSTR_PLEASE_TRY_BACK_IN) + str, 3, frameRect);
 }
 
 //----- (0044D406) --------------------------------------------------------

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -691,8 +691,12 @@ GUIWindow_PartyCreation::GUIWindow_PartyCreation() :
     ui_partycreation_buttmake = assets->getImage_Solid("BUTTMAKE");
     ui_partycreation_buttmake2 = assets->getImage_Solid("BUTTMAKE2");
 
-    pPlayerCreationUI_BtnOK = CreateButton("PartyCreation_OK", {580, 431}, {51, 39}, BUTTON_TYPE_NORMAL, 0, UIMSG_PlayerCreationClickOK, 0, INPUT_ACTION_PARTY_CREATION_DONE, "", {ui_partycreation_buttmake});
-    pPlayerCreationUI_BtnReset = CreateButton("PartyCreation_Clear", {527, 431}, {51, 39}, BUTTON_TYPE_NORMAL, 0, UIMSG_PlayerCreationClickReset, 0, INPUT_ACTION_PARTY_CREATION_CLEAR, "", {ui_partycreation_buttmake2});
+    pPlayerCreationUI_BtnOK = CreateButton("PartyCreation_OK", {580, 431}, {51, 39}, BUTTON_TYPE_NORMAL, 0,
+                                           UIMSG_PlayerCreationClickOK, 0, INPUT_ACTION_PARTY_CREATION_DONE, "",
+                                           {ui_partycreation_buttmake});
+    pPlayerCreationUI_BtnReset = CreateButton("PartyCreation_Clear", {527, 431}, {51, 39}, BUTTON_TYPE_NORMAL, 0,
+                                              UIMSG_PlayerCreationClickReset, 0, INPUT_ACTION_PARTY_CREATION_CLEAR, "",
+                                              {ui_partycreation_buttmake2});
     pPlayerCreationUI_BtnMinus = CreateButton({523, 393}, {20, 35}, BUTTON_TYPE_NORMAL, 0, UIMSG_PlayerCreationClickMinus, 0, INPUT_ACTION_PARTY_CREATION_DEC, "", {ui_partycreation_minus});
     pPlayerCreationUI_BtnPlus = CreateButton({613, 393}, {20, 35}, BUTTON_TYPE_NORMAL, 0, UIMSG_PlayerCreationClickPlus, 1, INPUT_ACTION_PARTY_CREATION_INC, "", {ui_partycreation_plus});
 


### PR DESCRIPTION
`check_style` now enforces a line length limit, something the `-whitespace/line_length` filter in `CPPLINT.cfg` used to switch off entirely. The hard limit is 200 columns.

The rule in `HACKING.md` is: 120 is still the preferred width, and comments stay within 120. Code can go up to 200 in the cases where squeezing it into 120 would make it uglier or harder to read, so don't contort the code to fit. A trailing comment is part of the line it's on and only has to fit in 200 with it.

`master` had 14 lines that cpplint flags at 200:

- 12 code lines, all single call expressions (8 `fmt::format` calls in `EvtInstruction.cpp`, the `BLV_GetFloorLevel` debug string in `Engine.cpp`, `DrawTitleText` in `GUIWindow.cpp`, two `CreateButton` calls in `UIPartyCreation.cpp`). Wrapped with paren-aligned continuations, keeping `(x, y, z)` triples on one line. Three of the resulting lines run 129-137 columns because the format string alone doesn't fit in 120.
- A `portraitVariants` row in `mm7_data.cpp` that was only over because of a trailing comment, which got shortened.
- The `MUSIC_CASTLE_HARMONDALE` enumerator in `SoundEnums.h`, whose 200-character trailing comment moved above it and wrapped at 120.

The three remaining raw lines over 200 bytes are two Cyrillic rows in `mm7text_ru.cpp` (cpplint counts characters, not bytes) and a debugger dump inside a block comment in `Localization.cpp`, which cpplint exempts.

Local `check_style`, `Run_UnitTest` (398/398) and `Run_GameTest_Headless_Parallel` (357/357) pass.
