### PR TITLE
Use the vector length for actor collision speed

### DIFF
--- a/src/Engine/Graphics/Collisions.cpp
+++ b/src/Engine/Graphics/Collisions.cpp
@@ -694,8 +694,7 @@ void ProcessActorCollisionsBLV(Actor &actor, bool isAboveGround, bool isFlying) 
         }
 
         if (type == OBJECT_Decoration) {
-            // TODO(captainurist): use length() here and retrace
-            int speed = std::sqrt(static_cast<int>(actor.velocity.xy().lengthSqr()));
+            int speed = actor.velocity.xy().length();
             int angle = TrigLUT.atan2(actor.pos.x - pLevelDecorations[id].vPosition.x, actor.pos.y - pLevelDecorations[id].vPosition.y); // Face away from the decoration.
             actor.velocity.x = TrigLUT.cos(angle) * speed;
             actor.velocity.y = TrigLUT.sin(angle) * speed;
@@ -835,8 +834,7 @@ void ProcessActorCollisionsODM(Actor &actor, bool isFlying) {
         }
 
         if (type == OBJECT_Decoration) {
-            // TODO(captainurist): use length() here and retrace
-            int speed = std::sqrt(static_cast<int>(actor.velocity.xy().lengthSqr()));
+            int speed = actor.velocity.xy().length();
             int angle = TrigLUT.atan2(actor.pos.x - pLevelDecorations[id].vPosition.x, actor.pos.y - pLevelDecorations[id].vPosition.y);
             actor.velocity.x = TrigLUT.cos(angle) * speed;
             actor.velocity.y = TrigLUT.sin(angle) * speed;

--- a/test/Data/issue_1997.json
+++ b/test/Data/issue_1997.json
@@ -265,9 +265,9 @@
             ],
             "locationName": "d04.blv",
             "partyPosition": {
-                "x": 357,
-                "y": 4134,
-                "z": -1664
+                "x": 329,
+                "y": 4261,
+                "z": -1572
             }
         },
         "saveFileSize": 548017,
@@ -724,37 +724,37 @@
             "type": "keyPress"
         },
         {
-            "randomState": 647670,
+            "randomState": 901190,
             "tickCount": 6000,
             "type": "paint"
         },
         {
-            "randomState": 1026221,
+            "randomState": 243689,
             "tickCount": 6200,
             "type": "paint"
         },
         {
-            "randomState": 980001,
+            "randomState": 44492,
             "tickCount": 6400,
             "type": "paint"
         },
         {
-            "randomState": 458157,
+            "randomState": 691646,
             "tickCount": 6600,
             "type": "paint"
         },
         {
-            "randomState": 842388,
+            "randomState": 139639,
             "tickCount": 6800,
             "type": "paint"
         },
         {
-            "randomState": 540041,
+            "randomState": 864689,
             "tickCount": 7000,
             "type": "paint"
         },
         {
-            "randomState": 111375,
+            "randomState": 1019087,
             "tickCount": 7200,
             "type": "paint"
         },
@@ -771,22 +771,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 992558,
+            "randomState": 325572,
             "tickCount": 7400,
             "type": "paint"
         },
         {
-            "randomState": 773629,
+            "randomState": 1047611,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 555496,
+            "randomState": 1029321,
             "tickCount": 7800,
             "type": "paint"
         },
         {
-            "randomState": 200198,
+            "randomState": 762202,
             "tickCount": 8000,
             "type": "paint"
         },
@@ -797,12 +797,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 783633,
+            "randomState": 557944,
             "tickCount": 8200,
             "type": "paint"
         },
         {
-            "randomState": 864421,
+            "randomState": 273393,
             "tickCount": 8400,
             "type": "paint"
         },
@@ -813,7 +813,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 342608,
+            "randomState": 449971,
             "tickCount": 8600,
             "type": "paint"
         },
@@ -824,27 +824,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 511898,
+            "randomState": 556651,
             "tickCount": 8800,
             "type": "paint"
         },
         {
-            "randomState": 686236,
+            "randomState": 95235,
             "tickCount": 9000,
             "type": "paint"
         },
         {
-            "randomState": 444022,
+            "randomState": 71295,
             "tickCount": 9200,
             "type": "paint"
         },
         {
-            "randomState": 668686,
+            "randomState": 534887,
             "tickCount": 9400,
             "type": "paint"
         },
         {
-            "randomState": 318583,
+            "randomState": 3146,
             "tickCount": 9600,
             "type": "paint"
         },
@@ -855,12 +855,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 631421,
+            "randomState": 756818,
             "tickCount": 9800,
             "type": "paint"
         },
         {
-            "randomState": 1018108,
+            "randomState": 282131,
             "tickCount": 10000,
             "type": "paint"
         },
@@ -871,7 +871,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 201059,
+            "randomState": 995847,
             "tickCount": 10200,
             "type": "paint"
         },
@@ -882,7 +882,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 716558,
+            "randomState": 694472,
             "tickCount": 10400,
             "type": "paint"
         },
@@ -893,12 +893,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 636804,
+            "randomState": 1011825,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 1040966,
+            "randomState": 658397,
             "tickCount": 10800,
             "type": "paint"
         },
@@ -909,7 +909,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 678755,
+            "randomState": 98377,
             "tickCount": 11000,
             "type": "paint"
         },
@@ -920,37 +920,37 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 222490,
+            "randomState": 33948,
             "tickCount": 11200,
             "type": "paint"
         },
         {
-            "randomState": 704046,
+            "randomState": 772108,
             "tickCount": 11400,
             "type": "paint"
         },
         {
-            "randomState": 376678,
+            "randomState": 861637,
             "tickCount": 11600,
             "type": "paint"
         },
         {
-            "randomState": 77744,
+            "randomState": 110479,
             "tickCount": 11800,
             "type": "paint"
         },
         {
-            "randomState": 226512,
+            "randomState": 616590,
             "tickCount": 12000,
             "type": "paint"
         },
         {
-            "randomState": 918810,
+            "randomState": 556130,
             "tickCount": 12200,
             "type": "paint"
         },
         {
-            "randomState": 670331,
+            "randomState": 519230,
             "tickCount": 12400,
             "type": "paint"
         },
@@ -961,117 +961,117 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 865687,
+            "randomState": 196954,
             "tickCount": 12600,
             "type": "paint"
         },
         {
-            "randomState": 711618,
+            "randomState": 35203,
             "tickCount": 12800,
             "type": "paint"
         },
         {
-            "randomState": 162992,
+            "randomState": 521136,
             "tickCount": 13000,
             "type": "paint"
         },
         {
-            "randomState": 521136,
+            "randomState": 765200,
             "tickCount": 13200,
             "type": "paint"
         },
         {
-            "randomState": 609690,
+            "randomState": 33545,
             "tickCount": 13400,
             "type": "paint"
         },
         {
-            "randomState": 231741,
+            "randomState": 564759,
             "tickCount": 13600,
             "type": "paint"
         },
         {
-            "randomState": 728931,
+            "randomState": 367941,
             "tickCount": 13800,
             "type": "paint"
         },
         {
-            "randomState": 215980,
+            "randomState": 414729,
             "tickCount": 14000,
             "type": "paint"
         },
         {
-            "randomState": 976435,
+            "randomState": 960514,
             "tickCount": 14200,
             "type": "paint"
         },
         {
-            "randomState": 471893,
+            "randomState": 417951,
             "tickCount": 14400,
             "type": "paint"
         },
         {
-            "randomState": 441877,
+            "randomState": 849776,
             "tickCount": 14600,
             "type": "paint"
         },
         {
-            "randomState": 185710,
+            "randomState": 97213,
             "tickCount": 14800,
             "type": "paint"
         },
         {
-            "randomState": 442184,
+            "randomState": 857949,
             "tickCount": 15000,
             "type": "paint"
         },
         {
-            "randomState": 491224,
+            "randomState": 547236,
             "tickCount": 15200,
             "type": "paint"
         },
         {
-            "randomState": 606243,
+            "randomState": 956440,
             "tickCount": 15400,
             "type": "paint"
         },
         {
-            "randomState": 206211,
+            "randomState": 74923,
             "tickCount": 15600,
             "type": "paint"
         },
         {
-            "randomState": 755399,
+            "randomState": 970032,
             "tickCount": 15800,
             "type": "paint"
         },
         {
-            "randomState": 667200,
+            "randomState": 798412,
             "tickCount": 16000,
             "type": "paint"
         },
         {
-            "randomState": 841180,
+            "randomState": 947439,
             "tickCount": 16200,
             "type": "paint"
         },
         {
-            "randomState": 741609,
+            "randomState": 686060,
             "tickCount": 16400,
             "type": "paint"
         },
         {
-            "randomState": 777261,
+            "randomState": 417320,
             "tickCount": 16600,
             "type": "paint"
         },
         {
-            "randomState": 134172,
+            "randomState": 53825,
             "tickCount": 16800,
             "type": "paint"
         },
         {
-            "randomState": 770658,
+            "randomState": 685571,
             "tickCount": 17000,
             "type": "paint"
         },
@@ -1082,17 +1082,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 544402,
+            "randomState": 90423,
             "tickCount": 17200,
             "type": "paint"
         },
         {
-            "randomState": 875831,
+            "randomState": 424989,
             "tickCount": 17400,
             "type": "paint"
         },
         {
-            "randomState": 298629,
+            "randomState": 884869,
             "tickCount": 17600,
             "type": "paint"
         },
@@ -1103,17 +1103,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 473682,
+            "randomState": 728500,
             "tickCount": 17800,
             "type": "paint"
         },
         {
-            "randomState": 81698,
+            "randomState": 946825,
             "tickCount": 18000,
             "type": "paint"
         },
         {
-            "randomState": 490499,
+            "randomState": 794162,
             "tickCount": 18200,
             "type": "paint"
         },
@@ -1130,12 +1130,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 193392,
+            "randomState": 730262,
             "tickCount": 18400,
             "type": "paint"
         },
         {
-            "randomState": 627291,
+            "randomState": 385729,
             "tickCount": 18600,
             "type": "paint"
         },
@@ -1146,7 +1146,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 590589,
+            "randomState": 936297,
             "tickCount": 18800,
             "type": "paint"
         },
@@ -1157,7 +1157,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 444947,
+            "randomState": 584884,
             "tickCount": 19000,
             "type": "paint"
         },
@@ -1168,7 +1168,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1003420,
+            "randomState": 175932,
             "tickCount": 19200,
             "type": "paint"
         },
@@ -1179,12 +1179,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 796212,
+            "randomState": 770228,
             "tickCount": 19400,
             "type": "paint"
         },
         {
-            "randomState": 183511,
+            "randomState": 626513,
             "tickCount": 19600,
             "type": "paint"
         },
@@ -1207,17 +1207,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 484853,
+            "randomState": 1003420,
             "tickCount": 19800,
             "type": "paint"
         },
         {
-            "randomState": 267792,
+            "randomState": 714667,
             "tickCount": 20000,
             "type": "paint"
         },
         {
-            "randomState": 945886,
+            "randomState": 183511,
             "tickCount": 20200,
             "type": "paint"
         },
@@ -1228,7 +1228,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 935968,
+            "randomState": 429394,
             "tickCount": 20400,
             "type": "paint"
         },
@@ -1239,27 +1239,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 661849,
+            "randomState": 685454,
             "tickCount": 20600,
             "type": "paint"
         },
         {
-            "randomState": 388353,
+            "randomState": 38459,
             "tickCount": 20800,
             "type": "paint"
         },
         {
-            "randomState": 758302,
+            "randomState": 854106,
             "tickCount": 21000,
             "type": "paint"
         },
         {
-            "randomState": 954801,
+            "randomState": 997085,
             "tickCount": 21200,
             "type": "paint"
         },
         {
-            "randomState": 84759,
+            "randomState": 438502,
             "tickCount": 21400,
             "type": "paint"
         },
@@ -1276,7 +1276,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 717056,
+            "randomState": 969493,
             "tickCount": 21600,
             "type": "paint"
         },
@@ -1287,7 +1287,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 430575,
+            "randomState": 1023908,
             "tickCount": 21800,
             "type": "paint"
         },
@@ -1304,7 +1304,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 256025,
+            "randomState": 678195,
             "tickCount": 22000,
             "type": "paint"
         },
@@ -1321,7 +1321,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1039747,
+            "randomState": 464251,
             "tickCount": 22200,
             "type": "paint"
         },
@@ -1332,12 +1332,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 114069,
+            "randomState": 646387,
             "tickCount": 22400,
             "type": "paint"
         },
         {
-            "randomState": 235171,
+            "randomState": 299782,
             "tickCount": 22600,
             "type": "paint"
         },
@@ -1348,7 +1348,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 688050,
+            "randomState": 715245,
             "tickCount": 22800,
             "type": "paint"
         },
@@ -1359,7 +1359,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 939410,
+            "randomState": 476782,
             "tickCount": 23000,
             "type": "paint"
         },
@@ -1376,7 +1376,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 137075,
+            "randomState": 761375,
             "tickCount": 23200,
             "type": "paint"
         },
@@ -1387,7 +1387,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 593394,
+            "randomState": 934139,
             "tickCount": 23400,
             "type": "paint"
         },
@@ -1404,12 +1404,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 192378,
+            "randomState": 688050,
             "tickCount": 23600,
             "type": "paint"
         },
         {
-            "randomState": 499473,
+            "randomState": 513554,
             "tickCount": 23800,
             "type": "paint"
         },
@@ -1420,7 +1420,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 343675,
+            "randomState": 106465,
             "tickCount": 24000,
             "type": "paint"
         },
@@ -1431,7 +1431,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 189924,
+            "randomState": 624987,
             "tickCount": 24200,
             "type": "paint"
         },
@@ -1448,7 +1448,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 144454,
+            "randomState": 192378,
             "tickCount": 24400,
             "type": "paint"
         },
@@ -1459,7 +1459,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1046521,
+            "randomState": 649563,
             "tickCount": 24600,
             "type": "paint"
         },
@@ -1476,12 +1476,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 699526,
+            "randomState": 4217,
             "tickCount": 24800,
             "type": "paint"
         },
         {
-            "randomState": 132136,
+            "randomState": 692519,
             "tickCount": 25000,
             "type": "paint"
         },
@@ -1492,7 +1492,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 329155,
+            "randomState": 107314,
             "tickCount": 25200,
             "type": "paint"
         },
@@ -1503,7 +1503,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 57453,
+            "randomState": 890042,
             "tickCount": 25400,
             "type": "paint"
         },
@@ -1526,7 +1526,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 828345,
+            "randomState": 44352,
             "tickCount": 25600,
             "type": "paint"
         },
@@ -1537,12 +1537,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 528364,
+            "randomState": 905287,
             "tickCount": 25800,
             "type": "paint"
         },
         {
-            "randomState": 587035,
+            "randomState": 749670,
             "tickCount": 26000,
             "type": "paint"
         },
@@ -1559,27 +1559,27 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 437411,
+            "randomState": 433789,
             "tickCount": 26200,
             "type": "paint"
         },
         {
-            "randomState": 360342,
+            "randomState": 563537,
             "tickCount": 26400,
             "type": "paint"
         },
         {
-            "randomState": 161430,
+            "randomState": 770825,
             "tickCount": 26600,
             "type": "paint"
         },
         {
-            "randomState": 744005,
+            "randomState": 136831,
             "tickCount": 26800,
             "type": "paint"
         },
         {
-            "randomState": 585404,
+            "randomState": 498674,
             "tickCount": 27000,
             "type": "paint"
         },
@@ -1602,12 +1602,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 422090,
+            "randomState": 437411,
             "tickCount": 27200,
             "type": "paint"
         },
         {
-            "randomState": 478595,
+            "randomState": 869828,
             "tickCount": 27400,
             "type": "paint"
         },
@@ -1618,12 +1618,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 430320,
+            "randomState": 426484,
             "tickCount": 27600,
             "type": "paint"
         },
         {
-            "randomState": 102065,
+            "randomState": 258670,
             "tickCount": 27800,
             "type": "paint"
         },
@@ -1640,12 +1640,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 77813,
+            "randomState": 524633,
             "tickCount": 28000,
             "type": "paint"
         },
         {
-            "randomState": 1021545,
+            "randomState": 288659,
             "tickCount": 28200,
             "type": "paint"
         },
@@ -1656,7 +1656,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 779436,
+            "randomState": 602655,
             "tickCount": 28400,
             "type": "paint"
         },
@@ -1667,12 +1667,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 63772,
+            "randomState": 6706,
             "tickCount": 28600,
             "type": "paint"
         },
         {
-            "randomState": 1012979,
+            "randomState": 472615,
             "tickCount": 28800,
             "type": "paint"
         },
@@ -1683,12 +1683,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 100716,
+            "randomState": 339969,
             "tickCount": 29000,
             "type": "paint"
         },
         {
-            "randomState": 679112,
+            "randomState": 901062,
             "tickCount": 29200,
             "type": "paint"
         },
@@ -1699,12 +1699,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 405101,
+            "randomState": 592763,
             "tickCount": 29400,
             "type": "paint"
         },
         {
-            "randomState": 872647,
+            "randomState": 655389,
             "tickCount": 29600,
             "type": "paint"
         },
@@ -1715,12 +1715,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 35206,
+            "randomState": 732388,
             "tickCount": 29800,
             "type": "paint"
         },
         {
-            "randomState": 932195,
+            "randomState": 501454,
             "tickCount": 30000,
             "type": "paint"
         },
@@ -1737,7 +1737,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 385026,
+            "randomState": 757814,
             "tickCount": 30200,
             "type": "paint"
         },
@@ -1748,12 +1748,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 327124,
+            "randomState": 16404,
             "tickCount": 30400,
             "type": "paint"
         },
         {
-            "randomState": 668960,
+            "randomState": 703768,
             "tickCount": 30600,
             "type": "paint"
         },
@@ -1764,12 +1764,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 60137,
+            "randomState": 545395,
             "tickCount": 30800,
             "type": "paint"
         },
         {
-            "randomState": 394276,
+            "randomState": 529670,
             "tickCount": 31000,
             "type": "paint"
         },
@@ -1780,17 +1780,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 626069,
+            "randomState": 480559,
             "tickCount": 31200,
             "type": "paint"
         },
         {
-            "randomState": 176661,
+            "randomState": 385026,
             "tickCount": 31400,
             "type": "paint"
         },
         {
-            "randomState": 954408,
+            "randomState": 147068,
             "tickCount": 31600,
             "type": "paint"
         },
@@ -1801,7 +1801,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 506760,
+            "randomState": 413016,
             "tickCount": 31800,
             "type": "paint"
         },
@@ -1824,12 +1824,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 760107,
+            "randomState": 145383,
             "tickCount": 32000,
             "type": "paint"
         },
         {
-            "randomState": 798539,
+            "randomState": 559221,
             "tickCount": 32200,
             "type": "paint"
         },
@@ -1840,12 +1840,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 129205,
+            "randomState": 21910,
             "tickCount": 32400,
             "type": "paint"
         },
         {
-            "randomState": 207795,
+            "randomState": 538235,
             "tickCount": 32600,
             "type": "paint"
         },
@@ -1856,7 +1856,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 26062,
+            "randomState": 894502,
             "tickCount": 32800,
             "type": "paint"
         },
@@ -1867,7 +1867,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 496643,
+            "randomState": 161647,
             "tickCount": 33000,
             "type": "paint"
         },
@@ -1878,7 +1878,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 358239,
+            "randomState": 353778,
             "tickCount": 33200,
             "type": "paint"
         },
@@ -1889,12 +1889,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 151782,
+            "randomState": 783981,
             "tickCount": 33400,
             "type": "paint"
         },
         {
-            "randomState": 294952,
+            "randomState": 96623,
             "tickCount": 33600,
             "type": "paint"
         },
@@ -1905,7 +1905,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 640091,
+            "randomState": 558139,
             "tickCount": 33800,
             "type": "paint"
         },
@@ -1916,27 +1916,27 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 94735,
+            "randomState": 411759,
             "tickCount": 34000,
             "type": "paint"
         },
         {
-            "randomState": 234835,
+            "randomState": 1010816,
             "tickCount": 34200,
             "type": "paint"
         },
         {
-            "randomState": 81951,
+            "randomState": 873755,
             "tickCount": 34400,
             "type": "paint"
         },
         {
-            "randomState": 613040,
+            "randomState": 862742,
             "tickCount": 34600,
             "type": "paint"
         },
         {
-            "randomState": 704079,
+            "randomState": 520396,
             "tickCount": 34800,
             "type": "paint"
         },
@@ -1947,12 +1947,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 558209,
+            "randomState": 56331,
             "tickCount": 35000,
             "type": "paint"
         },
         {
-            "randomState": 399525,
+            "randomState": 493074,
             "tickCount": 35200,
             "type": "paint"
         },
@@ -1963,12 +1963,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 195634,
+            "randomState": 351651,
             "tickCount": 35400,
             "type": "paint"
         },
         {
-            "randomState": 66615,
+            "randomState": 722125,
             "tickCount": 35600,
             "type": "paint"
         },
@@ -1991,12 +1991,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 800769,
+            "randomState": 63993,
             "tickCount": 35800,
             "type": "paint"
         },
         {
-            "randomState": 821598,
+            "randomState": 333556,
             "tickCount": 36000,
             "type": "paint"
         },
@@ -2013,7 +2013,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 566808,
+            "randomState": 592919,
             "tickCount": 36200,
             "type": "paint"
         },
@@ -2030,7 +2030,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 839826,
+            "randomState": 1022189,
             "tickCount": 36400,
             "type": "paint"
         },
@@ -2041,7 +2041,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 207850,
+            "randomState": 776599,
             "tickCount": 36600,
             "type": "paint"
         },
@@ -2058,12 +2058,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 578437,
+            "randomState": 413562,
             "tickCount": 36800,
             "type": "paint"
         },
         {
-            "randomState": 556107,
+            "randomState": 1042539,
             "tickCount": 37000,
             "type": "paint"
         },
@@ -2074,7 +2074,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 884793,
+            "randomState": 471795,
             "tickCount": 37200,
             "type": "paint"
         },
@@ -2091,22 +2091,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 885492,
+            "randomState": 569027,
             "tickCount": 37400,
             "type": "paint"
         },
         {
-            "randomState": 161243,
+            "randomState": 1043217,
             "tickCount": 37600,
             "type": "paint"
         },
         {
-            "randomState": 664098,
+            "randomState": 645215,
             "tickCount": 37800,
             "type": "paint"
         },
         {
-            "randomState": 927021,
+            "randomState": 806738,
             "tickCount": 38000,
             "type": "paint"
         },
@@ -2117,7 +2117,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 943700,
+            "randomState": 218596,
             "tickCount": 38200,
             "type": "paint"
         },
@@ -2128,7 +2128,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 85219,
+            "randomState": 148165,
             "tickCount": 38400,
             "type": "paint"
         },
@@ -2139,7 +2139,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1042108,
+            "randomState": 622892,
             "tickCount": 38600,
             "type": "paint"
         },
@@ -2150,7 +2150,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 150898,
+            "randomState": 364450,
             "tickCount": 38800,
             "type": "paint"
         },
@@ -2173,12 +2173,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 806980,
+            "randomState": 187669,
             "tickCount": 39000,
             "type": "paint"
         },
         {
-            "randomState": 341100,
+            "randomState": 927021,
             "tickCount": 39200,
             "type": "paint"
         },
@@ -2189,7 +2189,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 447628,
+            "randomState": 300069,
             "tickCount": 39400,
             "type": "paint"
         },
@@ -2206,7 +2206,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 632928,
+            "randomState": 363080,
             "tickCount": 39600,
             "type": "paint"
         },
@@ -2217,7 +2217,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 635129,
+            "randomState": 778468,
             "tickCount": 39800,
             "type": "paint"
         },
@@ -2234,12 +2234,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 579413,
+            "randomState": 366095,
             "tickCount": 40000,
             "type": "paint"
         },
         {
-            "randomState": 434560,
+            "randomState": 426113,
             "tickCount": 40200,
             "type": "paint"
         },
@@ -2250,7 +2250,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 896631,
+            "randomState": 776329,
             "tickCount": 40400,
             "type": "paint"
         },
@@ -2261,7 +2261,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 192748,
+            "randomState": 275737,
             "tickCount": 40600,
             "type": "paint"
         },
@@ -2272,7 +2272,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 118784,
+            "randomState": 791905,
             "tickCount": 40800,
             "type": "paint"
         },
@@ -2295,7 +2295,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1588,
+            "randomState": 635129,
             "tickCount": 41000,
             "type": "paint"
         },
@@ -2306,12 +2306,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 450960,
+            "randomState": 558231,
             "tickCount": 41200,
             "type": "paint"
         },
         {
-            "randomState": 169274,
+            "randomState": 539564,
             "tickCount": 41400,
             "type": "paint"
         },
@@ -2322,17 +2322,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 102341,
+            "randomState": 340774,
             "tickCount": 41600,
             "type": "paint"
         },
         {
-            "randomState": 480593,
+            "randomState": 371744,
             "tickCount": 41800,
             "type": "paint"
         },
         {
-            "randomState": 111901,
+            "randomState": 417164,
             "tickCount": 42000,
             "type": "paint"
         },
@@ -2343,12 +2343,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1040371,
+            "randomState": 639953,
             "tickCount": 42200,
             "type": "paint"
         },
         {
-            "randomState": 1000107,
+            "randomState": 304571,
             "tickCount": 42400,
             "type": "paint"
         },
@@ -2359,7 +2359,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 326026,
+            "randomState": 110172,
             "tickCount": 42600,
             "type": "paint"
         },
@@ -2370,12 +2370,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 495984,
+            "randomState": 450156,
             "tickCount": 42800,
             "type": "paint"
         },
         {
-            "randomState": 37144,
+            "randomState": 343748,
             "tickCount": 43000,
             "type": "paint"
         },
@@ -2386,7 +2386,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 54727,
+            "randomState": 467304,
             "tickCount": 43200,
             "type": "paint"
         },
@@ -2397,12 +2397,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 668926,
+            "randomState": 166773,
             "tickCount": 43400,
             "type": "paint"
         },
         {
-            "randomState": 987567,
+            "randomState": 421405,
             "tickCount": 43600,
             "type": "paint"
         },
@@ -2419,7 +2419,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 389444,
+            "randomState": 513441,
             "tickCount": 43800,
             "type": "paint"
         },
@@ -2430,12 +2430,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 668101,
+            "randomState": 690861,
             "tickCount": 44000,
             "type": "paint"
         },
         {
-            "randomState": 623927,
+            "randomState": 1008723,
             "tickCount": 44200,
             "type": "paint"
         },
@@ -2446,7 +2446,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 324546,
+            "randomState": 933270,
             "tickCount": 44400,
             "type": "paint"
         },
@@ -2457,12 +2457,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 735420,
+            "randomState": 295509,
             "tickCount": 44600,
             "type": "paint"
         },
         {
-            "randomState": 488398,
+            "randomState": 495984,
             "tickCount": 44800,
             "type": "paint"
         },
@@ -2473,12 +2473,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 152811,
+            "randomState": 608053,
             "tickCount": 45000,
             "type": "paint"
         },
         {
-            "randomState": 644258,
+            "randomState": 713897,
             "tickCount": 45200,
             "type": "paint"
         },
@@ -2489,12 +2489,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 523919,
+            "randomState": 349624,
             "tickCount": 45400,
             "type": "paint"
         },
         {
-            "randomState": 887840,
+            "randomState": 237224,
             "tickCount": 45600,
             "type": "paint"
         },
@@ -2505,17 +2505,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 164052,
+            "randomState": 34583,
             "tickCount": 45800,
             "type": "paint"
         },
         {
-            "randomState": 238036,
+            "randomState": 466136,
             "tickCount": 46000,
             "type": "paint"
         },
         {
-            "randomState": 178253,
+            "randomState": 187561,
             "tickCount": 46200,
             "type": "paint"
         },
@@ -2526,57 +2526,57 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 304281,
+            "randomState": 238876,
             "tickCount": 46400,
             "type": "paint"
         },
         {
-            "randomState": 763828,
+            "randomState": 129500,
             "tickCount": 46600,
             "type": "paint"
         },
         {
-            "randomState": 972735,
+            "randomState": 430592,
             "tickCount": 46800,
             "type": "paint"
         },
         {
-            "randomState": 291096,
+            "randomState": 342092,
             "tickCount": 47000,
             "type": "paint"
         },
         {
-            "randomState": 326605,
+            "randomState": 30757,
             "tickCount": 47200,
             "type": "paint"
         },
         {
-            "randomState": 313500,
+            "randomState": 322486,
             "tickCount": 47400,
             "type": "paint"
         },
         {
-            "randomState": 529250,
+            "randomState": 310642,
             "tickCount": 47600,
             "type": "paint"
         },
         {
-            "randomState": 45544,
+            "randomState": 67602,
             "tickCount": 47800,
             "type": "paint"
         },
         {
-            "randomState": 266906,
+            "randomState": 878798,
             "tickCount": 48000,
             "type": "paint"
         },
         {
-            "randomState": 769521,
+            "randomState": 559062,
             "tickCount": 48200,
             "type": "paint"
         },
         {
-            "randomState": 720078,
+            "randomState": 666771,
             "tickCount": 48400,
             "type": "paint"
         },
@@ -2587,17 +2587,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 150614,
+            "randomState": 291096,
             "tickCount": 48600,
             "type": "paint"
         },
         {
-            "randomState": 734047,
+            "randomState": 727547,
             "tickCount": 48800,
             "type": "paint"
         },
         {
-            "randomState": 439896,
+            "randomState": 909026,
             "tickCount": 49000,
             "type": "paint"
         },
@@ -2608,12 +2608,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 736656,
+            "randomState": 86710,
             "tickCount": 49200,
             "type": "paint"
         },
         {
-            "randomState": 835683,
+            "randomState": 1037236,
             "tickCount": 49400,
             "type": "paint"
         },
@@ -2624,12 +2624,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 926065,
+            "randomState": 775400,
             "tickCount": 49600,
             "type": "paint"
         },
         {
-            "randomState": 961603,
+            "randomState": 371636,
             "tickCount": 49800,
             "type": "paint"
         },
@@ -2640,12 +2640,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 671095,
+            "randomState": 879566,
             "tickCount": 50000,
             "type": "paint"
         },
         {
-            "randomState": 23906,
+            "randomState": 454371,
             "tickCount": 50200,
             "type": "paint"
         },
@@ -2656,7 +2656,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 5124,
+            "randomState": 629697,
             "tickCount": 50400,
             "type": "paint"
         },
@@ -2667,37 +2667,37 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 522300,
+            "randomState": 454276,
             "tickCount": 50600,
             "type": "paint"
         },
         {
-            "randomState": 903448,
+            "randomState": 138247,
             "tickCount": 50800,
             "type": "paint"
         },
         {
-            "randomState": 676115,
+            "randomState": 897844,
             "tickCount": 51000,
             "type": "paint"
         },
         {
-            "randomState": 256033,
+            "randomState": 70013,
             "tickCount": 51200,
             "type": "paint"
         },
         {
-            "randomState": 258936,
+            "randomState": 213137,
             "tickCount": 51400,
             "type": "paint"
         },
         {
-            "randomState": 436077,
+            "randomState": 448461,
             "tickCount": 51600,
             "type": "paint"
         },
         {
-            "randomState": 899021,
+            "randomState": 703381,
             "tickCount": 51800,
             "type": "paint"
         },
@@ -2708,37 +2708,37 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 875985,
+            "randomState": 400148,
             "tickCount": 52000,
             "type": "paint"
         },
         {
-            "randomState": 630612,
+            "randomState": 544140,
             "tickCount": 52200,
             "type": "paint"
         },
         {
-            "randomState": 784848,
+            "randomState": 567650,
             "tickCount": 52400,
             "type": "paint"
         },
         {
-            "randomState": 736400,
+            "randomState": 729484,
             "tickCount": 52600,
             "type": "paint"
         },
         {
-            "randomState": 359525,
+            "randomState": 491887,
             "tickCount": 52800,
             "type": "paint"
         },
         {
-            "randomState": 356261,
+            "randomState": 271866,
             "tickCount": 53000,
             "type": "paint"
         },
         {
-            "randomState": 412327,
+            "randomState": 983566,
             "tickCount": 53200,
             "type": "paint"
         },
@@ -2749,62 +2749,62 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 1005983,
+            "randomState": 676115,
             "tickCount": 53400,
             "type": "paint"
         },
         {
-            "randomState": 134180,
+            "randomState": 251890,
             "tickCount": 53600,
             "type": "paint"
         },
         {
-            "randomState": 634837,
+            "randomState": 68337,
             "tickCount": 53800,
             "type": "paint"
         },
         {
-            "randomState": 594993,
+            "randomState": 88468,
             "tickCount": 54000,
             "type": "paint"
         },
         {
-            "randomState": 932850,
+            "randomState": 738051,
             "tickCount": 54200,
             "type": "paint"
         },
         {
-            "randomState": 260281,
+            "randomState": 216882,
             "tickCount": 54400,
             "type": "paint"
         },
         {
-            "randomState": 897948,
+            "randomState": 468504,
             "tickCount": 54600,
             "type": "paint"
         },
         {
-            "randomState": 281547,
+            "randomState": 882889,
             "tickCount": 54800,
             "type": "paint"
         },
         {
-            "randomState": 632239,
+            "randomState": 25194,
             "tickCount": 55000,
             "type": "paint"
         },
         {
-            "randomState": 935208,
+            "randomState": 669611,
             "tickCount": 55200,
             "type": "paint"
         },
         {
-            "randomState": 743344,
+            "randomState": 749177,
             "tickCount": 55400,
             "type": "paint"
         },
         {
-            "randomState": 71692,
+            "randomState": 222150,
             "tickCount": 55600,
             "type": "paint"
         },
@@ -2821,27 +2821,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 854384,
+            "randomState": 908563,
             "tickCount": 55800,
             "type": "paint"
         },
         {
-            "randomState": 637419,
+            "randomState": 907452,
             "tickCount": 56000,
             "type": "paint"
         },
         {
-            "randomState": 981441,
+            "randomState": 604553,
             "tickCount": 56200,
             "type": "paint"
         },
         {
-            "randomState": 683009,
+            "randomState": 36066,
             "tickCount": 56400,
             "type": "paint"
         },
         {
-            "randomState": 918920,
+            "randomState": 685241,
             "tickCount": 56600,
             "type": "paint"
         },
@@ -2864,32 +2864,32 @@
             "type": "windowActivate"
         },
         {
-            "randomState": 267607,
+            "randomState": 926396,
             "tickCount": 56800,
             "type": "paint"
         },
         {
-            "randomState": 1035509,
+            "randomState": 480387,
             "tickCount": 57000,
             "type": "paint"
         },
         {
-            "randomState": 520657,
+            "randomState": 935208,
             "tickCount": 57200,
             "type": "paint"
         },
         {
-            "randomState": 618122,
+            "randomState": 205936,
             "tickCount": 57400,
             "type": "paint"
         },
         {
-            "randomState": 982068,
+            "randomState": 441975,
             "tickCount": 57600,
             "type": "paint"
         },
         {
-            "randomState": 825918,
+            "randomState": 129374,
             "tickCount": 57800,
             "type": "paint"
         },
@@ -2906,12 +2906,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 764309,
+            "randomState": 480690,
             "tickCount": 58000,
             "type": "paint"
         },
         {
-            "randomState": 964599,
+            "randomState": 782184,
             "tickCount": 58200,
             "type": "paint"
         }

--- a/test/Data/issue_735b.json
+++ b/test/Data/issue_735b.json
@@ -122,8 +122,8 @@
             ],
             "locationName": "out02.odm",
             "partyPosition": {
-                "x": 14917,
-                "y": 10780,
+                "x": 11697,
+                "y": 6569,
                 "z": 1
             }
         },
@@ -1582,12 +1582,12 @@
             "type": "paint"
         },
         {
-            "randomState": 8387,
+            "randomState": 8346,
             "tickCount": 20600,
             "type": "paint"
         },
         {
-            "randomState": 8504,
+            "randomState": 8463,
             "tickCount": 20700,
             "type": "paint"
         },
@@ -1598,12 +1598,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 8545,
+            "randomState": 8505,
             "tickCount": 20800,
             "type": "paint"
         },
         {
-            "randomState": 8618,
+            "randomState": 8579,
             "tickCount": 20900,
             "type": "paint"
         },
@@ -1614,17 +1614,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 8622,
+            "randomState": 8585,
             "tickCount": 21000,
             "type": "paint"
         },
         {
-            "randomState": 8655,
+            "randomState": 8619,
             "tickCount": 21100,
             "type": "paint"
         },
         {
-            "randomState": 8682,
+            "randomState": 8644,
             "tickCount": 21200,
             "type": "paint"
         },
@@ -1635,17 +1635,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 8748,
+            "randomState": 8712,
             "tickCount": 21300,
             "type": "paint"
         },
         {
-            "randomState": 8759,
+            "randomState": 8715,
             "tickCount": 21400,
             "type": "paint"
         },
         {
-            "randomState": 8842,
+            "randomState": 8859,
             "tickCount": 21500,
             "type": "paint"
         },
@@ -1656,7 +1656,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 8921,
+            "randomState": 8915,
             "tickCount": 21600,
             "type": "paint"
         },
@@ -1667,12 +1667,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9057,
+            "randomState": 9020,
             "tickCount": 21700,
             "type": "paint"
         },
         {
-            "randomState": 9079,
+            "randomState": 9061,
             "tickCount": 21800,
             "type": "paint"
         },
@@ -1683,12 +1683,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 9138,
+            "randomState": 9089,
             "tickCount": 21900,
             "type": "paint"
         },
         {
-            "randomState": 9200,
+            "randomState": 9155,
             "tickCount": 22000,
             "type": "paint"
         },
@@ -1699,12 +1699,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9275,
+            "randomState": 9187,
             "tickCount": 22100,
             "type": "paint"
         },
         {
-            "randomState": 9297,
+            "randomState": 9198,
             "tickCount": 22200,
             "type": "paint"
         },
@@ -1715,12 +1715,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 9325,
+            "randomState": 9228,
             "tickCount": 22300,
             "type": "paint"
         },
         {
-            "randomState": 9407,
+            "randomState": 9294,
             "tickCount": 22400,
             "type": "paint"
         },
@@ -1731,7 +1731,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9481,
+            "randomState": 9336,
             "tickCount": 22500,
             "type": "paint"
         },
@@ -1742,17 +1742,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 9546,
+            "randomState": 9341,
             "tickCount": 22600,
             "type": "paint"
         },
         {
-            "randomState": 9634,
+            "randomState": 9469,
             "tickCount": 22700,
             "type": "paint"
         },
         {
-            "randomState": 9637,
+            "randomState": 9475,
             "tickCount": 22800,
             "type": "paint"
         },
@@ -1763,12 +1763,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9708,
+            "randomState": 9500,
             "tickCount": 22900,
             "type": "paint"
         },
         {
-            "randomState": 9726,
+            "randomState": 9515,
             "tickCount": 23000,
             "type": "paint"
         },
@@ -1779,7 +1779,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 9828,
+            "randomState": 9544,
             "tickCount": 23100,
             "type": "paint"
         },
@@ -1790,97 +1790,97 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9836,
+            "randomState": 9601,
             "tickCount": 23200,
             "type": "paint"
         },
         {
-            "randomState": 9873,
+            "randomState": 9633,
             "tickCount": 23300,
             "type": "paint"
         },
         {
-            "randomState": 9916,
+            "randomState": 9635,
             "tickCount": 23400,
             "type": "paint"
         },
         {
-            "randomState": 9947,
+            "randomState": 9660,
             "tickCount": 23500,
             "type": "paint"
         },
         {
-            "randomState": 9956,
+            "randomState": 9669,
             "tickCount": 23600,
             "type": "paint"
         },
         {
-            "randomState": 10047,
+            "randomState": 9738,
             "tickCount": 23700,
             "type": "paint"
         },
         {
-            "randomState": 10139,
+            "randomState": 9764,
             "tickCount": 23800,
             "type": "paint"
         },
         {
-            "randomState": 10166,
+            "randomState": 9790,
             "tickCount": 23900,
             "type": "paint"
         },
         {
-            "randomState": 10169,
+            "randomState": 9797,
             "tickCount": 24000,
             "type": "paint"
         },
         {
-            "randomState": 10195,
+            "randomState": 9832,
             "tickCount": 24100,
             "type": "paint"
         },
         {
-            "randomState": 10249,
+            "randomState": 9850,
             "tickCount": 24200,
             "type": "paint"
         },
         {
-            "randomState": 10314,
+            "randomState": 9872,
             "tickCount": 24300,
             "type": "paint"
         },
         {
-            "randomState": 10315,
+            "randomState": 9875,
             "tickCount": 24400,
             "type": "paint"
         },
         {
-            "randomState": 10350,
+            "randomState": 9908,
             "tickCount": 24500,
             "type": "paint"
         },
         {
-            "randomState": 10352,
+            "randomState": 9958,
             "tickCount": 24600,
             "type": "paint"
         },
         {
-            "randomState": 10379,
+            "randomState": 10017,
             "tickCount": 24700,
             "type": "paint"
         },
         {
-            "randomState": 10434,
+            "randomState": 10017,
             "tickCount": 24800,
             "type": "paint"
         },
         {
-            "randomState": 10460,
+            "randomState": 10042,
             "tickCount": 24900,
             "type": "paint"
         },
         {
-            "randomState": 10463,
+            "randomState": 10054,
             "tickCount": 25000,
             "type": "paint"
         },
@@ -1891,7 +1891,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 10485,
+            "randomState": 10095,
             "tickCount": 25100,
             "type": "paint"
         },
@@ -1908,27 +1908,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 10498,
+            "randomState": 10145,
             "tickCount": 25200,
             "type": "paint"
         },
         {
-            "randomState": 10585,
+            "randomState": 10175,
             "tickCount": 25300,
             "type": "paint"
         },
         {
-            "randomState": 10586,
+            "randomState": 10177,
             "tickCount": 25400,
             "type": "paint"
         },
         {
-            "randomState": 10711,
+            "randomState": 10202,
             "tickCount": 25500,
             "type": "paint"
         },
         {
-            "randomState": 10715,
+            "randomState": 10206,
             "tickCount": 25600,
             "type": "paint"
         },
@@ -1945,7 +1945,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 10746,
+            "randomState": 10237,
             "tickCount": 25700,
             "type": "paint"
         },
@@ -1956,12 +1956,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 10819,
+            "randomState": 10302,
             "tickCount": 25800,
             "type": "paint"
         },
         {
-            "randomState": 10899,
+            "randomState": 10333,
             "tickCount": 25900,
             "type": "paint"
         },
@@ -1972,12 +1972,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 10905,
+            "randomState": 10342,
             "tickCount": 26000,
             "type": "paint"
         },
         {
-            "randomState": 10991,
+            "randomState": 10437,
             "tickCount": 26100,
             "type": "paint"
         },
@@ -1988,12 +1988,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 11001,
+            "randomState": 10444,
             "tickCount": 26200,
             "type": "paint"
         },
         {
-            "randomState": 11040,
+            "randomState": 10467,
             "tickCount": 26300,
             "type": "paint"
         },
@@ -2004,12 +2004,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 11103,
+            "randomState": 10474,
             "tickCount": 26400,
             "type": "paint"
         },
         {
-            "randomState": 11305,
+            "randomState": 10572,
             "tickCount": 26500,
             "type": "paint"
         },
@@ -2026,7 +2026,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 11320,
+            "randomState": 10575,
             "tickCount": 26600,
             "type": "paint"
         },
@@ -2043,32 +2043,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 11342,
+            "randomState": 10608,
             "tickCount": 26700,
             "type": "paint"
         },
         {
-            "randomState": 11382,
+            "randomState": 10608,
             "tickCount": 26800,
             "type": "paint"
         },
         {
-            "randomState": 11460,
+            "randomState": 10633,
             "tickCount": 26900,
             "type": "paint"
         },
         {
-            "randomState": 11484,
+            "randomState": 10638,
             "tickCount": 27000,
             "type": "paint"
         },
         {
-            "randomState": 11526,
+            "randomState": 10676,
             "tickCount": 27100,
             "type": "paint"
         },
         {
-            "randomState": 11536,
+            "randomState": 10685,
             "tickCount": 27200,
             "type": "paint"
         },
@@ -2079,7 +2079,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 11565,
+            "randomState": 10710,
             "tickCount": 27300,
             "type": "paint"
         },
@@ -2090,32 +2090,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 11635,
+            "randomState": 10775,
             "tickCount": 27400,
             "type": "paint"
         },
         {
-            "randomState": 11659,
+            "randomState": 10800,
             "tickCount": 27500,
             "type": "paint"
         },
         {
-            "randomState": 11668,
+            "randomState": 10878,
             "tickCount": 27600,
             "type": "paint"
         },
         {
-            "randomState": 11732,
+            "randomState": 10943,
             "tickCount": 27700,
             "type": "paint"
         },
         {
-            "randomState": 11805,
+            "randomState": 10951,
             "tickCount": 27800,
             "type": "paint"
         },
         {
-            "randomState": 11874,
+            "randomState": 11023,
             "tickCount": 27900,
             "type": "paint"
         },
@@ -2126,17 +2126,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 11920,
+            "randomState": 11032,
             "tickCount": 28000,
             "type": "paint"
         },
         {
-            "randomState": 11952,
+            "randomState": 11061,
             "tickCount": 28100,
             "type": "paint"
         },
         {
-            "randomState": 12035,
+            "randomState": 11065,
             "tickCount": 28200,
             "type": "paint"
         },
@@ -2147,42 +2147,42 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 12057,
+            "randomState": 11088,
             "tickCount": 28300,
             "type": "paint"
         },
         {
-            "randomState": 12110,
+            "randomState": 11921,
             "tickCount": 28400,
             "type": "paint"
         },
         {
-            "randomState": 12138,
+            "randomState": 11956,
             "tickCount": 28500,
             "type": "paint"
         },
         {
-            "randomState": 12146,
+            "randomState": 11996,
             "tickCount": 28600,
             "type": "paint"
         },
         {
-            "randomState": 12171,
+            "randomState": 12019,
             "tickCount": 28700,
             "type": "paint"
         },
         {
-            "randomState": 12171,
+            "randomState": 12023,
             "tickCount": 28800,
             "type": "paint"
         },
         {
-            "randomState": 12202,
+            "randomState": 12049,
             "tickCount": 28900,
             "type": "paint"
         },
         {
-            "randomState": 12210,
+            "randomState": 12054,
             "tickCount": 29000,
             "type": "paint"
         },
@@ -2193,12 +2193,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 12237,
+            "randomState": 12085,
             "tickCount": 29100,
             "type": "paint"
         },
         {
-            "randomState": 12239,
+            "randomState": 12089,
             "tickCount": 29200,
             "type": "paint"
         },
@@ -2209,7 +2209,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13087,
+            "randomState": 12114,
             "tickCount": 29300,
             "type": "paint"
         },
@@ -2220,12 +2220,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13153,
+            "randomState": 12430,
             "tickCount": 29400,
             "type": "paint"
         },
         {
-            "randomState": 13212,
+            "randomState": 12452,
             "tickCount": 29500,
             "type": "paint"
         },
@@ -2236,12 +2236,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13215,
+            "randomState": 12458,
             "tickCount": 29600,
             "type": "paint"
         },
         {
-            "randomState": 13303,
+            "randomState": 12545,
             "tickCount": 29700,
             "type": "paint"
         },
@@ -2252,12 +2252,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13309,
+            "randomState": 12558,
             "tickCount": 29800,
             "type": "paint"
         },
         {
-            "randomState": 13339,
+            "randomState": 12625,
             "tickCount": 29900,
             "type": "paint"
         },
@@ -2274,7 +2274,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13350,
+            "randomState": 12630,
             "tickCount": 30000,
             "type": "paint"
         },
@@ -2291,7 +2291,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13446,
+            "randomState": 12724,
             "tickCount": 30100,
             "type": "paint"
         },
@@ -2302,7 +2302,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13459,
+            "randomState": 12748,
             "tickCount": 30200,
             "type": "paint"
         },
@@ -2313,12 +2313,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13490,
+            "randomState": 12772,
             "tickCount": 30300,
             "type": "paint"
         },
         {
-            "randomState": 13552,
+            "randomState": 12784,
             "tickCount": 30400,
             "type": "paint"
         },
@@ -2329,7 +2329,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13581,
+            "randomState": 12817,
             "tickCount": 30500,
             "type": "paint"
         },
@@ -2340,7 +2340,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13582,
+            "randomState": 12819,
             "tickCount": 30600,
             "type": "paint"
         },
@@ -2351,22 +2351,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13607,
+            "randomState": 12884,
             "tickCount": 30700,
             "type": "paint"
         },
         {
-            "randomState": 13658,
+            "randomState": 12885,
             "tickCount": 30800,
             "type": "paint"
         },
         {
-            "randomState": 13704,
+            "randomState": 12927,
             "tickCount": 30900,
             "type": "paint"
         },
         {
-            "randomState": 13709,
+            "randomState": 12985,
             "tickCount": 31000,
             "type": "paint"
         },
@@ -2377,12 +2377,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 13774,
+            "randomState": 13127,
             "tickCount": 31100,
             "type": "paint"
         },
         {
-            "randomState": 13777,
+            "randomState": 13132,
             "tickCount": 31200,
             "type": "paint"
         },
@@ -2393,32 +2393,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13804,
+            "randomState": 13156,
             "tickCount": 31300,
             "type": "paint"
         },
         {
-            "randomState": 13827,
+            "randomState": 13160,
             "tickCount": 31400,
             "type": "paint"
         },
         {
-            "randomState": 13930,
+            "randomState": 13179,
             "tickCount": 31500,
             "type": "paint"
         },
         {
-            "randomState": 13930,
+            "randomState": 13180,
             "tickCount": 31600,
             "type": "paint"
         },
         {
-            "randomState": 13964,
+            "randomState": 13210,
             "tickCount": 31700,
             "type": "paint"
         },
         {
-            "randomState": 13969,
+            "randomState": 13271,
             "tickCount": 31800,
             "type": "paint"
         },
@@ -2429,12 +2429,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 13997,
+            "randomState": 13350,
             "tickCount": 31900,
             "type": "paint"
         },
         {
-            "randomState": 14042,
+            "randomState": 13401,
             "tickCount": 32000,
             "type": "paint"
         },
@@ -2445,7 +2445,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14068,
+            "randomState": 13426,
             "tickCount": 32100,
             "type": "paint"
         },
@@ -2456,7 +2456,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14069,
+            "randomState": 13445,
             "tickCount": 32200,
             "type": "paint"
         },
@@ -2467,22 +2467,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14094,
+            "randomState": 13469,
             "tickCount": 32300,
             "type": "paint"
         },
         {
-            "randomState": 14101,
+            "randomState": 13516,
             "tickCount": 32400,
             "type": "paint"
         },
         {
-            "randomState": 14133,
+            "randomState": 13544,
             "tickCount": 32500,
             "type": "paint"
         },
         {
-            "randomState": 14136,
+            "randomState": 13545,
             "tickCount": 32600,
             "type": "paint"
         },
@@ -2493,7 +2493,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14157,
+            "randomState": 13567,
             "tickCount": 32700,
             "type": "paint"
         },
@@ -2504,7 +2504,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14258,
+            "randomState": 13628,
             "tickCount": 32800,
             "type": "paint"
         },
@@ -2515,7 +2515,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14286,
+            "randomState": 13677,
             "tickCount": 32900,
             "type": "paint"
         },
@@ -2526,12 +2526,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14351,
+            "randomState": 13781,
             "tickCount": 33000,
             "type": "paint"
         },
         {
-            "randomState": 14376,
+            "randomState": 13806,
             "tickCount": 33100,
             "type": "paint"
         },
@@ -2542,7 +2542,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14378,
+            "randomState": 13814,
             "tickCount": 33200,
             "type": "paint"
         },
@@ -2553,7 +2553,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14470,
+            "randomState": 13938,
             "tickCount": 33300,
             "type": "paint"
         },
@@ -2570,7 +2570,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14471,
+            "randomState": 13941,
             "tickCount": 33400,
             "type": "paint"
         },
@@ -2593,12 +2593,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14555,
+            "randomState": 14041,
             "tickCount": 33500,
             "type": "paint"
         },
         {
-            "randomState": 14558,
+            "randomState": 14043,
             "tickCount": 33600,
             "type": "paint"
         },
@@ -2609,7 +2609,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14587,
+            "randomState": 14075,
             "tickCount": 33700,
             "type": "paint"
         },
@@ -2620,12 +2620,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14593,
+            "randomState": 14082,
             "tickCount": 33800,
             "type": "paint"
         },
         {
-            "randomState": 14657,
+            "randomState": 14103,
             "tickCount": 33900,
             "type": "paint"
         },
@@ -2636,7 +2636,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14661,
+            "randomState": 14112,
             "tickCount": 34000,
             "type": "paint"
         },
@@ -2647,12 +2647,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14685,
+            "randomState": 14136,
             "tickCount": 34100,
             "type": "paint"
         },
         {
-            "randomState": 14690,
+            "randomState": 14179,
             "tickCount": 34200,
             "type": "paint"
         },
@@ -2663,12 +2663,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14711,
+            "randomState": 14201,
             "tickCount": 34300,
             "type": "paint"
         },
         {
-            "randomState": 14721,
+            "randomState": 14205,
             "tickCount": 34400,
             "type": "paint"
         },
@@ -2679,7 +2679,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14784,
+            "randomState": 14237,
             "tickCount": 34500,
             "type": "paint"
         },
@@ -2690,7 +2690,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14786,
+            "randomState": 14237,
             "tickCount": 34600,
             "type": "paint"
         },
@@ -2701,7 +2701,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14806,
+            "randomState": 14273,
             "tickCount": 34700,
             "type": "paint"
         },
@@ -2712,7 +2712,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14818,
+            "randomState": 14274,
             "tickCount": 34800,
             "type": "paint"
         },
@@ -2723,12 +2723,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14844,
+            "randomState": 14302,
             "tickCount": 34900,
             "type": "paint"
         },
         {
-            "randomState": 14849,
+            "randomState": 14304,
             "tickCount": 35000,
             "type": "paint"
         },
@@ -2739,7 +2739,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14889,
+            "randomState": 14329,
             "tickCount": 35100,
             "type": "paint"
         },
@@ -2750,12 +2750,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14891,
+            "randomState": 14333,
             "tickCount": 35200,
             "type": "paint"
         },
         {
-            "randomState": 14918,
+            "randomState": 14360,
             "tickCount": 35300,
             "type": "paint"
         },
@@ -2766,62 +2766,62 @@
             "type": "keyPress"
         },
         {
-            "randomState": 14923,
+            "randomState": 14361,
             "tickCount": 35400,
             "type": "paint"
         },
         {
-            "randomState": 14942,
+            "randomState": 14381,
             "tickCount": 35500,
             "type": "paint"
         },
         {
-            "randomState": 14946,
+            "randomState": 14424,
             "tickCount": 35600,
             "type": "paint"
         },
         {
-            "randomState": 14978,
+            "randomState": 14661,
             "tickCount": 35700,
             "type": "paint"
         },
         {
-            "randomState": 14981,
+            "randomState": 14666,
             "tickCount": 35800,
             "type": "paint"
         },
         {
-            "randomState": 14999,
+            "randomState": 14690,
             "tickCount": 35900,
             "type": "paint"
         },
         {
-            "randomState": 14999,
+            "randomState": 14690,
             "tickCount": 36000,
             "type": "paint"
         },
         {
-            "randomState": 15024,
+            "randomState": 14753,
             "tickCount": 36100,
             "type": "paint"
         },
         {
-            "randomState": 15032,
+            "randomState": 14759,
             "tickCount": 36200,
             "type": "paint"
         },
         {
-            "randomState": 15052,
+            "randomState": 14779,
             "tickCount": 36300,
             "type": "paint"
         },
         {
-            "randomState": 15060,
+            "randomState": 14784,
             "tickCount": 36400,
             "type": "paint"
         },
         {
-            "randomState": 15088,
+            "randomState": 14819,
             "tickCount": 36500,
             "type": "paint"
         },
@@ -2832,7 +2832,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15093,
+            "randomState": 14821,
             "tickCount": 36600,
             "type": "paint"
         },
@@ -2843,32 +2843,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15114,
+            "randomState": 14862,
             "tickCount": 36700,
             "type": "paint"
         },
         {
-            "randomState": 15114,
+            "randomState": 14901,
             "tickCount": 36800,
             "type": "paint"
         },
         {
-            "randomState": 15139,
+            "randomState": 14932,
             "tickCount": 36900,
             "type": "paint"
         },
         {
-            "randomState": 15143,
+            "randomState": 14935,
             "tickCount": 37000,
             "type": "paint"
         },
         {
-            "randomState": 15164,
+            "randomState": 14960,
             "tickCount": 37100,
             "type": "paint"
         },
         {
-            "randomState": 15168,
+            "randomState": 14963,
             "tickCount": 37200,
             "type": "paint"
         },
@@ -2879,27 +2879,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15193,
+            "randomState": 14990,
             "tickCount": 37300,
             "type": "paint"
         },
         {
-            "randomState": 15200,
+            "randomState": 14991,
             "tickCount": 37400,
             "type": "paint"
         },
         {
-            "randomState": 15218,
+            "randomState": 15015,
             "tickCount": 37500,
             "type": "paint"
         },
         {
-            "randomState": 15220,
+            "randomState": 15023,
             "tickCount": 37600,
             "type": "paint"
         },
         {
-            "randomState": 15254,
+            "randomState": 15089,
             "tickCount": 37700,
             "type": "paint"
         },
@@ -2910,7 +2910,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15256,
+            "randomState": 15093,
             "tickCount": 37800,
             "type": "paint"
         },
@@ -2921,7 +2921,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15275,
+            "randomState": 15116,
             "tickCount": 37900,
             "type": "paint"
         },
@@ -2938,12 +2938,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15341,
+            "randomState": 15176,
             "tickCount": 38000,
             "type": "paint"
         },
         {
-            "randomState": 15366,
+            "randomState": 15206,
             "tickCount": 38100,
             "type": "paint"
         },
@@ -2954,12 +2954,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15369,
+            "randomState": 15208,
             "tickCount": 38200,
             "type": "paint"
         },
         {
-            "randomState": 15391,
+            "randomState": 15231,
             "tickCount": 38300,
             "type": "paint"
         },
@@ -2976,7 +2976,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15397,
+            "randomState": 15234,
             "tickCount": 38400,
             "type": "paint"
         },
@@ -2987,12 +2987,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15485,
+            "randomState": 15323,
             "tickCount": 38500,
             "type": "paint"
         },
         {
-            "randomState": 15490,
+            "randomState": 15324,
             "tickCount": 38600,
             "type": "paint"
         },
@@ -3003,7 +3003,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15512,
+            "randomState": 15344,
             "tickCount": 38700,
             "type": "paint"
         },
@@ -3014,17 +3014,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15572,
+            "randomState": 15409,
             "tickCount": 38800,
             "type": "paint"
         },
         {
-            "randomState": 15597,
+            "randomState": 15435,
             "tickCount": 38900,
             "type": "paint"
         },
         {
-            "randomState": 15600,
+            "randomState": 15443,
             "tickCount": 39000,
             "type": "paint"
         },
@@ -3035,7 +3035,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15622,
+            "randomState": 15468,
             "tickCount": 39100,
             "type": "paint"
         },
@@ -3046,7 +3046,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15687,
+            "randomState": 15546,
             "tickCount": 39200,
             "type": "paint"
         },
@@ -3057,7 +3057,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15712,
+            "randomState": 15571,
             "tickCount": 39300,
             "type": "paint"
         },
@@ -3068,12 +3068,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15727,
+            "randomState": 15579,
             "tickCount": 39400,
             "type": "paint"
         },
         {
-            "randomState": 15747,
+            "randomState": 15606,
             "tickCount": 39500,
             "type": "paint"
         },
@@ -3084,47 +3084,47 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15753,
+            "randomState": 15609,
             "tickCount": 39600,
             "type": "paint"
         },
         {
-            "randomState": 15788,
+            "randomState": 15694,
             "tickCount": 39700,
             "type": "paint"
         },
         {
-            "randomState": 15820,
+            "randomState": 15699,
             "tickCount": 39800,
             "type": "paint"
         },
         {
-            "randomState": 15841,
+            "randomState": 15722,
             "tickCount": 39900,
             "type": "paint"
         },
         {
-            "randomState": 15841,
+            "randomState": 15725,
             "tickCount": 40000,
             "type": "paint"
         },
         {
-            "randomState": 15868,
+            "randomState": 15753,
             "tickCount": 40100,
             "type": "paint"
         },
         {
-            "randomState": 15874,
+            "randomState": 15757,
             "tickCount": 40200,
             "type": "paint"
         },
         {
-            "randomState": 15897,
+            "randomState": 15779,
             "tickCount": 40300,
             "type": "paint"
         },
         {
-            "randomState": 15939,
+            "randomState": 15785,
             "tickCount": 40400,
             "type": "paint"
         },
@@ -3135,12 +3135,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 15964,
+            "randomState": 15812,
             "tickCount": 40500,
             "type": "paint"
         },
         {
-            "randomState": 15965,
+            "randomState": 15813,
             "tickCount": 40600,
             "type": "paint"
         },
@@ -3151,32 +3151,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 15987,
+            "randomState": 15861,
             "tickCount": 40700,
             "type": "paint"
         },
         {
-            "randomState": 15988,
+            "randomState": 15863,
             "tickCount": 40800,
             "type": "paint"
         },
         {
-            "randomState": 16015,
+            "randomState": 15890,
             "tickCount": 40900,
             "type": "paint"
         },
         {
-            "randomState": 16019,
+            "randomState": 15905,
             "tickCount": 41000,
             "type": "paint"
         },
         {
-            "randomState": 16040,
+            "randomState": 15926,
             "tickCount": 41100,
             "type": "paint"
         },
         {
-            "randomState": 16044,
+            "randomState": 15927,
             "tickCount": 41200,
             "type": "paint"
         },
@@ -3187,7 +3187,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16069,
+            "randomState": 15952,
             "tickCount": 41300,
             "type": "paint"
         },
@@ -3198,17 +3198,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16072,
+            "randomState": 15952,
             "tickCount": 41400,
             "type": "paint"
         },
         {
-            "randomState": 16091,
+            "randomState": 15973,
             "tickCount": 41500,
             "type": "paint"
         },
         {
-            "randomState": 16093,
+            "randomState": 15978,
             "tickCount": 41600,
             "type": "paint"
         },
@@ -3219,7 +3219,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16122,
+            "randomState": 16006,
             "tickCount": 41700,
             "type": "paint"
         },
@@ -3230,22 +3230,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16123,
+            "randomState": 16011,
             "tickCount": 41800,
             "type": "paint"
         },
         {
-            "randomState": 16148,
+            "randomState": 16030,
             "tickCount": 41900,
             "type": "paint"
         },
         {
-            "randomState": 16149,
+            "randomState": 16031,
             "tickCount": 42000,
             "type": "paint"
         },
         {
-            "randomState": 16174,
+            "randomState": 16057,
             "tickCount": 42100,
             "type": "paint"
         },
@@ -3256,17 +3256,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16177,
+            "randomState": 16062,
             "tickCount": 42200,
             "type": "paint"
         },
         {
-            "randomState": 16200,
+            "randomState": 16086,
             "tickCount": 42300,
             "type": "paint"
         },
         {
-            "randomState": 16203,
+            "randomState": 16091,
             "tickCount": 42400,
             "type": "paint"
         },
@@ -3277,7 +3277,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16228,
+            "randomState": 16117,
             "tickCount": 42500,
             "type": "paint"
         },
@@ -3288,17 +3288,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16231,
+            "randomState": 16118,
             "tickCount": 42600,
             "type": "paint"
         },
         {
-            "randomState": 16253,
+            "randomState": 16139,
             "tickCount": 42700,
             "type": "paint"
         },
         {
-            "randomState": 16253,
+            "randomState": 16140,
             "tickCount": 42800,
             "type": "paint"
         },
@@ -3309,27 +3309,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16280,
+            "randomState": 16167,
             "tickCount": 42900,
             "type": "paint"
         },
         {
-            "randomState": 16284,
+            "randomState": 16173,
             "tickCount": 43000,
             "type": "paint"
         },
         {
-            "randomState": 16305,
+            "randomState": 16193,
             "tickCount": 43100,
             "type": "paint"
         },
         {
-            "randomState": 16307,
+            "randomState": 16196,
             "tickCount": 43200,
             "type": "paint"
         },
         {
-            "randomState": 16332,
+            "randomState": 16221,
             "tickCount": 43300,
             "type": "paint"
         },
@@ -3340,12 +3340,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16334,
+            "randomState": 16221,
             "tickCount": 43400,
             "type": "paint"
         },
         {
-            "randomState": 16354,
+            "randomState": 16243,
             "tickCount": 43500,
             "type": "paint"
         },
@@ -3356,22 +3356,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16357,
+            "randomState": 16246,
             "tickCount": 43600,
             "type": "paint"
         },
         {
-            "randomState": 16385,
+            "randomState": 16275,
             "tickCount": 43700,
             "type": "paint"
         },
         {
-            "randomState": 16387,
+            "randomState": 16277,
             "tickCount": 43800,
             "type": "paint"
         },
         {
-            "randomState": 16408,
+            "randomState": 16297,
             "tickCount": 43900,
             "type": "paint"
         },
@@ -3382,22 +3382,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16409,
+            "randomState": 16299,
             "tickCount": 44000,
             "type": "paint"
         },
         {
-            "randomState": 16435,
+            "randomState": 16323,
             "tickCount": 44100,
             "type": "paint"
         },
         {
-            "randomState": 16440,
+            "randomState": 16327,
             "tickCount": 44200,
             "type": "paint"
         },
         {
-            "randomState": 16463,
+            "randomState": 16350,
             "tickCount": 44300,
             "type": "paint"
         },
@@ -3408,12 +3408,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16466,
+            "randomState": 16354,
             "tickCount": 44400,
             "type": "paint"
         },
         {
-            "randomState": 16490,
+            "randomState": 16379,
             "tickCount": 44500,
             "type": "paint"
         },
@@ -3424,22 +3424,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16492,
+            "randomState": 16381,
             "tickCount": 44600,
             "type": "paint"
         },
         {
-            "randomState": 16513,
+            "randomState": 16403,
             "tickCount": 44700,
             "type": "paint"
         },
         {
-            "randomState": 16513,
+            "randomState": 16404,
             "tickCount": 44800,
             "type": "paint"
         },
         {
-            "randomState": 16540,
+            "randomState": 16433,
             "tickCount": 44900,
             "type": "paint"
         },
@@ -3450,17 +3450,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16543,
+            "randomState": 16436,
             "tickCount": 45000,
             "type": "paint"
         },
         {
-            "randomState": 16567,
+            "randomState": 16461,
             "tickCount": 45100,
             "type": "paint"
         },
         {
-            "randomState": 16569,
+            "randomState": 16467,
             "tickCount": 45200,
             "type": "paint"
         },
@@ -3471,12 +3471,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16595,
+            "randomState": 16491,
             "tickCount": 45300,
             "type": "paint"
         },
         {
-            "randomState": 16598,
+            "randomState": 16494,
             "tickCount": 45400,
             "type": "paint"
         },
@@ -3487,67 +3487,67 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16619,
+            "randomState": 16514,
             "tickCount": 45500,
             "type": "paint"
         },
         {
-            "randomState": 16623,
+            "randomState": 16518,
             "tickCount": 45600,
             "type": "paint"
         },
         {
-            "randomState": 16653,
+            "randomState": 16546,
             "tickCount": 45700,
             "type": "paint"
         },
         {
-            "randomState": 16654,
+            "randomState": 16547,
             "tickCount": 45800,
             "type": "paint"
         },
         {
-            "randomState": 16673,
+            "randomState": 16568,
             "tickCount": 45900,
             "type": "paint"
         },
         {
-            "randomState": 16674,
+            "randomState": 16570,
             "tickCount": 46000,
             "type": "paint"
         },
         {
-            "randomState": 16698,
+            "randomState": 16596,
             "tickCount": 46100,
             "type": "paint"
         },
         {
-            "randomState": 16702,
+            "randomState": 16604,
             "tickCount": 46200,
             "type": "paint"
         },
         {
-            "randomState": 16724,
+            "randomState": 16627,
             "tickCount": 46300,
             "type": "paint"
         },
         {
-            "randomState": 16728,
+            "randomState": 16630,
             "tickCount": 46400,
             "type": "paint"
         },
         {
-            "randomState": 16755,
+            "randomState": 16654,
             "tickCount": 46500,
             "type": "paint"
         },
         {
-            "randomState": 16757,
+            "randomState": 16656,
             "tickCount": 46600,
             "type": "paint"
         },
         {
-            "randomState": 16786,
+            "randomState": 16678,
             "tickCount": 46700,
             "type": "paint"
         },
@@ -3564,17 +3564,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16787,
+            "randomState": 16679,
             "tickCount": 46800,
             "type": "paint"
         },
         {
-            "randomState": 16814,
+            "randomState": 16708,
             "tickCount": 46900,
             "type": "paint"
         },
         {
-            "randomState": 16817,
+            "randomState": 16709,
             "tickCount": 47000,
             "type": "paint"
         },
@@ -3585,7 +3585,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16838,
+            "randomState": 16729,
             "tickCount": 47100,
             "type": "paint"
         },
@@ -3596,22 +3596,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16841,
+            "randomState": 16732,
             "tickCount": 47200,
             "type": "paint"
         },
         {
-            "randomState": 16866,
+            "randomState": 16756,
             "tickCount": 47300,
             "type": "paint"
         },
         {
-            "randomState": 16869,
+            "randomState": 16758,
             "tickCount": 47400,
             "type": "paint"
         },
         {
-            "randomState": 16895,
+            "randomState": 16779,
             "tickCount": 47500,
             "type": "paint"
         },
@@ -3628,12 +3628,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16898,
+            "randomState": 16783,
             "tickCount": 47600,
             "type": "paint"
         },
         {
-            "randomState": 16923,
+            "randomState": 16810,
             "tickCount": 47700,
             "type": "paint"
         },
@@ -3644,12 +3644,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16925,
+            "randomState": 16811,
             "tickCount": 47800,
             "type": "paint"
         },
         {
-            "randomState": 16946,
+            "randomState": 16833,
             "tickCount": 47900,
             "type": "paint"
         },
@@ -3660,47 +3660,47 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 16947,
+            "randomState": 16836,
             "tickCount": 48000,
             "type": "paint"
         },
         {
-            "randomState": 16973,
+            "randomState": 16861,
             "tickCount": 48100,
             "type": "paint"
         },
         {
-            "randomState": 16979,
+            "randomState": 16868,
             "tickCount": 48200,
             "type": "paint"
         },
         {
-            "randomState": 17000,
+            "randomState": 16890,
             "tickCount": 48300,
             "type": "paint"
         },
         {
-            "randomState": 17002,
+            "randomState": 16893,
             "tickCount": 48400,
             "type": "paint"
         },
         {
-            "randomState": 17026,
+            "randomState": 16922,
             "tickCount": 48500,
             "type": "paint"
         },
         {
-            "randomState": 17028,
+            "randomState": 16924,
             "tickCount": 48600,
             "type": "paint"
         },
         {
-            "randomState": 17054,
+            "randomState": 16946,
             "tickCount": 48700,
             "type": "paint"
         },
         {
-            "randomState": 17060,
+            "randomState": 16948,
             "tickCount": 48800,
             "type": "paint"
         },
@@ -3711,7 +3711,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 17087,
+            "randomState": 16975,
             "tickCount": 48900,
             "type": "paint"
         },
@@ -3722,22 +3722,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 17093,
+            "randomState": 16979,
             "tickCount": 49000,
             "type": "paint"
         },
         {
-            "randomState": 17117,
+            "randomState": 16998,
             "tickCount": 49100,
             "type": "paint"
         },
         {
-            "randomState": 17121,
+            "randomState": 17000,
             "tickCount": 49200,
             "type": "paint"
         },
         {
-            "randomState": 17144,
+            "randomState": 17026,
             "tickCount": 49300,
             "type": "paint"
         },
@@ -3748,7 +3748,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 17149,
+            "randomState": 17029,
             "tickCount": 49400,
             "type": "paint"
         },
@@ -3759,97 +3759,97 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 17172,
+            "randomState": 17051,
             "tickCount": 49500,
             "type": "paint"
         },
         {
-            "randomState": 17176,
+            "randomState": 17055,
             "tickCount": 49600,
             "type": "paint"
         },
         {
-            "randomState": 17204,
+            "randomState": 17081,
             "tickCount": 49700,
             "type": "paint"
         },
         {
-            "randomState": 17208,
+            "randomState": 17083,
             "tickCount": 49800,
             "type": "paint"
         },
         {
-            "randomState": 17232,
+            "randomState": 17102,
             "tickCount": 49900,
             "type": "paint"
         },
         {
-            "randomState": 17234,
+            "randomState": 17104,
             "tickCount": 50000,
             "type": "paint"
         },
         {
-            "randomState": 17257,
+            "randomState": 17131,
             "tickCount": 50100,
             "type": "paint"
         },
         {
-            "randomState": 17264,
+            "randomState": 17136,
             "tickCount": 50200,
             "type": "paint"
         },
         {
-            "randomState": 17283,
+            "randomState": 17158,
             "tickCount": 50300,
             "type": "paint"
         },
         {
-            "randomState": 17286,
+            "randomState": 17161,
             "tickCount": 50400,
             "type": "paint"
         },
         {
-            "randomState": 17314,
+            "randomState": 17186,
             "tickCount": 50500,
             "type": "paint"
         },
         {
-            "randomState": 17315,
+            "randomState": 17193,
             "tickCount": 50600,
             "type": "paint"
         },
         {
-            "randomState": 17338,
+            "randomState": 17253,
             "tickCount": 50700,
             "type": "paint"
         },
         {
-            "randomState": 17349,
+            "randomState": 17261,
             "tickCount": 50800,
             "type": "paint"
         },
         {
-            "randomState": 17381,
+            "randomState": 17288,
             "tickCount": 50900,
             "type": "paint"
         },
         {
-            "randomState": 17391,
+            "randomState": 17292,
             "tickCount": 51000,
             "type": "paint"
         },
         {
-            "randomState": 17411,
+            "randomState": 17313,
             "tickCount": 51100,
             "type": "paint"
         },
         {
-            "randomState": 17414,
+            "randomState": 17316,
             "tickCount": 51200,
             "type": "paint"
         },
         {
-            "randomState": 17482,
+            "randomState": 17342,
             "tickCount": 51300,
             "type": "paint"
         },
@@ -3860,7 +3860,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 17488,
+            "randomState": 17345,
             "tickCount": 51400,
             "type": "paint"
         },
@@ -3871,52 +3871,52 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 17513,
+            "randomState": 17368,
             "tickCount": 51500,
             "type": "paint"
         },
         {
-            "randomState": 17517,
+            "randomState": 17371,
             "tickCount": 51600,
             "type": "paint"
         },
         {
-            "randomState": 17542,
+            "randomState": 17398,
             "tickCount": 51700,
             "type": "paint"
         },
         {
-            "randomState": 17552,
+            "randomState": 17398,
             "tickCount": 51800,
             "type": "paint"
         },
         {
-            "randomState": 17573,
+            "randomState": 17418,
             "tickCount": 51900,
             "type": "paint"
         },
         {
-            "randomState": 17578,
+            "randomState": 17423,
             "tickCount": 52000,
             "type": "paint"
         },
         {
-            "randomState": 17605,
+            "randomState": 17454,
             "tickCount": 52100,
             "type": "paint"
         },
         {
-            "randomState": 17616,
+            "randomState": 17459,
             "tickCount": 52200,
             "type": "paint"
         },
         {
-            "randomState": 17639,
+            "randomState": 17481,
             "tickCount": 52300,
             "type": "paint"
         },
         {
-            "randomState": 17639,
+            "randomState": 17482,
             "tickCount": 52400,
             "type": "paint"
         },
@@ -3927,77 +3927,77 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 17667,
+            "randomState": 17506,
             "tickCount": 52500,
             "type": "paint"
         },
         {
-            "randomState": 17670,
+            "randomState": 17507,
             "tickCount": 52600,
             "type": "paint"
         },
         {
-            "randomState": 17688,
+            "randomState": 17529,
             "tickCount": 52700,
             "type": "paint"
         },
         {
-            "randomState": 17715,
+            "randomState": 17532,
             "tickCount": 52800,
             "type": "paint"
         },
         {
-            "randomState": 17781,
+            "randomState": 17559,
             "tickCount": 52900,
             "type": "paint"
         },
         {
-            "randomState": 17789,
+            "randomState": 17563,
             "tickCount": 53000,
             "type": "paint"
         },
         {
-            "randomState": 17805,
+            "randomState": 17589,
             "tickCount": 53100,
             "type": "paint"
         },
         {
-            "randomState": 17811,
+            "randomState": 17592,
             "tickCount": 53200,
             "type": "paint"
         },
         {
-            "randomState": 17847,
+            "randomState": 17617,
             "tickCount": 53300,
             "type": "paint"
         },
         {
-            "randomState": 17857,
+            "randomState": 17619,
             "tickCount": 53400,
             "type": "paint"
         },
         {
-            "randomState": 17882,
+            "randomState": 17640,
             "tickCount": 53500,
             "type": "paint"
         },
         {
-            "randomState": 17888,
+            "randomState": 17643,
             "tickCount": 53600,
             "type": "paint"
         },
         {
-            "randomState": 17922,
+            "randomState": 17671,
             "tickCount": 53700,
             "type": "paint"
         },
         {
-            "randomState": 17930,
+            "randomState": 17671,
             "tickCount": 53800,
             "type": "paint"
         },
         {
-            "randomState": 17957,
+            "randomState": 17691,
             "tickCount": 53900,
             "type": "paint"
         },
@@ -4014,27 +4014,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 17958,
+            "randomState": 17695,
             "tickCount": 54000,
             "type": "paint"
         },
         {
-            "randomState": 17984,
+            "randomState": 17724,
             "tickCount": 54100,
             "type": "paint"
         },
         {
-            "randomState": 17989,
+            "randomState": 17729,
             "tickCount": 54200,
             "type": "paint"
         },
         {
-            "randomState": 18011,
+            "randomState": 17751,
             "tickCount": 54300,
             "type": "paint"
         },
         {
-            "randomState": 18022,
+            "randomState": 17752,
             "tickCount": 54400,
             "type": "paint"
         }


### PR DESCRIPTION
Resolves the two TODOs that #2681 left in the collision code. `integer_sqrt` took an `int` while actor velocities are `Vec3f`, so the squared length was truncated before the root, and the speed that comes out goes straight back into the velocity. Using the vector length instead shifts that speed by a unit in rounding edge cases, so `issue_735b` and `issue_1997` are retraced here. Only the recorded random states and one actor position per trace move, the input events are untouched.