### PR TITLE
Load and sort the item table for console use

### DIFF
--- a/resources/scripts/_definitions/def_game.lua
+++ b/resources/scripts/_definitions/def_game.lua
@@ -62,9 +62,14 @@
 --- @field name string
 --- @field level integer
 
+--- @class ItemListEntry
+--- @field id integer
+--- @field name string
+
 --- @class ItemsBindings
 --- @field getItemInfo fun(itemId: integer):ItemInfo
 --- @field getRandomItem fun(filter: fun(item: table)?):integer
+--- @field allItems fun():table<integer, ItemListEntry>
 
 --- ENUMS
 

--- a/resources/scripts/_definitions/def_game.lua
+++ b/resources/scripts/_definitions/def_game.lua
@@ -62,14 +62,10 @@
 --- @field name string
 --- @field level integer
 
---- @class ItemListEntry
---- @field id integer
---- @field name string
-
 --- @class ItemsBindings
 --- @field getItemInfo fun(itemId: integer):ItemInfo
 --- @field getRandomItem fun(filter: fun(item: table)?):integer
---- @field allItems fun():table<integer, ItemListEntry>
+--- @field allItems fun():table<integer, string> -- item id to localized name, for every item that has one
 
 --- ENUMS
 

--- a/resources/scripts/dev/commands/command_utils.lua
+++ b/resources/scripts/dev/commands/command_utils.lua
@@ -176,6 +176,13 @@ CommandUtilities.renderCharacterIndexParam = function (name, value)
     return result;
 end
 
+--- Number of entries above which the combo box gets a filter field. Anything longer is unusable without one, imgui
+--- shows 8 rows at a time.
+local filterThreshold = 20
+
+--- Filter text per parameter, kept across frames since the combo box is rebuilt on each one
+local enumFilters = {}
+
 --- @param name string
 --- @param value string
 --- @param enumValues table<string, integer>|fun(value:any):table
@@ -195,17 +202,30 @@ CommandUtilities.renderEnumParam = function (name, value, enumValues, allDataPar
         values = enumValues
     end
 
-    local index = Utilities.getIndexByKey(values, value)
+    local keys = Utilities.sortedKeys(values)
+    if #keys > filterThreshold then
+        imgui.sameLine()
+        enumFilters[name] = imgui.inputTextWithHint("##" .. name .. "filter", "filter", enumFilters[name] or "",
+            imgui.ImGuiInputTextFlags.None)
+        keys = Utilities.filterStrings(keys, enumFilters[name])
+    end
+
+    if #keys == 0 then
+        imgui.sameLine()
+        imgui.textUnformatted("No " .. name .. " matches the filter.")
+        return ""
+    end
+
+    local index = Utilities.findIndex(keys, function (key) return key == value end)
     if index == nil then
         index = 1
-        value = Utilities.getKeyAtIndex(values, 1)
+        value = keys[1]
     end
 
     imgui.sameLine()
-    local options = enumTableToZeroSeparatedList(values)
-    local changed, selectedValue = imgui.combo("##" .. name, index, options)
+    local changed, selectedValue = imgui.combo("##" .. name, index, stringListToZeroSeparatedList(keys))
     if changed then
-        value = Utilities.getKeyAtIndex(values, selectedValue)
+        value = keys[selectedValue]
     end
 
     return value

--- a/resources/scripts/dev/commands/command_utils.lua
+++ b/resources/scripts/dev/commands/command_utils.lua
@@ -181,6 +181,7 @@ end
 local filterThreshold = 20
 
 --- Filter text per parameter, kept across frames since the combo box is rebuilt on each one
+--- @type table<string, string>
 local enumFilters = {}
 
 --- @param name string

--- a/resources/scripts/dev/commands/inventory_command.lua
+++ b/resources/scripts/dev/commands/inventory_command.lua
@@ -19,8 +19,30 @@ local addItemToInventory = function (itemId, characterIndex)
     end
 end
 
+--- @type table<string, integer>|nil
+local itemsByName = nil
+
+--- Item names are localized, so this map can only be built once the item table is loaded. Names are not unique
+--- either - two different items are both called "Lich Jar" - so colliding names get their item id appended.
+--- @return table<string, integer>
+local function itemNameToIdMap()
+    if itemsByName then
+        return itemsByName
+    end
+
+    itemsByName = {}
+    for _, item in ipairs(Game.items.allItems()) do
+        local name = string.gsub(item.name, " ", "_")
+        if itemsByName[name] then
+            name = name .. "_" .. item.id
+        end
+        itemsByName[name] = item.id
+    end
+    return itemsByName
+end
+
 local addItemToInventoryByName = function (itemName, characterIndex)
-    local itemId = stringToEnum(Game.ItemType, itemName)
+    local itemId = stringToEnum(itemNameToIdMap(), itemName)
     return addItemToInventory(itemId, characterIndex)
 end
 
@@ -47,7 +69,7 @@ local subCommands = {
             {
                 name = "itemId",
                 type = "enum",
-                enumValues = Game.ItemType,
+                enumValues = itemNameToIdMap,
                 description = "Item ID to add to the inventory."
             },
             { name = "char", type = "characterIndex", description = "Character index to add the item to. Defaults to active character." }

--- a/resources/scripts/dev/commands/inventory_command.lua
+++ b/resources/scripts/dev/commands/inventory_command.lua
@@ -30,13 +30,23 @@ local function itemNameToIdMap()
         return itemsByName
     end
 
+    local allItems = Game.items.allItems()
+    --- Walked in id order so that the lowest id is the one that keeps the plain name. Without the sort the winner
+    --- would depend on hash order, which LuaJIT reseeds on every launch.
+    --- @type table<integer, integer>
+    local ids = {}
+    for id in pairs(allItems) do
+        table.insert(ids, id)
+    end
+    table.sort(ids)
+
     itemsByName = {}
-    for _, item in ipairs(Game.items.allItems()) do
-        local name = string.gsub(item.name, " ", "_")
+    for _, id in ipairs(ids) do
+        local name = string.gsub(allItems[id], " ", "_")
         if itemsByName[name] then
-            name = name .. "_" .. item.id
+            name = name .. "_" .. id
         end
-        itemsByName[name] = item.id
+        itemsByName[name] = id
     end
     return itemsByName
 end

--- a/resources/scripts/utils.lua
+++ b/resources/scripts/utils.lua
@@ -162,6 +162,7 @@ end
 --- @param t table<string, any>
 --- @return table<integer, string>
 Utilities.sortedKeys = function (t)
+    --- @type table<integer, string>
     local result = {}
     for k, _ in pairs(t) do
         table.insert(result, k)

--- a/resources/scripts/utils.lua
+++ b/resources/scripts/utils.lua
@@ -150,16 +150,54 @@ function stringToEnum(enumTable, valueStr)
     return nil
 end
 
---- Convert an enum table to string containing all the keys separated by \0 (zero) separator. Useful for imgui combo boxes
---- @param enumTable any - The enum table ( ex: Game.SkillType, Game.SkillMastery )
---- @return string - A zero-separated list of strings representing the enum keys
-function enumTableToZeroSeparatedList(enumTable)
-    ---@cast enumTable table<string, any>
+--- Convert a list of strings into a \0 (zero) separated string. Useful for imgui combo boxes
+--- @param list table<integer, string>
+--- @return string - A zero-separated list of the passed strings
+function stringListToZeroSeparatedList(list)
+    return table.concat(list, "\0") .. "\0"
+end
+
+--- Get the keys of a table in a stable, sorted order. LuaJIT reseeds its string hash on every launch, so `pairs`
+--- yields a different order each run and can't be used to render anything a human is expected to read.
+--- @param t table<string, any>
+--- @return table<integer, string>
+Utilities.sortedKeys = function (t)
     local result = {}
-    for k, _ in pairs(enumTable) do
+    for k, _ in pairs(t) do
         table.insert(result, k)
     end
-    return table.concat(result, "\0") .. "\0"
+    table.sort(result, function (a, b)
+        local lowerA, lowerB = string.lower(a), string.lower(b)
+        if lowerA == lowerB then
+            return a < b
+        end
+        return lowerA < lowerB
+    end)
+    return result
+end
+
+--- Filter a list of strings down to the ones containing the given substring. Matching ignores case, and treats
+--- underscores and spaces as the same character so that a typed "lich jar" finds the "Lich_Jar" enum key.
+--- @param list table<integer, string>
+--- @param filter string
+--- @return table<integer, string>
+Utilities.filterStrings = function (list, filter)
+    if Utilities.isEmpty(filter) then
+        return list
+    end
+
+    local normalize = function (value)
+        return string.gsub(string.lower(value), "_", " ")
+    end
+
+    local result = {}
+    local normalizedFilter = normalize(filter)
+    for _, value in ipairs(list) do
+        if string.find(normalize(value), normalizedFilter, 1, true) then
+            table.insert(result, value)
+        end
+    end
+    return result
 end
 
 --- Get the nth element of a table treated as a map

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -690,9 +690,6 @@ void Engine::MM7_Initialize() {
     pMediaPlayer = new MPlayer();
     pMediaPlayer->Initialize();
 
-    pItemTable = new ItemTable();
-    pItemTable->Initialize(engine->resources());
-
     pTileGenerator = new TileGenerator();
     if (engine->config->graphics.GenerateTiles.value())
         pTileGenerator->fillTable();
@@ -719,6 +716,9 @@ void Engine::SecondaryInitialization() {
 
     pHistoryTable = new HistoryTable();
     pHistoryTable->Initialize(engine->resources()->eventsData("history.txt"));
+
+    pItemTable = new ItemTable();
+    pItemTable->Initialize(engine->resources());
 
     initializeHouses(engine->resources()->eventsData("2dEvents.txt"));
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -690,6 +690,9 @@ void Engine::MM7_Initialize() {
     pMediaPlayer = new MPlayer();
     pMediaPlayer->Initialize();
 
+    pItemTable = new ItemTable();
+    pItemTable->Initialize(engine->resources());
+
     pTileGenerator = new TileGenerator();
     if (engine->config->graphics.GenerateTiles.value())
         pTileGenerator->fillTable();
@@ -716,9 +719,6 @@ void Engine::SecondaryInitialization() {
 
     pHistoryTable = new HistoryTable();
     pHistoryTable->Initialize(engine->resources()->eventsData("history.txt"));
-
-    pItemTable = new ItemTable();
-    pItemTable->Initialize(engine->resources());
 
     initializeHouses(engine->resources()->eventsData("2dEvents.txt"));
 

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -1,11 +1,14 @@
 #include "GameBindings.h"
 
+#include <algorithm>
 #include <string_view>
 #include <memory>
 #include <vector>
 #include <ranges>
 #include <optional>
 #include <sol/sol.hpp>
+#include <string>
+#include <utility>
 
 #include "Engine/Party.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
@@ -369,7 +372,7 @@ void GameBindings::_registerEnums(sol::state_view &solState, sol::table &table) 
         }
     }
 
-    // Sort alphabetically by name  
+    // Sort alphabetically by name
     std::sort(sortedItems.begin(), sortedItems.end());
 
     for (const auto& [name, id] : sortedItems) {

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -1,14 +1,14 @@
 #include "GameBindings.h"
 
 #include <algorithm>
+#include <string>
+#include <utility>
 #include <string_view>
 #include <memory>
 #include <vector>
 #include <ranges>
 #include <optional>
 #include <sol/sol.hpp>
-#include <string>
-#include <utility>
 
 #include "Engine/Party.h"
 #include "Engine/Graphics/Renderer/Renderer.h"

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -1,8 +1,5 @@
 #include "GameBindings.h"
 
-#include <algorithm>
-#include <string>
-#include <utility>
 #include <string_view>
 #include <memory>
 #include <vector>
@@ -221,6 +218,15 @@ void GameBindings::_registerItemBindings(sol::state_view &solState, sol::table &
             }
             return sol::make_object(solState, sol::lua_nil);
         }),
+        // An array rather than a name-keyed table, because item names are localized and several items share one -
+        // both lich jars are called "Lich Jar". Entries come out in item id order.
+        "allItems", sol::as_function([&solState]() {
+            sol::table result = solState.create_table();
+            for (ItemId itemId : pItemTable->items.indices())
+                if (!pItemTable->items[itemId].name.empty())
+                    result.add(solState.create_table_with("id", itemId, "name", pItemTable->items[itemId].name));
+            return result;
+        }),
         // The getRandomItem function accept an optional filter function to exclude some items from the randomization
         "getRandomItem", sol::as_function([](const FilterItemFunction &filter) {
             if (filter) {
@@ -360,26 +366,11 @@ void GameBindings::_registerEnums(sol::state_view &solState, sol::table &table) 
         "LightPath", QBIT_LIGHT_PATH
     );
 
-    sol::table itemTypeEnum = solState.create_table();
-    std::vector<std::pair<std::string, ItemId>> sortedItems;
-
-    for (ItemId itemId : pItemTable->items.indices()) {
-        const ItemData& itemDesc = pItemTable->items[itemId];
-        if (!itemDesc.name.empty()) {
-            std::string luaKey = itemDesc.name;
-            std::replace(luaKey.begin(), luaKey.end(), ' ', '_');
-            sortedItems.emplace_back(luaKey, itemId);
-        }
-    }
-
-    // Sort alphabetically by name
-    std::sort(sortedItems.begin(), sortedItems.end());
-
-    for (const auto& [name, id] : sortedItems) {
-        itemTypeEnum[name] = std::to_underlying(id);
-    }
-
-    table["ItemType"] = itemTypeEnum;
+    // Item names are localized and not unique, so they can't be used as enum keys. Scripts that need a specific item
+    // go through this enum, everything else goes through `items.allItems`.
+    table.new_enum<false>("ItemType",
+        "LichJarFull", ITEM_QUEST_LICH_JAR_FULL
+    );
 }
 
 void GameBindings::_registerFunctions(sol::state_view &solState, sol::table &table) const {

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -357,10 +357,26 @@ void GameBindings::_registerEnums(sol::state_view &solState, sol::table &table) 
         "LightPath", QBIT_LIGHT_PATH
     );
 
-    // Let's not expose all the item types for now. I feel like it's too early.
-    table.new_enum<false>("ItemType",
-        "LichJarFull", ITEM_QUEST_LICH_JAR_FULL
-    );
+    sol::table itemTypeEnum = solState.create_table();
+    std::vector<std::pair<std::string, ItemId>> sortedItems;
+
+    for (ItemId itemId : pItemTable->items.indices()) {
+        const ItemData& itemDesc = pItemTable->items[itemId];
+        if (!itemDesc.name.empty()) {
+            std::string luaKey = itemDesc.name;
+            std::replace(luaKey.begin(), luaKey.end(), ' ', '_');
+            sortedItems.emplace_back(luaKey, itemId);
+        }
+    }
+
+    // Sort alphabetically by name  
+    std::sort(sortedItems.begin(), sortedItems.end());
+
+    for (const auto& [name, id] : sortedItems) {
+        itemTypeEnum[name] = std::to_underlying(id);
+    }
+
+    table["ItemType"] = itemTypeEnum;
 }
 
 void GameBindings::_registerFunctions(sol::state_view &solState, sol::table &table) const {

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -218,13 +218,13 @@ void GameBindings::_registerItemBindings(sol::state_view &solState, sol::table &
             }
             return sol::make_object(solState, sol::lua_nil);
         }),
-        // An array rather than a name-keyed table, because item names are localized and several items share one -
-        // both lich jars are called "Lich Jar". Entries come out in item id order.
+        // Keyed by item id and not by name, because item names are localized and several items share one - both lich
+        // jars are called "Lich Jar".
         "allItems", sol::as_function([&solState]() {
             sol::table result = solState.create_table();
             for (ItemId itemId : pItemTable->items.indices())
                 if (!pItemTable->items[itemId].name.empty())
-                    result.add(solState.create_table_with("id", itemId, "name", pItemTable->items[itemId].name));
+                    result[itemId] = pItemTable->items[itemId].name;
             return result;
         }),
         // The getRandomItem function accept an optional filter function to exclude some items from the randomization


### PR DESCRIPTION
Supersedes #2159, cherry-picked from @Novicek's branch and rebased on master.

Adds an item selector that somehow works. Can add unimplemented items with it. I also find the select quite ugly but it does it's job, for now X).