### PR TITLE
Ship capstone and pefile in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-pip \
   python3-pil \
   python3-numpy \
+  python3-capstone \
+  python3-pefile \
   wget \
   ca-certificates \
   curl \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-numpy \
   python3-capstone \
   python3-pefile \
+  binutils-multiarch \
   wget \
   ca-certificates \
   curl \


### PR DESCRIPTION
Two stock python3 packages for binary archaeology, prompted by the vanilla research rounds on #2668 and the MM8 decoration mapping: `python3-capstone` for disassembling the original binaries (MM6.exe, the PS2 MM8 ELF) and `python3-pefile` so nobody parses PE section tables by hand again. Installing capstone at runtime needed the PEP 668 `--break-system-packages` override and a firewall-allowlisted pypi, both of which this avoids. `binutils-multiarch` rides along so plain `objdump -d` handles the MIPS ELF and `-b binary -m i386` covers raw x86 windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

