### PR TITLE
Reworked CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,8 @@ Build `check_style` target to check style. You *MUST* always check style after y
 
 Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your changes. You *MUST* always run tests after your changes. If you can't find the game data - ask the user to help you locate it, *NEVER* silently skip game tests.
 
+*NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.
+
 Before every commit, re-read the diff's comments against the Comments section, as a separate pass with fresh eyes. You *MUST* do this - the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
 
 *NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call, made when they're ready.
@@ -34,5 +36,3 @@ Comments in tests are the opposite. State the bug that the test guards against, 
 When you do write about a past bug, spell out that it *was* a bug and name it. "We used to keep the old buffer" reads like a reasonable choice that happened to change. "This used to be a heap buffer overflow" doesn't.
 
 *NEVER* use semicolons in prose - in comments, commit messages, PR descriptions or documentation. Write two sentences instead.
-
-*NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,7 @@
+# General
+
+*NEVER* use semicolons in prose - in comments, commit messages, PR descriptions or documentation. Write two sentences instead.
+
 # Workflow
 
 You *MUST* read `HACKING.md` before doing any changes in this repo. You *MUST* follow the guidelines in `HACKING.md`, consider it a part of this document.
@@ -8,22 +12,19 @@ Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your c
 
 *NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.
 
-Before every commit, re-read the diff's comments against the Comments section, as a separate pass with fresh eyes. You *MUST* do this - the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
+Before every commit, re-read the code comments in the diff against the Comments section, as a separate pass. You *MUST* do this - the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
 
-*NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call, made when they're ready.
+*NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call.
 
 Put the `🤖 Human Needed` label on every pull request you open, once its CI is green. The label means a human has to look at the PR, and it's the only label you may ever add or remove - every other label belongs to the humans. Don't add it to a pull request that already carries any other label, a PR that a human has already triaged is in their pipeline anyway. Take the label off while you're working on review comments, and put it back when the ball is with the humans again.
-
 
 # Comments
 
 Keep comments terse - prefer a single trailing comment over a multi-line block, and never write comments explaining what you *didn't* do.
 
-A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about when to call, it sits at the call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
+Explanations live where the logic lives. A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about why this particular call happens here, it sits at that call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
 
-Explanations live where the logic lives. Why a detection works goes next to the detection, and the bug a test guards goes on the test.
-
-Every sentence in a comment must say something the code, the names, or the previous sentence don't already say. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead - an enum parameter reads at the call site, a bool doesn't.
+Every sentence in a comment must say something not already said by the code, the names, or the previous sentence. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 
 Any comment on a function, class, struct or table that's longer than a trailing one-liner is a doxygen block. Every doxygen block on a function *MUST* carry a `@param` tag for each parameter and a `@return` tag if the function returns something. A prose-only block isn't finished. Descriptions start at column 41, like the rest of the codebase.
 
@@ -34,5 +35,3 @@ Comments in production code should say how the present code works, and only wher
 Comments in tests are the opposite. State the bug that the test guards against, otherwise it's unclear why the test exists, and someone will eventually delete it as redundant.
 
 When you do write about a past bug, spell out that it *was* a bug and name it. "We used to keep the old buffer" reads like a reasonable choice that happened to change. "This used to be a heap buffer overflow" doesn't.
-
-*NEVER* use semicolons in prose - in comments, commit messages, PR descriptions or documentation. Write two sentences instead.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,8 @@ Build `check_style` target to check style. You *MUST* always check style after y
 
 Keep comments terse - prefer a single trailing comment over a multi-line block, and never write comments explaining what you *didn't* do.
 
+A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about when to call, it sits at the call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
+
 Any comment on a function, class, struct or table that's longer than a trailing one-liner is a doxygen block. Every doxygen block on a function *MUST* carry a `@param` tag for each parameter and a `@return` tag if the function returns something. A prose-only block isn't finished. Descriptions start at column 41, like the rest of the codebase.
 
 An invariant is an assert, not a comment. If you're about to write a comment saying what must be true at this point in the code, write an `assert` instead.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ Keep comments terse - prefer a single trailing comment over a multi-line block, 
 
 A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about when to call, it sits at the call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
 
-Explanations live where the logic lives. Why a detection works goes next to the detection, the bug a test guards goes on the test, and a helper that just crashes needs no essay.
+Explanations live where the logic lives. Why a detection works goes next to the detection, and the bug a test guards goes on the test.
 
 Every sentence in a comment must say something the code, the names, or the previous sentence don't already say. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead - an enum parameter reads at the call site, a bool doesn't.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,20 +1,31 @@
+# Workflow
+
 You *MUST* read `HACKING.md` before doing any changes in this repo. You *MUST* follow the guidelines in `HACKING.md`, consider it a part of this document.
 
 Build `check_style` target to check style. You *MUST* always check style after your changes.
+
+Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your changes. You *MUST* always run tests after your changes. If you can't find the game data - ask the user to help you locate it, *NEVER* silently skip game tests.
+
+Before every commit, re-read the diff's comments against the Comments section, as a separate pass with fresh eyes. You *MUST* do this - the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
+
+*NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call, made when they're ready.
+
+Put the `🤖 Human Needed` label on every pull request you open, once its CI is green. The label means a human has to look at the PR, and it's the only label you may ever add or remove - every other label belongs to the humans. Don't add it to a pull request that already carries any other label, a PR that a human has already triaged is in their pipeline anyway. Take the label off while you're working on review comments, and put it back when the ball is with the humans again.
+
+
+# Comments
 
 Keep comments terse - prefer a single trailing comment over a multi-line block, and never write comments explaining what you *didn't* do.
 
 A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about when to call, it sits at the call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
 
+Explanations live where the logic lives. Why a detection works goes next to the detection, the bug a test guards goes on the test, and a helper that just crashes needs no essay.
+
+Every sentence in a comment must say something the code, the names, or the previous sentence don't already say. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead - an enum parameter reads at the call site, a bool doesn't.
+
 Any comment on a function, class, struct or table that's longer than a trailing one-liner is a doxygen block. Every doxygen block on a function *MUST* carry a `@param` tag for each parameter and a `@return` tag if the function returns something. A prose-only block isn't finished. Descriptions start at column 41, like the rest of the codebase.
 
 An invariant is an assert, not a comment. If you're about to write a comment saying what must be true at this point in the code, write an `assert` instead.
-
-*NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.
-
-Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your changes. You *MUST* always run tests after your changes. If you can't find the game data - ask the user to help you locate it, *NEVER* silently skip game tests.
-
-*NEVER* use semicolons in prose - in comments, commit messages, PR descriptions or documentation. Write two sentences instead.
 
 Comments in production code should say how the present code works, and only where the workings are non-trivial. *NEVER* narrate past bugs there - the reader needs the current invariant, not the history.
 
@@ -22,4 +33,6 @@ Comments in tests are the opposite. State the bug that the test guards against, 
 
 When you do write about a past bug, spell out that it *was* a bug and name it. "We used to keep the old buffer" reads like a reasonable choice that happened to change. "This used to be a heap buffer overflow" doesn't.
 
-Put the `🤖 Human Needed` label on every pull request you open, once its CI is green. The label means a human has to look at the PR, and it's the only label you may ever add or remove - every other label belongs to the humans. Don't add it to a pull request that already carries any other label, a PR that a human has already triaged is in their pipeline anyway. Take the label off while you're working on review comments, and put it back when the ball is with the humans again.
+*NEVER* use semicolons in prose - in comments, commit messages, PR descriptions or documentation. Write two sentences instead.
+
+*NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.


### PR DESCRIPTION
CLAUDE.md is split into three sections. General is the prose rules that govern everything - comments, commit messages, PR text. Workflow is the working loop - read HACKING.md, check style, run tests, never claim what wasn't checked, label the PR. Comments is everything about what gets written into the code.

Three new rules, all distilled from a long review of the crash handler branch, where each had to be pointed out by hand more than once:

- Explanations live where the logic lives. A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about why this particular call happens here, it sits at that call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
- Every sentence in a comment must say something not already said by the code, the names, or the previous sentence. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
- Never amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits, and squashing is the human's call.

Plus a checkpoint in the loop: before every commit, re-read the code comments in the diff against the Comments section as a separate pass. These rules kept being broken at writing time and caught only in review, and a forced second pass is what actually catches them.

The last commits are a review round run on the rulebook itself, against its own rules. It caught a contradiction between the call-site sentence and the callers-only doxygen rule, a paragraph that restated its neighbors, an ambiguous checkpoint phrasing, and a comma splice sitting exactly where the banned semicolon would go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)