### PR TITLE
PROBE: why the stack overflow test hangs under rosetta (do not merge)

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -264,6 +264,7 @@ jobs:
           GITHUBARCH: '${{env.MATRIX_ARCHITECTURE}}'
 
       - name: '[darwin/windows/linux] Run unit tests'
+        timeout-minutes: 12
         if: env.MATRIX_PLATFORM != 'android'
         working-directory: build
         run: |

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -474,6 +474,7 @@ static void installHandlers() {
         action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
         sigfillset(&action.sa_mask);
         sigdelset(&action.sa_mask, signal);
+        sigdelset(&action.sa_mask, SIGALRM); // Or the watchdog alarm sits pending while the handler hangs, and never fires.
         action.sa_sigaction = &onSignal;
         sigaction(signal, &action, nullptr);
     }

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -433,6 +433,11 @@ static void onSignal(int signal, siginfo_t *info, void *context) {
     // dump. A second thread raising the same signal never gets here, SA_RESETHAND already put the default
     // handler back, so the kernel kills the process and whatever was printed so far is all there is.
     if (!crashHandled.test_and_set()) {
+        // Symbolizing allocates and takes locks, and the header spells out how that can deadlock. A wedged
+        // handler is worse than a lost trace, so the alarm kills the process - SIGALRM keeps its default
+        // disposition - and whatever was printed by then still reaches the reader.
+        alarm(30);
+
         char reason[128];
         std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
         printCrashHeader(reason);

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -380,6 +380,10 @@ static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &cras
         if (frame[1] == 0)
             break;
         frames.push_back(frame[1] - 1);
+        // A frame built without a frame pointer holds something else in that slot. The caller's frame is always
+        // further up the stack, so a value that isn't stops the walk instead of being followed.
+        if (frame[0] <= fp || frame[0] % sizeof(uintptr_t) != 0)
+            break;
         fp = frame[0];
     }
     return frames;

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -45,6 +45,8 @@ StackTraceOnCrash::StackTraceOnCrash(void (*)()) {}
 // inside a handler re-enters it - and one trace is what's actually useful.
 static std::atomic_flag crashHandled = ATOMIC_FLAG_INIT;
 
+bool probeNoAltStack = false; // PROBE
+
 static void (*crashCallback)() = nullptr;
 
 static void runCrashCallback() {
@@ -470,12 +472,13 @@ static void installHandlers() {
     stack.ss_sp = alternateStack;
     stack.ss_size = sizeof(alternateStack);
     stack.ss_flags = 0;
-    sigaltstack(&stack, nullptr);
+    if (!probeNoAltStack)
+        sigaltstack(&stack, nullptr);
 
     for (int signal : handledSignals) {
         struct sigaction action;
         std::memset(&action, 0, sizeof(action));
-        action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
+        action.sa_flags = SA_SIGINFO | (probeNoAltStack ? 0 : SA_ONSTACK) | SA_NODEFER | SA_RESETHAND;
         sigfillset(&action.sa_mask);
         sigdelset(&action.sa_mask, signal);
         sigdelset(&action.sa_mask, SIGALRM); // Or the watchdog alarm sits pending while the handler hangs, and never fires.

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -13,6 +13,8 @@
  * locks, so a crash while another thread holds one of those hangs the process instead of killing it. Crashing
  * inside the allocator does the same.
  */
+extern bool probeNoAltStack; // PROBE
+
 class StackTraceOnCrash {
  public:
     /**

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,8 +123,11 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
     volatile char pad[1024]; // Big frames run out of stack fast.
+    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
     pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <thread>
 #include <unistd.h> // PROBE
+#include <dlfcn.h> // PROBE
+#include <sys/ucontext.h> // PROBE
 #include <sys/wait.h> // PROBE
 
 #include "Testing/Unit/UnitTest.h"
@@ -139,12 +141,42 @@ static volatile uintptr_t probeSp0 = 0;
 static int probePrintEvery = 0;
 static int probeSyscallEvery = 0;
 
-static void probeOnAlarm(int, siginfo_t *, void *) {
-    char line[128];
-    int n = std::snprintf(line, sizeof(line), "[probe alarm] still recursing or wedged, depth=%d sp0=%#zx sp=%#zx used=%zu\n",
-                          probeDepth, static_cast<size_t>(probeSp0), static_cast<size_t>(probeSp), static_cast<size_t>(probeSp0 - probeSp));
+static void probeOnAlarm(int, siginfo_t *, void *context) {
+    const ucontext_t &uc = *static_cast<ucontext_t *>(context);
+#if defined(__APPLE__) && defined(__x86_64__)
+    size_t pc = uc.uc_mcontext->__ss.__rip, sp = uc.uc_mcontext->__ss.__rsp;
+#elif defined(__APPLE__) && defined(__aarch64__)
+    size_t pc = arm_thread_state64_get_pc(uc.uc_mcontext->__ss), sp = arm_thread_state64_get_sp(uc.uc_mcontext->__ss);
+#elif defined(__aarch64__)
+    size_t pc = uc.uc_mcontext.pc, sp = uc.uc_mcontext.sp;
+#else
+    size_t pc = uc.uc_mcontext.gregs[REG_RIP], sp = uc.uc_mcontext.gregs[REG_RSP];
+#endif
+    Dl_info info = {};
+    dladdr(reinterpret_cast<void *>(pc), &info);
+    char line[256];
+    int n = std::snprintf(line, sizeof(line), "[probe alarm] wedged: pc=%#zx in %s sp=%#zx sp0=%#zx used=%zu depth=%d\n",
+                          pc, info.dli_sname ? info.dli_sname : "?", sp, static_cast<size_t>(probeSp0),
+                          static_cast<size_t>(probeSp0 - sp), probeDepth);
     (void) !write(1, line, n);
     _exit(42);
+}
+
+// PROBE: the real helper pair, byte for byte, with nothing added to the recursion.
+MM_NOINLINE int probeRealOverflow2(int depth);
+
+MM_NOINLINE int probeRealOverflow1(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeRealOverflow2(depth + 1);
+}
+
+MM_NOINLINE int probeRealOverflow2(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeRealOverflow1(depth + 1);
 }
 
 static void probeArm() {
@@ -159,11 +191,9 @@ static void probeArm() {
 MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
     probeDepth = depth;
     probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
-    if (depth == 0)
-        probeSp0 = probeSp;
     if (probePrintEvery && depth % probePrintEvery == 0) {
         char line[64];
-        int n = std::snprintf(line, sizeof(line), "[probe depth] %d\n", depth);
+        int n = std::snprintf(line, sizeof(line), "[probe depth] %d used=%zu\n", depth, static_cast<size_t>(probeSp0 - probeSp));
         (void) !write(1, line, n);
     }
     if (probeSyscallEvery && depth % probeSyscallEvery == 0)
@@ -241,24 +271,23 @@ static bool probeDiedOfTheOverflow(int status) {
     return WIFSIGNALED(status) && WTERMSIG(status) != SIGALRM;
 }
 
-#define PROBE_VARIANT(NAME, HANDLER, PRINT, SYSCALL)                                                            \
+#define PROBE_VARIANT(NAME, HANDLER, PRINT, FUNCTION)                                                           \
     UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NAME) {                                                              \
         (void) !write(1, "[probe] " #NAME "\n", sizeof("[probe] " #NAME "\n") - 1);                             \
         EXPECT_EXIT({                                                                                           \
             GTEST_FLAG_SET(catch_exceptions, false);                                                            \
             probePrintEvery = PRINT;                                                                            \
-            probeSyscallEvery = SYSCALL;                                                                        \
+            probeSp0 = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));                                 \
             if (HANDLER) new StackTraceOnCrash();                                                               \
             probeArm();                                                                                         \
-            stackTraceOverflowFunction1(0);                                                                     \
+            FUNCTION(0);                                                                                        \
         }, probeDiedOfTheOverflow, "");                                                                         \
     }
 
-PROBE_VARIANT(Probe1_NoHandler_Silent, false, 0, 0)
-PROBE_VARIANT(Probe2_Handler_Silent, true, 0, 0)
-PROBE_VARIANT(Probe3_Handler_PrintEvery1000, true, 1000, 0)
-PROBE_VARIANT(Probe4_Handler_GetpidEvery1000, true, 0, 1000)
-PROBE_VARIANT(Probe5_NoHandler_PrintEvery1000, false, 1000, 0)
+PROBE_VARIANT(Probe1_RealShape_Handler, true, 0, probeRealOverflow1)
+PROBE_VARIANT(Probe2_RealShape_NoHandler, false, 0, probeRealOverflow1)
+PROBE_VARIANT(Probe3_Instrumented_Handler_Silent, true, 0, stackTraceOverflowFunction1)
+PROBE_VARIANT(Probe4_Instrumented_Handler_Print, true, 1000, stackTraceOverflowFunction1)
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -8,6 +8,9 @@
 #include <thread>
 #include <unistd.h> // PROBE
 #include <dlfcn.h> // PROBE
+#ifdef __APPLE__
+#   include <mach/mach.h> // PROBE
+#endif
 #include <sys/ucontext.h> // PROBE
 #include <sys/wait.h> // PROBE
 
@@ -179,6 +182,82 @@ MM_NOINLINE int probeRealOverflow2(int depth) {
     return pad[0] + pad[1023] + probeRealOverflow1(depth + 1);
 }
 
+// PROBE: the real shape plus one global store per call.
+MM_NOINLINE int probeStoreOverflow2(int depth);
+
+MM_NOINLINE int probeStoreOverflow1(int depth) {
+    probeDepth = depth;
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeStoreOverflow2(depth + 1);
+}
+
+MM_NOINLINE int probeStoreOverflow2(int depth) {
+    probeDepth = depth;
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeStoreOverflow1(depth + 1);
+}
+
+// PROBE: the real shape plus one frame address store per call.
+MM_NOINLINE int probeFrameOverflow2(int depth);
+
+MM_NOINLINE int probeFrameOverflow1(int depth) {
+    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeFrameOverflow2(depth + 1);
+}
+
+MM_NOINLINE int probeFrameOverflow2(int depth) {
+    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + probeFrameOverflow1(depth + 1);
+}
+
+static void probeWatchdog(uintptr_t sp0) {
+    sleep(20);
+#ifdef __APPLE__
+    thread_act_array_t threads = nullptr;
+    mach_msg_type_number_t count = 0;
+    task_threads(mach_task_self(), &threads, &count);
+    for (mach_msg_type_number_t i = 0; i < count; i++) {
+        if (threads[i] == mach_thread_self())
+            continue;
+        thread_basic_info_data_t basic = {};
+        mach_msg_type_number_t basicCount = THREAD_BASIC_INFO_COUNT;
+        thread_info(threads[i], THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&basic), &basicCount);
+        thread_extended_info_data_t extended = {};
+        mach_msg_type_number_t extendedCount = THREAD_EXTENDED_INFO_COUNT;
+        thread_info(threads[i], THREAD_EXTENDED_INFO, reinterpret_cast<thread_info_t>(&extended), &extendedCount);
+        size_t pc = 0, sp = 0;
+        kern_return_t stateResult = KERN_FAILURE;
+#if defined(__x86_64__)
+        x86_thread_state64_t state;
+        mach_msg_type_number_t stateCount = x86_THREAD_STATE64_COUNT;
+        stateResult = thread_get_state(threads[i], x86_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &stateCount);
+        if (stateResult == KERN_SUCCESS) { pc = state.__rip; sp = state.__rsp; }
+#endif
+        Dl_info info = {};
+        if (pc) dladdr(reinterpret_cast<void *>(pc), &info);
+        char line[320];
+        int n = std::snprintf(line, sizeof(line),
+            "[probe watchdog] thread %u name='%s' run_state=%d flags=%#x suspend=%d cpu=%d%% state=%d pc=%#zx in %s+%#zx sp=%#zx used=%zu\n",
+            i, extended.pth_name, basic.run_state, basic.flags, basic.suspend_count, basic.cpu_usage / 10, stateResult, pc,
+            info.dli_sname ? info.dli_sname : "?", info.dli_saddr ? pc - reinterpret_cast<size_t>(info.dli_saddr) : 0, sp, sp ? sp0 - sp : 0);
+        (void) !write(1, line, n);
+    }
+#else
+    (void) !write(1, "[probe watchdog] not apple\n", 27);
+#endif
+    _exit(42);
+}
+
 static void probeArm() {
     struct sigaction action;
     std::memset(&action, 0, sizeof(action));
@@ -280,14 +359,16 @@ static bool probeDiedOfTheOverflow(int status) {
             probeSp0 = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));                                 \
             if (HANDLER) new StackTraceOnCrash();                                                               \
             probeArm();                                                                                         \
+            std::thread(probeWatchdog, static_cast<uintptr_t>(probeSp0)).detach();                              \
             FUNCTION(0);                                                                                        \
         }, probeDiedOfTheOverflow, "");                                                                         \
     }
 
 PROBE_VARIANT(Probe1_RealShape_Handler, true, 0, probeRealOverflow1)
 PROBE_VARIANT(Probe2_RealShape_NoHandler, false, 0, probeRealOverflow1)
-PROBE_VARIANT(Probe3_Instrumented_Handler_Silent, true, 0, stackTraceOverflowFunction1)
-PROBE_VARIANT(Probe4_Instrumented_Handler_Print, true, 1000, stackTraceOverflowFunction1)
+PROBE_VARIANT(Probe3_StorePerCall_Handler, true, 0, probeStoreOverflow1)
+PROBE_VARIANT(Probe4_FrameAddressPerCall_Handler, true, 0, probeFrameOverflow1)
+PROBE_VARIANT(Probe5_Instrumented_Handler_Silent, true, 0, stackTraceOverflowFunction1)
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,6 +31,16 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
+// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
+// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
+// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
+class StackTraceDeathTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+    }
+};
+
 /**
  * Matches when the frame numbered `index` names `function`. The regexes gtest's own death test matchers take
  * aren't portable - gtest picks between two engines with different grammars depending on the platform - so
@@ -128,7 +138,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -139,7 +149,7 @@ UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -152,7 +162,7 @@ UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -164,7 +174,7 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -175,7 +185,7 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
@@ -186,7 +196,7 @@ UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -203,7 +213,7 @@ UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST(StackTrace, AbortIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -213,7 +223,7 @@ UNIT_TEST(StackTrace, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST(StackTrace, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -223,7 +233,7 @@ UNIT_TEST(StackTrace, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +244,7 @@ UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST(StackTrace, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -130,12 +130,40 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
 
 MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
+// PROBE: per-variant knobs and the state the alarm handler reports.
+static volatile int probeDepth = 0;
+static volatile uintptr_t probeSp = 0;
+static volatile uintptr_t probeSp0 = 0;
+static int probePrintEvery = 0;
+static int probeSyscallEvery = 0;
+
+static void probeOnAlarm(int) {
+    char line[128];
+    int n = std::snprintf(line, sizeof(line), "[probe alarm] still recursing or wedged, depth=%d sp0=%#zx sp=%#zx used=%zu\n",
+                          probeDepth, static_cast<size_t>(probeSp0), static_cast<size_t>(probeSp), static_cast<size_t>(probeSp0 - probeSp));
+    (void) !write(1, line, n);
+    _exit(42);
+}
+
+static void probeArm() {
+    struct sigaction action = {};
+    action.sa_handler = &probeOnAlarm;
+    sigaction(SIGALRM, &action, nullptr);
+    alarm(20);
+}
+
 MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
-    if (depth % 1000 == 0) { // PROBE
+    probeDepth = depth;
+    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
+    if (depth == 0)
+        probeSp0 = probeSp;
+    if (probePrintEvery && depth % probePrintEvery == 0) {
         char line[64];
         int n = std::snprintf(line, sizeof(line), "[probe depth] %d\n", depth);
         (void) !write(1, line, n);
     }
+    if (probeSyscallEvery && depth % probeSyscallEvery == 0)
+        (void) getpid();
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
@@ -204,40 +232,29 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-// PROBE: a wedge anywhere shows up as death by SIGALRM within 20s instead of a 60 minute hang.
+// PROBE: overflow death is a signal other than SIGALRM. The alarm handler exits 42 after reporting the depth.
 static bool probeDiedOfTheOverflow(int status) {
     return WIFSIGNALED(status) && WTERMSIG(status) != SIGALRM;
 }
 
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoHandler) {
-    (void) !write(1, "[probe] no handler\n", 19);
-    EXPECT_EXIT({
-        GTEST_FLAG_SET(catch_exceptions, false);
-        alarm(20);
-        stackTraceOverflowFunction1(0);
-    }, probeDiedOfTheOverflow, "");
-}
+#define PROBE_VARIANT(NAME, HANDLER, PRINT, SYSCALL)                                                            \
+    UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NAME) {                                                              \
+        (void) !write(1, "[probe] " #NAME "\n", sizeof("[probe] " #NAME "\n") - 1);                             \
+        EXPECT_EXIT({                                                                                           \
+            GTEST_FLAG_SET(catch_exceptions, false);                                                            \
+            probePrintEvery = PRINT;                                                                            \
+            probeSyscallEvery = SYSCALL;                                                                        \
+            if (HANDLER) new StackTraceOnCrash();                                                               \
+            probeArm();                                                                                         \
+            stackTraceOverflowFunction1(0);                                                                     \
+        }, probeDiedOfTheOverflow, "");                                                                         \
+    }
 
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoAltStack) {
-    (void) !write(1, "[probe] handler without altstack\n", 33);
-    EXPECT_EXIT({
-        GTEST_FLAG_SET(catch_exceptions, false);
-        probeNoAltStack = true;
-        StackTraceOnCrash handler;
-        alarm(20);
-        stackTraceOverflowFunction1(0);
-    }, probeDiedOfTheOverflow, "");
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowFull) {
-    (void) !write(1, "[probe] handler with altstack\n", 30);
-    EXPECT_EXIT({
-        GTEST_FLAG_SET(catch_exceptions, false);
-        StackTraceOnCrash handler;
-        alarm(20);
-        stackTraceOverflowFunction1(0);
-    }, probeDiedOfTheOverflow, "");
-}
+PROBE_VARIANT(Probe1_NoHandler_Silent, false, 0, 0)
+PROBE_VARIANT(Probe2_Handler_Silent, true, 0, 0)
+PROBE_VARIANT(Probe3_Handler_PrintEvery1000, true, 1000, 0)
+PROBE_VARIANT(Probe4_Handler_GetpidEvery1000, true, 0, 1000)
+PROBE_VARIANT(Probe5_NoHandler_PrintEvery1000, false, 1000, 0)
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -176,7 +176,8 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
-    // everything above it.
+    // everything above it. The walk used to follow the frame pointer slot of a frame that had none, past main
+    // into garbage, and on i386 that crashed the handler before it printed a single frame.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,10 +31,12 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
-// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
-// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
-// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
-class StackTraceDeathTest : public testing::Test {
+/**
+ * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
+ * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
+ * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ */
+class ThreadSafeDeathTest : public testing::Test {
  protected:
     void SetUp() override {
         GTEST_FLAG_SET(death_test_style, "threadsafe");
@@ -123,23 +125,20 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
-// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
-MM_NOINLINE int stackTraceOverflowFunction(int depth);
+MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
-// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
-MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
-    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
+MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction2(depth + 1); // Mutual, or this folds into a loop that never overflows.
 }
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
     volatile char pad[1024];
     pad[0] = static_cast<char>(depth);
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
@@ -149,7 +148,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -160,7 +159,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -173,7 +172,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -185,7 +184,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -196,18 +195,18 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
-        stackTraceOverflowFunction(0);
+        stackTraceOverflowFunction1(0);
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -224,7 +223,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +233,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -244,7 +243,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -255,7 +254,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -32,9 +32,9 @@ constexpr bool isMac = false;
 #endif
 
 /**
- * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
- * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
- * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ * Death tests in this suite re-exec the binary instead of forking it. The darwin_x86_64 leg runs under
+ * Rosetta on the arm64 runners, where gtest counts a second thread in the process and warns that a forked
+ * child inherits whatever locks that thread held at that instant. A re-exec'd child starts clean.
  */
 class ThreadSafeDeathTest : public testing::Test {
  protected:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <string>
 #include <thread>
+#include <unistd.h> // PROBE
 
 #include "Testing/Unit/UnitTest.h"
 
@@ -129,6 +130,11 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
 MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
 MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
+    if (depth % 1000 == 0) { // PROBE
+        char line[64];
+        int n = std::snprintf(line, sizeof(line), "[probe depth] %d\n", depth);
+        (void) !write(1, line, n);
+    }
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
@@ -195,6 +201,33 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
         StackTraceOnCrash handler;
         stackTraceBadTargetCallFunction();
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
+}
+
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoHandler) {
+    (void) !write(1, "[probe] no handler\n", 19);
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+        stackTraceOverflowFunction1(0);
+    }, "");
+}
+
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoAltStack) {
+    (void) !write(1, "[probe] handler without altstack\n", 33);
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+        probeNoAltStack = true;
+        StackTraceOnCrash handler;
+        stackTraceOverflowFunction1(0);
+    }, "");
+}
+
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowFull) {
+    (void) !write(1, "[probe] handler with altstack\n", 30);
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+        StackTraceOnCrash handler;
+        stackTraceOverflowFunction1(0);
+    }, "");
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -182,168 +182,25 @@ MM_NOINLINE int probeRealOverflow2(int depth) {
     return pad[0] + pad[1023] + probeRealOverflow1(depth + 1);
 }
 
-// PROBE: the real shape plus one global store per call.
-MM_NOINLINE int probeStoreOverflow2(int depth);
-
-MM_NOINLINE int probeStoreOverflow1(int depth) {
-    probeDepth = depth;
-    volatile char pad[1024];
-    pad[0] = static_cast<char>(depth);
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + probeStoreOverflow2(depth + 1);
-}
-
-MM_NOINLINE int probeStoreOverflow2(int depth) {
-    probeDepth = depth;
-    volatile char pad[1024];
-    pad[0] = static_cast<char>(depth);
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + probeStoreOverflow1(depth + 1);
-}
-
-// PROBE: the real shape plus one frame address store per call.
-MM_NOINLINE int probeFrameOverflow2(int depth);
-
-MM_NOINLINE int probeFrameOverflow1(int depth) {
-    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
-    volatile char pad[1024];
-    pad[0] = static_cast<char>(depth);
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + probeFrameOverflow2(depth + 1);
-}
-
-MM_NOINLINE int probeFrameOverflow2(int depth) {
-    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
-    volatile char pad[1024];
-    pad[0] = static_cast<char>(depth);
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + probeFrameOverflow1(depth + 1);
-}
-
-static void probeWatchdog(uintptr_t sp0) {
-    sleep(20);
-#ifdef __APPLE__
-    thread_act_array_t threads = nullptr;
-    mach_msg_type_number_t count = 0;
-    task_threads(mach_task_self(), &threads, &count);
-    for (mach_msg_type_number_t i = 0; i < count; i++) {
-        if (threads[i] == mach_thread_self())
-            continue;
-        thread_basic_info_data_t basic = {};
-        mach_msg_type_number_t basicCount = THREAD_BASIC_INFO_COUNT;
-        thread_info(threads[i], THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&basic), &basicCount);
-        thread_extended_info_data_t extended = {};
-        mach_msg_type_number_t extendedCount = THREAD_EXTENDED_INFO_COUNT;
-        thread_info(threads[i], THREAD_EXTENDED_INFO, reinterpret_cast<thread_info_t>(&extended), &extendedCount);
-        size_t pc = 0, sp = 0;
-        kern_return_t stateResult = KERN_FAILURE;
-#if defined(__x86_64__)
-        x86_thread_state64_t state;
-        mach_msg_type_number_t stateCount = x86_THREAD_STATE64_COUNT;
-        stateResult = thread_get_state(threads[i], x86_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &stateCount);
-        if (stateResult == KERN_SUCCESS) { pc = state.__rip; sp = state.__rsp; }
-#endif
-        Dl_info info = {};
-        if (pc) dladdr(reinterpret_cast<void *>(pc), &info);
-        char line[320];
-        int n = std::snprintf(line, sizeof(line),
-            "[probe watchdog] thread %u name='%s' run_state=%d flags=%#x suspend=%d cpu=%d%% state=%d pc=%#zx in %s+%#zx sp=%#zx used=%zu\n",
-            i, extended.pth_name, basic.run_state, basic.flags, basic.suspend_count, basic.cpu_usage / 10, stateResult, pc,
-            info.dli_sname ? info.dli_sname : "?", info.dli_saddr ? pc - reinterpret_cast<size_t>(info.dli_saddr) : 0, sp, sp ? sp0 - sp : 0);
-        (void) !write(1, line, n);
+#define PROBE_ESCAPED_PAIR(NAME, SIZE)                                                                          \
+    MM_NOINLINE int NAME##2(int depth);                                                                        \
+    MM_NOINLINE int NAME##1(int depth) {                                                                       \
+        volatile char pad[SIZE];                                                                               \
+        asm volatile("" : : "r"(pad) : "memory"); /* The address escapes, so the array stays on the stack. */  \
+        pad[0] = static_cast<char>(depth);                                                                     \
+        pad[SIZE - 1] = static_cast<char>(depth);                                                              \
+        return pad[0] + pad[SIZE - 1] + NAME##2(depth + 1);                                                    \
+    }                                                                                                          \
+    MM_NOINLINE int NAME##2(int depth) {                                                                       \
+        volatile char pad[SIZE];                                                                               \
+        asm volatile("" : : "r"(pad) : "memory");                                                              \
+        pad[0] = static_cast<char>(depth);                                                                     \
+        pad[SIZE - 1] = static_cast<char>(depth);                                                              \
+        return pad[0] + pad[SIZE - 1] + NAME##1(depth + 1);                                                    \
     }
-#else
-    (void) !write(1, "[probe watchdog] not apple\n", 27);
-#endif
-    _exit(42);
-}
 
-static void probeArm() {
-    struct sigaction action;
-    std::memset(&action, 0, sizeof(action));
-    action.sa_flags = SA_SIGINFO;
-    action.sa_sigaction = &probeOnAlarm;
-    sigaction(SIGALRM, &action, nullptr);
-    alarm(20);
-}
-
-MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
-    probeDepth = depth;
-    probeSp = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
-    if (probePrintEvery && depth % probePrintEvery == 0) {
-        char line[64];
-        int n = std::snprintf(line, sizeof(line), "[probe depth] %d used=%zu\n", depth, static_cast<size_t>(probeSp0 - probeSp));
-        (void) !write(1, line, n);
-    }
-    if (probeSyscallEvery && depth % probeSyscallEvery == 0)
-        (void) getpid();
-    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
-    pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction2(depth + 1); // Mutual, or this folds into a loop that never overflows.
-}
-
-MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
-    volatile char pad[1024];
-    pad[0] = static_cast<char>(depth);
-    pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
-}
-
-UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
-    std::string trace = stackTraceMarkerFunction();
-
-    EXPECT_THAT(trace, HasFrame(1, "stackTraceMarkerFunction"));
-    EXPECT_CONTAINS(trace, "main");
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashHandlerNamesTheCrashingFunction) {
-    EXPECT_DEATH({
-        // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
-        // exception filter, so on windows ours would never see the access violation below.
-        GTEST_FLAG_SET(catch_exceptions, false);
-
-        StackTraceOnCrash handler;
-        stackTraceCrashingFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
-    // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
-    // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
-    EXPECT_DEATH({
-        GTEST_FLAG_SET(catch_exceptions, false);
-
-        StackTraceOnCrash handler;
-        std::thread(stackTraceCrashingFunction).join();
-    // A worker's stack ends at the thread entry, so main being absent is what says we traced the thread that
-    // crashed rather than the one that installed the handlers.
-    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
-    // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
-    // return address first though, and walking on from that names the function that made the call and
-    // everything above it. The walk used to follow the frame pointer slot of a frame that had none, past main
-    // into garbage, and on i386 that crashed the handler before it printed a single frame.
-    EXPECT_DEATH({
-        GTEST_FLAG_SET(catch_exceptions, false);
-
-        StackTraceOnCrash handler;
-        stackTraceNullCallFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
-    // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
-    // to walk from the caller instead.
-    EXPECT_DEATH({
-        GTEST_FLAG_SET(catch_exceptions, false);
-
-        StackTraceOnCrash handler;
-        stackTraceBadTargetCallFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
-}
+PROBE_ESCAPED_PAIR(probeEscaped1kOverflow, 1024)
+PROBE_ESCAPED_PAIR(probeEscaped16kOverflow, 16 * 1024)
 
 // PROBE: overflow death is a signal other than SIGALRM. The alarm handler exits 42 after reporting the depth.
 static bool probeDiedOfTheOverflow(int status) {
@@ -352,7 +209,9 @@ static bool probeDiedOfTheOverflow(int status) {
 
 #define PROBE_VARIANT(NAME, HANDLER, PRINT, FUNCTION)                                                           \
     UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NAME) {                                                              \
-        (void) !write(1, "[probe] " #NAME "\n", sizeof("[probe] " #NAME "\n") - 1);                             \
+        for (int sample = 0; sample < 8; sample++) {                                                            \
+        char head[96];                                                                                          \
+        (void) !write(1, head, std::snprintf(head, sizeof(head), "[probe] " #NAME " sample %d\n", sample));      \
         EXPECT_EXIT({                                                                                           \
             GTEST_FLAG_SET(catch_exceptions, false);                                                            \
             probePrintEvery = PRINT;                                                                            \
@@ -362,13 +221,12 @@ static bool probeDiedOfTheOverflow(int status) {
             std::thread(probeWatchdog, static_cast<uintptr_t>(probeSp0)).detach();                              \
             FUNCTION(0);                                                                                        \
         }, probeDiedOfTheOverflow, "");                                                                         \
+        }                                                                                                       \
     }
 
-PROBE_VARIANT(Probe1_RealShape_Handler, true, 0, probeRealOverflow1)
-PROBE_VARIANT(Probe2_RealShape_NoHandler, false, 0, probeRealOverflow1)
-PROBE_VARIANT(Probe3_StorePerCall_Handler, true, 0, probeStoreOverflow1)
-PROBE_VARIANT(Probe4_FrameAddressPerCall_Handler, true, 0, probeFrameOverflow1)
-PROBE_VARIANT(Probe5_Instrumented_Handler_Silent, true, 0, stackTraceOverflowFunction1)
+PROBE_VARIANT(Probe1_Escaped16k_Handler, true, 0, probeEscaped16kOverflow1)
+PROBE_VARIANT(Probe2_Escaped1k_Handler, true, 0, probeEscaped1kOverflow1)
+PROBE_VARIANT(Probe3_RealShape_Handler, true, 0, probeRealOverflow1)
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -33,8 +33,9 @@ constexpr bool isMac = false;
 
 /**
  * Death tests in this suite re-exec the binary instead of forking it. The darwin_x86_64 leg runs under
- * Rosetta on the arm64 runners, where gtest counts a second thread in the process and warns that a forked
- * child inherits whatever locks that thread held at that instant. A re-exec'd child starts clean.
+ * Rosetta on the arm64 runners, and Rosetta plants its exception server thread in every translated process,
+ * so gtest counts two threads there and warns that a forked child inherits whatever locks the other one held
+ * at that instant. A re-exec'd child starts clean.
  */
 class ThreadSafeDeathTest : public testing::Test {
  protected:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,15 +123,23 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
+// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
+MM_NOINLINE int stackTraceOverflowFunction(int depth);
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
-    volatile char pad[1024]; // Big frames run out of stack fast.
-    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
+// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
+MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.
-    return pad[0] + pad[1023];
+    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+}
+
+MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <thread>
 #include <unistd.h> // PROBE
+#include <sys/wait.h> // PROBE
 
 #include "Testing/Unit/UnitTest.h"
 
@@ -203,42 +204,39 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
+// PROBE: a wedge anywhere shows up as death by SIGALRM within 20s instead of a 60 minute hang.
+static bool probeDiedOfTheOverflow(int status) {
+    return WIFSIGNALED(status) && WTERMSIG(status) != SIGALRM;
+}
+
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoHandler) {
     (void) !write(1, "[probe] no handler\n", 19);
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
+        alarm(20);
         stackTraceOverflowFunction1(0);
-    }, "");
+    }, probeDiedOfTheOverflow, "");
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowNoAltStack) {
     (void) !write(1, "[probe] handler without altstack\n", 33);
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
         probeNoAltStack = true;
         StackTraceOnCrash handler;
+        alarm(20);
         stackTraceOverflowFunction1(0);
-    }, "");
+    }, probeDiedOfTheOverflow, "");
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, ProbeOverflowFull) {
     (void) !write(1, "[probe] handler with altstack\n", 30);
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
         StackTraceOnCrash handler;
+        alarm(20);
         stackTraceOverflowFunction1(0);
-    }, "");
-}
-
-UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
-    // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
-    // faults on the exhausted stack and the crash prints nothing at all.
-    EXPECT_DEATH({
-        GTEST_FLAG_SET(catch_exceptions, false);
-
-        StackTraceOnCrash handler;
-        stackTraceOverflowFunction1(0);
-    }, HasFrame(0, "stackTraceOverflowFunction"));
+    }, probeDiedOfTheOverflow, "");
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -1,6 +1,8 @@
 #include <cstdio>
 #include <cstdint>
+#include <csignal>
 #include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <string>
 #include <thread>
@@ -137,7 +139,7 @@ static volatile uintptr_t probeSp0 = 0;
 static int probePrintEvery = 0;
 static int probeSyscallEvery = 0;
 
-static void probeOnAlarm(int) {
+static void probeOnAlarm(int, siginfo_t *, void *) {
     char line[128];
     int n = std::snprintf(line, sizeof(line), "[probe alarm] still recursing or wedged, depth=%d sp0=%#zx sp=%#zx used=%zu\n",
                           probeDepth, static_cast<size_t>(probeSp0), static_cast<size_t>(probeSp), static_cast<size_t>(probeSp0 - probeSp));
@@ -146,8 +148,10 @@ static void probeOnAlarm(int) {
 }
 
 static void probeArm() {
-    struct sigaction action = {};
-    action.sa_handler = &probeOnAlarm;
+    struct sigaction action;
+    std::memset(&action, 0, sizeof(action));
+    action.sa_flags = SA_SIGINFO;
+    action.sa_sigaction = &probeOnAlarm;
     sigaction(SIGALRM, &action, nullptr);
     alarm(20);
 }

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -182,6 +182,48 @@ MM_NOINLINE int probeRealOverflow2(int depth) {
     return pad[0] + pad[1023] + probeRealOverflow1(depth + 1);
 }
 
+static void probeWatchdog(uintptr_t sp0) {
+    sleep(20);
+#ifdef __APPLE__
+    thread_act_array_t threads = nullptr;
+    mach_msg_type_number_t count = 0;
+    task_threads(mach_task_self(), &threads, &count);
+    for (mach_msg_type_number_t i = 0; i < count; i++) {
+        if (threads[i] == mach_thread_self())
+            continue;
+        thread_basic_info_data_t basic = {};
+        mach_msg_type_number_t basicCount = THREAD_BASIC_INFO_COUNT;
+        thread_info(threads[i], THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&basic), &basicCount);
+        size_t pc = 0, sp = 0;
+        kern_return_t stateResult = KERN_FAILURE;
+#if defined(__x86_64__)
+        x86_thread_state64_t state;
+        mach_msg_type_number_t stateCount = x86_THREAD_STATE64_COUNT;
+        stateResult = thread_get_state(threads[i], x86_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &stateCount);
+        if (stateResult == KERN_SUCCESS) { pc = state.__rip; sp = state.__rsp; }
+#endif
+        Dl_info info = {};
+        if (pc) dladdr(reinterpret_cast<void *>(pc), &info);
+        char line[320];
+        int n = std::snprintf(line, sizeof(line), "[probe watchdog] thread %u run_state=%d suspend=%d state=%d pc=%#zx in %s sp=%#zx used=%zu\n",
+                              i, basic.run_state, basic.suspend_count, stateResult, pc, info.dli_sname ? info.dli_sname : "?", sp, sp ? sp0 - sp : 0);
+        (void) !write(1, line, n);
+    }
+#else
+    (void) !write(1, "[probe watchdog] not apple\n", 27);
+#endif
+    _exit(42);
+}
+
+static void probeArm() {
+    struct sigaction action;
+    std::memset(&action, 0, sizeof(action));
+    action.sa_flags = SA_SIGINFO;
+    action.sa_sigaction = &probeOnAlarm;
+    sigaction(SIGALRM, &action, nullptr);
+    alarm(20);
+}
+
 #define PROBE_ESCAPED_PAIR(NAME, SIZE)                                                                          \
     MM_NOINLINE int NAME##2(int depth);                                                                        \
     MM_NOINLINE int NAME##1(int depth) {                                                                       \


### PR DESCRIPTION
Throwaway, on top of #2661. Three overflow variants on the darwin_x86_64 leg, each bounded by a 20s alarm in the child so a wedge reports as death by SIGALRM instead of a cancelled hour: no handler at all, the handler without its alternate stack, and the full setup. The recursion prints its depth every thousand levels to stdout, so the log shows whether it ever reached the guard page. Closed once read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)