### PR TITLE
The crash handler survives the instruction faults, and the tests pin the signal

### DIFF
--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -173,7 +173,10 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
 
 /**
  * Structured exceptions are what access violations, illegal instructions and division by zero arrive as.
- * Signals cover none of those on windows.
+ * Signals cover none of those on windows. A fast fail arrives nowhere - the kernel takes it straight off the
+ * `int 0x29` without dispatching it to user mode, which is what makes it fast, so the checks that raise it
+ * die with no trace. That's the stack cookie and the control flow guard, both of which mean memory this
+ * walk would have to read is already corrupt.
  *
  * @param exceptionInfo                 Exception record and register state of the crash.
  * @return                              Always `EXCEPTION_CONTINUE_SEARCH`, so that the crash proceeds.

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -299,10 +299,11 @@ static void fillUnwindContext(const ucontext_t &crashContext, unw_context_t *con
  * its return address first though, so the pc is set back into that call and the walk carries on from there.
  *
  * @param crashContext                  Register state the signal was delivered with.
+ * @param signal                        Signal that was delivered, `si_signo`.
  * @param faultAddress                  Address the signal was about, `si_addr`.
  * @return                              Stack trace starting at the faulting frame, one frame per line.
  */
-static std::string traceFromContext(const ucontext_t &crashContext, const void *faultAddress) {
+static std::string traceFromContext(const ucontext_t &crashContext, int signal, const void *faultAddress) {
     unw_context_t context;
     fillUnwindContext(crashContext, &context);
 
@@ -311,15 +312,21 @@ static std::string traceFromContext(const ucontext_t &crashContext, const void *
     uint64_t *regs = reinterpret_cast<uint64_t *>(&context);
 #if defined(__aarch64__)
     uint64_t &pc = regs[32];
-    if (pc == reinterpret_cast<uint64_t>(faultAddress))
-        pc = regs[30] - 1; // Minus one, so the pc points into the call, not one past it.
 #else
     uint64_t &pc = regs[16];
-    if (pc == reinterpret_cast<uint64_t>(faultAddress)) {
+#endif
+
+    // A jump to a bad address is the one case where the pc is unwalkable and the pushed return address is the
+    // frame to restart from. It reads as pc equal to si_addr, but so does SIGFPE, which sits at a perfectly
+    // walkable instruction - hence the signal gate, only a bad access can be a bad jump.
+    if ((signal == SIGSEGV || signal == SIGBUS) && pc == reinterpret_cast<uint64_t>(faultAddress)) {
+#if defined(__aarch64__)
+        pc = regs[30] - 1; // Minus one, so the pc points into the call, not one past it.
+#else
         pc = *reinterpret_cast<const uint64_t *>(regs[7]) - 1; // Return address is at [rsp].
         regs[7] += sizeof(uint64_t); // And it's been popped.
-    }
 #endif
+    }
 
     unw_cursor_t cursor;
     unw_init_local(&cursor, &context);
@@ -482,7 +489,7 @@ static void onSignal(int signal, siginfo_t *info, void *context) {
         std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
         printCrashHeader(reason);
 #ifdef __APPLE__
-        printTrace(traceFromContext(*static_cast<ucontext_t *>(context), info->si_addr));
+        printTrace(traceFromContext(*static_cast<ucontext_t *>(context), info->si_signo, info->si_addr));
 #else
         printTrace(traceFromContext(*static_cast<ucontext_t *>(context)));
 #endif

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -316,10 +316,11 @@ static std::string traceFromContext(const ucontext_t &crashContext, int signal, 
     uint64_t &pc = regs[16];
 #endif
 
-    // A jump to a bad address is the one case where the pc is unwalkable and the pushed return address is the
-    // frame to restart from. It reads as pc equal to si_addr, but so does SIGFPE, which sits at a perfectly
-    // walkable instruction - hence the signal gate, only a bad access can be a bad jump.
-    if ((signal == SIGSEGV || signal == SIGBUS) && pc == reinterpret_cast<uint64_t>(faultAddress)) {
+    // A pc equal to si_addr means the pc itself is the problem - a jump to a bad address, or abort parked in
+    // a kill syscall stub the unwinder can't step out of - and the pushed return address is the frame to
+    // restart from. The instruction faults are the exception, SIGFPE, SIGILL and SIGTRAP put the pc of a
+    // perfectly walkable instruction into si_addr, and restarting would seed the walk with garbage.
+    if (signal != SIGFPE && signal != SIGILL && signal != SIGTRAP && pc == reinterpret_cast<uint64_t>(faultAddress)) {
 #if defined(__aarch64__)
         pc = regs[30] - 1; // Minus one, so the pc points into the call, not one past it.
 #else

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -173,10 +173,7 @@ static std::string traceFromContext(const CONTEXT &crashContext, const void *exc
 
 /**
  * Structured exceptions are what access violations, illegal instructions and division by zero arrive as.
- * Signals cover none of those on windows. A fast fail arrives nowhere - the kernel takes it straight off the
- * `int 0x29` without dispatching it to user mode, which is what makes it fast, so the checks that raise it
- * die with no trace. That's the stack cookie and the control flow guard, both of which mean memory this
- * walk would have to read is already corrupt.
+ * Signals cover none of those on windows.
  *
  * @param exceptionInfo                 Exception record and register state of the crash.
  * @return                              Always `EXCEPTION_CONTINUE_SEARCH`, so that the crash proceeds.

--- a/src/Library/StackTrace/StackTraceOnCrash.cpp
+++ b/src/Library/StackTrace/StackTraceOnCrash.cpp
@@ -481,10 +481,15 @@ static std::string traceFromContext(const ucontext_t &crashContext) {
 #endif // __APPLE__
 
 static void onSignal(int signal, siginfo_t *info, void *context) {
+    // Darwin honors SA_RESETHAND for every signal except SIGILL and SIGTRAP, and leaves this handler
+    // installed for those two. Restoring the default by hand is what stops the raise below from re-entering
+    // the handler instead of killing us.
+    std::signal(info->si_signo, SIG_DFL);
+
     // Only the first crash prints. A second thread raising a different signal while this one symbolizes
     // would interleave with it, so it skips to the raise below instead - exiting here would cost the core
-    // dump. A second thread raising the same signal never gets here, SA_RESETHAND already put the default
-    // handler back, so the kernel kills the process and whatever was printed so far is all there is.
+    // dump. A second thread raising the same signal never gets here, the default handler is back in place,
+    // so the kernel kills the process and whatever was printed so far is all there is.
     if (!crashHandled.test_and_set()) {
         char reason[128];
         std::snprintf(reason, sizeof(reason), "%s at %p", strsignal(info->si_signo), info->si_addr);
@@ -498,8 +503,8 @@ static void onSignal(int signal, siginfo_t *info, void *context) {
     }
 
     // Die of the original signal, so that a core dump still happens and whoever launched the process sees it
-    // was killed by a SIGSEGV. SA_RESETHAND put the default handler back before we were called, so raising it
-    // here is what actually kills us.
+    // was killed by a SIGSEGV. The default handler is back in place, so raising it here is what actually
+    // kills us.
     std::raise(info->si_signo);
     _exit(EXIT_FAILURE);
 }

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -26,7 +26,7 @@ bool isRunningUnderRosetta();
  * hangs the process for good, where the default handler kills it. Only translated x86_64 is affected, so the
  * check is at runtime, and the same build still traces aborts on an intel mac.
  *
- * A `__fastfail` on windows - a security cookie check and the like - is not handled, and leaves no trace.
+ * A `__fastfail` on windows is not handled and leaves no trace. A failed security cookie check raises one.
  */
 class StackTraceOnCrash {
  public:

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -25,6 +25,8 @@ bool isRunningUnderRosetta();
  * faulting thread still parked in the mach exception path where no signal reaches it. A SIGABRT handler then
  * hangs the process for good, where the default handler kills it. Only translated x86_64 is affected, so the
  * check is at runtime, and the same build still traces aborts on an intel mac.
+ *
+ * A `__fastfail` on windows - a security cookie check and the like - is not handled, and leaves no trace.
  */
 class StackTraceOnCrash {
  public:

--- a/src/Library/StackTrace/StackTraceOnCrash.h
+++ b/src/Library/StackTrace/StackTraceOnCrash.h
@@ -26,7 +26,7 @@ bool isRunningUnderRosetta();
  * hangs the process for good, where the default handler kills it. Only translated x86_64 is affected, so the
  * check is at runtime, and the same build still traces aborts on an intel mac.
  *
- * A `__fastfail` on windows is not handled and leaves no trace. A failed security cookie check raises one.
+ * A `__fastfail` on windows is not handled and leaves no trace (e.g. a failed security cookie check raises one).
  */
 class StackTraceOnCrash {
  public:

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <csignal>
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
@@ -139,7 +140,13 @@ MM_NOINLINE int stackTraceDivisionFunction() {
 }
 #endif
 
-#if !defined(_WINDOWS) && !defined(__APPLE__)
+#ifndef _WINDOWS
+#if defined(__aarch64__)
+constexpr int trapSignal = SIGTRAP; // brk raises a breakpoint trap.
+#else
+constexpr int trapSignal = SIGILL; // ud2 and udf are both illegal instructions.
+#endif
+
 MM_NOINLINE void stackTraceTrapFunction() {
     __builtin_trap(); // ud2 on x86, brk on arm.
 }
@@ -220,20 +227,23 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
 }
 #endif
 
-// Compiled out on darwin, where a trap wedges the death test child for good instead of killing it - an
-// optimized native brk and a translated ud2 both, while an unoptimized native brk traces fine. That hang is
-// its own bug, still open.
-#if !defined(_WINDOWS) && !defined(__APPLE__)
+#ifndef _WINDOWS
 UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
     // A compiler trap sits at its own instruction, so si_addr equals the pc, and the darwin handler used to
     // take that as a jump to a bad address and restart the walk from a fake return address - one garbage
     // frame was the whole trace. It's SIGILL from ud2 on x86 and SIGTRAP from brk on arm.
-    EXPECT_DEATH({
+    //
+    // These are also the two signals darwin doesn't reset to the default handler on delivery, and the handler
+    // used to re-enter itself through its own re-raise until it ran off the alternate signal stack - a hang
+    // on some darwin versions, a death by the wrong signal on others. Checking the signal is what catches
+    // that everywhere rather than only where the runaway recursion happens to wedge.
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceTrapFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
+    }, testing::KilledBySignal(trapSignal),
+       testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
 }
 #endif
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -230,9 +230,10 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
 
 #ifndef _WINDOWS
 UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
-    // The signal is checked because the trace can't stand in for it. Dying of the signal it took is the
-    // handler's own contract, and a handler that re-enters itself through its own re-raise dies too, having
-    // already printed everything the matcher below looks for.
+    // A death with a matching trace doesn't prove the handler worked here. The trace goes out first, so a
+    // handler that goes wrong afterwards still leaves it behind and still ends up dead, just killed by
+    // something other than the trap that started it. Checking the signal is what tells those two apart, and
+    // dying of the signal it took is what the handler is meant to do.
     EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -41,7 +41,7 @@ constexpr bool isMac = false;
 #   if defined(__aarch64__)
 constexpr int SIG_BUILTIN_TRAP = SIGTRAP; // brk raises a breakpoint trap.
 #   else
-constexpr int SIG_BUILTIN_TRAP = SIGILL; // ud2 and udf are both illegal instructions.
+constexpr int SIG_BUILTIN_TRAP = SIGILL; // x86's ud2 and arm32's udf are both illegal instructions.
 #   endif
 #endif
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -219,7 +219,6 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
 
 #if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
 UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
-    // Nothing else in the suite raises SIGFPE, so this is what notices it going missing from the handled signal list.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -174,7 +174,7 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
-#if !defined(__aarch64__) && !defined(__arm__)
+#if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
 MM_NOINLINE int stackTraceDivisionFunction() {
     volatile int zero = 0; // Volatile, or the compiler sees the division by zero and emits a trap instead of dividing.
     volatile int result = 64 / zero; // Using the result keeps this out of tail position, which keeps the frame.
@@ -251,7 +251,7 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     }, killedBy(SIGSEGV), testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
-#if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
+#if !defined(__aarch64__) && !defined(__arm__)
 UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
     EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -45,6 +45,20 @@ constexpr int SIG_BUILTIN_TRAP = SIGILL; // x86's ud2 and arm32's udf are both i
 #   endif
 #endif
 
+// Libc++abi hooks a pure call and aborts, where libstdc++ leaves the vtable slot null and the call faults.
+#ifdef __APPLE__
+constexpr int SIG_PURE_CALL = SIGABRT;
+#else
+constexpr int SIG_PURE_CALL = SIGSEGV;
+#endif
+
+// Darwin maps its stack guard without access, where linux leaves the page unmapped.
+#ifdef __APPLE__
+constexpr int SIG_STACK_OVERFLOW = SIGBUS;
+#else
+constexpr int SIG_STACK_OVERFLOW = SIGSEGV;
+#endif
+
 /**
  * Predicate for `EXPECT_EXIT` that pins how the process died, rather than just that it did. Gtest has no
  * `KilledBySignal` on windows, where a death test reports an exit code, so there this only asserts a death.
@@ -152,7 +166,7 @@ MM_NOINLINE int stackTraceNullCallFunction() {
 }
 
 MM_NOINLINE int stackTraceBadTargetCallFunction() {
-    int (*volatile nowhere)() = reinterpret_cast<int (*)()>(static_cast<uintptr_t>(0xdeadbeefdeadULL));
+    int (*volatile nowhere)() = reinterpret_cast<int (*)()>(static_cast<uintptr_t>(0xdeadbeefdeacULL)); // Aligned, or arm faults on the fetch alignment instead of the mapping.
     volatile int result = nowhere(); // Using the result keeps this out of tail position, which keeps the frame.
     return result + 1;
 }
@@ -224,14 +238,14 @@ UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
 }
 
 UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
-    // Calling 0xdeadbeefdead faults with the pc at the bad address, and the handler has to recognize that
+    // Calling 0xdeadbeefdeac faults with the pc at the bad address, and the handler has to recognize that
     // to walk from the caller instead.
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceBadTargetCallFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
+    }, killedBy(SIGSEGV), testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
 #if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
@@ -267,12 +281,12 @@ UNIT_TEST(StackTrace, StackOverflowIsTraced) {
 
     // The handlers run on an alternate stack, and this is what checks it. Without one the handler itself
     // faults on the exhausted stack and the crash prints nothing at all.
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceOverflowFunction(0);
-    }, HasFrame(0, "stackTraceOverflowFunction"));
+    }, killedBy(SIG_STACK_OVERFLOW), HasFrame(0, "stackTraceOverflowFunction"));
 }
 
 UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
@@ -339,13 +353,13 @@ UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
     if (detail::isRunningUnderRosetta())
         GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
 
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTracePureCallFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "pure virtual function call" : "callPureIndirectly"),
-                      testing::HasSubstr("stackTracePureCallFunction")));
+    }, killedBy(SIG_PURE_CALL), testing::AllOf(testing::HasSubstr(isWindows ? "pure virtual function call" : "callPureIndirectly"),
+                                               testing::HasSubstr("stackTracePureCallFunction")));
 }
 
 #ifdef _WINDOWS

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -53,13 +53,6 @@ constexpr int SIG_PURE_CALL = SIGABRT;
 constexpr int SIG_PURE_CALL = SIGSEGV;
 #endif
 
-// Darwin maps its stack guard without access, where linux leaves the page unmapped.
-#ifdef __APPLE__
-constexpr int SIG_STACK_OVERFLOW = SIGBUS;
-#else
-constexpr int SIG_STACK_OVERFLOW = SIGSEGV;
-#endif
-
 /**
  * Predicate for `EXPECT_EXIT` that pins how the process died, rather than just that it did. Gtest has no
  * `KilledBySignal` on windows, where a death test reports an exit code, so there this only asserts a death.
@@ -281,7 +274,7 @@ UNIT_TEST(StackTrace, StackOverflowIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceOverflowFunction(0);
-    }, killedBy(SIG_STACK_OVERFLOW), HasFrame(0, "stackTraceOverflowFunction"));
+    }, killedBy(SIGSEGV), HasFrame(0, "stackTraceOverflowFunction"));
 }
 
 UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -45,7 +45,8 @@ constexpr int SIG_BUILTIN_TRAP = SIGILL; // x86's ud2 and arm32's udf are both i
 #   endif
 #endif
 
-// Libc++abi hooks a pure call and aborts, where libstdc++ leaves the vtable slot null and the call faults.
+// Darwin gets the pure call hook from the system libc++abi and aborts inside it. We link libstdc++ statically
+// elsewhere, and the vtable's weak reference to that hook pulls nothing in, so the null slot faults instead.
 #ifdef __APPLE__
 constexpr int SIG_PURE_CALL = SIGABRT;
 #else
@@ -66,15 +67,13 @@ constexpr int SIG_STACK_OVERFLOW = SIGSEGV;
  * @param signal                        Signal the process is expected to die of, ignored on windows.
  * @return                              Predicate over the exit status.
  */
+static auto killedBy([[maybe_unused]] int signal) {
 #ifdef _WINDOWS
-static auto killedBy(int) {
     return [] (int status) { return status != 0; };
-}
 #else
-static auto killedBy(int signal) {
     return testing::KilledBySignal(signal);
-}
 #endif
+}
 
 static void sendAssertReportsToStderr() {
 #ifdef _WINDOWS
@@ -261,10 +260,6 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
 
 #ifndef _WINDOWS
 UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
-    // A death with a matching trace doesn't prove the handler worked here. The trace goes out first, so a
-    // handler that goes wrong afterwards still leaves it behind and still ends up dead, just killed by
-    // something other than the trap that started it. Checking the signal is what tells those two apart, and
-    // dying of the signal it took is what the handler is meant to do.
     EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -131,6 +131,12 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+MM_NOINLINE int stackTraceDivisionFunction() {
+    volatile int zero = 0; // Volatile, or the compiler sees the division by zero and emits a trap instead of dividing.
+    volatile int result = 64 / zero; // Using the result keeps this out of tail position, which keeps the frame.
+    return result + 1;
+}
+
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
@@ -192,6 +198,22 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
         StackTraceOnCrash handler;
         stackTraceBadTargetCallFunction();
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
+}
+
+UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
+#if defined(__aarch64__) || defined(__arm__)
+    GTEST_SKIP() << "Integer division by zero doesn't trap on arm, it just yields zero.";
+#else
+    // Division by zero arrives as SIGFPE, and nothing else in the suite raises it, so this is the test that
+    // notices SIGFPE going missing from the handled signal list. Windows delivers it as one more structured
+    // exception instead.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceDivisionFunction();
+    }, testing::AllOf(HasFrame(0, "stackTraceDivisionFunction"), testing::HasSubstr("main")));
+#endif
 }
 
 UNIT_TEST(StackTrace, StackOverflowIsTraced) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -139,7 +139,7 @@ MM_NOINLINE int stackTraceDivisionFunction() {
 }
 #endif
 
-#ifndef _WINDOWS
+#if !defined(_WINDOWS) && !defined(__APPLE__)
 MM_NOINLINE void stackTraceTrapFunction() {
     __builtin_trap(); // ud2 on x86, brk on arm.
 }
@@ -220,12 +220,14 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
 }
 #endif
 
-#ifndef _WINDOWS
+// Compiled out on darwin, where a trap wedges the death test child for good instead of killing it - an
+// optimized native brk and a translated ud2 both, while an unoptimized native brk traces fine. That hang is
+// its own bug, still open.
+#if !defined(_WINDOWS) && !defined(__APPLE__)
 UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
     // A compiler trap sits at its own instruction, so si_addr equals the pc, and the darwin handler used to
     // take that as a jump to a bad address and restart the walk from a fake return address - one garbage
-    // frame was the whole trace. It's SIGILL from ud2 on x86 and SIGTRAP from brk on arm, so between them the
-    // platforms cover both signals the restart must skip.
+    // frame was the whole trace. It's SIGILL from ud2 on x86 and SIGTRAP from brk on arm.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
@@ -233,7 +235,7 @@ UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
         stackTraceTrapFunction();
     }, testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
 }
-#endif // _WINDOWS
+#endif
 
 UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     if (detail::isRunningUnderRosetta())

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -139,6 +139,12 @@ MM_NOINLINE int stackTraceDivisionFunction() {
 }
 #endif
 
+#ifndef _WINDOWS
+MM_NOINLINE void stackTraceTrapFunction() {
+    __builtin_trap(); // ud2 on x86, brk on arm.
+}
+#endif
+
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
 MM_NOINLINE int stackTraceOverflowFunction(int depth) {
@@ -213,6 +219,21 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceDivisionFunction"), testing::HasSubstr("main")));
 }
 #endif
+
+#ifndef _WINDOWS
+UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
+    // A compiler trap sits at its own instruction, so si_addr equals the pc, and the darwin handler used to
+    // take that as a jump to a bad address and restart the walk from a fake return address - one garbage
+    // frame was the whole trace. It's SIGILL from ud2 on x86 and SIGTRAP from brk on arm, so between them the
+    // platforms cover both signals the restart must skip.
+    EXPECT_DEATH({
+        GTEST_FLAG_SET(catch_exceptions, false);
+
+        StackTraceOnCrash handler;
+        stackTraceTrapFunction();
+    }, testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
+}
+#endif // _WINDOWS
 
 UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     if (detail::isRunningUnderRosetta())

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -131,11 +131,13 @@ MM_NOINLINE int stackTraceBadTargetCallFunction() {
     return result + 1;
 }
 
+#if !defined(__aarch64__) && !defined(__arm__)
 MM_NOINLINE int stackTraceDivisionFunction() {
     volatile int zero = 0; // Volatile, or the compiler sees the division by zero and emits a trap instead of dividing.
     volatile int result = 64 / zero; // Using the result keeps this out of tail position, which keeps the frame.
     return result + 1;
 }
+#endif
 
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
@@ -200,21 +202,17 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
     }, testing::AllOf(HasFrame(0, "stackTraceBadTargetCallFunction"), testing::HasSubstr("main")));
 }
 
+#if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
 UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
-#if defined(__aarch64__) || defined(__arm__)
-    GTEST_SKIP() << "Integer division by zero doesn't trap on arm, it just yields zero.";
-#else
-    // Division by zero arrives as SIGFPE, and nothing else in the suite raises it, so this is the test that
-    // notices SIGFPE going missing from the handled signal list. Windows delivers it as one more structured
-    // exception instead.
+    // Nothing else in the suite raises SIGFPE, so this is what notices it going missing from the handled signal list.
     EXPECT_DEATH({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceDivisionFunction();
     }, testing::AllOf(HasFrame(0, "stackTraceDivisionFunction"), testing::HasSubstr("main")));
-#endif
 }
+#endif
 
 UNIT_TEST(StackTrace, StackOverflowIsTraced) {
     if (detail::isRunningUnderRosetta())

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -45,6 +45,23 @@ constexpr int SIG_BUILTIN_TRAP = SIGILL; // x86's ud2 and arm32's udf are both i
 #   endif
 #endif
 
+/**
+ * Predicate for `EXPECT_EXIT` that pins how the process died, rather than just that it did. Gtest has no
+ * `KilledBySignal` on windows, where a death test reports an exit code, so there this only asserts a death.
+ *
+ * @param signal                        Signal the process is expected to die of, ignored on windows.
+ * @return                              Predicate over the exit status.
+ */
+#ifdef _WINDOWS
+static auto killedBy(int) {
+    return [] (int status) { return status != 0; };
+}
+#else
+static auto killedBy(int signal) {
+    return testing::KilledBySignal(signal);
+}
+#endif
+
 static void sendAssertReportsToStderr() {
 #ifdef _WINDOWS
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE); // The debug CRT would otherwise put up a dialog and wait.
@@ -171,39 +188,39 @@ UNIT_TEST(StackTrace, FunctionNamesAreResolved) {
 }
 
 UNIT_TEST(StackTrace, CrashHandlerNamesTheCrashingFunction) {
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         // Gtest wraps test bodies in __try/__except, and a frame-based handler runs before any unhandled
         // exception filter, so on windows ours would never see the access violation below.
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceCrashingFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
+    }, killedBy(SIGSEGV), testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::HasSubstr("main")));
 }
 
 UNIT_TEST(StackTrace, CrashOnAnotherThreadIsTraced) {
     // The handlers are process-wide, but only the thread that installs them gets an alternate signal stack,
     // so this one runs on the worker's own stack. That's enough for anything short of stack exhaustion.
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         std::thread(stackTraceCrashingFunction).join();
     // A worker's stack ends at the thread entry, so main being absent is what says we traced the thread that
     // crashed rather than the one that installed the handlers.
-    }, testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
+    }, killedBy(SIGSEGV), testing::AllOf(HasFrame(0, "stackTraceCrashingFunction"), testing::Not(testing::HasSubstr("main"))));
 }
 
 UNIT_TEST(StackTrace, NullFunctionCallIsTraced) {
     // Calling a null pointer faults at address zero, where there's nothing to unwind from. The call pushed its
     // return address first though, and walking on from that names the function that made the call and
     // everything above it.
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceNullCallFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
+    }, killedBy(SIGSEGV), testing::AllOf(HasFrame(0, "stackTraceNullCallFunction"), testing::HasSubstr("main")));
 }
 
 UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
@@ -219,12 +236,12 @@ UNIT_TEST(StackTrace, BadTargetCallIsTraced) {
 
 #if !defined(__aarch64__) && !defined(__arm__) // No trap to test on arm, integer division by zero just yields zero there.
 UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceDivisionFunction();
-    }, testing::AllOf(HasFrame(0, "stackTraceDivisionFunction"), testing::HasSubstr("main")));
+    }, killedBy(SIGFPE), testing::AllOf(HasFrame(0, "stackTraceDivisionFunction"), testing::HasSubstr("main")));
 }
 #endif
 
@@ -239,7 +256,7 @@ UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
 
         StackTraceOnCrash handler;
         stackTraceTrapFunction();
-    }, testing::KilledBySignal(SIG_BUILTIN_TRAP),
+    }, killedBy(SIG_BUILTIN_TRAP),
        testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
 }
 #endif
@@ -267,25 +284,25 @@ UNIT_TEST(StackTrace, CrashCallbackRunsAfterTheTrace) {
         return tracePos != std::string::npos && callbackPos != std::string::npos && tracePos < callbackPos;
     });
 
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler([] { std::fputs("crash callback ran", stderr); });
         stackTraceCrashingFunction();
-    }, callbackAfterTrace);
+    }, killedBy(SIGSEGV), callbackAfterTrace);
 }
 
 UNIT_TEST(StackTrace, AbortIsTraced) {
     if (detail::isRunningUnderRosetta())
         GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
 
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceAbortFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : isMac ? "Abort trap" : "abort"),
-                      testing::HasSubstr("stackTraceAbortFunction")));
+    }, killedBy(SIGABRT), testing::AllOf(testing::HasSubstr(isWindows ? "abort()" : isMac ? "Abort trap" : "abort"),
+                                         testing::HasSubstr("stackTraceAbortFunction")));
 }
 
 UNIT_TEST(StackTrace, AssertIsTraced) {
@@ -294,28 +311,28 @@ UNIT_TEST(StackTrace, AssertIsTraced) {
 
     // A failed assert is the crash a debug build produces most. It arrives as an abort with the assertion
     // message printed in front, and the trace has to follow that message rather than replace it.
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
         sendAssertReportsToStderr();
 
         StackTraceOnCrash handler;
         stackTraceAssertFunction();
-    }, testing::AllOf(testing::HasSubstr("Assertion"),
-                      testing::HasSubstr(isWindows ? "abort()" : isMac ? "Abort trap" : "abort"),
-                      testing::HasSubstr("stackTraceAssertFunction")));
+    }, killedBy(SIGABRT), testing::AllOf(testing::HasSubstr("Assertion"),
+                                         testing::HasSubstr(isWindows ? "abort()" : isMac ? "Abort trap" : "abort"),
+                                         testing::HasSubstr("stackTraceAssertFunction")));
 }
 
 UNIT_TEST(StackTrace, TerminateIsTraced) {
     if (detail::isRunningUnderRosetta())
         GTEST_SKIP() << "SIGABRT is left at its default under Rosetta, so there is no trace to match.";
 
-    EXPECT_DEATH({
+    EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceTerminateFunction();
-    }, testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : isMac ? "terminating" : "terminate"),
-                      testing::HasSubstr("stackTraceTerminateFunction")));
+    }, killedBy(SIGABRT), testing::AllOf(testing::HasSubstr(isWindows ? "std::terminate()" : isMac ? "terminating" : "terminate"),
+                                         testing::HasSubstr("stackTraceTerminateFunction")));
 }
 
 UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -37,6 +37,14 @@ constexpr bool isMac = true;
 constexpr bool isMac = false;
 #endif
 
+#ifndef _WINDOWS
+#   if defined(__aarch64__)
+constexpr int SIG_BUILTIN_TRAP = SIGTRAP; // brk raises a breakpoint trap.
+#   else
+constexpr int SIG_BUILTIN_TRAP = SIGILL; // ud2 and udf are both illegal instructions.
+#   endif
+#endif
+
 static void sendAssertReportsToStderr() {
 #ifdef _WINDOWS
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE); // The debug CRT would otherwise put up a dialog and wait.
@@ -141,12 +149,6 @@ MM_NOINLINE int stackTraceDivisionFunction() {
 #endif
 
 #ifndef _WINDOWS
-#if defined(__aarch64__)
-constexpr int trapSignal = SIGTRAP; // brk raises a breakpoint trap.
-#else
-constexpr int trapSignal = SIGILL; // ud2 and udf are both illegal instructions.
-#endif
-
 MM_NOINLINE void stackTraceTrapFunction() {
     __builtin_trap(); // ud2 on x86, brk on arm.
 }
@@ -229,20 +231,15 @@ UNIT_TEST(StackTrace, DivisionByZeroIsTraced) {
 
 #ifndef _WINDOWS
 UNIT_TEST(StackTrace, BuiltinTrapIsTraced) {
-    // A compiler trap sits at its own instruction, so si_addr equals the pc, and the darwin handler used to
-    // take that as a jump to a bad address and restart the walk from a fake return address - one garbage
-    // frame was the whole trace. It's SIGILL from ud2 on x86 and SIGTRAP from brk on arm.
-    //
-    // These are also the two signals darwin doesn't reset to the default handler on delivery, and the handler
-    // used to re-enter itself through its own re-raise until it ran off the alternate signal stack - a hang
-    // on some darwin versions, a death by the wrong signal on others. Checking the signal is what catches
-    // that everywhere rather than only where the runaway recursion happens to wedge.
+    // The signal is checked because the trace can't stand in for it. Dying of the signal it took is the
+    // handler's own contract, and a handler that re-enters itself through its own re-raise dies too, having
+    // already printed everything the matcher below looks for.
     EXPECT_EXIT({
         GTEST_FLAG_SET(catch_exceptions, false);
 
         StackTraceOnCrash handler;
         stackTraceTrapFunction();
-    }, testing::KilledBySignal(trapSignal),
+    }, testing::KilledBySignal(SIG_BUILTIN_TRAP),
        testing::AllOf(HasFrame(0, "stackTraceTrapFunction"), testing::HasSubstr("main")));
 }
 #endif

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -45,13 +45,24 @@ constexpr int SIG_BUILTIN_TRAP = SIGILL; // x86's ud2 and arm32's udf are both i
 #   endif
 #endif
 
-// Darwin gets the pure call hook from the system libc++abi and aborts inside it. We link libstdc++ statically
-// elsewhere, and the vtable's weak reference to that hook pulls nothing in, so the null slot faults instead.
-#ifdef __APPLE__
-constexpr int SIG_PURE_CALL = SIGABRT;
-#else
-constexpr int SIG_PURE_CALL = SIGSEGV;
+#ifndef _WINDOWS
+extern "C" void __cxa_pure_virtual() __attribute__((weak)); // Weak, so asking about it below links nothing in.
 #endif
+
+/**
+ * A pure virtual call lands on a hook that aborts, and the vtable's reference to that hook is weak. Linking
+ * the standard library statically then leaves the hook out and the slot null, and the call faults instead of
+ * aborting. Asking whether the hook made it into the binary is what keeps this right either way.
+ *
+ * @return                              Signal a pure virtual call dies of.
+ */
+static int sigPureCall() {
+#ifdef _WINDOWS
+    return SIGABRT; // Windows dies through the CRT hook rather than a signal, and killedBy ignores this.
+#else
+    return &__cxa_pure_virtual != nullptr ? SIGABRT : SIGSEGV;
+#endif
+}
 
 /**
  * Predicate for `EXPECT_EXIT` that pins how the process died, rather than just that it did. Gtest has no
@@ -346,7 +357,7 @@ UNIT_TEST(StackTrace, PureVirtualCallIsTraced) {
 
         StackTraceOnCrash handler;
         stackTracePureCallFunction();
-    }, killedBy(SIG_PURE_CALL), testing::AllOf(testing::HasSubstr(isWindows ? "pure virtual function call" : "callPureIndirectly"),
+    }, killedBy(sigPureCall()), testing::AllOf(testing::HasSubstr(isWindows ? "pure virtual function call" : "callPureIndirectly"),
                                                testing::HasSubstr("stackTracePureCallFunction")));
 }
 


### PR DESCRIPTION
Division by zero had no test, and nothing else in the suite raises SIGFPE, so it going missing from the handled signal list had nothing to notice it. A death test now divides by a volatile zero, and a second one traps with __builtin_trap, which is ud2 and SIGILL on x86 and brk and SIGTRAP on arm. Between them they cover the three instruction faults, the signals whose si_addr is their own faulting instruction rather than an address that was accessed.

Both tests found real bugs on darwin. The handler read si_addr equal to the pc as a jump to a bad address, so for an instruction fault it restarted the walk from a return address that was never pushed and the whole trace came out as one garbage frame. That restart now skips those three signals and still runs for everything else, abort's un-unwindable kill syscall stub included. The second bug is why this took a detour through a mac: darwin honors SA_RESETHAND for every signal except SIGILL and SIGTRAP, so for those two the handler's closing re-raise re-entered the handler rather than killing the process, and it recursed through _sigtramp until it ran off the alternate signal stack.

That second one was invisible to every test we had, because a death with a matching trace is all they asserted, and a handler that goes wrong after printing produces exactly that. So the death tests now also pin the signal the process dies of, which is the contract the handler's closing re-raise exists to keep. Four tests are left alone, where the signal is a platform's choice rather than ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
