### PR TITLE
Drop dead code from OurMath and unify pi on M_PI

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
-#include <numbers>
+#include <cmath>
 
 #include "Engine/Engine.h"
 
@@ -134,8 +134,8 @@ void Engine::drawWorld() {
 
     pCamera3D->_viewPitch = pParty->_viewPitch;
     pCamera3D->_viewYaw = pParty->_viewYaw;
-    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
     pCamera3D->vCameraPos.z = pParty->pos.z + pParty->eyeLevel;  // 193, but real 353
 
     pCamera3D->CalculateRotations(pParty->_viewYaw, pParty->_viewPitch);
@@ -351,7 +351,7 @@ static void drawDebugCylinder(Vec3f center_lo, float radius, float height, Color
     static constexpr int SEGMENTS = 12;
     RenderVertexSoft prev_lo, prev_hi, cur_lo, cur_hi;
     for (int i = 0; i <= SEGMENTS; ++i) {
-        float angle = 2.0f * std::numbers::pi * i / SEGMENTS;
+        float angle = 2.0f * M_PI * i / SEGMENTS;
         float dx = radius * std::cos(angle);
         float dy = radius * std::sin(angle);
         cur_lo.vWorldPosition = Vec3f(center_lo.x + dx, center_lo.y + dy, center_lo.z);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1,10 +1,10 @@
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <string>
 #include <algorithm>
 #include <memory>
 #include <optional>
-#include <cmath>
 
 #include "Engine/Engine.h"
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <numbers>
 
 #include "Engine/Engine.h"
 
@@ -40,7 +41,6 @@
 #include "Engine/Objects/SpriteObject.h"
 #include "Engine/Objects/NPC.h"
 #include "Engine/Objects/MonsterEnumFunctions.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/PartyPlacement.h"
 #include "Engine/Random/Random.h"
@@ -134,8 +134,8 @@ void Engine::drawWorld() {
 
     pCamera3D->_viewPitch = pParty->_viewPitch;
     pCamera3D->_viewYaw = pParty->_viewYaw;
-    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
-    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
     pCamera3D->vCameraPos.z = pParty->pos.z + pParty->eyeLevel;  // 193, but real 353
 
     pCamera3D->CalculateRotations(pParty->_viewYaw, pParty->_viewPitch);
@@ -351,7 +351,7 @@ static void drawDebugCylinder(Vec3f center_lo, float radius, float height, Color
     static constexpr int SEGMENTS = 12;
     RenderVertexSoft prev_lo, prev_hi, cur_lo, cur_hi;
     for (int i = 0; i <= SEGMENTS; ++i) {
-        float angle = 2.0f * M_PI * i / SEGMENTS;
+        float angle = 2.0f * std::numbers::pi * i / SEGMENTS;
         float dx = radius * std::cos(angle);
         float dy = radius * std::sin(angle);
         cur_lo.vWorldPosition = Vec3f(center_lo.x + dx, center_lo.y + dy, center_lo.z);

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -1,6 +1,7 @@
 #include "Engine/Graphics/Camera.h"
 
-#include <numbers>
+#include <cmath>
+
 
 #include "Engine/Engine.h"
 
@@ -127,7 +128,7 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     ViewPlaneDistPixels = (double)pViewport.w * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / std::numbers::pi_v<float>) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
+    fov_y_deg = (180.0 / static_cast<float>(M_PI)) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
     screenCenterX = (double)pViewport.center().x;
     screenCenterY = (double)pViewport.center().y - pViewport.y;
@@ -137,11 +138,11 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
 
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
-    float HalfAngleX = (std::numbers::pi_v<float> / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (std::numbers::pi_v<float> / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
+    float HalfAngleX = (static_cast<float>(M_PI) / 2.0) - (odm_fov_rad / 2.0);
+    float HalfAngleY = (static_cast<float>(M_PI) / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-        HalfAngleX = (std::numbers::pi_v<float> / 2.0) - (blv_fov_rad / 2.0);
+        HalfAngleX = (static_cast<float>(M_PI) / 2.0) - (blv_fov_rad / 2.0);
     }
 
     glm::vec3 PlaneVec(0);
@@ -329,11 +330,11 @@ void Camera3D::CalculateRotations(int cameraYaw, int cameraPitch) {
     _viewPitch = -cameraPitch;  // pitch
     _viewYaw = cameraYaw;  // yaw
 
-    _yawRotationSine = std::sin((2 * std::numbers::pi) * _viewYaw / 2048.0);
-    _yawRotationCosine = std::cos((2 * std::numbers::pi) * _viewYaw / 2048.0);
+    _yawRotationSine = std::sin((2 * M_PI) * _viewYaw / 2048.0);
+    _yawRotationCosine = std::cos((2 * M_PI) * _viewYaw / 2048.0);
 
-    _pitchRotationSine = std::sin((2 * std::numbers::pi) * _viewPitch / 2048.0);
-    _pitchRotationCosine = std::cos((2 * std::numbers::pi) * _viewPitch / 2048.0);
+    _pitchRotationSine = std::sin((2 * M_PI) * _viewPitch / 2048.0);
+    _pitchRotationCosine = std::cos((2 * M_PI) * _viewPitch / 2048.0);
 }
 
 void Camera3D::CullByNearClip(RenderVertexSoft *pverts, unsigned *unumverts) {

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -1,7 +1,8 @@
 #include "Engine/Graphics/Camera.h"
 
+#include <numbers>
+
 #include "Engine/Engine.h"
-#include "Engine/OurMath.h"
 
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Graphics/Viewport.h"
@@ -126,7 +127,7 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     ViewPlaneDistPixels = (double)pViewport.w * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / pi) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
+    fov_y_deg = (180.0 / std::numbers::pi_v<float>) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
     screenCenterX = (double)pViewport.center().x;
     screenCenterY = (double)pViewport.center().y - pViewport.y;
@@ -136,11 +137,11 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
 
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
-    float HalfAngleX = (pi / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (pi / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
+    float HalfAngleX = (std::numbers::pi_v<float> / 2.0) - (odm_fov_rad / 2.0);
+    float HalfAngleY = (std::numbers::pi_v<float> / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-        HalfAngleX = (pi / 2.0) - (blv_fov_rad / 2.0);
+        HalfAngleX = (std::numbers::pi_v<float> / 2.0) - (blv_fov_rad / 2.0);
     }
 
     glm::vec3 PlaneVec(0);
@@ -328,11 +329,11 @@ void Camera3D::CalculateRotations(int cameraYaw, int cameraPitch) {
     _viewPitch = -cameraPitch;  // pitch
     _viewYaw = cameraYaw;  // yaw
 
-    _yawRotationSine = std::sin((pi_double + pi_double) * _viewYaw / 2048.0);
-    _yawRotationCosine = std::cos((pi_double + pi_double) * _viewYaw / 2048.0);
+    _yawRotationSine = std::sin((2 * std::numbers::pi) * _viewYaw / 2048.0);
+    _yawRotationCosine = std::cos((2 * std::numbers::pi) * _viewYaw / 2048.0);
 
-    _pitchRotationSine = std::sin((pi_double + pi_double) * _viewPitch / 2048.0);
-    _pitchRotationCosine = std::cos((pi_double + pi_double) * _viewPitch / 2048.0);
+    _pitchRotationSine = std::sin((2 * std::numbers::pi) * _viewPitch / 2048.0);
+    _pitchRotationCosine = std::cos((2 * std::numbers::pi) * _viewPitch / 2048.0);
 }
 
 void Camera3D::CullByNearClip(RenderVertexSoft *pverts, unsigned *unumverts) {

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -128,7 +128,7 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
     ViewPlaneDistPixels = (double)pViewport.w * 0.5 / halfFovTan;
 
     // calculate vertical FOV in degrees for GL rendering
-    fov_y_deg = (180.0 / static_cast<float>(M_PI)) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
+    fov_y_deg = (180.0 / M_PI) * 2.0 * std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels);
 
     screenCenterX = (double)pViewport.center().x;
     screenCenterY = (double)pViewport.center().y - pViewport.y;
@@ -138,11 +138,11 @@ void Camera3D::CreateViewMatrixAndProjectionScale() {
 
 //----- (004374E8) --------------------------------------------------------
 void Camera3D::BuildViewFrustum() {
-    float HalfAngleX = (static_cast<float>(M_PI) / 2.0) - (odm_fov_rad / 2.0);
-    float HalfAngleY = (static_cast<float>(M_PI) / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
+    float HalfAngleX = (M_PI / 2.0) - (odm_fov_rad / 2.0);
+    float HalfAngleY = (M_PI / 2.0) - (std::atan((pViewport.h / 2.0) / pCamera3D->ViewPlaneDistPixels));
 
     if (uCurrentlyLoadedLevelType == LEVEL_INDOOR) {
-        HalfAngleX = (static_cast<float>(M_PI) / 2.0) - (blv_fov_rad / 2.0);
+        HalfAngleX = (M_PI / 2.0) - (blv_fov_rad / 2.0);
     }
 
     glm::vec3 PlaneVec(0);

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 
-
 #include "Engine/Engine.h"
 
 #include "Engine/Graphics/Indoor.h"

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <array>
-#include <numbers>
+#include <cmath>
 
 #include <glm/glm.hpp>
 
@@ -70,9 +70,9 @@ struct Camera3D {
 
     // Camera field of view angles in degrees and radians
     int odm_fov_deg = 75;
-    float odm_fov_rad = odm_fov_deg * std::numbers::pi / 180.0f;
+    float odm_fov_rad = odm_fov_deg * M_PI / 180.0f;
     int blv_fov_deg = 60;
-    float blv_fov_rad = blv_fov_deg * std::numbers::pi / 180.0f;
+    float blv_fov_rad = blv_fov_deg * M_PI / 180.0f;
 
     // game viewport aspect ratio
     float aspect = 0;

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <numbers>
 
 #include <glm/glm.hpp>
 
@@ -69,9 +70,9 @@ struct Camera3D {
 
     // Camera field of view angles in degrees and radians
     int odm_fov_deg = 75;
-    float odm_fov_rad = odm_fov_deg * M_PI / 180.0f;
+    float odm_fov_rad = odm_fov_deg * std::numbers::pi / 180.0f;
     int blv_fov_deg = 60;
-    float blv_fov_rad = blv_fov_deg * M_PI / 180.0f;
+    float blv_fov_rad = blv_fov_deg * std::numbers::pi / 180.0f;
 
     // game viewport aspect ratio
     float aspect = 0;

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <array>
 #include <cmath>
+#include <array>
 
 #include <glm/glm.hpp>
 

--- a/src/Engine/Graphics/DecalBuilder.cpp
+++ b/src/Engine/Graphics/DecalBuilder.cpp
@@ -6,7 +6,6 @@
 #include "Engine/Graphics/Outdoor.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/ClippingFunctions.h"
-#include "Engine/OurMath.h"
 #include "Engine/Timer.h"
 #include "Engine/stru314.h"
 

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -6,7 +6,7 @@
 #include <ranges>
 #include <string>
 #include <utility>
-#include <numbers>
+#include <cmath>
 
 #include "Engine/Engine.h"
 #include "Engine/AssetsManager.h"
@@ -1754,7 +1754,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(1024) + 512;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * std::numbers::pi_v<float>) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * static_cast<float>(M_PI)) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;
@@ -1790,7 +1790,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (loop_cnt = 0; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(512) + 256;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * std::numbers::pi_v<float>) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * static_cast<float>(M_PI)) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1,12 +1,12 @@
 #include "Engine/Graphics/Indoor.h"
 
+#include <cmath>
 #include <algorithm>
 #include <limits>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <utility>
-#include <cmath>
 
 #include "Engine/Engine.h"
 #include "Engine/AssetsManager.h"

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1754,7 +1754,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(1024) + 512;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * static_cast<float>(M_PI)) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * M_PI) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;
@@ -1790,7 +1790,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (loop_cnt = 0; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(512) + 256;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * static_cast<float>(M_PI)) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * M_PI) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -6,6 +6,7 @@
 #include <ranges>
 #include <string>
 #include <utility>
+#include <numbers>
 
 #include "Engine/Engine.h"
 #include "Engine/AssetsManager.h"
@@ -1753,7 +1754,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(1024) + 512;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * pi) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * std::numbers::pi_v<float>) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;
@@ -1789,7 +1790,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
         for (loop_cnt = 0; loop_cnt < 100; ++loop_cnt) {
             // random x,y at distance from party
             dist_from_party = grng->random(512) + 256;
-            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * pi) / TrigLUT.uIntegerDoublePi;
+            angle_from_party = (grng->random(TrigLUT.uIntegerDoublePi) * 2 * std::numbers::pi_v<float>) / TrigLUT.uIntegerDoublePi;
             enc_spawn_point.position.x = pParty->pos.x + std::cos(angle_from_party) * dist_from_party;
             enc_spawn_point.position.y = pParty->pos.y + std::sin(angle_from_party) * dist_from_party;
             enc_spawn_point.position.z = pParty->pos.z;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -334,9 +334,9 @@ void OutdoorLocation::UpdateSunlightVectors() {
     if (pParty->uCurrentHour >= 5 && pParty->uCurrentHour < 21) {
         minutes = pParty->uCurrentMinute + 60 * (pParty->uCurrentHour - 5);
 
-        this->vSunlight.x = std::cos((minutes * static_cast<float>(M_PI)) / 960.0);
+        this->vSunlight.x = std::cos((minutes * M_PI) / 960.0);
         this->vSunlight.y = 0;
-        this->vSunlight.z = std::sin((minutes * static_cast<float>(M_PI)) / 960.0);
+        this->vSunlight.z = std::sin((minutes * M_PI) / 960.0);
 
         if (minutes >= 480)
             v8 = 960 - minutes;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1,10 +1,10 @@
 #include "Engine/Graphics/Outdoor.h"
 
+#include <cmath>
 #include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
-#include <cmath>
 
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <numbers>
 
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
@@ -333,9 +334,9 @@ void OutdoorLocation::UpdateSunlightVectors() {
     if (pParty->uCurrentHour >= 5 && pParty->uCurrentHour < 21) {
         minutes = pParty->uCurrentMinute + 60 * (pParty->uCurrentHour - 5);
 
-        this->vSunlight.x = std::cos((minutes * pi) / 960.0);
+        this->vSunlight.x = std::cos((minutes * std::numbers::pi_v<float>) / 960.0);
         this->vSunlight.y = 0;
-        this->vSunlight.z = std::sin((minutes * pi) / 960.0);
+        this->vSunlight.z = std::sin((minutes * std::numbers::pi_v<float>) / 960.0);
 
         if (minutes >= 480)
             v8 = 960 - minutes;
@@ -1059,11 +1060,11 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_StrafeLeft:
             {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
                 float dx = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.x -= 3 * dx / 4;
 
-                float cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
                 float dy = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.y += 3 * dy / 4;
 
@@ -1072,11 +1073,11 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_StrafeRight:
             {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
                 float dx = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.x += 3 * dx / 4;
 
-                float cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
                 float dy = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.y -= 3 * dy / 4;
 
@@ -1085,8 +1086,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_WalkForward:
             {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0),
-                      cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0),
+                      cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
@@ -1104,8 +1105,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_RunForward:
             {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
@@ -1136,8 +1137,8 @@ void ODM_ProcessPartyActions() {
             } break;
 
             case PARTY_WalkBackward: {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;
                 partyInputSpeed.x -= dx;
@@ -1149,8 +1150,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_RunBackward:
             {
-                float sin_y = sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <numbers>
+#include <cmath>
 
 #include "Engine/Engine.h"
 #include "Engine/EngineGlobals.h"
@@ -334,9 +334,9 @@ void OutdoorLocation::UpdateSunlightVectors() {
     if (pParty->uCurrentHour >= 5 && pParty->uCurrentHour < 21) {
         minutes = pParty->uCurrentMinute + 60 * (pParty->uCurrentHour - 5);
 
-        this->vSunlight.x = std::cos((minutes * std::numbers::pi_v<float>) / 960.0);
+        this->vSunlight.x = std::cos((minutes * static_cast<float>(M_PI)) / 960.0);
         this->vSunlight.y = 0;
-        this->vSunlight.z = std::sin((minutes * std::numbers::pi_v<float>) / 960.0);
+        this->vSunlight.z = std::sin((minutes * static_cast<float>(M_PI)) / 960.0);
 
         if (minutes >= 480)
             v8 = 960 - minutes;
@@ -1060,11 +1060,11 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_StrafeLeft:
             {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
                 float dx = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.x -= 3 * dx / 4;
 
-                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
                 float dy = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.y += 3 * dy / 4;
 
@@ -1073,11 +1073,11 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_StrafeRight:
             {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
                 float dx = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.x += 3 * dx / 4;
 
-                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
                 float dy = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 partyInputSpeed.y -= 3 * dy / 4;
 
@@ -1086,8 +1086,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_WalkForward:
             {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0),
-                      cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0),
+                      cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
@@ -1105,8 +1105,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_RunForward:
             {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fWalkSpeedMultiplier;
@@ -1137,8 +1137,8 @@ void ODM_ProcessPartyActions() {
             } break;
 
             case PARTY_WalkBackward: {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;
                 partyInputSpeed.x -= dx;
@@ -1150,8 +1150,8 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_RunBackward:
             {
-                float sin_y = sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-                float cos_y = cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+                float sin_y = sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
+                float cos_y = cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
 
                 float dx = cos_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;
                 float dy = sin_y * pParty->walkSpeed * fBackwardWalkSpeedMultiplier;

--- a/src/Engine/Graphics/ParticleEngine.cpp
+++ b/src/Engine/Graphics/ParticleEngine.cpp
@@ -3,7 +3,6 @@
 #include "Engine/Graphics/Camera.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Random/Random.h"
-#include "Engine/OurMath.h"
 #include "Engine/Timer.h"
 
 #include "Utility/Math/TrigLut.h"

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -2,13 +2,13 @@
 
 #include "OpenGLVertexBuffer.h"
 
+#include <cmath>
 #include <algorithm>
 #include <memory>
 #include <utility>
 #include <map>
 #include <string>
 #include <tuple>
-#include <cmath>
 
 #include <glad/gl.h> // NOLINT: not a C system header.
 

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -8,7 +8,7 @@
 #include <map>
 #include <string>
 #include <tuple>
-#include <numbers>
+#include <cmath>
 
 #include <glad/gl.h> // NOLINT: not a C system header.
 
@@ -646,7 +646,7 @@ void OpenGLRenderer::DrawIndoorSky(int /*uNumVertices*/, int uFaceID) {
 
 
     // TODO(pskelton): repeated maths could be saved when calculating sky planes
-    double rot_to_rads = ((2 * std::numbers::pi) / 2048);
+    double rot_to_rads = ((2 * M_PI) / 2048);
 
     // lowers clouds as party goes up
     float  blv_horizon_height_offset = ((pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
@@ -766,8 +766,8 @@ RgbaImage OpenGLRenderer::MakeViewportScreenshot(const int width, const int heig
 
     pCamera3D->_viewPitch = pParty->_viewPitch;
     pCamera3D->_viewYaw = pParty->_viewYaw;
-    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
     pCamera3D->vCameraPos.z = pParty->pos.z + pParty->eyeLevel;  // 193, but real 353
     pCamera3D->CalculateRotations(pParty->_viewYaw, pParty->_viewPitch);
     pCamera3D->CreateViewMatrixAndProjectionScale();
@@ -949,9 +949,9 @@ void OpenGLRenderer::_set_3d_modelview_matrix() {
 
     // build view matrix with glm
     glm::vec3 campos = glm::vec3(camera_x, camera_y, camera_z);
-    glm::vec3 eyepos = glm::vec3(camera_x - cosf(2.0f * std::numbers::pi * pCamera3D->_viewYaw / 2048.0f),
-        camera_y - sinf(2.0f * std::numbers::pi * pCamera3D->_viewYaw / 2048.0f),
-        camera_z - tanf(2.0f * std::numbers::pi * -pCamera3D->_viewPitch / 2048.0f));
+    glm::vec3 eyepos = glm::vec3(camera_x - cosf(2.0f * M_PI * pCamera3D->_viewYaw / 2048.0f),
+        camera_y - sinf(2.0f * M_PI * pCamera3D->_viewYaw / 2048.0f),
+        camera_z - tanf(2.0f * M_PI * -pCamera3D->_viewPitch / 2048.0f));
     glm::vec3 upvec = glm::vec3(0.0f, 0.0f, 1.0f);
 
     viewmat = glm::lookAtLH(campos, eyepos, upvec);
@@ -1195,8 +1195,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
     TerrainUniforms uniforms;
     uniforms.projection = projmat;
     uniforms.view = viewmat;
-    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
-    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * M_PI * pParty->_viewYaw / 2048.0);
+    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * M_PI * pParty->_viewYaw / 2048.0);
     uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
     uniforms.fog = fog;
     uniforms.gamma = gamma;
@@ -1204,7 +1204,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
 
     // sun lighting stuff
     float ambient = pParty->uCurrentMinute + pParty->uCurrentHour * 60.0;  // 0 - > 1439
-    ambient = 0.15 + (sinf(((ambient - 360.0) * 2 * std::numbers::pi) / 1440) + 1) * 0.27;
+    ambient = 0.15 + (sinf(((ambient - 360.0) * 2 * M_PI) / 1440) + 1) * 0.27;
     float diffuseon = pWeather->bNight ? 0 : 1;
 
     uniforms.sun.direction = pOutdoor->vSunlight;
@@ -1389,7 +1389,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
 
 // TODO(pskelton): renderbase
 void OpenGLRenderer::DrawOutdoorSky() {
-    double rot_to_rads = ((2 * std::numbers::pi) / 2048);
+    double rot_to_rads = ((2 * M_PI) / 2048);
 
     // lowers clouds as party goes up
     float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
@@ -2575,8 +2575,8 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
     OutBuildUniforms uniforms;
     uniforms.projection = projmat;
     uniforms.view = viewmat;
-    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
-    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
+    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * M_PI * pParty->_viewYaw / 2048.0f);
+    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * M_PI * pParty->_viewYaw / 2048.0f);
     uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
     uniforms.fog = fog;
     uniforms.gamma = gamma;
@@ -2586,7 +2586,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
 
     // sun lighting stuff
     float ambient = pParty->uCurrentMinute + pParty->uCurrentHour * 60.0f;  // 0 - > 1439
-    ambient = 0.15 + (sinf(((ambient - 360.0f) * 2 * std::numbers::pi) / 1440) + 1) * 0.27f;
+    ambient = 0.15 + (sinf(((ambient - 360.0f) * 2 * M_PI) / 1440) + 1) * 0.27f;
     float diffuseon = pWeather->bNight ? 0.0f : 1.0f;
 
     uniforms.sun.direction = pOutdoor->vSunlight;
@@ -3091,8 +3091,8 @@ void OpenGLRenderer::DrawIndoorFaces() {
         BSPUniforms uniforms;
         uniforms.projection = projmat;
         uniforms.view = viewmat;
-        uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
-        uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
+        uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * M_PI * pParty->_viewYaw / 2048.0f);
+        uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * M_PI * pParty->_viewYaw / 2048.0f);
         uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
         uniforms.gamma = gamma;
         uniforms.waterframe = waterAnimationFrame();

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 #include <tuple>
+#include <numbers>
 
 #include <glad/gl.h> // NOLINT: not a C system header.
 
@@ -645,7 +646,7 @@ void OpenGLRenderer::DrawIndoorSky(int /*uNumVertices*/, int uFaceID) {
 
 
     // TODO(pskelton): repeated maths could be saved when calculating sky planes
-    double rot_to_rads = ((2 * pi_double) / 2048);
+    double rot_to_rads = ((2 * std::numbers::pi) / 2048);
 
     // lowers clouds as party goes up
     float  blv_horizon_height_offset = ((pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
@@ -765,8 +766,8 @@ RgbaImage OpenGLRenderer::MakeViewportScreenshot(const int width, const int heig
 
     pCamera3D->_viewPitch = pParty->_viewPitch;
     pCamera3D->_viewYaw = pParty->_viewYaw;
-    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
-    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    pCamera3D->vCameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
     pCamera3D->vCameraPos.z = pParty->pos.z + pParty->eyeLevel;  // 193, but real 353
     pCamera3D->CalculateRotations(pParty->_viewYaw, pParty->_viewPitch);
     pCamera3D->CreateViewMatrixAndProjectionScale();
@@ -948,9 +949,9 @@ void OpenGLRenderer::_set_3d_modelview_matrix() {
 
     // build view matrix with glm
     glm::vec3 campos = glm::vec3(camera_x, camera_y, camera_z);
-    glm::vec3 eyepos = glm::vec3(camera_x - cosf(2.0f * pi_double * pCamera3D->_viewYaw / 2048.0f),
-        camera_y - sinf(2.0f * pi_double * pCamera3D->_viewYaw / 2048.0f),
-        camera_z - tanf(2.0f * pi_double * -pCamera3D->_viewPitch / 2048.0f));
+    glm::vec3 eyepos = glm::vec3(camera_x - cosf(2.0f * std::numbers::pi * pCamera3D->_viewYaw / 2048.0f),
+        camera_y - sinf(2.0f * std::numbers::pi * pCamera3D->_viewYaw / 2048.0f),
+        camera_z - tanf(2.0f * std::numbers::pi * -pCamera3D->_viewPitch / 2048.0f));
     glm::vec3 upvec = glm::vec3(0.0f, 0.0f, 1.0f);
 
     viewmat = glm::lookAtLH(campos, eyepos, upvec);
@@ -1194,8 +1195,8 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
     TerrainUniforms uniforms;
     uniforms.projection = projmat;
     uniforms.view = viewmat;
-    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * pi_double * pParty->_viewYaw / 2048.0);
-    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * pi_double * pParty->_viewYaw / 2048.0);
+    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
+    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0);
     uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
     uniforms.fog = fog;
     uniforms.gamma = gamma;
@@ -1203,7 +1204,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
 
     // sun lighting stuff
     float ambient = pParty->uCurrentMinute + pParty->uCurrentHour * 60.0;  // 0 - > 1439
-    ambient = 0.15 + (sinf(((ambient - 360.0) * 2 * pi_double) / 1440) + 1) * 0.27;
+    ambient = 0.15 + (sinf(((ambient - 360.0) * 2 * std::numbers::pi) / 1440) + 1) * 0.27;
     float diffuseon = pWeather->bNight ? 0 : 1;
 
     uniforms.sun.direction = pOutdoor->vSunlight;
@@ -1388,7 +1389,7 @@ void OpenGLRenderer::DrawOutdoorTerrain() {
 
 // TODO(pskelton): renderbase
 void OpenGLRenderer::DrawOutdoorSky() {
-    double rot_to_rads = ((2 * pi_double) / 2048);
+    double rot_to_rads = ((2 * std::numbers::pi) / 2048);
 
     // lowers clouds as party goes up
     float  horizon_height_offset = ((double)(pCamera3D->ViewPlaneDistPixels * pCamera3D->vCameraPos.z)
@@ -2574,8 +2575,8 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
     OutBuildUniforms uniforms;
     uniforms.projection = projmat;
     uniforms.view = viewmat;
-    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * pi_double * pParty->_viewYaw / 2048.0f);
-    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * pi_double * pParty->_viewYaw / 2048.0f);
+    uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
+    uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
     uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
     uniforms.fog = fog;
     uniforms.gamma = gamma;
@@ -2585,7 +2586,7 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
 
     // sun lighting stuff
     float ambient = pParty->uCurrentMinute + pParty->uCurrentHour * 60.0f;  // 0 - > 1439
-    ambient = 0.15 + (sinf(((ambient - 360.0f) * 2 * pi_double) / 1440) + 1) * 0.27f;
+    ambient = 0.15 + (sinf(((ambient - 360.0f) * 2 * std::numbers::pi) / 1440) + 1) * 0.27f;
     float diffuseon = pWeather->bNight ? 0.0f : 1.0f;
 
     uniforms.sun.direction = pOutdoor->vSunlight;
@@ -3090,8 +3091,8 @@ void OpenGLRenderer::DrawIndoorFaces() {
         BSPUniforms uniforms;
         uniforms.projection = projmat;
         uniforms.view = viewmat;
-        uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * pi_double * pParty->_viewYaw / 2048.0f);
-        uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * pi_double * pParty->_viewYaw / 2048.0f);
+        uniforms.cameraPos.x = pParty->pos.x - pParty->_yawGranularity * cosf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
+        uniforms.cameraPos.y = pParty->pos.y - pParty->_yawGranularity * sinf(2 * std::numbers::pi * pParty->_viewYaw / 2048.0f);
         uniforms.cameraPos.z = pParty->pos.z + pParty->eyeLevel;
         uniforms.gamma = gamma;
         uniforms.waterframe = waterAnimationFrame();

--- a/src/Engine/Graphics/Sprites.cpp
+++ b/src/Engine/Graphics/Sprites.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <string>
 
-#include "Engine/OurMath.h"
 #include "Engine/Objects/DecorationList.h"
 #include "Engine/Graphics/PaletteManager.h"
 #include "Engine/Graphics/Image.h"

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -14,7 +14,6 @@
 #include "Engine/Objects/SpriteObject.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Spells/Spells.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -20,7 +20,6 @@
 #include "Engine/Objects/SpriteObject.h"
 #include "Engine/Graphics/Sprites.h"
 #include "Engine/Tables/ItemTable.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/MapInfo.h"
 #include "Engine/Tables/ChestTable.h"

--- a/src/Engine/Objects/Item.cpp
+++ b/src/Engine/Objects/Item.cpp
@@ -11,7 +11,6 @@
 #include "Engine/Objects/CharacterEnums.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Tables/HouseTable.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 
 

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -9,7 +9,6 @@
 #include "Engine/SpellFxRenderer.h"
 #include "Engine/Timer.h"
 #include "Engine/Evt/Processor.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/AttackList.h"

--- a/src/Engine/OurMath.cpp
+++ b/src/Engine/OurMath.cpp
@@ -1,5 +1,6 @@
 #include "Engine/OurMath.h"
 
+#include <cmath>
 #include <utility>
 
 //----- (00452A9E) --------------------------------------------------------

--- a/src/Engine/OurMath.cpp
+++ b/src/Engine/OurMath.cpp
@@ -4,38 +4,7 @@
 
 //----- (00452A9E) --------------------------------------------------------
 int integer_sqrt(int val) {
-    ///////////////////////////////
-    //Получение квадратного корня//
-    ///////////////////////////////
-
     return int(std::sqrt(val));
-
-    // binary square root algo
-    // (int) sqrt(i) probably faster?
-
-
-    int result;       // eax@2
-    unsigned int v2;  // edx@3
-    unsigned int v3;  // edi@3
-    int v5;           // esi@4
-
-    if (val < 1) return val;
-
-    v2 = 0;
-    v3 = val;
-    result = 0;
-    for (unsigned int i = 0; i < 16; ++i) {
-        result *= 2;
-        v2 = (v3 >> 30) | 4 * v2;
-        v5 = 2 * result + 1;
-        v3 *= 4;
-        if (v2 >= v5) {
-            ++result;
-            v2 -= v5;
-        }
-    }
-    if (val - result * result >= (unsigned int)(result - 1)) ++result;
-    return result;
 }
 
 uint32_t int_get_vector_length(int32_t x, int32_t y, int32_t z) { // approx distance

--- a/src/Engine/OurMath.h
+++ b/src/Engine/OurMath.h
@@ -1,20 +1,14 @@
 #pragma once
 
 #include <cassert>
-#include <cmath>
 #include <cstdint>
 #include <limits>
 
 // TODO(captainurist): drop this header
 
-#define pi_double 3.14159265358979323846
-
-const float pi = static_cast<float>(M_PI);
-
 int integer_sqrt(int val);
 
 uint32_t int_get_vector_length(int32_t x, int32_t y, int32_t z);
-
 
 template <typename FloatType>
 inline int bankersRounding(const FloatType &value) {
@@ -45,4 +39,3 @@ inline int bankersRounding<double>(const double &inValue) {
     c.d = inValue + 6755399441055744.0;
     return c.l;
 }
-

--- a/src/Engine/OurMath.h
+++ b/src/Engine/OurMath.h
@@ -12,65 +12,9 @@
 const float pi = static_cast<float>(M_PI);
 
 int integer_sqrt(int val);
-inline int round_to_int(float x) { return (int)std::floor(x + 0.5f); }
 
 uint32_t int_get_vector_length(int32_t x, int32_t y, int32_t z);
 
-
-// struct fixed {  // fixed-point decimal
-//    inline fixed() : _internal(0) {}
-//    explicit fixed(int _bits) : _internal(_bits) {}
-//
-//    static fixed FromFloat(float f) {
-//        return fixed::Raw(fixpoint_from_float(f));
-//    }
-//
-//    static fixed FromInt(int value) { return fixed::Raw(value << 16); }
-//
-//    static fixed Raw(int value) { return fixed(value); }
-//
-//    float GetFloatFraction() const {
-//        return (float)((double)((unsigned int)this->_internal & 0xFFFF) /
-//                       65530.0);
-//    }
-//    float GetFloat() const {
-//        return (float)this->GetInt() + this->GetFloatFraction();
-//    }
-//    int GetInt() const { return this->_internal >> 16; }
-//    int GetUnsignedInt() const { return (unsigned int)this->_internal >> 16; }
-//
-//    //----- (0042EBBE) --------------------------------------------------------
-//    //----- (004453C0) mm6-----------------------------------------------------
-//    //----- (004A1760) mm6_chinese---------------------------------------------
-//    inline fixed operator*(const fixed &rhs) {
-//        return fixed::Raw(((int64_t)this->_internal * (int64_t)rhs._internal) >> 16);
-//    }
-//
-//    inline fixed operator/(const fixed &rhs) {
-//        return fixed::Raw(((int64_t)this->_internal << 16) / rhs._internal);
-//    }
-//
-//    inline fixed operator+(const fixed &rhs) {
-//        return fixed::Raw(this->_internal + rhs._internal);
-//    }
-//    inline fixed operator-(const fixed &rhs) {
-//        return fixed::Raw(this->_internal - rhs._internal);
-//    }
-//    inline bool operator>=(const fixed &rhs) {
-//        return this->_internal >= rhs._internal;
-//    }
-//    inline bool operator<=(const fixed &rhs) {
-//        return this->_internal <= rhs._internal;
-//    }
-//    inline bool operator>(const fixed &rhs) {
-//        return this->_internal > rhs._internal;
-//    }
-//    inline bool operator<(const fixed &rhs) {
-//        return this->_internal < rhs._internal;
-//    }
-//
-//    int32_t _internal;
-// };
 
 template <typename FloatType>
 inline int bankersRounding(const FloatType &value) {

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-#include "Engine/OurMath.h"
 #include "Engine/Timer.h"
 #include "Engine/Party.h"
 #include "Engine/AssetsManager.h"

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -19,7 +19,6 @@
 #include "Engine/Objects/NPC.h"
 #include "Engine/Objects/CharacterEnumFunctions.h"
 #include "Engine/Objects/MonsterEnumFunctions.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/MapEnumFunctions.h"
 #include "Engine/SpellFxRenderer.h"

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -20,7 +20,6 @@
 #include "Engine/Random/Random.h"
 #include "Engine/Objects/CharacterEnums.h"
 #include "Engine/Objects/CharacterEnumFunctions.h"
-#include "Engine/OurMath.h"
 #include "Engine/Party.h"
 #include "Engine/PriceCalculator.h"
 #include "Engine/EngineIocContainer.h"

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -1,12 +1,12 @@
 #include "AudioPlayer.h"
 
+#include <cmath>
 #include <algorithm>
 #include <map>
 #include <string>
 #include <utility>
 #include <thread>
 #include <memory>
-#include <cmath>
 
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Objects/Decoration.h"

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <thread>
 #include <memory>
+#include <numbers>
 
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Objects/Decoration.h"
@@ -374,8 +375,8 @@ bool AudioPlayer::loadSoundDataSource(SoundInfo* si) {
 }
 
 void AudioPlayer::UpdateSounds() {
-    float pitch = M_PI * pParty->_viewPitch / 1024.f;
-    float yaw = M_PI * pParty->_viewYaw / 1024.f;
+    float pitch = std::numbers::pi * pParty->_viewPitch / 1024.f;
+    float yaw = std::numbers::pi * pParty->_viewYaw / 1024.f;
 
     provider->SetOrientation(yaw, pitch);
     provider->SetListenerPosition(pParty->pos.x, pParty->pos.y, pParty->pos.z);

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <thread>
 #include <memory>
-#include <numbers>
+#include <cmath>
 
 #include "Engine/Graphics/Indoor.h"
 #include "Engine/Objects/Decoration.h"
@@ -375,8 +375,8 @@ bool AudioPlayer::loadSoundDataSource(SoundInfo* si) {
 }
 
 void AudioPlayer::UpdateSounds() {
-    float pitch = std::numbers::pi * pParty->_viewPitch / 1024.f;
-    float yaw = std::numbers::pi * pParty->_viewYaw / 1024.f;
+    float pitch = M_PI * pParty->_viewPitch / 1024.f;
+    float yaw = M_PI * pParty->_viewYaw / 1024.f;
 
     provider->SetOrientation(yaw, pitch);
     provider->SetListenerPosition(pParty->pos.x, pParty->pos.y, pParty->pos.z);

--- a/src/Utility/Math/TrigLut.cpp
+++ b/src/Utility/Math/TrigLut.cpp
@@ -1,13 +1,12 @@
 #include "TrigLut.h"
 
 #include <cmath>
-#include <numbers>
 
 TrigTableLookup TrigLUT;
 
 TrigTableLookup::TrigTableLookup() {
     for (int i = 0; i <= this->uIntegerHalfPi; i++)
-        _cosTable[i] = std::cos(i * std::numbers::pi / uIntegerPi);
+        _cosTable[i] = std::cos(i * M_PI / uIntegerPi);
 }
 
 float TrigTableLookup::cos(int angle) const {
@@ -29,5 +28,5 @@ int TrigTableLookup::atan2(int x, int y) const {
     double angle = std::atan2(static_cast<double>(y), static_cast<double>(x));
 
     // Note that std::round call is important here, otherwise atan2(x, y) + atan2(y, x) != uIntegerHalfPi.
-    return static_cast<int>(std::round(angle / std::numbers::pi * 1024)) & uDoublePiMask;
+    return static_cast<int>(std::round(angle / M_PI * 1024)) & uDoublePiMask;
 }

--- a/src/Utility/Math/TrigLut.cpp
+++ b/src/Utility/Math/TrigLut.cpp
@@ -1,12 +1,13 @@
 #include "TrigLut.h"
 
 #include <cmath>
+#include <numbers>
 
 TrigTableLookup TrigLUT;
 
 TrigTableLookup::TrigTableLookup() {
     for (int i = 0; i <= this->uIntegerHalfPi; i++)
-        _cosTable[i] = std::cos(i * M_PI / uIntegerPi);
+        _cosTable[i] = std::cos(i * std::numbers::pi / uIntegerPi);
 }
 
 float TrigTableLookup::cos(int angle) const {
@@ -28,5 +29,5 @@ int TrigTableLookup::atan2(int x, int y) const {
     double angle = std::atan2(static_cast<double>(y), static_cast<double>(x));
 
     // Note that std::round call is important here, otherwise atan2(x, y) + atan2(y, x) != uIntegerHalfPi.
-    return static_cast<int>(std::round(angle / M_PI * 1024)) & uDoublePiMask;
+    return static_cast<int>(std::round(angle / std::numbers::pi * 1024)) & uDoublePiMask;
 }


### PR DESCRIPTION
Cleanup in `OurMath.h`, which carries a `TODO(captainurist): drop this header`.

## Dead code

* `round_to_int` had no callers left.
* The commented-out `fixed` point struct, 54 lines of it.
* `integer_sqrt` returned `int(std::sqrt(val))` before ever reaching its binary square root loop, so that loop never ran. The function now says what it does.

## One spelling of pi

The codebase spelled pi three ways - the `pi_double` macro (33 uses) and the `pi` float (8 uses) from `OurMath.h`, plus bare `M_PI` (7 uses) in `Engine.cpp`, `Camera.h`, `TrigLut.cpp` and `AudioPlayer.cpp`. Everything is `M_PI` now, which already worked everywhere because `CMakeLists.txt:159` defines `_USE_MATH_DEFINES` for MSVC.

Nothing moves numerically. `pi_double` expanded to the same literal `M_PI` holds, verified bit for bit.

All 8 sites that used the `pi` float now take bare `M_PI`, so pi is spelled one way in the whole tree.

That does move those results slightly, since the old `pi` was pi pre-rounded to float. It is a move toward the more accurate constant, and none of the sites care:

* `Camera3D` - the cast never kept the arithmetic in single precision anyway, dividing by a double promotes straight back. `HalfAngleX` shifts by 6e-08 at the 75 degree outdoor FOV and is bit identical at the 60 degree indoor one.
* `vSunlight` - only ever reaches the GL renderer as a sun direction and a terrain shading dot product. Worst absolute shift across a whole game day is 1.8e-07.
* `SpawnEncounterMonsters` - places random encounter monsters off `grng`, so this one could in principle desync a trace. It cannot in practice: instrumenting both call sites and replaying the whole suite gives **zero** hits, so no trace in `test/Data` reaches that function at all.

The one expression that changed shape is `(pi_double + pi_double)` in `Camera.cpp`, now `(2 * M_PI)`. Doubling is exact in IEEE, so that is bit identical too.

Also worth noting `const float pi` sat at namespace scope in a header, so every one of the 23 translation units including `OurMath.h` got its own copy.

## Fallout

Twelve files included `OurMath.h` only for pi and no longer need it. The header itself no longer needs `<cmath>`, so the files that were getting it transitively now include it directly. What is left in `OurMath.h` is `integer_sqrt`, `int_get_vector_length` and `bankersRounding`.

`int_get_vector_length` is worth a note for whoever finishes the TODO - it is MM7's octagonal distance approximation, `x + (11*y >> 5) + (z >> 2)` over sorted components. It has to move rather than be replaced, since a true Euclidean length would shift AI aggro ranges, light attenuation and the minimap.

## Testing

`check_style` clean, unit tests 408 passed with 1 platform skip, game tests 360/360.
