### PR TITLE
Ask for short pull request descriptions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,8 @@ Before every commit, re-read the code comments in the diff against the Comments 
 
 *NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call.
 
+Keep pull request descriptions short - a few sentences on what was done and how, and that's it. Two or three paragraphs at most, humans don't want to read an essay. The evidence you gathered along the way belongs in a comment on the PR if it belongs anywhere.
+
 Put the `🤖 Human Needed` label on every pull request you open, once its CI is green. The label means a human has to look at the PR, and it's the only label you may ever add or remove - every other label belongs to the humans. Don't add it to a pull request that already carries any other label, a PR that a human has already triaged is in their pipeline anyway. Take the label off while you're working on review comments, and put it back when the ball is with the humans again.
 
 # Comments


### PR DESCRIPTION
Adds a line to `CLAUDE.md` asking for short pull request descriptions - a few sentences on what was done and how, two or three paragraphs at most.

Long descriptions bury the change under the investigation that led to it. The supporting evidence still has a home as a comment on the PR, where it does not compete with the summary.
