### PR TITLE
The agent view leaves the mouse to the terminal, Cmd+C copies again

### DIFF
--- a/scripts/run_claude_devcontainer.sh
+++ b/scripts/run_claude_devcontainer.sh
@@ -23,5 +23,16 @@ devcontainer up --workspace-folder "$REPO_DIR" >/dev/null
 #
 # TERM and COLORTERM are forwarded by hand. Plain `devcontainer exec` passes a bare TERM=xterm and drops
 # COLORTERM.
+#
+# TERM_PROGRAM and TERM_PROGRAM_VERSION go the same way, and they are how Claude names the host terminal.
+# Without them it assumes a generic Linux one and says to hold Shift to select text, but Terminal.app needs
+# Fn and iTerm2 needs Option.
+#
+# The agent view turns on mouse reporting, and a terminal that has handed the mouse over stops making
+# selections of its own, which leaves Cmd+C nothing to copy. CLAUDE_CODE_DISABLE_MOUSE turns it back off at
+# the cost of wheel scrolling.
 exec devcontainer exec --workspace-folder "$REPO_DIR" \
-  bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' exec claude agents --dangerously-skip-permissions"
+  bash -lc "TERM='${TERM:-xterm-256color}' COLORTERM='${COLORTERM:-}' \
+            TERM_PROGRAM='${TERM_PROGRAM:-}' TERM_PROGRAM_VERSION='${TERM_PROGRAM_VERSION:-}' \
+            CLAUDE_CODE_DISABLE_MOUSE=1 \
+            exec claude agents --dangerously-skip-permissions"


### PR DESCRIPTION
The agent view runs fullscreen with mouse reporting on. The host terminal hands every drag to Claude instead
of making a selection of its own, so Cmd+C has nothing to copy. `CLAUDE_CODE_DISABLE_MOUSE=1` turns the
reporting off and trades wheel scrolling for a working selection.

Captured from a pty inside the container, to pin down which switch actually controls what:

| env | mouse sequences emitted |
| --- | --- |
| none | `?1000h` `?1002h` `?1003h` `?1006h` |
| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1` | `?1000h` `?1006h` |
| `CLAUDE_CODE_DISABLE_MOUSE=1` | none |

`DISABLE_MOUSE_CLICKS` only drops drag and motion tracking. Mode 1000 stays on, so the terminal still counts
the mouse as claimed and the selection stays broken. Only `DISABLE_MOUSE` clears all four.

`TERM_PROGRAM` and `TERM_PROGRAM_VERSION` are forwarded for a separate reason. `devcontainer exec` drops them
the way it drops `COLORTERM`, and they are what Claude reads to identify the terminal. Lacking them it assumes
a generic Linux terminal and advises Shift to force a native selection, while Terminal.app wants Fn and iTerm2
wants Option.

Checked with stub `devcontainer` and `claude` binaries that all five variables arrive with the right values,
including the case where the host leaves them unset.

### A full container restart is needed to pick this up

The daemon that hosts dispatched sessions is spawned by the first `claude agents` that finds none running, and
later runs reattach to it rather than replace it. It keeps the environment it was born with, so rerunning the
launch script on its own changes nothing. Verified on a live container - after a full restart the daemon carried
`CLAUDE_CODE_DISABLE_MOUSE=1` and `TERM_PROGRAM=Apple_Terminal`, where the stale one had only `TERM` and
`COLORTERM`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

