### PR TITLE
Document BackToHouseMenu as MM6's movie house re-entry hook

### DIFF
--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -665,14 +665,10 @@ void createHouseUI(HouseId houseId) {
     }
 }
 
-/**
- * In MM6 this is the seam between a movie house's movie and the game. It runs on every return to the house
- * menu, and when the house is the High Council - where the ending ceremony movie plays - it rebuilds the
- * house window under the game over flag. MM7 has no movie houses, so in MM7 there is nothing to do.
- */
 void BackToHouseMenu() {
-    // MM6 house 165 is the High Council. MM7 reused that id for the Erathian Master Guild of Body, and
-    // running this there was the #840 crash, so the block stays disabled until MM6 support gives it a home.
+    // Dead since #840, the crash this block caused in MM7 - id 165 is MM6's High Council but MM7's Master
+    // Guild of Body in Erathia. It rebuilt house 165's window on a return to the menu with no movie playing.
+    // Four things in it no longer compile, so MM6 will need more than flipping the #if.
 #if 0
     if (window_SpeakInHouse && window_SpeakInHouse->houseId() == 165 &&
         !pMovie_Track) {

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -42,7 +42,6 @@
 #include "GUI/UI/Houses/TownHall.h"
 #include "GUI/UI/Houses/Shops.h"
 
-#include "Io/Mouse.h"
 #include "Io/KeyboardInputHandler.h"
 
 #include "Media/Audio/AudioPlayer.h"
@@ -666,10 +665,14 @@ void createHouseUI(HouseId houseId) {
     }
 }
 
-// TODO(Nik-RE-dev): looks like this function is not needed anymore
+/**
+ * In MM6 this is the seam between a movie house's movie and the game. It runs on every return to the house
+ * menu, and when the house is the High Council - where the ending ceremony movie plays - it rebuilds the
+ * house window under the game over flag. MM7 has no movie houses, so in MM7 there is nothing to do.
+ */
 void BackToHouseMenu() {
-    auto pMouse = EngineIocContainer::ResolveMouse();
-    // TODO(Nik-RE-dev): Looks like it's artifact of MM6
+    // MM6 house 165 is the High Council. MM7 reused that id for the Erathian Master Guild of Body, and
+    // running this there was the #840 crash, so the block stays disabled until MM6 support gives it a home.
 #if 0
     if (window_SpeakInHouse && window_SpeakInHouse->houseId() == 165 &&
         !pMovie_Track) {


### PR DESCRIPTION
Resolves the two `TODO(Nik-RE-dev)` on `BackToHouseMenu` in `UIHouses.cpp` - "looks like this function is not needed anymore" and "Looks like it's artifact of MM6" - by answering them instead of deleting the code. Per review, the `#if 0` block stays for MM6 support.

What the artifact is, dug out of `MM6.exe` and MM6's `2dEvents.txt` (details in the comment below): id 165 in MM6 is the High Council, where the ending ceremony movie plays, and this block re-entered that house to rebuild its window once no movie was playing. MM7 kept the routine but never re-pointed the id, which there names the Master Guild of Body in Erathia, and running the block on it was the #840 crash that got it disabled in 2023.

The function and its nine call sites stay - the call sites are what mark where the hook fires. The two TODOs become a single comment on the disabled block. The only deletions are the dead `EngineIocContainer::ResolveMouse()` line, a leftover since 729f69cd4fc dropped `ClearPickedItem`, and the `Io/Mouse.h` include that only served it.

The comment also records something the review turned up: the block cannot simply be switched back on. Compiling it with the `#if` flipped gives four errors - `houseId() == 165` no longer type-checks, `GUIWindow_House` has no `Release` since `window_SpeakInHouse` became a `unique_ptr`, `pParty->uFlags` is now a typed `Flags<PartyFlag>`, and `HOUSE_BODY_GUILD_MASTER_ERATHIA` was renamed to `HOUSE_BODY_GUILD_ERATHIA` and no longer resolves.

Behavior-preserving by construction. Local battery: 408 unit tests, 364/364 game tests, style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
