### PR TITLE
Drop eight TODO comments that describe work already done

### DIFF
--- a/src/Core/Trace/EventTrace.h
+++ b/src/Core/Trace/EventTrace.h
@@ -11,8 +11,6 @@
 
 #include "Utility/Memory/Blob.h"
 
-// TODO(captainurist): this should go to Core/, not Library/,
-
 struct EventTraceCharacterState {
     int hp = 0;
     int mp = 0;

--- a/src/Engine/Evt/EvtInstruction.cpp
+++ b/src/Engine/Evt/EvtInstruction.cpp
@@ -884,9 +884,7 @@ static Enum narrowToEnum(Int value, std::string_view what) {
 }
 
 EvtInstruction EvtInstruction::parse(InputStream &stream, size_t size) {
-    // TODO(yoctozepto): zeroing-out the struct to prevent values from previous events from lingering;
-    //                   this makes it slightly easier to spot uninitialised members but, since the 0s may have a proper meaning, not always;
-    EvtInstruction ir = {};
+    EvtInstruction ir = {};  // A zeroed member may be unset or may be a real 0, the two are not distinguishable here.
 
     ir.step = fromStream<uint8_t>(stream);
     ir.opcode = EvtOpcode(fromStream<uint8_t>(stream));

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -757,7 +757,6 @@ void OpenGLRenderer::DrawIndoorSkyPolygon(int uNumVertices, GraphicsImage *textu
             v.color = uTint;
             v.texid = texid;
         }
-        // TODO (pskelton): should force drawing if buffer is full
     }
 }
 
@@ -2247,9 +2246,6 @@ void OpenGLRenderer::DrawOutdoorBuildings() {
     // verts are streamed to gpu as required
     // textures can be different sizes
 
-    // TODO(pskelton): might have to pass a texture width through for the waterr flow textures to size right
-    // and get the correct water speed
-
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
     glFrontFace(GL_CCW);
@@ -2747,10 +2743,6 @@ void OpenGLRenderer::DrawIndoorFaces() {
     _initWaterTiles();
     // void RenderOpenGL::DrawIndoorBSP() {
 
-    // TODO(pskelton): might have to pass a texture width through for the waterr flow textures to size right
-    // and get the correct water speed
-
-
         glEnable(GL_CULL_FACE);
 
         glCullFace(GL_BACK);
@@ -3026,7 +3018,6 @@ void OpenGLRenderer::DrawIndoorFaces() {
                     // copy first
                     ShaderVertex &v0 = _bspVertices[texunit].emplace_back();
                     v0.pos = pIndoor->vertices[face->vertexIds[0]];
-                    // TODO(captainurist): adding in IDs below?
                     v0.texuv = Vec2f(face->textureUs[0] + face->textureDeltaU,
                                      face->textureVs[0] + face->textureDeltaV);
                     if (face->Indoor_sky()) {
@@ -3041,7 +3032,6 @@ void OpenGLRenderer::DrawIndoorFaces() {
                     for (unsigned i = 1; i < 3; ++i) {
                         ShaderVertex &v = _bspVertices[texunit].emplace_back();
                         v.pos = pIndoor->vertices[face->vertexIds[z + i]];
-                        // TODO(captainurist): adding in IDs???
                         v.texuv = Vec2f(face->textureUs[z + i] + face->textureDeltaU,
                                         face->textureVs[z + i] + face->textureDeltaV);
                         if (face->Indoor_sky()) {
@@ -3510,7 +3500,6 @@ bool OpenGLRenderer::Reinitialize(bool firstInit) {
 
     if (config->window.ReloadTex.value()) {
         // Added config option for this - may not always be required - #199 no longer replicates on windows??
-        // TODO: invalidate all previously loaded textures and then load them again as they can be no longer alive on GPU (issue #199).
         // TODO(pskelton): Needs testings on other platforms
         assets->releaseAllTextures();
         ReleaseTerrain();


### PR DESCRIPTION
Eight TODO comments that ask for something the surrounding code already does. No code changes.

The force-draw note predates `_forcePerVertices` becoming a growing vector, both `waterr` flow notes predate the shaders deriving their own texture size via `textureSize()`, the two "adding in IDs" notes predate `pVertexUIDs` becoming plain `textureUs` UV coordinates, the texture invalidation is on the three lines under it, and Trace already moved into `Core` in #2643. The zeroing note described the line below it, so only its caveat survives as a trailing comment.

A ninth candidate, the `_46ED8A_collide_against_sprite_objects` TODO in `Collisions.cpp`, was dropped from this sweep - review showed it is still open. Details in a comment below.
