### PR TITLE
Allow mmmodding.miraheze.org through the devcontainer firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -60,6 +60,7 @@ ALLOWED_DOMAINS=(
     code.visualstudio.com   # update.code.visualstudio.com
     mightandmagic.fandom.com # MM7 wiki — game data references during refactoring.
     celestialheavens.com    # Might & Magic fan site — game data references.
+    mmmodding.miraheze.org  # Might & Magic modding wiki — evt format references.
     godbolt.org             # Compiler Explorer — checking codegen across compilers.
 )
 


### PR DESCRIPTION
It hosts the evt command reference, useful when digging through script semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)