### PR TITLE
Overlay data and table move to Engine/Data and Engine/Tables

### DIFF
--- a/src/Engine/Data/CMakeLists.txt
+++ b/src/Engine/Data/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ENGINE_DATA_HEADERS
         HouseEnums.h
         IconFrameData.h
         ItemData.h
+        OverlayData.h
         PortraitFrameData.h
         SoundEnums.h
         SpecialEnchantmentData.h

--- a/src/Engine/Data/OverlayData.h
+++ b/src/Engine/Data/OverlayData.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+
+struct OverlayData {
+    uint16_t uOverlayID = 0; // Id this row is looked up by, see ActiveOverlayList::_4418B6.
+    uint16_t uOverlayType = 0; // Zero in all shipped MM6 and MM7 data, and nothing reads it.
+    uint16_t uSpriteFramesetID = 0; // Index into SpriteFrameTable, zero for every MM7 overlay.
+    int16_t spriteFramesetGroup = 0; // Zero in all shipped MM6 and MM7 data, and nothing reads it.
+};

--- a/src/Engine/Data/OverlayData.h
+++ b/src/Engine/Data/OverlayData.h
@@ -6,5 +6,4 @@ struct OverlayData {
     uint16_t uOverlayID = 0; // Id this row is looked up by, see ActiveOverlayList::_4418B6.
     uint16_t uOverlayType = 0; // Placement mode, 0 centers the sprite and 2 is transparent. MM6 branches on it, we don't.
     uint16_t uSpriteFramesetID = 0; // Index into SpriteFrameTable. Set only in MM6, zero in every MM7 and MM8 record.
-    int16_t spriteFramesetGroup = 0; // TODO(captainurist): name is a guess, zero everywhere and no engine reads it.
 };

--- a/src/Engine/Data/OverlayData.h
+++ b/src/Engine/Data/OverlayData.h
@@ -4,7 +4,7 @@
 
 struct OverlayData {
     uint16_t uOverlayID = 0; // Id this row is looked up by, see ActiveOverlayList::_4418B6.
-    uint16_t uOverlayType = 0; // Zero in all shipped MM6 and MM7 data, and nothing reads it.
-    uint16_t uSpriteFramesetID = 0; // Index into SpriteFrameTable, zero for every MM7 overlay.
-    int16_t spriteFramesetGroup = 0; // Zero in all shipped MM6 and MM7 data, and nothing reads it.
+    uint16_t uOverlayType = 0; // Placement mode, 0 centers the sprite and 2 is transparent. MM6 branches on it, we don't.
+    uint16_t uSpriteFramesetID = 0; // Index into SpriteFrameTable. Set only in MM6, zero in every MM7 and MM8 record.
+    int16_t spriteFramesetGroup = 0; // TODO(captainurist): name is a guess, zero everywhere and no engine reads it.
 };

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -54,6 +54,7 @@
 #include "Engine/Tables/HouseTable.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Tables/IconFrameTable.h"
+#include "Engine/Tables/OverlayTable.h"
 #include "Engine/Tables/PortraitFrameTable.h"
 #include "Engine/Tables/TileTable.h"
 #include "Engine/Tables/HostilityTable.h"
@@ -677,8 +678,8 @@ void Engine::MM7_Initialize() {
     pMonsterList = new MonsterList;
     deserialize(engine->resources()->eventsData("dmonlist.bin"), pMonsterList);
 
-    pOverlayList = new OverlayList;
-    deserialize(engine->resources()->eventsData("doverlay.bin"), pOverlayList);
+    pOverlayTable = new OverlayTable;
+    deserialize(engine->resources()->eventsData("doverlay.bin"), pOverlayTable);
 
     pSoundList = new SoundList;
     deserialize(engine->resources()->eventsData("dsounds.bin"), pSoundList);
@@ -724,7 +725,7 @@ void Engine::SecondaryInitialization() {
     //pPaletteManager->SetMistColor(128, 128, 128);
     //pPaletteManager->RecalculateAll();
     pObjectList->InitializeSprites();
-    pOverlayList->InitializeSprites();
+    pOverlayTable->initializeSprites();
 
     // TODO(captainurist): try resurrecting the food / gold animations using resource files from MM6?
     //for (unsigned i = 0; i < 4; ++i) {

--- a/src/Engine/Graphics/Overlays.cpp
+++ b/src/Engine/Graphics/Overlays.cpp
@@ -4,6 +4,7 @@
 #include "Engine/Timer.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Tables/IconFrameTable.h"
+#include "Engine/Tables/OverlayTable.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 
 
@@ -11,7 +12,6 @@
 
 
 ActiveOverlayList *pActiveOverlayList = new ActiveOverlayList;  // idb
-OverlayList *pOverlayList = new OverlayList;
 
 // inlined
 //----- (mm6c::0045BD50) --------------------------------------------------
@@ -29,15 +29,15 @@ int ActiveOverlayList::_4418B6(int uOverlayID, Pid pid, Duration animLength, int
             this->pOverlays[i].screenSpaceX = 0;
             this->pOverlays[i].pid = pid;
             int indexer = 0;
-            for (; indexer < (signed int)pOverlayList->pOverlays.size(); ++indexer) {
-                if (uOverlayID == pOverlayList->pOverlays[indexer].uOverlayID) break;
+            for (; indexer < (signed int)pOverlayTable->overlays.size(); ++indexer) {
+                if (uOverlayID == pOverlayTable->overlays[indexer].uOverlayID) break;
             }
-            this->pOverlays[i].indexToOverlayList = indexer;
+            this->pOverlays[i].indexToOverlayTable = indexer;
             this->pOverlays[i].spriteFrameTime = 0;
             if (animLength)
                 v11 = animLength;
             else
-                v11 = pSpriteFrameTable->pSpriteSFrames[pOverlayList->pOverlays[indexer].uSpriteFramesetID].animationLength;
+                v11 = pSpriteFrameTable->pSpriteSFrames[pOverlayTable->overlays[indexer].uSpriteFramesetID].animationLength;
             this->pOverlays[i].animLength = v11.ticks();
             this->pOverlays[i].fpDamageMod = fpDamageMod;
             this->pOverlays[i].projSize = projSize;
@@ -47,15 +47,9 @@ int ActiveOverlayList::_4418B6(int uOverlayID, Pid pid, Duration animLength, int
     return 0;
 }
 
-//----- (00458D97) --------------------------------------------------------
-void OverlayList::InitializeSprites() {
-    for (size_t i = 0; i < pOverlays.size(); ++i)
-        pSpriteFrameTable->InitializeSprite(pOverlays[i].uSpriteFramesetID);
-}
-
 //----- (0045855F) --------------------------------------------------------
 void ActiveOverlay::Reset() {
-    this->indexToOverlayList = 0;
+    this->indexToOverlayTable = 0;
     this->spriteFrameTime = 0;
     this->animLength = 0;
     this->screenSpaceX = 0;

--- a/src/Engine/Graphics/Overlays.h
+++ b/src/Engine/Graphics/Overlays.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <vector>
 
+#include "Engine/Data/OverlayData.h"
 #include "Engine/Pid.h"
 
 #include "Core/Time/Duration.h"
@@ -31,17 +32,11 @@ struct ActiveOverlayList {
     std::array<ActiveOverlay, 50> pOverlays;
 };
 
-struct OverlayDesc {
-    uint16_t uOverlayID = 0;
-    uint16_t uOverlayType = 0;
-    uint16_t uSpriteFramesetID = 0;
-    int16_t spriteFramesetGroup = 0;
-};
-
+// TODO(captainurist): move to Engine/Tables as OverlayTable.
 struct OverlayList {
     void InitializeSprites();
 
-    std::vector<OverlayDesc> pOverlays;
+    std::vector<OverlayData> pOverlays;
 };
 
 extern ActiveOverlayList *pActiveOverlayList;

--- a/src/Engine/Graphics/Overlays.h
+++ b/src/Engine/Graphics/Overlays.h
@@ -2,9 +2,7 @@
 
 #include <cstdint>
 #include <array>
-#include <vector>
 
-#include "Engine/Data/OverlayData.h"
 #include "Engine/Pid.h"
 
 #include "Core/Time/Duration.h"
@@ -15,7 +13,7 @@ struct ActiveOverlay {
     ActiveOverlay();
     void Reset();
 
-    int16_t indexToOverlayList = 0;
+    int16_t indexToOverlayTable = 0;
     int16_t spriteFrameTime = 0;
     int16_t animLength = 0;
     int16_t screenSpaceX = 0;
@@ -32,12 +30,4 @@ struct ActiveOverlayList {
     std::array<ActiveOverlay, 50> pOverlays;
 };
 
-// TODO(captainurist): move to Engine/Tables as OverlayTable.
-struct OverlayList {
-    void InitializeSprites();
-
-    std::vector<OverlayData> pOverlays;
-};
-
 extern ActiveOverlayList *pActiveOverlayList;
-extern OverlayList *pOverlayList;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -24,6 +24,7 @@
 #include "Engine/Party.h"
 #include "Engine/SaveLoad.h"
 #include "Engine/Data/IconFrameData.h"
+#include "Engine/Data/OverlayData.h"
 #include "Engine/Data/PortraitFrameData.h"
 #include "Engine/Data/TileData.h"
 #include "Engine/Data/TileEnumFunctions.h"
@@ -1758,7 +1759,7 @@ void reconstruct(const BLVLight_MM7 &src, BLVLight *dst) {
     dst->uBrightness = src.uBrightness;
 }
 
-void reconstruct(const OverlayDesc_MM7 &src, OverlayDesc *dst) {
+void reconstruct(const OverlayData_MM7 &src, OverlayData *dst) {
     dst->uOverlayID = src.uOverlayID;
     dst->uOverlayType = src.uOverlayType;
     dst->uSpriteFramesetID = src.uSpriteFramesetID;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1763,7 +1763,6 @@ void reconstruct(const OverlayData_MM7 &src, OverlayData *dst) {
     dst->uOverlayID = src.uOverlayID;
     dst->uOverlayType = src.uOverlayType;
     dst->uSpriteFramesetID = src.uSpriteFramesetID;
-    dst->spriteFramesetGroup = src.spriteFramesetGroup;
 }
 
 void reconstruct(const PortraitFrameData_MM7 &src, PortraitFrameData *dst) {

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -392,7 +392,7 @@ void reconstruct(const NPCData_MM7 &src, NPCData *dst) {
 void snapshot(const ActiveOverlay &src, ActiveOverlay_MM7 *dst) {
     memzero(dst);
 
-    dst->indexToOverlayList = src.indexToOverlayList;
+    dst->indexToOverlayTable = src.indexToOverlayTable;
     dst->spriteFrameTime = src.spriteFrameTime;
     dst->animLength = src.animLength;
     dst->screenSpaceX = src.screenSpaceX;
@@ -405,7 +405,7 @@ void snapshot(const ActiveOverlay &src, ActiveOverlay_MM7 *dst) {
 void reconstruct(const ActiveOverlay_MM7 &src, ActiveOverlay *dst) {
     memzero(dst);
 
-    dst->indexToOverlayList = src.indexToOverlayList;
+    dst->indexToOverlayTable = src.indexToOverlayTable;
     dst->spriteFrameTime = src.spriteFrameTime;
     dst->animLength = src.animLength;
     dst->screenSpaceX = src.screenSpaceX;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -591,7 +591,7 @@ void reconstruct(const Timer_MM7 &src, Timer *dst);
 
 struct ActiveOverlay_MM7 {
     int16_t field_0;
-    int16_t indexToOverlayList;
+    int16_t indexToOverlayTable;
     int16_t spriteFrameTime;
     int16_t animLength;
     int16_t screenSpaceX;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1071,7 +1071,7 @@ struct OverlayData_MM7 {
     uint16_t uOverlayID;
     uint16_t uOverlayType;
     uint16_t uSpriteFramesetID;
-    int16_t spriteFramesetGroup;
+    int16_t field_6; // Zero in all shipped MM6, MM7 and MM8 records, and no engine reads it.
 };
 static_assert(sizeof(OverlayData_MM7) == 8);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(OverlayData_MM7)

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -51,7 +51,7 @@ struct MonsterDesc;
 struct NPCData;
 struct ObjectDesc;
 struct OutdoorTileType;
-struct OverlayDesc;
+struct OverlayData;
 struct Party;
 struct PersistentVariables;
 struct PortraitFrameData;
@@ -1067,16 +1067,16 @@ MM_DECLARE_MEMCOPY_SERIALIZABLE(BLVLight_MM7)
 void reconstruct(const BLVLight_MM7 &src, BLVLight *dst);
 
 
-struct OverlayDesc_MM7 {
+struct OverlayData_MM7 {
     uint16_t uOverlayID;
     uint16_t uOverlayType;
     uint16_t uSpriteFramesetID;
     int16_t spriteFramesetGroup;
 };
-static_assert(sizeof(OverlayDesc_MM7) == 8);
-MM_DECLARE_MEMCOPY_SERIALIZABLE(OverlayDesc_MM7)
+static_assert(sizeof(OverlayData_MM7) == 8);
+MM_DECLARE_MEMCOPY_SERIALIZABLE(OverlayData_MM7)
 
-void reconstruct(const OverlayDesc_MM7 &src, OverlayDesc *dst);
+void reconstruct(const OverlayData_MM7 &src, OverlayData *dst);
 
 
 struct PortraitFrameData_MM7 {

--- a/src/Engine/Snapshots/TableSerialization.cpp
+++ b/src/Engine/Snapshots/TableSerialization.cpp
@@ -4,12 +4,12 @@
 
 #include "Engine/Tables/PortraitFrameTable.h"
 #include "Engine/Tables/IconFrameTable.h"
+#include "Engine/Tables/OverlayTable.h"
 #include "Engine/Tables/TextureFrameTable.h"
 #include "Engine/Tables/TileTable.h"
 #include "Engine/Objects/Monsters.h"
 #include "Engine/Objects/ObjectList.h"
 #include "Engine/Objects/DecorationList.h"
-#include "Engine/Graphics/Overlays.h"
 
 #include "Media/Audio/SoundList.h"
 
@@ -67,11 +67,11 @@ void deserialize(const Blob &src, ObjectList *dst) {
     assert(!dst->pObjects.empty());
 }
 
-void deserialize(const Blob &src, OverlayList *dst) {
-    dst->pOverlays.clear();
-    deserialize(src, &dst->pOverlays, tags::append, tags::each, tags::via<OverlayData_MM7>);
+void deserialize(const Blob &src, OverlayTable *dst) {
+    dst->overlays.clear();
+    deserialize(src, &dst->overlays, tags::append, tags::each, tags::via<OverlayData_MM7>);
 
-    assert(!dst->pOverlays.empty());
+    assert(!dst->overlays.empty());
 }
 
 void deserialize(const Blob &src, SpriteFrameTable *dst) {

--- a/src/Engine/Snapshots/TableSerialization.cpp
+++ b/src/Engine/Snapshots/TableSerialization.cpp
@@ -69,7 +69,7 @@ void deserialize(const Blob &src, ObjectList *dst) {
 
 void deserialize(const Blob &src, OverlayList *dst) {
     dst->pOverlays.clear();
-    deserialize(src, &dst->pOverlays, tags::append, tags::each, tags::via<OverlayDesc_MM7>);
+    deserialize(src, &dst->pOverlays, tags::append, tags::each, tags::via<OverlayData_MM7>);
 
     assert(!dst->pOverlays.empty());
 }

--- a/src/Engine/Snapshots/TableSerialization.h
+++ b/src/Engine/Snapshots/TableSerialization.h
@@ -7,7 +7,7 @@ class ObjectList;
 class SoundList;
 class IconFrameTable;
 struct MonsterList;
-struct OverlayList;
+struct OverlayTable;
 struct PortraitFrameTable;
 struct SpriteFrameTable;
 class TextureFrameTable;
@@ -38,7 +38,7 @@ void deserialize(const Blob &src, ObjectList *dst);
 /**
  * @offset 0x00458E08
  */
-void deserialize(const Blob &src, OverlayList *dst);
+void deserialize(const Blob &src, OverlayTable *dst);
 
 /**
  * @offset 0x0044D9D7

--- a/src/Engine/Tables/CMakeLists.txt
+++ b/src/Engine/Tables/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ENGINE_TABLES_SOURCES
         MerchantTable.cpp
         MessageScrollTable.cpp
         NPCTable.cpp
+        OverlayTable.cpp
         PortraitFrameTable.cpp
         QuestTable.cpp
         TextureFrameTable.cpp
@@ -30,6 +31,7 @@ set(ENGINE_TABLES_HEADERS
         MerchantTable.h
         MessageScrollTable.h
         NPCTable.h
+        OverlayTable.h
         PortraitFrameTable.h
         QuestTable.h
         TextureFrameTable.h

--- a/src/Engine/Tables/OverlayTable.cpp
+++ b/src/Engine/Tables/OverlayTable.cpp
@@ -1,0 +1,11 @@
+#include "Engine/Tables/OverlayTable.h"
+
+#include "Engine/Graphics/Sprites.h"
+
+OverlayTable *pOverlayTable = new OverlayTable;
+
+//----- (00458D97) --------------------------------------------------------
+void OverlayTable::initializeSprites() {
+    for (size_t i = 0; i < overlays.size(); ++i)
+        pSpriteFrameTable->InitializeSprite(overlays[i].uSpriteFramesetID);
+}

--- a/src/Engine/Tables/OverlayTable.h
+++ b/src/Engine/Tables/OverlayTable.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+
+#include "Engine/Data/OverlayData.h"
+
+class Blob;
+
+struct OverlayTable {
+    void initializeSprites();
+
+    friend void deserialize(const Blob &src, OverlayTable *dst); // In TableSerialization.cpp.
+
+    std::vector<OverlayData> overlays;
+};
+
+extern OverlayTable *pOverlayTable;

--- a/src/Engine/Tables/OverlayTable.h
+++ b/src/Engine/Tables/OverlayTable.h
@@ -4,12 +4,8 @@
 
 #include "Engine/Data/OverlayData.h"
 
-class Blob;
-
 struct OverlayTable {
     void initializeSprites();
-
-    friend void deserialize(const Blob &src, OverlayTable *dst); // In TableSerialization.cpp.
 
     std::vector<OverlayData> overlays;
 };


### PR DESCRIPTION
`OverlayDesc` is a row of the `doverlay.bin` table, so it becomes `OverlayData` in `Engine/Data`, and `OverlayList` follows it as `OverlayTable` in `Engine/Tables`. That is the pairing every other data table already uses. `Engine/Graphics` keeps `ActiveOverlay` and `ActiveOverlayList`, which are the runtime and savegame half, so that header no longer mixes the two. Names come along for the ride, `InitializeSprites` is now `initializeSprites` and the row vector is `overlays`, which no longer collides with `ActiveOverlayList::pOverlays`.

The snapshot type becomes `OverlayData_MM7` to match `TileData_MM7` and friends. Its layout is untouched and `MM_DECLARE_MEMCOPY_SERIALIZABLE` keys off the type rather than its name, so no data file or save is affected.

The last two bytes of the row are gone from the runtime struct. They were called `spriteFramesetGroup`, but nothing supports that name, and digging into MM6.exe and MMExtension turned up what the other fields really are. `uOverlayType` is a placement mode that `overlay.txt` spelled as a keyword, and MM6 branches on it, while `uSpriteFramesetID` is populated in MM6 alone. Details are in a comment below.