### PR TITLE
PROBE: trace the i386 bad call walk on current master (do not merge)

### DIFF
--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -474,6 +474,7 @@ static void installHandlers() {
         action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
         sigfillset(&action.sa_mask);
         sigdelset(&action.sa_mask, signal);
+        sigdelset(&action.sa_mask, SIGALRM); // Or the watchdog alarm sits pending while the handler hangs, and never fires.
         action.sa_sigaction = &onSignal;
         sigaction(signal, &action, nullptr);
     }

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -433,6 +433,11 @@ static void onSignal(int signal, siginfo_t *info, void *context) {
     // dump. A second thread raising the same signal never gets here, SA_RESETHAND already put the default
     // handler back, so the kernel kills the process and whatever was printed so far is all there is.
     if (!crashHandled.test_and_set()) {
+        // Symbolizing allocates and takes locks, and the header spells out how that can deadlock. A wedged
+        // handler is worse than a lost trace, so the alarm kills the process - SIGALRM keeps its default
+        // disposition - and whatever was printed by then still reaches the reader.
+        alarm(30);
+
         char reason[128];
         std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
         printCrashHeader(reason);

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -374,14 +374,18 @@ static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &cras
     uintptr_t returnAddress = crashContext.uc_mcontext.arm_lr;
     uintptr_t fp = crashContext.uc_mcontext.arm_fp;
 #endif
+    std::fprintf(stderr, "[probe walk] return=%#zx fp=%#zx\n", static_cast<size_t>(returnAddress), static_cast<size_t>(fp));
     frames.push_back(returnAddress - 1); // Minus one, so it points into the call, not one past it.
     while (fp != 0 && frames.size() < detail::MAX_TRACE_DEPTH) {
         const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp); // [fp] = caller's fp, [fp + 1] = return.
+        std::fprintf(stderr, "[probe walk] deref fp=%#zx\n", static_cast<size_t>(fp));
         if (frame[1] == 0)
             break;
+        std::fprintf(stderr, "[probe walk]   -> return=%#zx next fp=%#zx\n", static_cast<size_t>(frame[1]), static_cast<size_t>(frame[0]));
         frames.push_back(frame[1] - 1);
         fp = frame[0];
     }
+    std::fprintf(stderr, "[probe walk] done, %zu frames, resolving\n", frames.size());
     return frames;
 }
 
@@ -400,6 +404,8 @@ static std::string traceFromContext(const ucontext_t &crashContext) {
     cpptrace::raw_trace raw;
 
     dwarf_eh_bases bases;
+    std::fprintf(stderr, "[probe trace] pc=%#zx fde=%p\n", static_cast<size_t>(faultingProgramCounter(crashContext)),
+                 _Unwind_Find_FDE(reinterpret_cast<const void *>(faultingProgramCounter(crashContext)), &bases));
     if (!_Unwind_Find_FDE(reinterpret_cast<const void *>(faultingProgramCounter(crashContext)), &bases)) {
         raw.frames = walkFramePointers(crashContext);
         return raw.resolve().to_string();

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,8 +123,11 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
     volatile char pad[1024]; // Big frames run out of stack fast.
+    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
     pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,6 +31,16 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
+// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
+// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
+// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
+class StackTraceDeathTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+    }
+};
+
 /**
  * Matches when the frame numbered `index` names `function`. The regexes gtest's own death test matchers take
  * aren't portable - gtest picks between two engines with different grammars depending on the platform - so
@@ -128,7 +138,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -139,7 +149,7 @@ UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -152,7 +162,7 @@ UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -164,7 +174,7 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -175,7 +185,7 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
@@ -186,7 +196,7 @@ UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -203,7 +213,7 @@ UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST(StackTrace, AbortIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -213,7 +223,7 @@ UNIT_TEST(StackTrace, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST(StackTrace, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -223,7 +233,7 @@ UNIT_TEST(StackTrace, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +244,7 @@ UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST(StackTrace, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,10 +31,12 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
-// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
-// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
-// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
-class StackTraceDeathTest : public testing::Test {
+/**
+ * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
+ * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
+ * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ */
+class ThreadSafeDeathTest : public testing::Test {
  protected:
     void SetUp() override {
         GTEST_FLAG_SET(death_test_style, "threadsafe");
@@ -123,23 +125,20 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
-// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
-MM_NOINLINE int stackTraceOverflowFunction(int depth);
+MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
-// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
-MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
-    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
+MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction2(depth + 1); // Mutual, or this folds into a loop that never overflows.
 }
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
     volatile char pad[1024];
     pad[0] = static_cast<char>(depth);
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
@@ -149,7 +148,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -160,7 +159,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -173,7 +172,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -185,7 +184,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -196,18 +195,18 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
-        stackTraceOverflowFunction(0);
+        stackTraceOverflowFunction1(0);
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -224,7 +223,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +233,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -244,7 +243,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -255,7 +254,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -32,9 +32,9 @@ constexpr bool isMac = false;
 #endif
 
 /**
- * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
- * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
- * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ * Death tests in this suite re-exec the binary instead of forking it. The darwin_x86_64 leg runs under
+ * Rosetta on the arm64 runners, where gtest counts a second thread in the process and warns that a forked
+ * child inherits whatever locks that thread held at that instant. A re-exec'd child starts clean.
  */
 class ThreadSafeDeathTest : public testing::Test {
  protected:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,15 +123,23 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
+// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
+MM_NOINLINE int stackTraceOverflowFunction(int depth);
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
-    volatile char pad[1024]; // Big frames run out of stack fast.
-    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
+// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
+MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.
-    return pad[0] + pad[1023];
+    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+}
+
+MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {


### PR DESCRIPTION
Throwaway. The threadsafe death test branch fails NullFunctionCall, BadTargetCall and PureVirtualCall on linux_x86 RelWithDebInfo - the child prints the crash header and dies inside traceFromContext. This is the fix branch on current master plus step-by-step prints of the bad call walk, to see which dereference faults. Closed once the log is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)