### PR TITLE
The devcontainer runs the agent view, tmux retires

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   nano \
   vim \
-  tmux \
   imagemagick \
   python3-pip \
   python3-pil \
@@ -122,9 +121,6 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
-
-# tmux config — Claude runs inside tmux so it survives host terminal disconnects.
-COPY --chown=$USERNAME:$USERNAME tmux.conf /home/$USERNAME/.tmux.conf
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/

--- a/.devcontainer/tmux.conf
+++ b/.devcontainer/tmux.conf
@@ -1,8 +1,0 @@
-# Minimal config: tmux here is a persistence daemon, not a multiplexer.
-# Claude Code owns the whole screen, so stay out of its way.
-set -g status off                          # no status bar - looks like a plain terminal
-set -sg escape-time 10                     # Esc reaches Claude immediately, not after 500ms
-set -ga terminal-overrides ',*:smcup@:rmcup@'  # no alt screen, so the host terminal keeps scrollback and selection
-set -g history-limit 100000                # long build logs
-set -g default-terminal "tmux-256color"
-set -g set-clipboard on                    # OSC-52 copy out to the host

--- a/scripts/run_claude_devcontainer.sh
+++ b/scripts/run_claude_devcontainer.sh
@@ -17,9 +17,11 @@ fi
 echo "Starting devcontainer (no-op if already running)..."
 devcontainer up --workspace-folder "$REPO_DIR" >/dev/null
 
-# The agent view is the entry point. Sessions dispatched from it run under the supervisor and keep working
-# when the host terminal dies - only the view dies, and rerunning this script brings it back with every
-# session still in it. TERM and COLORTERM are forwarded from the host, because plain `devcontainer exec`
-# passes a bare TERM=xterm and drops COLORTERM.
+# Claude's agent view is the entry point. Sessions dispatched from it keep running when the host terminal
+# dies. A dead terminal only takes down the view itself. Rerun this script to get it back, with every
+# session still in it.
+#
+# TERM and COLORTERM are forwarded by hand. Plain `devcontainer exec` passes a bare TERM=xterm and drops
+# COLORTERM.
 exec devcontainer exec --workspace-folder "$REPO_DIR" \
   bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' exec claude agents --dangerously-skip-permissions"

--- a/scripts/run_claude_devcontainer.sh
+++ b/scripts/run_claude_devcontainer.sh
@@ -17,9 +17,9 @@ fi
 echo "Starting devcontainer (no-op if already running)..."
 devcontainer up --workspace-folder "$REPO_DIR" >/dev/null
 
-# Run Claude inside tmux so it survives disconnects from the host terminal. `-A` attaches to an existing session,
-# so this same command both starts and reattaches; `-D` kicks off any stale client so the terminal size is right.
-# TERM and COLORTERM are forwarded from the host - `devcontainer exec` passes a bare TERM=xterm and drops
-# COLORTERM, which makes tmux quantize colors down to 8.
+# The agent view is the entry point. Sessions dispatched from it run under the supervisor and keep working
+# when the host terminal dies - only the view dies, and rerunning this script brings it back with every
+# session still in it. TERM and COLORTERM are forwarded from the host, `devcontainer exec` passes a bare
+# TERM=xterm and drops COLORTERM.
 exec devcontainer exec --workspace-folder "$REPO_DIR" \
-  bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' exec tmux new-session -A -D -s claude 'claude --dangerously-skip-permissions; exec bash -l'"
+  bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' exec claude agents --dangerously-skip-permissions"

--- a/scripts/run_claude_devcontainer.sh
+++ b/scripts/run_claude_devcontainer.sh
@@ -19,7 +19,7 @@ devcontainer up --workspace-folder "$REPO_DIR" >/dev/null
 
 # The agent view is the entry point. Sessions dispatched from it run under the supervisor and keep working
 # when the host terminal dies - only the view dies, and rerunning this script brings it back with every
-# session still in it. TERM and COLORTERM are forwarded from the host, `devcontainer exec` passes a bare
-# TERM=xterm and drops COLORTERM.
+# session still in it. TERM and COLORTERM are forwarded from the host, because plain `devcontainer exec`
+# passes a bare TERM=xterm and drops COLORTERM.
 exec devcontainer exec --workspace-folder "$REPO_DIR" \
   bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' exec claude agents --dangerously-skip-permissions"


### PR DESCRIPTION
Tmux existed so that Claude survived host terminal disconnects - the current container has a 21 hour old claude under a tmux server with a minutes-old client attached, which is that mechanism doing its job. Claude Code now has the same semantics first class: sessions dispatched from `claude agents` run under a supervisor and keep working with no terminal at all, `claude attach` reconnects, and the view itself is the only thing a dead terminal takes down. So the launch script now execs the agent view, dispatched sessions default to bypass permissions exactly as the old command line did, and tmux leaves the Dockerfile along with its config.

What changes in daily use: rerunning the script is the reattach, same as before. What goes away: the fallback login shell the tmux wrapper dropped into when claude exited.

Verified against the installed claude 2.1.251 in the container - the flags exist and the view lists and reattaches sessions. The Dockerfile change itself is proven at the next container rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)