### PR TITLE
Leave SIGABRT alone under Rosetta, handling it deadlocks the process

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -264,6 +264,7 @@ jobs:
           GITHUBARCH: '${{env.MATRIX_ARCHITECTURE}}'
 
       - name: '[darwin/windows/linux] Run unit tests'
+        timeout-minutes: 15
         if: env.MATRIX_PLATFORM != 'android'
         working-directory: build
         run: |

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -474,6 +474,7 @@ static void installHandlers() {
         action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
         sigfillset(&action.sa_mask);
         sigdelset(&action.sa_mask, signal);
+        sigdelset(&action.sa_mask, SIGALRM); // Or the watchdog alarm sits pending while the handler hangs, and never fires.
         action.sa_sigaction = &onSignal;
         sigaction(signal, &action, nullptr);
     }

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -433,6 +433,11 @@ static void onSignal(int signal, siginfo_t *info, void *context) {
     // dump. A second thread raising the same signal never gets here, SA_RESETHAND already put the default
     // handler back, so the kernel kills the process and whatever was printed so far is all there is.
     if (!crashHandled.test_and_set()) {
+        // Symbolizing allocates and takes locks, and the header spells out how that can deadlock. A wedged
+        // handler is worse than a lost trace, so the alarm kills the process - SIGALRM keeps its default
+        // disposition - and whatever was printed by then still reaches the reader.
+        alarm(30);
+
         char reason[128];
         std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
         printCrashHeader(reason);

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -380,6 +380,10 @@ static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &cras
         if (frame[1] == 0)
             break;
         frames.push_back(frame[1] - 1);
+        // A frame built without a frame pointer holds something else in that slot. The caller's frame is always
+        // further up the stack, so a value that isn't stops the walk instead of being followed.
+        if (frame[0] <= fp || frame[0] % sizeof(uintptr_t) != 0)
+            break;
         fp = frame[0];
     }
     return frames;

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -25,6 +25,7 @@
 #   include <sys/ucontext.h> // NOLINT: not a C++ system header.
 #   ifdef __APPLE__
 #       include <libunwind.h> // NOLINT: not a C++ system header.
+#       include <sys/sysctl.h> // NOLINT: not a C++ system header.
 #   else
 #       include <unwind.h> // NOLINT: not a C++ system header.
 #   endif
@@ -51,6 +52,16 @@ static void (*crashCallback)() = nullptr;
 static void runCrashCallback() {
     if (crashCallback)
         crashCallback();
+}
+
+bool detail::isRunningUnderRosetta() {
+#ifdef __APPLE__
+    int translated = 0;
+    size_t size = sizeof(translated);
+    return sysctlbyname("sysctl.proc_translated", &translated, &size, nullptr, 0) == 0 && translated == 1; // The key only exists in a translated process.
+#else
+    return false;
+#endif
 }
 
 static void printCrashHeader(std::string_view reason) {
@@ -505,6 +516,15 @@ static void installHandlers() {
     sigaltstack(&stack, nullptr);
 
     for (int signal : handledSignals) {
+        // Rosetta gives up on a fault that lands on any push of a function prologue's push run but the first,
+        // reports that it can't emulate forward on a synchronous exception, and aborts the process with the
+        // faulting thread still parked in the mach exception path, where no signal reaches it. A SIGABRT
+        // handler would then deadlock the process where the default disposition kills it. A stack overflow is
+        // the crash that hits this, a prologue being where a new frame first touches new stack. Only translated
+        // x86_64 is affected, hence a runtime check - the same build still traces aborts on an intel mac.
+        if (signal == SIGABRT && detail::isRunningUnderRosetta())
+            continue;
+
         struct sigaction action;
         std::memset(&action, 0, sizeof(action));
         action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -349,6 +349,11 @@ static uintptr_t faultingProgramCounter(const ucontext_t &crashContext) {
 #endif
 }
 
+static bool isMapped(uintptr_t address) {
+    uintptr_t page = address & ~static_cast<uintptr_t>(getpagesize() - 1);
+    return msync(reinterpret_cast<void *>(page), 1, MS_ASYNC) == 0; // Fails with ENOMEM on an unmapped page, and touches nothing.
+}
+
 /**
  * Walks the frame pointer chain from the register state a signal was delivered with. This is for a call
  * through a bad pointer, which faults at the bad address where the unwinder has nothing to go on. The call
@@ -358,11 +363,6 @@ static uintptr_t faultingProgramCounter(const ucontext_t &crashContext) {
  * @param crashContext                  Register state the signal was delivered with.
  * @return                              Frames starting with the call that jumped to the bad address.
  */
-static bool isMapped(uintptr_t address) {
-    uintptr_t page = address & ~static_cast<uintptr_t>(getpagesize() - 1);
-    return msync(reinterpret_cast<void *>(page), 1, MS_ASYNC) == 0; // Fails with ENOMEM on an unmapped page, and touches nothing.
-}
-
 static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &crashContext) {
     std::vector<cpptrace::frame_ptr> frames;
 #if defined(__aarch64__)

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -21,6 +21,7 @@
 #   include <mutex>
 #elif !defined(__ANDROID__)
 #   include <unistd.h> // NOLINT: not a C++ system header.
+#   include <sys/mman.h> // NOLINT: not a C++ system header.
 #   include <sys/ucontext.h> // NOLINT: not a C++ system header.
 #   ifdef __APPLE__
 #       include <libunwind.h> // NOLINT: not a C++ system header.
@@ -357,6 +358,11 @@ static uintptr_t faultingProgramCounter(const ucontext_t &crashContext) {
  * @param crashContext                  Register state the signal was delivered with.
  * @return                              Frames starting with the call that jumped to the bad address.
  */
+static bool isMapped(uintptr_t address) {
+    uintptr_t page = address & ~static_cast<uintptr_t>(getpagesize() - 1);
+    return msync(reinterpret_cast<void *>(page), 1, MS_ASYNC) == 0; // Fails with ENOMEM on an unmapped page, and touches nothing.
+}
+
 static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &crashContext) {
     std::vector<cpptrace::frame_ptr> frames;
 #if defined(__aarch64__)
@@ -376,6 +382,8 @@ static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &cras
 #endif
     frames.push_back(returnAddress - 1); // Minus one, so it points into the call, not one past it.
     while (fp != 0 && frames.size() < detail::MAX_TRACE_DEPTH) {
+        if (!isMapped(fp) || !isMapped(fp + sizeof(uintptr_t)))
+            break; // Reading it would fault inside the handler.
         const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp); // [fp] = caller's fp, [fp + 1] = return.
         if (frame[1] == 0)
             break;

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -349,9 +349,15 @@ static uintptr_t faultingProgramCounter(const ucontext_t &crashContext) {
 #endif
 }
 
-static bool isMapped(uintptr_t address) {
-    uintptr_t page = address & ~static_cast<uintptr_t>(getpagesize() - 1);
-    return msync(reinterpret_cast<void *>(page), 1, MS_ASYNC) == 0; // Fails with ENOMEM on an unmapped page, and touches nothing.
+static const size_t crashPageSize = getpagesize(); // Resolved at load. It's a call, and the handler runs in a broken process.
+
+bool detail::isRangeMapped(uintptr_t address, size_t size) {
+    uintptr_t mask = ~static_cast<uintptr_t>(crashPageSize - 1);
+    uintptr_t last = (address + size - 1) & mask;
+    for (uintptr_t page = address & mask; page <= last; page += crashPageSize)
+        if (msync(reinterpret_cast<void *>(page), 1, MS_ASYNC) != 0)
+            return false; // Fails with ENOMEM on an unmapped page, and touches nothing.
+    return true;
 }
 
 /**
@@ -365,34 +371,52 @@ static bool isMapped(uintptr_t address) {
  */
 static std::vector<cpptrace::frame_ptr> walkFramePointers(const ucontext_t &crashContext) {
     std::vector<cpptrace::frame_ptr> frames;
+    uintptr_t returnAddress = 0;
+    uintptr_t fp = 0;
 #if defined(__aarch64__)
-    uintptr_t returnAddress = crashContext.uc_mcontext.regs[30]; // lr
-    uintptr_t fp = crashContext.uc_mcontext.regs[29];
-#elif defined(__x86_64__)
+    returnAddress = crashContext.uc_mcontext.regs[30]; // lr
+    fp = crashContext.uc_mcontext.regs[29];
+#elif defined(__x86_64__) || defined(__i386__)
+#   if defined(__x86_64__)
     uintptr_t sp = crashContext.uc_mcontext.gregs[REG_RSP];
-    uintptr_t returnAddress = *reinterpret_cast<const uintptr_t *>(sp); // The call pushed it.
-    uintptr_t fp = crashContext.uc_mcontext.gregs[REG_RBP];
-#elif defined(__i386__)
+    fp = crashContext.uc_mcontext.gregs[REG_RBP];
+#   else
     uintptr_t sp = crashContext.uc_mcontext.gregs[REG_ESP];
-    uintptr_t returnAddress = *reinterpret_cast<const uintptr_t *>(sp);
-    uintptr_t fp = crashContext.uc_mcontext.gregs[REG_EBP];
+    fp = crashContext.uc_mcontext.gregs[REG_EBP];
+#   endif
+    // The call pushed the return address, but sp comes out of a broken process, so it's checked like every
+    // other read here. Nothing to trace from if it isn't there.
+    if (!detail::isRangeMapped(sp, sizeof(uintptr_t)))
+        return frames;
+    returnAddress = *reinterpret_cast<const uintptr_t *>(sp);
 #elif defined(__arm__)
-    uintptr_t returnAddress = crashContext.uc_mcontext.arm_lr;
-    uintptr_t fp = crashContext.uc_mcontext.arm_fp;
+    returnAddress = crashContext.uc_mcontext.arm_lr;
+    fp = crashContext.uc_mcontext.arm_fp;
 #endif
     frames.push_back(returnAddress - 1); // Minus one, so it points into the call, not one past it.
-    while (fp != 0 && frames.size() < detail::MAX_TRACE_DEPTH) {
-        if (!isMapped(fp) || !isMapped(fp + sizeof(uintptr_t)))
-            break; // Reading it would fault inside the handler.
-        const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp); // [fp] = caller's fp, [fp + 1] = return.
-        if (frame[1] == 0)
+
+    while (frames.size() < detail::MAX_TRACE_DEPTH) {
+        // Both checks precede the read and cover its whole span - [fp] is the caller's frame pointer and
+        // [fp + 1] the return address, two words starting at fp. Checking alignment here rather than at the
+        // bottom of the loop is what covers the fp that came out of the crash context.
+        if (fp == 0 || fp % sizeof(uintptr_t) != 0)
             break;
-        frames.push_back(frame[1] - 1);
+        if (!detail::isRangeMapped(fp, 2 * sizeof(uintptr_t)))
+            break;
+
+        const uintptr_t *frame = reinterpret_cast<const uintptr_t *>(fp);
+        uintptr_t callerFp = frame[0];
+        uintptr_t callerPc = frame[1];
+        if (callerPc == 0)
+            break;
+        frames.push_back(callerPc - 1);
+
         // A frame built without a frame pointer holds something else in that slot. The caller's frame is always
-        // further up the stack, so a value that isn't stops the walk instead of being followed.
-        if (frame[0] <= fp || frame[0] % sizeof(uintptr_t) != 0)
+        // further up the stack, so a value that isn't ends the walk - after the push, since at the frame above
+        // main the return address is real while the slot is not.
+        if (callerFp <= fp)
             break;
-        fp = frame[0];
+        fp = callerFp;
     }
     return frames;
 }

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -1,5 +1,19 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__linux__) && !defined(__ANDROID__)
+namespace detail {
+/**
+ * @param address                       First byte of the range.
+ * @param size                          Range length in bytes.
+ * @return                              Whether every page the range touches is mapped.
+ */
+bool isRangeMapped(uintptr_t address, size_t size);
+} // namespace detail
+#endif
+
 /**
  * Installs crash handlers that dump a stack trace to stderr, then let the crash proceed so that the OS still
  * produces a core dump or a crash report. The handlers are never uninstalled, the process is dying anyway.

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -3,6 +3,13 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace detail {
+/**
+ * @return                              Whether this is an x86_64 binary running under Rosetta translation.
+ */
+bool isRunningUnderRosetta();
+} // namespace detail
+
 #if defined(__linux__) && !defined(__ANDROID__)
 namespace detail {
 /**
@@ -26,6 +33,10 @@ bool isRangeMapped(uintptr_t address, size_t size);
  * The handlers are not async-signal-safe, and can't be - symbolizing a trace allocates, reads files and takes
  * locks, so a crash while another thread holds one of those hangs the process instead of killing it. Crashing
  * inside the allocator does the same.
+ *
+ * Under Rosetta SIGABRT is left at its default disposition, so an abort, a terminate and a pure virtual call
+ * die there without a trace. Handling it would deadlock the process instead, the faulting thread being parked
+ * by Rosetta where no signal reaches it.
  */
 class StackTraceOnCrash {
  public:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,8 +123,11 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
     volatile char pad[1024]; // Big frames run out of stack fast.
+    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
     pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -5,6 +5,11 @@
 #include <string>
 #include <thread>
 
+#if defined(__linux__) && !defined(__ANDROID__)
+#   include <sys/mman.h> // NOLINT: not a C++ system header.
+#   include <unistd.h> // NOLINT: not a C++ system header.
+#endif
+
 #include "Testing/Unit/UnitTest.h"
 
 #include "Library/StackTrace/StackTrace.h"
@@ -145,6 +150,25 @@ MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
     pad[1023] = static_cast<char>(depth);
     return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
 }
+
+#if defined(__linux__) && !defined(__ANDROID__)
+UNIT_TEST(StackTrace, RangeCheckSpansEveryPageItReads) {
+    // The frame walk reads two words at fp. Checking only the page holding the first byte let a read whose tail
+    // crossed into an unmapped page fault, and that was the crash handler crashing mid-walk.
+    long pageSize = getpagesize();
+    char *pages = static_cast<char *>(mmap(nullptr, pageSize * 3, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(pages, MAP_FAILED);
+    munmap(pages + pageSize, pageSize); // A hole between two mapped pages.
+
+    EXPECT_TRUE(detail::isRangeMapped(reinterpret_cast<uintptr_t>(pages), 1));
+    EXPECT_FALSE(detail::isRangeMapped(reinterpret_cast<uintptr_t>(pages + pageSize), 1));
+    uintptr_t straddling = reinterpret_cast<uintptr_t>(pages + pageSize) - sizeof(uintptr_t) / 2;
+    EXPECT_FALSE(detail::isRangeMapped(straddling, 2 * sizeof(uintptr_t)));
+
+    munmap(pages, pageSize);
+    munmap(pages + 2 * pageSize, pageSize);
+}
+#endif
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     std::string trace = stackTraceMarkerFunction();

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,6 +31,16 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
+// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
+// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
+// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
+class StackTraceDeathTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+    }
+};
+
 /**
  * Matches when the frame numbered `index` names `function`. The regexes gtest's own death test matchers take
  * aren't portable - gtest picks between two engines with different grammars depending on the platform - so
@@ -128,7 +138,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -139,7 +149,7 @@ UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -152,7 +162,7 @@ UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -164,7 +174,7 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -175,7 +185,7 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST(StackTrace, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
@@ -186,7 +196,7 @@ UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -203,7 +213,7 @@ UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST(StackTrace, AbortIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -213,7 +223,7 @@ UNIT_TEST(StackTrace, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST(StackTrace, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -223,7 +233,7 @@ UNIT_TEST(StackTrace, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +244,7 @@ UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST(StackTrace, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -226,6 +226,9 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
+    if (detail::isRunningUnderRosetta())
+        GTEST_SKIP() << "Rosetta can't reliably deliver the guard page fault.";
+
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all. Under rosetta, where darwin_x86_64
     // runs in CI, an overflow of frames a few dozen bytes deep froze the process for good - no signal was
@@ -256,6 +259,9 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, AbortIsTraced) {
+    if (detail::isRunningUnderRosetta())
+        GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
+
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -266,6 +272,9 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, AbortIsTraced) {
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, TerminateIsTraced) {
+    if (detail::isRunningUnderRosetta())
+        GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
+
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -276,6 +285,9 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, TerminateIsTraced) {
 }
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, PureVirtualCallIsTraced) {
+    if (detail::isRunningUnderRosetta())
+        GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
+
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -176,7 +176,8 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
-    // everything above it.
+    // everything above it. The walk used to follow the frame pointer slot of a frame that had none, past main
+    // into garbage, and on i386 that crashed the handler before it printed a single frame.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -31,10 +31,12 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
-// Death tests re-exec the binary instead of forking. The parent has helper threads on mac, and a forked
-// child inherits whatever locks they held at that instant, so a handler that allocates while symbolizing
-// deadlocked darwin CI. A re-exec'd child starts clean. Windows spawns a fresh process either way.
-class StackTraceDeathTest : public testing::Test {
+/**
+ * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
+ * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
+ * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ */
+class ThreadSafeDeathTest : public testing::Test {
  protected:
     void SetUp() override {
         GTEST_FLAG_SET(death_test_style, "threadsafe");
@@ -123,23 +125,20 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
-// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
-MM_NOINLINE int stackTraceOverflowFunction(int depth);
+MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
-// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
-MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
-    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
+MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction2(depth + 1); // Mutual, or this folds into a loop that never overflows.
 }
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
     volatile char pad[1024];
     pad[0] = static_cast<char>(depth);
     pad[1023] = static_cast<char>(depth);
-    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
+    return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
@@ -149,7 +148,7 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
     EXPECT_CONTAINS(trace, "main");
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashHandlerNamesTheCrashingFunction) {
     EXPECT_DEATH({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
@@ -160,7 +159,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashHandlerNamesTheCrashingFunction) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
     EXPECT_DEATH({
@@ -173,7 +172,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashOnAnotherThreadIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
@@ -185,7 +184,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, NullFunctionCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
     // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
     EXPECT_DEATH({
@@ -196,18 +195,18 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, StackOverflowIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
-        stackTraceOverflowFunction(0);
+        stackTraceOverflowFunction1(0);
     }, HasFrame(0, "stackTraceOverflowFunction"));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, CrashCallbackRunsAfterTheTrace) {
     // The callback is what holds a console window open after a crash, so it has to fire after the trace is
     // printed. Matching on order and not just presence is what guards that.
     auto callbackAfterTrace = testing::Truly([](const std::string &output) {
@@ -224,7 +223,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, CrashCallbackRunsAfterTheTrace) {
     }, callbackAfterTrace);
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, AbortIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -234,7 +233,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, AbortIsTraced) {
                       testing::HasSubstr("stackTraceAbortFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, TerminateIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -244,7 +243,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, TerminateIsTraced) {
                       testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
-UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, PureVirtualCallIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -255,7 +254,7 @@ UNIT_TEST_FIXTURE(StackTraceDeathTest, PureVirtualCallIsTraced) {
 }
 
 #ifdef _WINDOWS
-UNIT_TEST_FIXTURE(StackTraceDeathTest, InvalidParameterIsTraced) {
+UNIT_TEST_FIXTURE(ThreadSafeDeathTest, InvalidParameterIsTraced) {
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -32,9 +32,9 @@ constexpr bool isMac = false;
 #endif
 
 /**
- * Death tests in this suite re-exec the binary instead of forking it. Gtest counts a second thread in this
- * process on mac and warns that a forked child inherits whatever locks that thread held at that instant,
- * which is a deadlock waiting to happen in a handler that allocates. A re-exec'd child starts clean.
+ * Death tests in this suite re-exec the binary instead of forking it. The darwin_x86_64 leg runs under
+ * Rosetta on the arm64 runners, where gtest counts a second thread in the process and warns that a forked
+ * child inherits whatever locks that thread held at that instant. A re-exec'd child starts clean.
  */
 class ThreadSafeDeathTest : public testing::Test {
  protected:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -33,8 +33,9 @@ constexpr bool isMac = false;
 
 /**
  * Death tests in this suite re-exec the binary instead of forking it. The darwin_x86_64 leg runs under
- * Rosetta on the arm64 runners, where gtest counts a second thread in the process and warns that a forked
- * child inherits whatever locks that thread held at that instant. A re-exec'd child starts clean.
+ * Rosetta on the arm64 runners, and Rosetta plants its exception server thread in every translated process,
+ * so gtest counts two threads there and warns that a forked child inherits whatever locks the other one held
+ * at that instant. A re-exec'd child starts clean.
  */
 class ThreadSafeDeathTest : public testing::Test {
  protected:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -123,15 +123,23 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-static volatile char *volatile stackTraceOverflowEscape; // Never read. Escaping each pad below keeps the frames apart.
+// Two functions so the recursion is mutual. The tail call accumulator rewrite folded a plain self-recursion
+// into a loop that never overflowed, and it only works within one function - MM_NOINLINE keeps the pair apart.
+MM_NOINLINE int stackTraceOverflowFunction(int depth);
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
-    volatile char pad[1024]; // Big frames run out of stack fast.
-    stackTraceOverflowEscape = pad; // Escaped, or the compiler may merge the frames and fold the recursion into a loop.
+// The name contains stackTraceOverflowFunction on purpose - frame zero is whichever of the two faulted.
+MM_NOINLINE int stackTraceOverflowFunctionToo(int depth) {
+    volatile char pad[1024]; // Big frames overflow fast, and the volatile writes make the endless recursion observable, not UB.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
-    pad[0] = static_cast<char>(pad[0] + stackTraceOverflowFunction(depth + 1)); // Result lands in this frame after the call. Plain `x + recurse()` became an accumulator loop at -O2 and hung.
-    return pad[0] + pad[1023];
+    return pad[0] + pad[1023] + stackTraceOverflowFunction(depth + 1);
+}
+
+MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    volatile char pad[1024];
+    pad[0] = static_cast<char>(depth);
+    pad[1023] = static_cast<char>(depth);
+    return pad[0] + pad[1023] + stackTraceOverflowFunctionToo(depth + 1);
 }
 
 UNIT_TEST(StackTrace, FunctionNamesAreResolved) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -126,10 +126,13 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+static volatile char *volatile stackTraceOverflowEscape; // Never read, the pads below are stored here so they exist.
+
 MM_NOINLINE int stackTraceOverflowFunction2(int depth);
 
 MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
+    stackTraceOverflowEscape = pad; // Or -O2 drops the pad, and rosetta freezes the whole process on an overflow of frames that small.
     pad[0] = static_cast<char>(depth); // Touching both ends, or the compiler is free to shrink the array.
     pad[1023] = static_cast<char>(depth);
     return pad[0] + pad[1023] + stackTraceOverflowFunction2(depth + 1); // Mutual, or this folds into a loop that never overflows.
@@ -137,6 +140,7 @@ MM_NOINLINE int stackTraceOverflowFunction1(int depth) {
 
 MM_NOINLINE int stackTraceOverflowFunction2(int depth) {
     volatile char pad[1024];
+    stackTraceOverflowEscape = pad;
     pad[0] = static_cast<char>(depth);
     pad[1023] = static_cast<char>(depth);
     return pad[0] + pad[1023] + stackTraceOverflowFunction1(depth + 1);
@@ -199,7 +203,9 @@ UNIT_TEST_FIXTURE(ThreadSafeDeathTest, BadTargetCallIsTraced) {
 
 UNIT_TEST_FIXTURE(ThreadSafeDeathTest, StackOverflowIsTraced) {
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
-    // faults on the exhausted stack and the crash prints nothing at all.
+    // faults on the exhausted stack and the crash prints nothing at all. Under rosetta, where darwin_x86_64
+    // runs in CI, an overflow of frames a few dozen bytes deep froze the process for good - no signal was
+    // delivered, not even to other threads. Frames holding a real 1kb pad were delivered 20 times out of 20.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 


### PR DESCRIPTION
Stacked on #2661 - merge that first, this branch is one commit on top of it.

Investigated on an arm64 mac running the x86_64 binaries under Rosetta. A stack overflow whose guard page fault lands on any push of a prologue's push run but the first makes Rosetta give up - it reports it can't emulate forward on a synchronous exception - and abort the process while the faulting thread is still parked in the mach exception path. No signal reaches that thread, SIGTERM included, so a SIGABRT handler deadlocks the process at zero CPU where the default disposition kills it. Across 48 stack alignments the handled build froze 16 times and the default one never did. The escaped pad from #2661 narrows the window but doesn't close it - 8 freezes in 530 alignments with a real 1 KB frame - and a real overflow in the shipped x86_64 build under Rosetta would hang the same way with the handler installed.

So under translation SIGABRT keeps its default disposition. The check is at runtime via sysctl.proc_translated rather than an ifdef, so the same build still traces abort, terminate and pure calls on an intel mac. The four tests that need either a SIGABRT trace or a delivered overflow skip under Rosetta - AbortIsTraced, TerminateIsTraced, PureVirtualCallIsTraced, StackOverflowIsTraced. Everything else traces as before there, checked for a bad call, a null call, a crash on another thread and the callback ordering.

What was measured versus inferred: which instruction sequences freeze and which deliver, the deadlock at zero CPU, SIGTERM not getting in, and the handled-versus-default counts are measurements. Why Rosetta can't deliver a fault on a later push of a run is inference - consistent with everything measured, not confirmed against Rosetta's translated output. The fix doesn't depend on the inference being right, only on the measurement.

Verified locally on linux in Debug and RelWithDebInfo, 11/11 both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)