### PR TITLE
Fix and test #1998

### DIFF
--- a/src/Engine/Objects/Item.h
+++ b/src/Engine/Objects/Item.h
@@ -43,6 +43,7 @@ struct Item {
 
     inline bool IsBroken() const { return flags & ITEM_BROKEN; }
     inline void SetBroken() { flags |= ITEM_BROKEN; }
+    inline void SetRepaired() { flags &= ~ITEM_BROKEN; }
     inline bool IsIdentified() const { return flags & ITEM_IDENTIFIED; }
     inline void SetIdentified() { flags |= ITEM_IDENTIFIED; }
     inline bool IsStolen() const { return flags & ITEM_STOLEN; }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -355,11 +355,13 @@ void GameUI_DrawItemInfo(Item *inspect_item) {
     }
 
     if (pParty->hasActiveCharacter()) {
+        SpeechId speech = SPEECH_NONE;
+
         // try to identify
         if (!inspect_item->IsIdentified()) {
             if (pParty->activeCharacter().CanIdentify(*inspect_item) == 1)
                 inspect_item->SetIdentified();
-            SpeechId speech = SPEECH_ID_ITEM_FAIL;
+            speech = SPEECH_ID_ITEM_FAIL;
             if (!inspect_item->IsIdentified()) {
                 engine->_statusBar->setEvent(LSTR_IDENTIFY_FAILED);
             } else {
@@ -368,24 +370,23 @@ void GameUI_DrawItemInfo(Item *inspect_item) {
                     speech = SPEECH_ID_ITEM_WEAK;
                 }
             }
-            if (!identifyOrRepairReactionPlayed) {
-                pParty->activeCharacter().playReaction(speech);
-                identifyOrRepairReactionPlayed = true;
-            }
         }
         inspect_item->UpdateTempBonus(pParty->GetPlayingTime());
         if (inspect_item->IsBroken()) {
             if (pParty->activeCharacter().CanRepair(*inspect_item) == 1)
-                inspect_item->flags = inspect_item->flags & ~ITEM_BROKEN | ITEM_IDENTIFIED;
-            SpeechId speech = SPEECH_REPAIR_FAIL;
-            if (!inspect_item->IsBroken())
+                inspect_item->SetRepaired();
+            if (!inspect_item->IsBroken()) { // Repair success outranks any identification speech, repair failure yields to it.
                 speech = SPEECH_REPAIR_SUCCESS;
-            else
+            } else {
                 engine->_statusBar->setEvent(LSTR_REPAIR_FAILED);
-            if (!identifyOrRepairReactionPlayed) {
-                pParty->activeCharacter().playReaction(speech);
-                identifyOrRepairReactionPlayed = true;
+                if (speech == SPEECH_NONE)
+                    speech = SPEECH_REPAIR_FAIL;
             }
+        }
+        // TODO(pskelton): replace identifyOrRepairReactionPlayed with a check that the character is already reacting.
+        if (speech != SPEECH_NONE && !identifyOrRepairReactionPlayed) {
+            pParty->activeCharacter().playReaction(speech);
+            identifyOrRepairReactionPlayed = true;
         }
     }
 

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -1070,3 +1070,37 @@ GAME_TEST(Issues, Issue1997) {
     EXPECT_EQ(blessTape.front(), 0);
     EXPECT_GT(blessTape.back(), 0); // Bless was cast at least once.
 }
+
+GAME_TEST(Issues, Issue1998) {
+    // Repairing an unidentified item from the inventory also identified it, even with no identify skill at all, and it
+    // played the failed identification speech instead of the repair one.
+    engine->config->debug.NoActors.setValue(true);
+    game.startNewGame();
+
+    Character &character = pParty->pCharacters[0];
+    character.setSkillValue(SKILL_REPAIR, CombinedSkillValue(10, MASTERY_GRANDMASTER)); // Grandmaster repair always succeeds.
+    character.setSkillValue(SKILL_ITEM_ID, CombinedSkillValue::none());
+    Item armor(ITEM_LEATHER_ARMOR); // A fresh item is unidentified.
+    armor.SetBroken();
+    ASSERT_GT(pItemTable->items[armor.itemId].identifyAndRepairDifficulty, 0); // Zero-difficulty items identify on inspection.
+    ASSERT_FALSE(character.CanIdentify(armor));
+    ASSERT_TRUE(character.CanRepair(armor));
+    character.inventory.clear();
+    character.inventory.add(Pointi(0, 0), armor);
+
+    // Right-click the item in the inventory grid, the popup does the repair.
+    auto portraitTape = charTapes.portrait(0);
+    game.goToInventory(1);
+    test.startTaping();
+    game.pressButton(BUTTON_RIGHT, 30, 30);
+    game.tick();
+    game.releaseButton(BUTTON_RIGHT, 30, 30);
+    game.tick();
+    test.stopTaping();
+
+    auto entry = character.inventory.entry(Pointi(0, 0));
+    ASSERT_TRUE(entry);
+    EXPECT_FALSE(entry->IsBroken());
+    EXPECT_FALSE(entry->IsIdentified());
+    EXPECT_CONTAINS(portraitTape, PORTRAIT_WIDE_SMILE); // Repair success portrait.
+}

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -1074,33 +1074,38 @@ GAME_TEST(Issues, Issue1997) {
 GAME_TEST(Issues, Issue1998) {
     // Repairing an unidentified item from the inventory also identified it, even with no identify skill at all, and it
     // played the failed identification speech instead of the repair one.
-    engine->config->debug.NoActors.setValue(true);
-    game.startNewGame();
+    for (bool canIdentify : {true, false}) {
+        SCOPED_TRACE(canIdentify ? "can identify" : "cannot identify");
+        test.prepareForNextTest();
+        engine->config->debug.NoActors.setValue(true);
+        game.startNewGame();
 
-    Character &character = pParty->pCharacters[0];
-    character.setSkillValue(SKILL_REPAIR, CombinedSkillValue(10, MASTERY_GRANDMASTER)); // Grandmaster repair always succeeds.
-    character.setSkillValue(SKILL_ITEM_ID, CombinedSkillValue::none());
-    Item armor(ITEM_LEATHER_ARMOR); // A fresh item is unidentified.
-    armor.SetBroken();
-    ASSERT_GT(pItemTable->items[armor.itemId].identifyAndRepairDifficulty, 0); // Zero-difficulty items identify on inspection.
-    ASSERT_FALSE(character.CanIdentify(armor));
-    ASSERT_TRUE(character.CanRepair(armor));
-    character.inventory.clear();
-    character.inventory.add(Pointi(0, 0), armor);
+        Character &character = pParty->pCharacters[0];
+        CombinedSkillValue grandmaster(10, MASTERY_GRANDMASTER); // Always succeeds, for both skills.
+        character.setSkillValue(SKILL_REPAIR, grandmaster);
+        character.setSkillValue(SKILL_ITEM_ID, canIdentify ? grandmaster : CombinedSkillValue::none());
+        Item armor(ITEM_LEATHER_ARMOR); // A fresh item is unidentified.
+        armor.SetBroken();
+        ASSERT_GT(pItemTable->items[armor.itemId].identifyAndRepairDifficulty, 0); // Zero-difficulty items identify on inspection.
+        ASSERT_EQ(character.CanIdentify(armor), canIdentify);
+        ASSERT_TRUE(character.CanRepair(armor));
+        character.inventory.clear();
+        character.inventory.add(Pointi(0, 0), armor);
 
-    // Right-click the item in the inventory grid, the popup does the repair.
-    auto portraitTape = charTapes.portrait(0);
-    game.goToInventory(1);
-    test.startTaping();
-    game.pressButton(BUTTON_RIGHT, 30, 30);
-    game.tick();
-    game.releaseButton(BUTTON_RIGHT, 30, 30);
-    game.tick();
-    test.stopTaping();
+        // Right-click the item in the inventory grid, the popup does the identification and the repair.
+        auto portraitTape = charTapes.portrait(0);
+        game.goToInventory(1);
+        test.startTaping();
+        game.pressButton(BUTTON_RIGHT, 30, 30);
+        game.tick();
+        game.releaseButton(BUTTON_RIGHT, 30, 30);
+        game.tick();
+        test.stopTaping();
 
-    auto entry = character.inventory.entry(Pointi(0, 0));
-    ASSERT_TRUE(entry);
-    EXPECT_FALSE(entry->IsBroken());
-    EXPECT_FALSE(entry->IsIdentified());
-    EXPECT_CONTAINS(portraitTape, PORTRAIT_WIDE_SMILE); // Repair success portrait.
+        auto entry = character.inventory.entry(Pointi(0, 0));
+        ASSERT_TRUE(entry);
+        EXPECT_FALSE(entry->IsBroken());
+        EXPECT_EQ(entry->IsIdentified(), canIdentify);
+        EXPECT_CONTAINS(portraitTape, PORTRAIT_WIDE_SMILE); // Repair success portrait, it outranks the identification one.
+    }
 }


### PR DESCRIPTION
`GameUI_DrawItemInfo` cleared the broken flag and set the identified flag in a single assignment, so a character with enough repair skill and no identify skill identified an item just by repairing it, and the failed identification speech played instead of the repair one. Repair now only clears the broken flag through a new `Item::SetRepaired()`, and the speech is picked once after both steps, so a successful repair speaks as a repair. That also covers a click that identifies and repairs at once, which used to speak the identification line. Shop repair is untouched.

`Issues.Issue1998` right-clicks a broken unidentified armor in the inventory with a grandmaster Repair character, once with grandmaster Item Id and once with no Item Id skill, and checks the armor is repaired, identified only in the first case, and that the repair speech portrait shows both times. On the unfixed code the second case comes back identified and both cases play the wrong speech.

Fixes #1998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
