### PR TITLE
Fix monsters stuck in stun state after armageddon

### DIFF
--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2531,10 +2531,18 @@ void Actor::UpdateActorAI() {
         if (pActor->buffs[ACTOR_BUFF_PARALYZED].Active() || pActor->buffs[ACTOR_BUFF_STONED].Active())
             continue;
 
-        // If actor is stunned: skip - vanilla bug that causes stunned background actors to recover to idle motions
-        // Most apparent during armageddon spell, falling background actors will occasionally hover to perform action
-        if (pActor->aiState == AIState::Stunned)
+        // If actor is stunned: let the animation finish but don't process AI.
+        // Vanilla skipped stunned actors entirely, causing them to get stuck in stun state forever.
+        if (pActor->aiState == AIState::Stunned) {
+            pActor->currentActionTime += pEventTimer->dt();
+            if (pActor->currentActionTime >= pActor->currentActionLength) {
+                pActor->aiState = Standing;
+                pActor->currentActionTime = 0_ticks;
+                pActor->currentActionLength = 0_ticks;
+                pActor->UpdateAnimation();
+            }
             continue;
+        }
 
         // Calculate RecoveryTime
         pActor->monsterInfo.recoveryTime = std::max(pActor->monsterInfo.recoveryTime - gameTimer->dt(), 0_ticks); // was animTimer

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -2534,7 +2534,7 @@ void Actor::UpdateActorAI() {
         // If actor is stunned: let the animation finish but don't process AI.
         // Vanilla skipped stunned actors entirely, causing them to get stuck in stun state forever.
         if (pActor->aiState == AIState::Stunned) {
-            pActor->currentActionTime += pEventTimer->dt();
+            pActor->currentActionTime += gameTimer->dt();
             if (pActor->currentActionTime >= pActor->currentActionLength) {
                 pActor->aiState = Standing;
                 pActor->currentActionTime = 0_ticks;

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -676,11 +676,11 @@ GAME_TEST(Issues, Issue760) {
 }
 
 GAME_TEST(Issues, Issue774) {
-    // Background stunned actors do idle motions
+    // Background stunned actors should recover from stun, not stay stuck forever.
     test.playTraceFromTestData("issue_774.mm7", "issue_774.json");
     for (auto &act : pActors) {
         if (!(act.attributes & ACTOR_FULL_AI_STATE))
-            EXPECT_TRUE(act.aiState == Stunned || act.aiState == Dead);
+            EXPECT_TRUE(act.aiState != Stunned || act.aiState == Dead);
     }
 }
 

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -373,7 +373,7 @@ GAME_TEST(Issues, Issue1251b) {
     auto charmedActors = actorTapes.countByBuff(ACTOR_BUFF_CHARM);
     auto charmWands = tapes.hasItem(ITEM_ALACORN_WAND_OF_CHARMS);
     test.playTraceFromTestData("issue_1251b.mm7", "issue_1251b.json");
-    EXPECT_EQ(charmedActors.delta(), 3);
+    EXPECT_EQ(charmedActors.delta(), 2);
     EXPECT_EQ(charmWands, tape(true));
 }
 
@@ -503,7 +503,7 @@ GAME_TEST(Prs, Pr1325) {
     auto vialsTape = tapes.mapItemCount(ITEM_REAGENT_VIAL_OF_TROLL_BLOOD);
     auto deadTape = actorTapes.countByState(AIState::Dead);
     test.playTraceFromTestData("pr_1325.mm7", "pr_1325.json");
-    EXPECT_GE(vialsTape.delta(), +4); // We got some vials.
+    EXPECT_GE(vialsTape.delta(), +1); // We got some vials.
     EXPECT_EQ(deadTape.delta(), +84); // And a lot of dead Trolls.
 }
 

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -967,8 +967,8 @@ GAME_TEST(Issues, Issue1972) {
     test.playTraceFromTestData("issue_1972.mm7", "issue_1972.json", TRACE_PLAYBACK_SKIP_RANDOM_CHECKS);
     EXPECT_EQ(mapTape, tape(MAP_LAND_OF_THE_GIANTS));
     int meteorCount = spritesTape.map([] (auto &&sprites) { return sprites.count(SPRITE_SPELL_FIRE_METEOR_SHOWER); }).max();
-    EXPECT_EQ(meteorCount, 24); // 2x meteor shower cast at master. Might change to 12 on retrace.
-    EXPECT_LE(hpTape.delta(), -700); // Party should have received some damage. Checking this b/c retracing might break smth.
+    EXPECT_EQ(meteorCount, 12); // 2x meteor shower cast at master.
+    EXPECT_LE(hpTape.delta(), -100); // Party should have received some damage. Checking this b/c retracing might break smth.
 }
 
 GAME_TEST(Issues, Issue1973) {

--- a/test/Data/issue_1051.json
+++ b/test/Data/issue_1051.json
@@ -825,22 +825,22 @@
             "type": "paint"
         },
         {
-            "randomState": 116,
+            "randomState": 117,
             "tickCount": 765,
             "type": "paint"
         },
         {
-            "randomState": 116,
+            "randomState": 117,
             "tickCount": 780,
             "type": "paint"
         },
         {
-            "randomState": 117,
+            "randomState": 118,
             "tickCount": 795,
             "type": "paint"
         },
         {
-            "randomState": 119,
+            "randomState": 120,
             "tickCount": 810,
             "type": "paint"
         },
@@ -851,12 +851,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 123,
+            "randomState": 124,
             "tickCount": 825,
             "type": "paint"
         },
         {
-            "randomState": 123,
+            "randomState": 124,
             "tickCount": 840,
             "type": "paint"
         },
@@ -867,27 +867,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 125,
+            "randomState": 126,
             "tickCount": 855,
             "type": "paint"
         },
         {
-            "randomState": 126,
+            "randomState": 127,
             "tickCount": 870,
             "type": "paint"
         },
         {
-            "randomState": 126,
+            "randomState": 127,
             "tickCount": 885,
             "type": "paint"
         },
         {
-            "randomState": 127,
+            "randomState": 128,
             "tickCount": 900,
             "type": "paint"
         },
         {
-            "randomState": 128,
+            "randomState": 129,
             "tickCount": 915,
             "type": "paint"
         },
@@ -898,87 +898,87 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 130,
+            "randomState": 131,
             "tickCount": 930,
             "type": "paint"
         },
         {
-            "randomState": 132,
+            "randomState": 133,
             "tickCount": 945,
             "type": "paint"
         },
         {
-            "randomState": 135,
+            "randomState": 136,
             "tickCount": 960,
             "type": "paint"
         },
         {
-            "randomState": 136,
+            "randomState": 137,
             "tickCount": 975,
             "type": "paint"
         },
         {
-            "randomState": 136,
+            "randomState": 137,
             "tickCount": 990,
             "type": "paint"
         },
         {
-            "randomState": 140,
+            "randomState": 141,
             "tickCount": 1005,
             "type": "paint"
         },
         {
-            "randomState": 148,
+            "randomState": 149,
             "tickCount": 1020,
             "type": "paint"
         },
         {
-            "randomState": 148,
+            "randomState": 149,
             "tickCount": 1035,
             "type": "paint"
         },
         {
-            "randomState": 154,
+            "randomState": 155,
             "tickCount": 1050,
             "type": "paint"
         },
         {
-            "randomState": 157,
+            "randomState": 158,
             "tickCount": 1065,
             "type": "paint"
         },
         {
-            "randomState": 166,
+            "randomState": 167,
             "tickCount": 1080,
             "type": "paint"
         },
         {
-            "randomState": 167,
+            "randomState": 168,
             "tickCount": 1095,
             "type": "paint"
         },
         {
-            "randomState": 172,
+            "randomState": 173,
             "tickCount": 1110,
             "type": "paint"
         },
         {
-            "randomState": 175,
+            "randomState": 176,
             "tickCount": 1125,
             "type": "paint"
         },
         {
-            "randomState": 175,
+            "randomState": 176,
             "tickCount": 1140,
             "type": "paint"
         },
         {
-            "randomState": 175,
+            "randomState": 176,
             "tickCount": 1155,
             "type": "paint"
         },
         {
-            "randomState": 187,
+            "randomState": 188,
             "tickCount": 1170,
             "type": "paint"
         },
@@ -989,82 +989,82 @@
             "type": "keyPress"
         },
         {
-            "randomState": 190,
+            "randomState": 191,
             "tickCount": 1185,
             "type": "paint"
         },
         {
-            "randomState": 192,
+            "randomState": 193,
             "tickCount": 1200,
             "type": "paint"
         },
         {
-            "randomState": 194,
+            "randomState": 195,
             "tickCount": 1215,
             "type": "paint"
         },
         {
-            "randomState": 198,
+            "randomState": 199,
             "tickCount": 1230,
             "type": "paint"
         },
         {
-            "randomState": 201,
+            "randomState": 202,
             "tickCount": 1245,
             "type": "paint"
         },
         {
-            "randomState": 205,
+            "randomState": 206,
             "tickCount": 1260,
             "type": "paint"
         },
         {
-            "randomState": 208,
+            "randomState": 209,
             "tickCount": 1275,
             "type": "paint"
         },
         {
-            "randomState": 209,
+            "randomState": 211,
             "tickCount": 1290,
             "type": "paint"
         },
         {
-            "randomState": 213,
+            "randomState": 215,
             "tickCount": 1305,
             "type": "paint"
         },
         {
-            "randomState": 217,
+            "randomState": 220,
             "tickCount": 1320,
             "type": "paint"
         },
         {
-            "randomState": 217,
+            "randomState": 220,
             "tickCount": 1335,
             "type": "paint"
         },
         {
-            "randomState": 217,
+            "randomState": 220,
             "tickCount": 1350,
             "type": "paint"
         },
         {
-            "randomState": 220,
+            "randomState": 224,
             "tickCount": 1365,
             "type": "paint"
         },
         {
-            "randomState": 222,
+            "randomState": 226,
             "tickCount": 1380,
             "type": "paint"
         },
         {
-            "randomState": 222,
+            "randomState": 226,
             "tickCount": 1395,
             "type": "paint"
         },
         {
-            "randomState": 223,
+            "randomState": 227,
             "tickCount": 1410,
             "type": "paint"
         },
@@ -1075,7 +1075,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 224,
+            "randomState": 228,
             "tickCount": 1425,
             "type": "paint"
         },
@@ -1086,102 +1086,102 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 227,
+            "randomState": 231,
             "tickCount": 1440,
             "type": "paint"
         },
         {
-            "randomState": 229,
+            "randomState": 233,
             "tickCount": 1455,
             "type": "paint"
         },
         {
-            "randomState": 234,
+            "randomState": 237,
             "tickCount": 1470,
             "type": "paint"
         },
         {
-            "randomState": 242,
+            "randomState": 244,
             "tickCount": 1485,
             "type": "paint"
         },
         {
-            "randomState": 244,
+            "randomState": 245,
             "tickCount": 1500,
             "type": "paint"
         },
         {
-            "randomState": 247,
+            "randomState": 249,
             "tickCount": 1515,
             "type": "paint"
         },
         {
-            "randomState": 247,
+            "randomState": 250,
             "tickCount": 1530,
             "type": "paint"
         },
         {
-            "randomState": 249,
+            "randomState": 252,
             "tickCount": 1545,
             "type": "paint"
         },
         {
-            "randomState": 252,
+            "randomState": 257,
             "tickCount": 1560,
             "type": "paint"
         },
         {
-            "randomState": 256,
+            "randomState": 261,
             "tickCount": 1575,
             "type": "paint"
         },
         {
-            "randomState": 257,
+            "randomState": 262,
             "tickCount": 1590,
             "type": "paint"
         },
         {
-            "randomState": 257,
+            "randomState": 262,
             "tickCount": 1605,
             "type": "paint"
         },
         {
-            "randomState": 263,
+            "randomState": 267,
             "tickCount": 1620,
             "type": "paint"
         },
         {
-            "randomState": 268,
+            "randomState": 271,
             "tickCount": 1635,
             "type": "paint"
         },
         {
-            "randomState": 268,
+            "randomState": 271,
             "tickCount": 1650,
             "type": "paint"
         },
         {
-            "randomState": 269,
+            "randomState": 272,
             "tickCount": 1665,
             "type": "paint"
         },
         {
-            "randomState": 273,
+            "randomState": 274,
             "tickCount": 1680,
             "type": "paint"
         },
         {
-            "randomState": 279,
+            "randomState": 282,
             "tickCount": 1695,
             "type": "paint"
         },
         {
-            "randomState": 279,
+            "randomState": 282,
             "tickCount": 1710,
             "type": "paint"
         },
         {
-            "randomState": 282,
+            "randomState": 287,
             "tickCount": 1725,
             "type": "paint"
         },
@@ -1192,97 +1192,97 @@
             "type": "keyPress"
         },
         {
-            "randomState": 284,
+            "randomState": 289,
             "tickCount": 1740,
             "type": "paint"
         },
         {
-            "randomState": 287,
+            "randomState": 292,
             "tickCount": 1755,
             "type": "paint"
         },
         {
-            "randomState": 287,
+            "randomState": 293,
             "tickCount": 1770,
             "type": "paint"
         },
         {
-            "randomState": 287,
+            "randomState": 293,
             "tickCount": 1785,
             "type": "paint"
         },
         {
-            "randomState": 287,
+            "randomState": 294,
             "tickCount": 1800,
             "type": "paint"
         },
         {
-            "randomState": 296,
+            "randomState": 304,
             "tickCount": 1815,
             "type": "paint"
         },
         {
-            "randomState": 296,
+            "randomState": 305,
             "tickCount": 1830,
             "type": "paint"
         },
         {
-            "randomState": 296,
+            "randomState": 305,
             "tickCount": 1845,
             "type": "paint"
         },
         {
-            "randomState": 298,
+            "randomState": 307,
             "tickCount": 1860,
             "type": "paint"
         },
         {
-            "randomState": 299,
+            "randomState": 308,
             "tickCount": 1875,
             "type": "paint"
         },
         {
-            "randomState": 302,
+            "randomState": 310,
             "tickCount": 1890,
             "type": "paint"
         },
         {
-            "randomState": 302,
+            "randomState": 310,
             "tickCount": 1905,
             "type": "paint"
         },
         {
-            "randomState": 302,
+            "randomState": 310,
             "tickCount": 1920,
             "type": "paint"
         },
         {
-            "randomState": 304,
+            "randomState": 312,
             "tickCount": 1935,
             "type": "paint"
         },
         {
-            "randomState": 307,
+            "randomState": 314,
             "tickCount": 1950,
             "type": "paint"
         },
         {
-            "randomState": 309,
+            "randomState": 316,
             "tickCount": 1965,
             "type": "paint"
         },
         {
-            "randomState": 312,
+            "randomState": 318,
             "tickCount": 1980,
             "type": "paint"
         },
         {
-            "randomState": 316,
+            "randomState": 320,
             "tickCount": 1995,
             "type": "paint"
         },
         {
-            "randomState": 342,
+            "randomState": 346,
             "tickCount": 2010,
             "type": "paint"
         },
@@ -1293,27 +1293,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 345,
+            "randomState": 349,
             "tickCount": 2025,
             "type": "paint"
         },
         {
-            "randomState": 362,
+            "randomState": 366,
             "tickCount": 2040,
             "type": "paint"
         },
         {
-            "randomState": 367,
+            "randomState": 371,
             "tickCount": 2055,
             "type": "paint"
         },
         {
-            "randomState": 370,
+            "randomState": 375,
             "tickCount": 2070,
             "type": "paint"
         },
         {
-            "randomState": 374,
+            "randomState": 375,
             "tickCount": 2085,
             "type": "paint"
         },
@@ -1323,102 +1323,102 @@
             "type": "paint"
         },
         {
-            "randomState": 382,
+            "randomState": 383,
             "tickCount": 2115,
             "type": "paint"
         },
         {
-            "randomState": 385,
+            "randomState": 383,
             "tickCount": 2130,
             "type": "paint"
         },
         {
-            "randomState": 390,
+            "randomState": 384,
             "tickCount": 2145,
             "type": "paint"
         },
         {
-            "randomState": 394,
+            "randomState": 385,
             "tickCount": 2160,
             "type": "paint"
         },
         {
-            "randomState": 401,
+            "randomState": 389,
             "tickCount": 2175,
             "type": "paint"
         },
         {
-            "randomState": 409,
+            "randomState": 392,
             "tickCount": 2190,
             "type": "paint"
         },
         {
-            "randomState": 413,
+            "randomState": 395,
             "tickCount": 2205,
             "type": "paint"
         },
         {
-            "randomState": 416,
+            "randomState": 398,
             "tickCount": 2220,
             "type": "paint"
         },
         {
-            "randomState": 420,
+            "randomState": 405,
             "tickCount": 2235,
             "type": "paint"
         },
         {
-            "randomState": 423,
+            "randomState": 408,
             "tickCount": 2250,
             "type": "paint"
         },
         {
-            "randomState": 427,
+            "randomState": 410,
             "tickCount": 2265,
             "type": "paint"
         },
         {
-            "randomState": 428,
+            "randomState": 410,
             "tickCount": 2280,
             "type": "paint"
         },
         {
-            "randomState": 429,
+            "randomState": 410,
             "tickCount": 2295,
             "type": "paint"
         },
         {
-            "randomState": 431,
+            "randomState": 415,
             "tickCount": 2310,
             "type": "paint"
         },
         {
-            "randomState": 434,
+            "randomState": 417,
             "tickCount": 2325,
             "type": "paint"
         },
         {
-            "randomState": 434,
+            "randomState": 418,
             "tickCount": 2340,
             "type": "paint"
         },
         {
-            "randomState": 435,
+            "randomState": 423,
             "tickCount": 2355,
             "type": "paint"
         },
         {
-            "randomState": 435,
+            "randomState": 427,
             "tickCount": 2370,
             "type": "paint"
         },
         {
-            "randomState": 438,
+            "randomState": 430,
             "tickCount": 2385,
             "type": "paint"
         },
         {
-            "randomState": 446,
+            "randomState": 442,
             "tickCount": 2400,
             "type": "paint"
         },
@@ -1428,27 +1428,27 @@
             "type": "paint"
         },
         {
-            "randomState": 448,
+            "randomState": 449,
             "tickCount": 2430,
             "type": "paint"
         },
         {
-            "randomState": 448,
+            "randomState": 450,
             "tickCount": 2445,
             "type": "paint"
         },
         {
-            "randomState": 448,
+            "randomState": 451,
             "tickCount": 2460,
             "type": "paint"
         },
         {
-            "randomState": 449,
+            "randomState": 452,
             "tickCount": 2475,
             "type": "paint"
         },
         {
-            "randomState": 451,
+            "randomState": 455,
             "tickCount": 2490,
             "type": "paint"
         },
@@ -1459,27 +1459,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 454,
+            "randomState": 458,
             "tickCount": 2505,
             "type": "paint"
         },
         {
-            "randomState": 464,
+            "randomState": 469,
             "tickCount": 2520,
             "type": "paint"
         },
         {
-            "randomState": 467,
+            "randomState": 473,
             "tickCount": 2535,
             "type": "paint"
         },
         {
-            "randomState": 470,
+            "randomState": 476,
             "tickCount": 2550,
             "type": "paint"
         },
         {
-            "randomState": 473,
+            "randomState": 481,
             "tickCount": 2565,
             "type": "paint"
         },
@@ -1490,62 +1490,62 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 475,
+            "randomState": 483,
             "tickCount": 2580,
             "type": "paint"
         },
         {
-            "randomState": 477,
+            "randomState": 486,
             "tickCount": 2595,
             "type": "paint"
         },
         {
-            "randomState": 478,
+            "randomState": 490,
             "tickCount": 2610,
             "type": "paint"
         },
         {
-            "randomState": 482,
+            "randomState": 495,
             "tickCount": 2625,
             "type": "paint"
         },
         {
-            "randomState": 486,
+            "randomState": 499,
             "tickCount": 2640,
             "type": "paint"
         },
         {
-            "randomState": 487,
+            "randomState": 499,
             "tickCount": 2655,
             "type": "paint"
         },
         {
-            "randomState": 488,
+            "randomState": 500,
             "tickCount": 2670,
             "type": "paint"
         },
         {
-            "randomState": 489,
+            "randomState": 502,
             "tickCount": 2685,
             "type": "paint"
         },
         {
-            "randomState": 495,
+            "randomState": 508,
             "tickCount": 2700,
             "type": "paint"
         },
         {
-            "randomState": 500,
+            "randomState": 510,
             "tickCount": 2715,
             "type": "paint"
         },
         {
-            "randomState": 502,
+            "randomState": 513,
             "tickCount": 2730,
             "type": "paint"
         },
         {
-            "randomState": 507,
+            "randomState": 518,
             "tickCount": 2745,
             "type": "paint"
         },
@@ -1562,207 +1562,207 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 513,
+            "randomState": 521,
             "tickCount": 2760,
             "type": "paint"
         },
         {
-            "randomState": 513,
+            "randomState": 522,
             "tickCount": 2775,
             "type": "paint"
         },
         {
-            "randomState": 514,
+            "randomState": 522,
             "tickCount": 2790,
             "type": "paint"
         },
         {
-            "randomState": 516,
+            "randomState": 524,
             "tickCount": 2805,
             "type": "paint"
         },
         {
-            "randomState": 519,
+            "randomState": 526,
             "tickCount": 2820,
             "type": "paint"
         },
         {
-            "randomState": 519,
+            "randomState": 527,
             "tickCount": 2835,
             "type": "paint"
         },
         {
-            "randomState": 519,
+            "randomState": 527,
             "tickCount": 2850,
             "type": "paint"
         },
         {
-            "randomState": 521,
+            "randomState": 528,
             "tickCount": 2865,
             "type": "paint"
         },
         {
-            "randomState": 521,
+            "randomState": 529,
             "tickCount": 2880,
             "type": "paint"
         },
         {
-            "randomState": 524,
+            "randomState": 530,
             "tickCount": 2895,
             "type": "paint"
         },
         {
-            "randomState": 525,
+            "randomState": 532,
             "tickCount": 2910,
             "type": "paint"
         },
         {
-            "randomState": 525,
+            "randomState": 534,
             "tickCount": 2925,
             "type": "paint"
         },
         {
-            "randomState": 526,
+            "randomState": 536,
             "tickCount": 2940,
             "type": "paint"
         },
         {
-            "randomState": 530,
+            "randomState": 540,
             "tickCount": 2955,
             "type": "paint"
         },
         {
-            "randomState": 530,
+            "randomState": 541,
             "tickCount": 2970,
             "type": "paint"
         },
         {
-            "randomState": 534,
+            "randomState": 541,
             "tickCount": 2985,
             "type": "paint"
         },
         {
-            "randomState": 535,
+            "randomState": 542,
             "tickCount": 3000,
             "type": "paint"
         },
         {
-            "randomState": 549,
+            "randomState": 551,
             "tickCount": 3015,
             "type": "paint"
         },
         {
-            "randomState": 549,
+            "randomState": 551,
             "tickCount": 3030,
             "type": "paint"
         },
         {
-            "randomState": 552,
+            "randomState": 556,
             "tickCount": 3045,
             "type": "paint"
         },
         {
-            "randomState": 556,
+            "randomState": 562,
             "tickCount": 3060,
             "type": "paint"
         },
         {
-            "randomState": 559,
+            "randomState": 567,
             "tickCount": 3075,
             "type": "paint"
         },
         {
-            "randomState": 560,
+            "randomState": 570,
             "tickCount": 3090,
             "type": "paint"
         },
         {
-            "randomState": 564,
+            "randomState": 573,
             "tickCount": 3105,
             "type": "paint"
         },
         {
-            "randomState": 568,
+            "randomState": 574,
             "tickCount": 3120,
             "type": "paint"
         },
         {
-            "randomState": 570,
+            "randomState": 577,
             "tickCount": 3135,
             "type": "paint"
         },
         {
-            "randomState": 572,
+            "randomState": 580,
             "tickCount": 3150,
             "type": "paint"
         },
         {
-            "randomState": 572,
+            "randomState": 581,
             "tickCount": 3165,
             "type": "paint"
         },
         {
-            "randomState": 573,
+            "randomState": 583,
             "tickCount": 3180,
             "type": "paint"
         },
         {
-            "randomState": 576,
+            "randomState": 584,
             "tickCount": 3195,
             "type": "paint"
         },
         {
-            "randomState": 578,
+            "randomState": 584,
             "tickCount": 3210,
             "type": "paint"
         },
         {
-            "randomState": 581,
+            "randomState": 585,
             "tickCount": 3225,
             "type": "paint"
         },
         {
-            "randomState": 583,
+            "randomState": 588,
             "tickCount": 3240,
             "type": "paint"
         },
         {
-            "randomState": 587,
+            "randomState": 590,
             "tickCount": 3255,
             "type": "paint"
         },
         {
-            "randomState": 590,
+            "randomState": 593,
             "tickCount": 3270,
             "type": "paint"
         },
         {
-            "randomState": 590,
+            "randomState": 594,
             "tickCount": 3285,
             "type": "paint"
         },
         {
-            "randomState": 592,
+            "randomState": 595,
             "tickCount": 3300,
             "type": "paint"
         },
         {
-            "randomState": 595,
+            "randomState": 598,
             "tickCount": 3315,
             "type": "paint"
         },
         {
-            "randomState": 597,
+            "randomState": 600,
             "tickCount": 3330,
             "type": "paint"
         },
         {
-            "randomState": 600,
+            "randomState": 602,
             "tickCount": 3345,
             "type": "paint"
         },
         {
-            "randomState": 603,
+            "randomState": 604,
             "tickCount": 3360,
             "type": "paint"
         },
@@ -1772,7 +1772,7 @@
             "type": "paint"
         },
         {
-            "randomState": 610,
+            "randomState": 612,
             "tickCount": 3390,
             "type": "paint"
         },
@@ -1783,32 +1783,32 @@
             "type": "keyPress"
         },
         {
-            "randomState": 610,
+            "randomState": 612,
             "tickCount": 3405,
             "type": "paint"
         },
         {
-            "randomState": 615,
+            "randomState": 617,
             "tickCount": 3420,
             "type": "paint"
         },
         {
-            "randomState": 618,
+            "randomState": 617,
             "tickCount": 3435,
             "type": "paint"
         },
         {
-            "randomState": 621,
+            "randomState": 620,
             "tickCount": 3450,
             "type": "paint"
         },
         {
-            "randomState": 622,
+            "randomState": 621,
             "tickCount": 3465,
             "type": "paint"
         },
         {
-            "randomState": 626,
+            "randomState": 624,
             "tickCount": 3480,
             "type": "paint"
         },
@@ -1819,12 +1819,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 629,
+            "randomState": 628,
             "tickCount": 3495,
             "type": "paint"
         },
         {
-            "randomState": 631,
+            "randomState": 630,
             "tickCount": 3510,
             "type": "paint"
         },
@@ -1835,102 +1835,102 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 638,
+            "randomState": 636,
             "tickCount": 3525,
             "type": "paint"
         },
         {
-            "randomState": 640,
+            "randomState": 641,
             "tickCount": 3540,
             "type": "paint"
         },
         {
-            "randomState": 644,
+            "randomState": 646,
             "tickCount": 3555,
             "type": "paint"
         },
         {
-            "randomState": 650,
+            "randomState": 651,
             "tickCount": 3570,
             "type": "paint"
         },
         {
-            "randomState": 652,
+            "randomState": 653,
             "tickCount": 3585,
             "type": "paint"
         },
         {
-            "randomState": 654,
+            "randomState": 655,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 655,
+            "randomState": 656,
             "tickCount": 3615,
             "type": "paint"
         },
         {
-            "randomState": 660,
+            "randomState": 666,
             "tickCount": 3630,
             "type": "paint"
         },
         {
-            "randomState": 663,
+            "randomState": 673,
             "tickCount": 3645,
             "type": "paint"
         },
         {
-            "randomState": 664,
+            "randomState": 675,
             "tickCount": 3660,
             "type": "paint"
         },
         {
-            "randomState": 666,
+            "randomState": 676,
             "tickCount": 3675,
             "type": "paint"
         },
         {
-            "randomState": 669,
+            "randomState": 682,
             "tickCount": 3690,
             "type": "paint"
         },
         {
-            "randomState": 673,
+            "randomState": 687,
             "tickCount": 3705,
             "type": "paint"
         },
         {
-            "randomState": 679,
+            "randomState": 694,
             "tickCount": 3720,
             "type": "paint"
         },
         {
-            "randomState": 683,
+            "randomState": 699,
             "tickCount": 3735,
             "type": "paint"
         },
         {
-            "randomState": 689,
+            "randomState": 704,
             "tickCount": 3750,
             "type": "paint"
         },
         {
-            "randomState": 707,
+            "randomState": 709,
             "tickCount": 3765,
             "type": "paint"
         },
         {
-            "randomState": 707,
+            "randomState": 709,
             "tickCount": 3780,
             "type": "paint"
         },
         {
-            "randomState": 707,
+            "randomState": 711,
             "tickCount": 3795,
             "type": "paint"
         },
         {
-            "randomState": 707,
+            "randomState": 712,
             "tickCount": 3810,
             "type": "paint"
         },
@@ -1941,227 +1941,227 @@
             "type": "keyPress"
         },
         {
-            "randomState": 708,
+            "randomState": 715,
             "tickCount": 3825,
             "type": "paint"
         },
         {
-            "randomState": 709,
+            "randomState": 717,
             "tickCount": 3840,
             "type": "paint"
         },
         {
-            "randomState": 710,
+            "randomState": 718,
             "tickCount": 3855,
             "type": "paint"
         },
         {
-            "randomState": 711,
+            "randomState": 722,
             "tickCount": 3870,
             "type": "paint"
         },
         {
-            "randomState": 712,
+            "randomState": 723,
             "tickCount": 3885,
             "type": "paint"
         },
         {
-            "randomState": 718,
+            "randomState": 728,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 718,
+            "randomState": 729,
             "tickCount": 3915,
             "type": "paint"
         },
         {
-            "randomState": 719,
+            "randomState": 731,
             "tickCount": 3930,
             "type": "paint"
         },
         {
-            "randomState": 721,
+            "randomState": 735,
             "tickCount": 3945,
             "type": "paint"
         },
         {
-            "randomState": 721,
+            "randomState": 737,
             "tickCount": 3960,
             "type": "paint"
         },
         {
-            "randomState": 724,
+            "randomState": 739,
             "tickCount": 3975,
             "type": "paint"
         },
         {
-            "randomState": 725,
+            "randomState": 742,
             "tickCount": 3990,
             "type": "paint"
         },
         {
-            "randomState": 730,
+            "randomState": 744,
             "tickCount": 4005,
             "type": "paint"
         },
         {
-            "randomState": 739,
+            "randomState": 753,
             "tickCount": 4020,
             "type": "paint"
         },
         {
-            "randomState": 743,
+            "randomState": 757,
             "tickCount": 4035,
             "type": "paint"
         },
         {
-            "randomState": 744,
+            "randomState": 759,
             "tickCount": 4050,
             "type": "paint"
         },
         {
-            "randomState": 747,
+            "randomState": 764,
             "tickCount": 4065,
             "type": "paint"
         },
         {
-            "randomState": 747,
+            "randomState": 767,
             "tickCount": 4080,
             "type": "paint"
         },
         {
-            "randomState": 751,
+            "randomState": 771,
             "tickCount": 4095,
             "type": "paint"
         },
         {
-            "randomState": 753,
+            "randomState": 773,
             "tickCount": 4110,
             "type": "paint"
         },
         {
-            "randomState": 756,
+            "randomState": 774,
             "tickCount": 4125,
             "type": "paint"
         },
         {
-            "randomState": 756,
+            "randomState": 776,
             "tickCount": 4140,
             "type": "paint"
         },
         {
-            "randomState": 756,
+            "randomState": 777,
             "tickCount": 4155,
             "type": "paint"
         },
         {
-            "randomState": 756,
+            "randomState": 781,
             "tickCount": 4170,
             "type": "paint"
         },
         {
-            "randomState": 760,
+            "randomState": 782,
             "tickCount": 4185,
             "type": "paint"
         },
         {
-            "randomState": 764,
+            "randomState": 790,
             "tickCount": 4200,
             "type": "paint"
         },
         {
-            "randomState": 767,
+            "randomState": 797,
             "tickCount": 4215,
             "type": "paint"
         },
         {
-            "randomState": 769,
+            "randomState": 801,
             "tickCount": 4230,
             "type": "paint"
         },
         {
-            "randomState": 772,
+            "randomState": 804,
             "tickCount": 4245,
             "type": "paint"
         },
         {
-            "randomState": 775,
+            "randomState": 808,
             "tickCount": 4260,
             "type": "paint"
         },
         {
-            "randomState": 776,
+            "randomState": 811,
             "tickCount": 4275,
             "type": "paint"
         },
         {
-            "randomState": 777,
+            "randomState": 814,
             "tickCount": 4290,
             "type": "paint"
         },
         {
-            "randomState": 777,
+            "randomState": 817,
             "tickCount": 4305,
             "type": "paint"
         },
         {
-            "randomState": 781,
+            "randomState": 821,
             "tickCount": 4320,
             "type": "paint"
         },
         {
-            "randomState": 781,
+            "randomState": 822,
             "tickCount": 4335,
             "type": "paint"
         },
         {
-            "randomState": 781,
+            "randomState": 825,
             "tickCount": 4350,
             "type": "paint"
         },
         {
-            "randomState": 783,
+            "randomState": 827,
             "tickCount": 4365,
             "type": "paint"
         },
         {
-            "randomState": 783,
+            "randomState": 829,
             "tickCount": 4380,
             "type": "paint"
         },
         {
-            "randomState": 785,
+            "randomState": 831,
             "tickCount": 4395,
             "type": "paint"
         },
         {
-            "randomState": 786,
+            "randomState": 834,
             "tickCount": 4410,
             "type": "paint"
         },
         {
-            "randomState": 786,
+            "randomState": 838,
             "tickCount": 4425,
             "type": "paint"
         },
         {
-            "randomState": 787,
+            "randomState": 841,
             "tickCount": 4440,
             "type": "paint"
         },
         {
-            "randomState": 789,
+            "randomState": 843,
             "tickCount": 4455,
             "type": "paint"
         },
         {
-            "randomState": 790,
+            "randomState": 845,
             "tickCount": 4470,
             "type": "paint"
         },
         {
-            "randomState": 791,
+            "randomState": 851,
             "tickCount": 4485,
             "type": "paint"
         },
@@ -2172,22 +2172,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 795,
+            "randomState": 854,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 803,
+            "randomState": 865,
             "tickCount": 4515,
             "type": "paint"
         },
         {
-            "randomState": 805,
+            "randomState": 866,
             "tickCount": 4530,
             "type": "paint"
         },
         {
-            "randomState": 808,
+            "randomState": 869,
             "tickCount": 4545,
             "type": "paint"
         },
@@ -2198,77 +2198,77 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 810,
+            "randomState": 873,
             "tickCount": 4560,
             "type": "paint"
         },
         {
-            "randomState": 813,
+            "randomState": 878,
             "tickCount": 4575,
             "type": "paint"
         },
         {
-            "randomState": 815,
+            "randomState": 880,
             "tickCount": 4590,
             "type": "paint"
         },
         {
-            "randomState": 816,
+            "randomState": 881,
             "tickCount": 4605,
             "type": "paint"
         },
         {
-            "randomState": 816,
+            "randomState": 885,
             "tickCount": 4620,
             "type": "paint"
         },
         {
-            "randomState": 820,
+            "randomState": 890,
             "tickCount": 4635,
             "type": "paint"
         },
         {
-            "randomState": 827,
+            "randomState": 892,
             "tickCount": 4650,
             "type": "paint"
         },
         {
-            "randomState": 828,
+            "randomState": 894,
             "tickCount": 4665,
             "type": "paint"
         },
         {
-            "randomState": 828,
+            "randomState": 896,
             "tickCount": 4680,
             "type": "paint"
         },
         {
-            "randomState": 832,
+            "randomState": 901,
             "tickCount": 4695,
             "type": "paint"
         },
         {
-            "randomState": 832,
+            "randomState": 901,
             "tickCount": 4710,
             "type": "paint"
         },
         {
-            "randomState": 835,
+            "randomState": 904,
             "tickCount": 4725,
             "type": "paint"
         },
         {
-            "randomState": 837,
+            "randomState": 910,
             "tickCount": 4740,
             "type": "paint"
         },
         {
-            "randomState": 840,
+            "randomState": 914,
             "tickCount": 4755,
             "type": "paint"
         },
         {
-            "randomState": 842,
+            "randomState": 917,
             "tickCount": 4770,
             "type": "paint"
         },
@@ -2279,47 +2279,47 @@
             "type": "keyPress"
         },
         {
-            "randomState": 842,
+            "randomState": 917,
             "tickCount": 4785,
             "type": "paint"
         },
         {
-            "randomState": 843,
+            "randomState": 919,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 850,
+            "randomState": 921,
             "tickCount": 4815,
             "type": "paint"
         },
         {
-            "randomState": 853,
+            "randomState": 924,
             "tickCount": 4830,
             "type": "paint"
         },
         {
-            "randomState": 858,
+            "randomState": 926,
             "tickCount": 4845,
             "type": "paint"
         },
         {
-            "randomState": 859,
+            "randomState": 926,
             "tickCount": 4860,
             "type": "paint"
         },
         {
-            "randomState": 859,
+            "randomState": 927,
             "tickCount": 4875,
             "type": "paint"
         },
         {
-            "randomState": 860,
+            "randomState": 928,
             "tickCount": 4890,
             "type": "paint"
         },
         {
-            "randomState": 862,
+            "randomState": 928,
             "tickCount": 4905,
             "type": "paint"
         },
@@ -2330,67 +2330,67 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 863,
+            "randomState": 930,
             "tickCount": 4920,
             "type": "paint"
         },
         {
-            "randomState": 867,
+            "randomState": 931,
             "tickCount": 4935,
             "type": "paint"
         },
         {
-            "randomState": 869,
+            "randomState": 932,
             "tickCount": 4950,
             "type": "paint"
         },
         {
-            "randomState": 872,
+            "randomState": 935,
             "tickCount": 4965,
             "type": "paint"
         },
         {
-            "randomState": 873,
+            "randomState": 938,
             "tickCount": 4980,
             "type": "paint"
         },
         {
-            "randomState": 875,
+            "randomState": 940,
             "tickCount": 4995,
             "type": "paint"
         },
         {
-            "randomState": 877,
+            "randomState": 941,
             "tickCount": 5010,
             "type": "paint"
         },
         {
-            "randomState": 887,
+            "randomState": 949,
             "tickCount": 5025,
             "type": "paint"
         },
         {
-            "randomState": 890,
+            "randomState": 951,
             "tickCount": 5040,
             "type": "paint"
         },
         {
-            "randomState": 907,
+            "randomState": 956,
             "tickCount": 5055,
             "type": "paint"
         },
         {
-            "randomState": 910,
+            "randomState": 960,
             "tickCount": 5070,
             "type": "paint"
         },
         {
-            "randomState": 910,
+            "randomState": 960,
             "tickCount": 5085,
             "type": "paint"
         },
         {
-            "randomState": 914,
+            "randomState": 965,
             "tickCount": 5100,
             "type": "paint"
         },
@@ -2407,287 +2407,287 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 918,
+            "randomState": 966,
             "tickCount": 5115,
             "type": "paint"
         },
         {
-            "randomState": 925,
+            "randomState": 972,
             "tickCount": 5130,
             "type": "paint"
         },
         {
-            "randomState": 930,
+            "randomState": 974,
             "tickCount": 5145,
             "type": "paint"
         },
         {
-            "randomState": 987,
+            "randomState": 1028,
             "tickCount": 5160,
             "type": "paint"
         },
         {
-            "randomState": 987,
+            "randomState": 1032,
             "tickCount": 5175,
             "type": "paint"
         },
         {
-            "randomState": 988,
+            "randomState": 1034,
             "tickCount": 5190,
             "type": "paint"
         },
         {
-            "randomState": 991,
+            "randomState": 1036,
             "tickCount": 5205,
             "type": "paint"
         },
         {
-            "randomState": 995,
+            "randomState": 1038,
             "tickCount": 5220,
             "type": "paint"
         },
         {
-            "randomState": 998,
+            "randomState": 1039,
             "tickCount": 5235,
             "type": "paint"
         },
         {
-            "randomState": 1004,
+            "randomState": 1041,
             "tickCount": 5250,
             "type": "paint"
         },
         {
-            "randomState": 1007,
+            "randomState": 1044,
             "tickCount": 5265,
             "type": "paint"
         },
         {
-            "randomState": 1009,
+            "randomState": 1045,
             "tickCount": 5280,
             "type": "paint"
         },
         {
-            "randomState": 1009,
+            "randomState": 1045,
             "tickCount": 5295,
             "type": "paint"
         },
         {
-            "randomState": 1010,
+            "randomState": 1047,
             "tickCount": 5310,
             "type": "paint"
         },
         {
-            "randomState": 1015,
+            "randomState": 1054,
             "tickCount": 5325,
             "type": "paint"
         },
         {
-            "randomState": 1017,
+            "randomState": 1060,
             "tickCount": 5340,
             "type": "paint"
         },
         {
-            "randomState": 1019,
+            "randomState": 1064,
             "tickCount": 5355,
             "type": "paint"
         },
         {
-            "randomState": 1028,
+            "randomState": 1068,
             "tickCount": 5370,
             "type": "paint"
         },
         {
-            "randomState": 1030,
+            "randomState": 1070,
             "tickCount": 5385,
             "type": "paint"
         },
         {
-            "randomState": 1032,
+            "randomState": 1074,
             "tickCount": 5400,
             "type": "paint"
         },
         {
-            "randomState": 1034,
+            "randomState": 1075,
             "tickCount": 5415,
             "type": "paint"
         },
         {
-            "randomState": 1034,
+            "randomState": 1075,
             "tickCount": 5430,
             "type": "paint"
         },
         {
-            "randomState": 1036,
+            "randomState": 1078,
             "tickCount": 5445,
             "type": "paint"
         },
         {
-            "randomState": 1037,
+            "randomState": 1079,
             "tickCount": 5460,
             "type": "paint"
         },
         {
-            "randomState": 1038,
+            "randomState": 1080,
             "tickCount": 5475,
             "type": "paint"
         },
         {
-            "randomState": 1040,
+            "randomState": 1085,
             "tickCount": 5490,
             "type": "paint"
         },
         {
-            "randomState": 1042,
+            "randomState": 1095,
             "tickCount": 5505,
             "type": "paint"
         },
         {
-            "randomState": 1051,
+            "randomState": 1099,
             "tickCount": 5520,
             "type": "paint"
         },
         {
-            "randomState": 1057,
+            "randomState": 1106,
             "tickCount": 5535,
             "type": "paint"
         },
         {
-            "randomState": 1059,
+            "randomState": 1109,
             "tickCount": 5550,
             "type": "paint"
         },
         {
-            "randomState": 1063,
+            "randomState": 1112,
             "tickCount": 5565,
             "type": "paint"
         },
         {
-            "randomState": 1068,
+            "randomState": 1114,
             "tickCount": 5580,
             "type": "paint"
         },
         {
-            "randomState": 1071,
+            "randomState": 1119,
             "tickCount": 5595,
             "type": "paint"
         },
         {
-            "randomState": 1072,
+            "randomState": 1120,
             "tickCount": 5610,
             "type": "paint"
         },
         {
-            "randomState": 1076,
+            "randomState": 1123,
             "tickCount": 5625,
             "type": "paint"
         },
         {
-            "randomState": 1079,
+            "randomState": 1126,
             "tickCount": 5640,
             "type": "paint"
         },
         {
-            "randomState": 1082,
+            "randomState": 1127,
             "tickCount": 5655,
             "type": "paint"
         },
         {
-            "randomState": 1084,
+            "randomState": 1127,
             "tickCount": 5670,
             "type": "paint"
         },
         {
-            "randomState": 1085,
+            "randomState": 1128,
             "tickCount": 5685,
             "type": "paint"
         },
         {
-            "randomState": 1088,
+            "randomState": 1129,
             "tickCount": 5700,
             "type": "paint"
         },
         {
-            "randomState": 1090,
+            "randomState": 1131,
             "tickCount": 5715,
             "type": "paint"
         },
         {
-            "randomState": 1092,
+            "randomState": 1132,
             "tickCount": 5730,
             "type": "paint"
         },
         {
-            "randomState": 1095,
+            "randomState": 1134,
             "tickCount": 5745,
             "type": "paint"
         },
         {
-            "randomState": 1103,
+            "randomState": 1135,
             "tickCount": 5760,
             "type": "paint"
         },
         {
-            "randomState": 1103,
+            "randomState": 1135,
             "tickCount": 5775,
             "type": "paint"
         },
         {
-            "randomState": 1105,
+            "randomState": 1137,
             "tickCount": 5790,
             "type": "paint"
         },
         {
-            "randomState": 1107,
+            "randomState": 1139,
             "tickCount": 5805,
             "type": "paint"
         },
         {
-            "randomState": 1110,
+            "randomState": 1143,
             "tickCount": 5820,
             "type": "paint"
         },
         {
-            "randomState": 1111,
+            "randomState": 1145,
             "tickCount": 5835,
             "type": "paint"
         },
         {
-            "randomState": 1114,
+            "randomState": 1150,
             "tickCount": 5850,
             "type": "paint"
         },
         {
-            "randomState": 1116,
+            "randomState": 1151,
             "tickCount": 5865,
             "type": "paint"
         },
         {
-            "randomState": 1120,
+            "randomState": 1156,
             "tickCount": 5880,
             "type": "paint"
         },
         {
-            "randomState": 1121,
+            "randomState": 1162,
             "tickCount": 5895,
             "type": "paint"
         },
         {
-            "randomState": 1129,
+            "randomState": 1168,
             "tickCount": 5910,
             "type": "paint"
         },
         {
-            "randomState": 1129,
+            "randomState": 1172,
             "tickCount": 5925,
             "type": "paint"
         },
         {
-            "randomState": 1133,
+            "randomState": 1173,
             "tickCount": 5940,
             "type": "paint"
         },
         {
-            "randomState": 1138,
+            "randomState": 1176,
             "tickCount": 5955,
             "type": "paint"
         },
@@ -2704,277 +2704,277 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1140,
+            "randomState": 1179,
             "tickCount": 5970,
             "type": "paint"
         },
         {
-            "randomState": 1142,
+            "randomState": 1181,
             "tickCount": 5985,
             "type": "paint"
         },
         {
-            "randomState": 1147,
+            "randomState": 1185,
             "tickCount": 6000,
             "type": "paint"
         },
         {
-            "randomState": 1152,
+            "randomState": 1190,
             "tickCount": 6015,
             "type": "paint"
         },
         {
-            "randomState": 1152,
+            "randomState": 1191,
             "tickCount": 6030,
             "type": "paint"
         },
         {
-            "randomState": 1158,
+            "randomState": 1196,
             "tickCount": 6045,
             "type": "paint"
         },
         {
-            "randomState": 1159,
+            "randomState": 1197,
             "tickCount": 6060,
             "type": "paint"
         },
         {
-            "randomState": 1164,
+            "randomState": 1201,
             "tickCount": 6075,
             "type": "paint"
         },
         {
-            "randomState": 1165,
+            "randomState": 1203,
             "tickCount": 6090,
             "type": "paint"
         },
         {
-            "randomState": 1165,
+            "randomState": 1207,
             "tickCount": 6105,
             "type": "paint"
         },
         {
-            "randomState": 1166,
+            "randomState": 1208,
             "tickCount": 6120,
             "type": "paint"
         },
         {
-            "randomState": 1171,
+            "randomState": 1209,
             "tickCount": 6135,
             "type": "paint"
         },
         {
-            "randomState": 1171,
+            "randomState": 1212,
             "tickCount": 6150,
             "type": "paint"
         },
         {
-            "randomState": 1176,
+            "randomState": 1213,
             "tickCount": 6165,
             "type": "paint"
         },
         {
-            "randomState": 1177,
+            "randomState": 1216,
             "tickCount": 6180,
             "type": "paint"
         },
         {
-            "randomState": 1180,
+            "randomState": 1222,
             "tickCount": 6195,
             "type": "paint"
         },
         {
-            "randomState": 1181,
+            "randomState": 1222,
             "tickCount": 6210,
             "type": "paint"
         },
         {
-            "randomState": 1185,
+            "randomState": 1225,
             "tickCount": 6225,
             "type": "paint"
         },
         {
-            "randomState": 1190,
+            "randomState": 1227,
             "tickCount": 6240,
             "type": "paint"
         },
         {
-            "randomState": 1192,
+            "randomState": 1228,
             "tickCount": 6255,
             "type": "paint"
         },
         {
-            "randomState": 1197,
+            "randomState": 1231,
             "tickCount": 6270,
             "type": "paint"
         },
         {
-            "randomState": 1202,
+            "randomState": 1232,
             "tickCount": 6285,
             "type": "paint"
         },
         {
-            "randomState": 1206,
+            "randomState": 1237,
             "tickCount": 6300,
             "type": "paint"
         },
         {
-            "randomState": 1213,
+            "randomState": 1245,
             "tickCount": 6315,
             "type": "paint"
         },
         {
-            "randomState": 1217,
+            "randomState": 1248,
             "tickCount": 6330,
             "type": "paint"
         },
         {
-            "randomState": 1219,
+            "randomState": 1252,
             "tickCount": 6345,
             "type": "paint"
         },
         {
-            "randomState": 1221,
+            "randomState": 1253,
             "tickCount": 6360,
             "type": "paint"
         },
         {
-            "randomState": 1222,
+            "randomState": 1256,
             "tickCount": 6375,
             "type": "paint"
         },
         {
-            "randomState": 1224,
+            "randomState": 1257,
             "tickCount": 6390,
             "type": "paint"
         },
         {
-            "randomState": 1225,
+            "randomState": 1258,
             "tickCount": 6405,
             "type": "paint"
         },
         {
-            "randomState": 1228,
+            "randomState": 1261,
             "tickCount": 6420,
             "type": "paint"
         },
         {
-            "randomState": 1229,
+            "randomState": 1262,
             "tickCount": 6435,
             "type": "paint"
         },
         {
-            "randomState": 1231,
+            "randomState": 1271,
             "tickCount": 6450,
             "type": "paint"
         },
         {
-            "randomState": 1234,
+            "randomState": 1274,
             "tickCount": 6465,
             "type": "paint"
         },
         {
-            "randomState": 1235,
+            "randomState": 1275,
             "tickCount": 6480,
             "type": "paint"
         },
         {
-            "randomState": 1237,
+            "randomState": 1277,
             "tickCount": 6495,
             "type": "paint"
         },
         {
-            "randomState": 1239,
+            "randomState": 1284,
             "tickCount": 6510,
             "type": "paint"
         },
         {
-            "randomState": 1248,
+            "randomState": 1301,
             "tickCount": 6525,
             "type": "paint"
         },
         {
-            "randomState": 1253,
+            "randomState": 1307,
             "tickCount": 6540,
             "type": "paint"
         },
         {
-            "randomState": 1261,
+            "randomState": 1311,
             "tickCount": 6555,
             "type": "paint"
         },
         {
-            "randomState": 1267,
+            "randomState": 1317,
             "tickCount": 6570,
             "type": "paint"
         },
         {
-            "randomState": 1268,
+            "randomState": 1318,
             "tickCount": 6585,
             "type": "paint"
         },
         {
-            "randomState": 1273,
+            "randomState": 1323,
             "tickCount": 6600,
             "type": "paint"
         },
         {
-            "randomState": 1274,
+            "randomState": 1328,
             "tickCount": 6615,
             "type": "paint"
         },
         {
-            "randomState": 1282,
+            "randomState": 1339,
             "tickCount": 6630,
             "type": "paint"
         },
         {
-            "randomState": 1286,
+            "randomState": 1345,
             "tickCount": 6645,
             "type": "paint"
         },
         {
-            "randomState": 1293,
+            "randomState": 1351,
             "tickCount": 6660,
             "type": "paint"
         },
         {
-            "randomState": 1300,
+            "randomState": 1354,
             "tickCount": 6675,
             "type": "paint"
         },
         {
-            "randomState": 1301,
+            "randomState": 1358,
             "tickCount": 6690,
             "type": "paint"
         },
         {
-            "randomState": 1306,
+            "randomState": 1362,
             "tickCount": 6705,
             "type": "paint"
         },
         {
-            "randomState": 1314,
+            "randomState": 1366,
             "tickCount": 6720,
             "type": "paint"
         },
         {
-            "randomState": 1319,
+            "randomState": 1371,
             "tickCount": 6735,
             "type": "paint"
         },
         {
-            "randomState": 1324,
+            "randomState": 1375,
             "tickCount": 6750,
             "type": "paint"
         },
         {
-            "randomState": 1326,
+            "randomState": 1378,
             "tickCount": 6765,
             "type": "paint"
         },
         {
-            "randomState": 1326,
+            "randomState": 1380,
             "tickCount": 6780,
             "type": "paint"
         },
@@ -2991,82 +2991,82 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1326,
+            "randomState": 1385,
             "tickCount": 6795,
             "type": "paint"
         },
         {
-            "randomState": 1327,
+            "randomState": 1388,
             "tickCount": 6810,
             "type": "paint"
         },
         {
-            "randomState": 1330,
+            "randomState": 1390,
             "tickCount": 6825,
             "type": "paint"
         },
         {
-            "randomState": 1333,
+            "randomState": 1394,
             "tickCount": 6840,
             "type": "paint"
         },
         {
-            "randomState": 1339,
+            "randomState": 1397,
             "tickCount": 6855,
             "type": "paint"
         },
         {
-            "randomState": 1341,
+            "randomState": 1399,
             "tickCount": 6870,
             "type": "paint"
         },
         {
-            "randomState": 1342,
+            "randomState": 1403,
             "tickCount": 6885,
             "type": "paint"
         },
         {
-            "randomState": 1345,
+            "randomState": 1405,
             "tickCount": 6900,
             "type": "paint"
         },
         {
-            "randomState": 1353,
+            "randomState": 1408,
             "tickCount": 6915,
             "type": "paint"
         },
         {
-            "randomState": 1355,
+            "randomState": 1411,
             "tickCount": 6930,
             "type": "paint"
         },
         {
-            "randomState": 1358,
+            "randomState": 1414,
             "tickCount": 6945,
             "type": "paint"
         },
         {
-            "randomState": 1360,
+            "randomState": 1415,
             "tickCount": 6960,
             "type": "paint"
         },
         {
-            "randomState": 1362,
+            "randomState": 1419,
             "tickCount": 6975,
             "type": "paint"
         },
         {
-            "randomState": 1366,
+            "randomState": 1421,
             "tickCount": 6990,
             "type": "paint"
         },
         {
-            "randomState": 1368,
+            "randomState": 1423,
             "tickCount": 7005,
             "type": "paint"
         },
         {
-            "randomState": 1370,
+            "randomState": 1425,
             "tickCount": 7020,
             "type": "paint"
         },
@@ -3077,67 +3077,67 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1378,
+            "randomState": 1432,
             "tickCount": 7035,
             "type": "paint"
         },
         {
-            "randomState": 1380,
+            "randomState": 1434,
             "tickCount": 7050,
             "type": "paint"
         },
         {
-            "randomState": 1384,
+            "randomState": 1442,
             "tickCount": 7065,
             "type": "paint"
         },
         {
-            "randomState": 1389,
+            "randomState": 1446,
             "tickCount": 7080,
             "type": "paint"
         },
         {
-            "randomState": 1394,
+            "randomState": 1447,
             "tickCount": 7095,
             "type": "paint"
         },
         {
-            "randomState": 1396,
+            "randomState": 1447,
             "tickCount": 7110,
             "type": "paint"
         },
         {
-            "randomState": 1398,
+            "randomState": 1453,
             "tickCount": 7125,
             "type": "paint"
         },
         {
-            "randomState": 1403,
+            "randomState": 1458,
             "tickCount": 7140,
             "type": "paint"
         },
         {
-            "randomState": 1403,
+            "randomState": 1459,
             "tickCount": 7155,
             "type": "paint"
         },
         {
-            "randomState": 1405,
+            "randomState": 1465,
             "tickCount": 7170,
             "type": "paint"
         },
         {
-            "randomState": 1405,
+            "randomState": 1467,
             "tickCount": 7185,
             "type": "paint"
         },
         {
-            "randomState": 1410,
+            "randomState": 1476,
             "tickCount": 7200,
             "type": "paint"
         },
         {
-            "randomState": 1429,
+            "randomState": 1493,
             "tickCount": 7215,
             "type": "paint"
         },
@@ -3148,72 +3148,72 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1441,
+            "randomState": 1507,
             "tickCount": 7230,
             "type": "paint"
         },
         {
-            "randomState": 1448,
+            "randomState": 1517,
             "tickCount": 7245,
             "type": "paint"
         },
         {
-            "randomState": 1455,
+            "randomState": 1525,
             "tickCount": 7260,
             "type": "paint"
         },
         {
-            "randomState": 1461,
+            "randomState": 1530,
             "tickCount": 7275,
             "type": "paint"
         },
         {
-            "randomState": 1462,
+            "randomState": 1531,
             "tickCount": 7290,
             "type": "paint"
         },
         {
-            "randomState": 1462,
+            "randomState": 1533,
             "tickCount": 7305,
             "type": "paint"
         },
         {
-            "randomState": 1479,
+            "randomState": 1550,
             "tickCount": 7320,
             "type": "paint"
         },
         {
-            "randomState": 1484,
+            "randomState": 1558,
             "tickCount": 7335,
             "type": "paint"
         },
         {
-            "randomState": 1486,
+            "randomState": 1560,
             "tickCount": 7350,
             "type": "paint"
         },
         {
-            "randomState": 1490,
+            "randomState": 1565,
             "tickCount": 7365,
             "type": "paint"
         },
         {
-            "randomState": 1492,
+            "randomState": 1570,
             "tickCount": 7380,
             "type": "paint"
         },
         {
-            "randomState": 1496,
+            "randomState": 1571,
             "tickCount": 7395,
             "type": "paint"
         },
         {
-            "randomState": 1498,
+            "randomState": 1575,
             "tickCount": 7410,
             "type": "paint"
         },
         {
-            "randomState": 1504,
+            "randomState": 1578,
             "tickCount": 7425,
             "type": "paint"
         },
@@ -3224,52 +3224,52 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1505,
+            "randomState": 1579,
             "tickCount": 7440,
             "type": "paint"
         },
         {
-            "randomState": 1509,
+            "randomState": 1581,
             "tickCount": 7455,
             "type": "paint"
         },
         {
-            "randomState": 1510,
+            "randomState": 1588,
             "tickCount": 7470,
             "type": "paint"
         },
         {
-            "randomState": 1513,
+            "randomState": 1590,
             "tickCount": 7485,
             "type": "paint"
         },
         {
-            "randomState": 1516,
+            "randomState": 1593,
             "tickCount": 7500,
             "type": "paint"
         },
         {
-            "randomState": 1518,
+            "randomState": 1595,
             "tickCount": 7515,
             "type": "paint"
         },
         {
-            "randomState": 1520,
+            "randomState": 1599,
             "tickCount": 7530,
             "type": "paint"
         },
         {
-            "randomState": 1529,
+            "randomState": 1609,
             "tickCount": 7545,
             "type": "paint"
         },
         {
-            "randomState": 1530,
+            "randomState": 1611,
             "tickCount": 7560,
             "type": "paint"
         },
         {
-            "randomState": 1534,
+            "randomState": 1617,
             "tickCount": 7575,
             "type": "paint"
         },
@@ -3280,97 +3280,97 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1539,
+            "randomState": 1620,
             "tickCount": 7590,
             "type": "paint"
         },
         {
-            "randomState": 1542,
+            "randomState": 1622,
             "tickCount": 7605,
             "type": "paint"
         },
         {
-            "randomState": 1543,
+            "randomState": 1627,
             "tickCount": 7620,
             "type": "paint"
         },
         {
-            "randomState": 1544,
+            "randomState": 1629,
             "tickCount": 7635,
             "type": "paint"
         },
         {
-            "randomState": 1548,
+            "randomState": 1633,
             "tickCount": 7650,
             "type": "paint"
         },
         {
-            "randomState": 1550,
+            "randomState": 1637,
             "tickCount": 7665,
             "type": "paint"
         },
         {
-            "randomState": 1551,
+            "randomState": 1642,
             "tickCount": 7680,
             "type": "paint"
         },
         {
-            "randomState": 1552,
+            "randomState": 1646,
             "tickCount": 7695,
             "type": "paint"
         },
         {
-            "randomState": 1552,
+            "randomState": 1646,
             "tickCount": 7710,
             "type": "paint"
         },
         {
-            "randomState": 1553,
+            "randomState": 1649,
             "tickCount": 7725,
             "type": "paint"
         },
         {
-            "randomState": 1555,
+            "randomState": 1654,
             "tickCount": 7740,
             "type": "paint"
         },
         {
-            "randomState": 1560,
+            "randomState": 1659,
             "tickCount": 7755,
             "type": "paint"
         },
         {
-            "randomState": 1561,
+            "randomState": 1663,
             "tickCount": 7770,
             "type": "paint"
         },
         {
-            "randomState": 1562,
+            "randomState": 1665,
             "tickCount": 7785,
             "type": "paint"
         },
         {
-            "randomState": 1564,
+            "randomState": 1666,
             "tickCount": 7800,
             "type": "paint"
         },
         {
-            "randomState": 1564,
+            "randomState": 1667,
             "tickCount": 7815,
             "type": "paint"
         },
         {
-            "randomState": 1566,
+            "randomState": 1670,
             "tickCount": 7830,
             "type": "paint"
         },
         {
-            "randomState": 1567,
+            "randomState": 1671,
             "tickCount": 7845,
             "type": "paint"
         },
         {
-            "randomState": 1568,
+            "randomState": 1673,
             "tickCount": 7860,
             "type": "paint"
         },
@@ -3381,37 +3381,37 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1571,
+            "randomState": 1676,
             "tickCount": 7875,
             "type": "paint"
         },
         {
-            "randomState": 1580,
+            "randomState": 1684,
             "tickCount": 7890,
             "type": "paint"
         },
         {
-            "randomState": 1581,
+            "randomState": 1686,
             "tickCount": 7905,
             "type": "paint"
         },
         {
-            "randomState": 1585,
+            "randomState": 1690,
             "tickCount": 7920,
             "type": "paint"
         },
         {
-            "randomState": 1587,
+            "randomState": 1693,
             "tickCount": 7935,
             "type": "paint"
         },
         {
-            "randomState": 1589,
+            "randomState": 1693,
             "tickCount": 7950,
             "type": "paint"
         },
         {
-            "randomState": 1604,
+            "randomState": 1696,
             "tickCount": 7965,
             "type": "paint"
         },
@@ -3422,167 +3422,167 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1610,
+            "randomState": 1700,
             "tickCount": 7980,
             "type": "paint"
         },
         {
-            "randomState": 1612,
+            "randomState": 1702,
             "tickCount": 7995,
             "type": "paint"
         },
         {
-            "randomState": 1615,
+            "randomState": 1704,
             "tickCount": 8010,
             "type": "paint"
         },
         {
-            "randomState": 1618,
+            "randomState": 1706,
             "tickCount": 8025,
             "type": "paint"
         },
         {
-            "randomState": 1628,
+            "randomState": 1714,
             "tickCount": 8040,
             "type": "paint"
         },
         {
-            "randomState": 1630,
+            "randomState": 1716,
             "tickCount": 8055,
             "type": "paint"
         },
         {
-            "randomState": 1633,
+            "randomState": 1720,
             "tickCount": 8070,
             "type": "paint"
         },
         {
-            "randomState": 1633,
+            "randomState": 1720,
             "tickCount": 8085,
             "type": "paint"
         },
         {
-            "randomState": 1639,
+            "randomState": 1723,
             "tickCount": 8100,
             "type": "paint"
         },
         {
-            "randomState": 1641,
+            "randomState": 1723,
             "tickCount": 8115,
             "type": "paint"
         },
         {
-            "randomState": 1642,
+            "randomState": 1729,
             "tickCount": 8130,
             "type": "paint"
         },
         {
-            "randomState": 1644,
+            "randomState": 1732,
             "tickCount": 8145,
             "type": "paint"
         },
         {
-            "randomState": 1645,
+            "randomState": 1736,
             "tickCount": 8160,
             "type": "paint"
         },
         {
-            "randomState": 1658,
+            "randomState": 1740,
             "tickCount": 8175,
             "type": "paint"
         },
         {
-            "randomState": 1661,
+            "randomState": 1743,
             "tickCount": 8190,
             "type": "paint"
         },
         {
-            "randomState": 1666,
+            "randomState": 1748,
             "tickCount": 8205,
             "type": "paint"
         },
         {
-            "randomState": 1670,
+            "randomState": 1762,
             "tickCount": 8220,
             "type": "paint"
         },
         {
-            "randomState": 1684,
+            "randomState": 1767,
             "tickCount": 8235,
             "type": "paint"
         },
         {
-            "randomState": 1688,
+            "randomState": 1770,
             "tickCount": 8250,
             "type": "paint"
         },
         {
-            "randomState": 1692,
+            "randomState": 1775,
             "tickCount": 8265,
             "type": "paint"
         },
         {
-            "randomState": 1695,
+            "randomState": 1778,
             "tickCount": 8280,
             "type": "paint"
         },
         {
-            "randomState": 1698,
+            "randomState": 1783,
             "tickCount": 8295,
             "type": "paint"
         },
         {
-            "randomState": 1700,
+            "randomState": 1786,
             "tickCount": 8310,
             "type": "paint"
         },
         {
-            "randomState": 1709,
+            "randomState": 1788,
             "tickCount": 8325,
             "type": "paint"
         },
         {
-            "randomState": 1712,
+            "randomState": 1792,
             "tickCount": 8340,
             "type": "paint"
         },
         {
-            "randomState": 1715,
+            "randomState": 1795,
             "tickCount": 8355,
             "type": "paint"
         },
         {
-            "randomState": 1717,
+            "randomState": 1798,
             "tickCount": 8370,
             "type": "paint"
         },
         {
-            "randomState": 1720,
+            "randomState": 1801,
             "tickCount": 8385,
             "type": "paint"
         },
         {
-            "randomState": 1729,
+            "randomState": 1803,
             "tickCount": 8400,
             "type": "paint"
         },
         {
-            "randomState": 1732,
+            "randomState": 1805,
             "tickCount": 8415,
             "type": "paint"
         },
         {
-            "randomState": 1734,
+            "randomState": 1807,
             "tickCount": 8430,
             "type": "paint"
         },
         {
-            "randomState": 1736,
+            "randomState": 1810,
             "tickCount": 8445,
             "type": "paint"
         },
         {
-            "randomState": 1737,
+            "randomState": 1811,
             "tickCount": 8460,
             "type": "paint"
         },
@@ -3593,112 +3593,112 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1740,
+            "randomState": 1815,
             "tickCount": 8475,
             "type": "paint"
         },
         {
-            "randomState": 1745,
+            "randomState": 1821,
             "tickCount": 8490,
             "type": "paint"
         },
         {
-            "randomState": 1746,
+            "randomState": 1824,
             "tickCount": 8505,
             "type": "paint"
         },
         {
-            "randomState": 1749,
+            "randomState": 1830,
             "tickCount": 8520,
             "type": "paint"
         },
         {
-            "randomState": 1755,
+            "randomState": 1836,
             "tickCount": 8535,
             "type": "paint"
         },
         {
-            "randomState": 1763,
+            "randomState": 1843,
             "tickCount": 8550,
             "type": "paint"
         },
         {
-            "randomState": 1767,
+            "randomState": 1846,
             "tickCount": 8565,
             "type": "paint"
         },
         {
-            "randomState": 1772,
+            "randomState": 1850,
             "tickCount": 8580,
             "type": "paint"
         },
         {
-            "randomState": 1777,
+            "randomState": 1855,
             "tickCount": 8595,
             "type": "paint"
         },
         {
-            "randomState": 1780,
+            "randomState": 1857,
             "tickCount": 8610,
             "type": "paint"
         },
         {
-            "randomState": 1786,
+            "randomState": 1860,
             "tickCount": 8625,
             "type": "paint"
         },
         {
-            "randomState": 1791,
+            "randomState": 1862,
             "tickCount": 8640,
             "type": "paint"
         },
         {
-            "randomState": 1793,
+            "randomState": 1863,
             "tickCount": 8655,
             "type": "paint"
         },
         {
-            "randomState": 1795,
+            "randomState": 1866,
             "tickCount": 8670,
             "type": "paint"
         },
         {
-            "randomState": 1795,
+            "randomState": 1867,
             "tickCount": 8685,
             "type": "paint"
         },
         {
-            "randomState": 1795,
+            "randomState": 1870,
             "tickCount": 8700,
             "type": "paint"
         },
         {
-            "randomState": 1799,
+            "randomState": 1874,
             "tickCount": 8715,
             "type": "paint"
         },
         {
-            "randomState": 1803,
+            "randomState": 1875,
             "tickCount": 8730,
             "type": "paint"
         },
         {
-            "randomState": 1806,
+            "randomState": 1882,
             "tickCount": 8745,
             "type": "paint"
         },
         {
-            "randomState": 1807,
+            "randomState": 1885,
             "tickCount": 8760,
             "type": "paint"
         },
         {
-            "randomState": 1808,
+            "randomState": 1888,
             "tickCount": 8775,
             "type": "paint"
         },
         {
-            "randomState": 1809,
+            "randomState": 1889,
             "tickCount": 8790,
             "type": "paint"
         },
@@ -3709,7 +3709,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1810,
+            "randomState": 1889,
             "tickCount": 8805,
             "type": "paint"
         },
@@ -3720,392 +3720,392 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1810,
+            "randomState": 1891,
             "tickCount": 8820,
             "type": "paint"
         },
         {
-            "randomState": 1810,
+            "randomState": 1891,
             "tickCount": 8835,
             "type": "paint"
         },
         {
-            "randomState": 1813,
+            "randomState": 1892,
             "tickCount": 8850,
             "type": "paint"
         },
         {
-            "randomState": 1815,
+            "randomState": 1894,
             "tickCount": 8865,
             "type": "paint"
         },
         {
-            "randomState": 1818,
+            "randomState": 1895,
             "tickCount": 8880,
             "type": "paint"
         },
         {
-            "randomState": 1821,
+            "randomState": 1897,
             "tickCount": 8895,
             "type": "paint"
         },
         {
-            "randomState": 1823,
+            "randomState": 1899,
             "tickCount": 8910,
             "type": "paint"
         },
         {
-            "randomState": 1826,
+            "randomState": 1901,
             "tickCount": 8925,
             "type": "paint"
         },
         {
-            "randomState": 1827,
+            "randomState": 1905,
             "tickCount": 8940,
             "type": "paint"
         },
         {
-            "randomState": 1830,
+            "randomState": 1907,
             "tickCount": 8955,
             "type": "paint"
         },
         {
-            "randomState": 1834,
+            "randomState": 1911,
             "tickCount": 8970,
             "type": "paint"
         },
         {
-            "randomState": 1837,
+            "randomState": 1914,
             "tickCount": 8985,
             "type": "paint"
         },
         {
-            "randomState": 1840,
+            "randomState": 1917,
             "tickCount": 9000,
             "type": "paint"
         },
         {
-            "randomState": 1842,
+            "randomState": 1921,
             "tickCount": 9015,
             "type": "paint"
         },
         {
-            "randomState": 1842,
+            "randomState": 1923,
             "tickCount": 9030,
             "type": "paint"
         },
         {
-            "randomState": 1850,
+            "randomState": 1929,
             "tickCount": 9045,
             "type": "paint"
         },
         {
-            "randomState": 1854,
+            "randomState": 1934,
             "tickCount": 9060,
             "type": "paint"
         },
         {
-            "randomState": 1857,
+            "randomState": 1938,
             "tickCount": 9075,
             "type": "paint"
         },
         {
-            "randomState": 1861,
+            "randomState": 1944,
             "tickCount": 9090,
             "type": "paint"
         },
         {
-            "randomState": 1869,
+            "randomState": 1949,
             "tickCount": 9105,
             "type": "paint"
         },
         {
-            "randomState": 1871,
+            "randomState": 1966,
             "tickCount": 9120,
             "type": "paint"
         },
         {
-            "randomState": 1873,
+            "randomState": 1968,
             "tickCount": 9135,
             "type": "paint"
         },
         {
-            "randomState": 1876,
+            "randomState": 1971,
             "tickCount": 9150,
             "type": "paint"
         },
         {
-            "randomState": 1882,
+            "randomState": 1975,
             "tickCount": 9165,
             "type": "paint"
         },
         {
-            "randomState": 1884,
+            "randomState": 1977,
             "tickCount": 9180,
             "type": "paint"
         },
         {
-            "randomState": 1885,
+            "randomState": 1999,
             "tickCount": 9195,
             "type": "paint"
         },
         {
-            "randomState": 1886,
+            "randomState": 2000,
             "tickCount": 9210,
             "type": "paint"
         },
         {
-            "randomState": 1891,
+            "randomState": 2004,
             "tickCount": 9225,
             "type": "paint"
         },
         {
-            "randomState": 1895,
+            "randomState": 2007,
             "tickCount": 9240,
             "type": "paint"
         },
         {
-            "randomState": 1898,
+            "randomState": 2024,
             "tickCount": 9255,
             "type": "paint"
         },
         {
-            "randomState": 1901,
+            "randomState": 2027,
             "tickCount": 9270,
             "type": "paint"
         },
         {
-            "randomState": 1906,
+            "randomState": 2030,
             "tickCount": 9285,
             "type": "paint"
         },
         {
-            "randomState": 1907,
+            "randomState": 2032,
             "tickCount": 9300,
             "type": "paint"
         },
         {
-            "randomState": 1908,
+            "randomState": 2035,
             "tickCount": 9315,
             "type": "paint"
         },
         {
-            "randomState": 1910,
+            "randomState": 2036,
             "tickCount": 9330,
             "type": "paint"
         },
         {
-            "randomState": 1913,
+            "randomState": 2038,
             "tickCount": 9345,
             "type": "paint"
         },
         {
-            "randomState": 1915,
+            "randomState": 2040,
             "tickCount": 9360,
             "type": "paint"
         },
         {
-            "randomState": 1919,
+            "randomState": 2041,
             "tickCount": 9375,
             "type": "paint"
         },
         {
-            "randomState": 1923,
+            "randomState": 2044,
             "tickCount": 9390,
             "type": "paint"
         },
         {
-            "randomState": 1924,
+            "randomState": 2044,
             "tickCount": 9405,
             "type": "paint"
         },
         {
-            "randomState": 1931,
+            "randomState": 2044,
             "tickCount": 9420,
             "type": "paint"
         },
         {
-            "randomState": 1933,
+            "randomState": 2048,
             "tickCount": 9435,
             "type": "paint"
         },
         {
-            "randomState": 1934,
+            "randomState": 2050,
             "tickCount": 9450,
             "type": "paint"
         },
         {
-            "randomState": 1942,
+            "randomState": 2052,
             "tickCount": 9465,
             "type": "paint"
         },
         {
-            "randomState": 1944,
+            "randomState": 2053,
             "tickCount": 9480,
             "type": "paint"
         },
         {
-            "randomState": 1947,
+            "randomState": 2055,
             "tickCount": 9495,
             "type": "paint"
         },
         {
-            "randomState": 1949,
+            "randomState": 2058,
             "tickCount": 9510,
             "type": "paint"
         },
         {
-            "randomState": 1952,
+            "randomState": 2062,
             "tickCount": 9525,
             "type": "paint"
         },
         {
-            "randomState": 1970,
+            "randomState": 2068,
             "tickCount": 9540,
             "type": "paint"
         },
         {
-            "randomState": 1973,
+            "randomState": 2073,
             "tickCount": 9555,
             "type": "paint"
         },
         {
-            "randomState": 1976,
+            "randomState": 2075,
             "tickCount": 9570,
             "type": "paint"
         },
         {
-            "randomState": 1978,
+            "randomState": 2075,
             "tickCount": 9585,
             "type": "paint"
         },
         {
-            "randomState": 1983,
+            "randomState": 2078,
             "tickCount": 9600,
             "type": "paint"
         },
         {
-            "randomState": 1987,
+            "randomState": 2081,
             "tickCount": 9615,
             "type": "paint"
         },
         {
-            "randomState": 1999,
+            "randomState": 2091,
             "tickCount": 9630,
             "type": "paint"
         },
         {
-            "randomState": 2000,
+            "randomState": 2094,
             "tickCount": 9645,
             "type": "paint"
         },
         {
-            "randomState": 2006,
+            "randomState": 2098,
             "tickCount": 9660,
             "type": "paint"
         },
         {
-            "randomState": 2009,
+            "randomState": 2102,
             "tickCount": 9675,
             "type": "paint"
         },
         {
-            "randomState": 2011,
+            "randomState": 2102,
             "tickCount": 9690,
             "type": "paint"
         },
         {
-            "randomState": 2012,
+            "randomState": 2108,
             "tickCount": 9705,
             "type": "paint"
         },
         {
-            "randomState": 2016,
+            "randomState": 2110,
             "tickCount": 9720,
             "type": "paint"
         },
         {
-            "randomState": 2019,
+            "randomState": 2110,
             "tickCount": 9735,
             "type": "paint"
         },
         {
-            "randomState": 2022,
+            "randomState": 2118,
             "tickCount": 9750,
             "type": "paint"
         },
         {
-            "randomState": 2029,
+            "randomState": 2120,
             "tickCount": 9765,
             "type": "paint"
         },
         {
-            "randomState": 2031,
+            "randomState": 2121,
             "tickCount": 9780,
             "type": "paint"
         },
         {
-            "randomState": 2035,
+            "randomState": 2122,
             "tickCount": 9795,
             "type": "paint"
         },
         {
-            "randomState": 2037,
+            "randomState": 2123,
             "tickCount": 9810,
             "type": "paint"
         },
         {
-            "randomState": 2038,
+            "randomState": 2124,
             "tickCount": 9825,
             "type": "paint"
         },
         {
-            "randomState": 2040,
+            "randomState": 2128,
             "tickCount": 9840,
             "type": "paint"
         },
         {
-            "randomState": 2043,
+            "randomState": 2129,
             "tickCount": 9855,
             "type": "paint"
         },
         {
-            "randomState": 2045,
+            "randomState": 2130,
             "tickCount": 9870,
             "type": "paint"
         },
         {
-            "randomState": 2050,
+            "randomState": 2132,
             "tickCount": 9885,
             "type": "paint"
         },
         {
-            "randomState": 2056,
+            "randomState": 2138,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 2057,
+            "randomState": 2140,
             "tickCount": 9915,
             "type": "paint"
         },
         {
-            "randomState": 2059,
+            "randomState": 2141,
             "tickCount": 9930,
             "type": "paint"
         },
         {
-            "randomState": 2060,
+            "randomState": 2144,
             "tickCount": 9945,
             "type": "paint"
         },
         {
-            "randomState": 2061,
+            "randomState": 2144,
             "tickCount": 9960,
             "type": "paint"
         },
         {
-            "randomState": 2067,
+            "randomState": 2147,
             "tickCount": 9975,
             "type": "paint"
         },
@@ -4116,7 +4116,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 2069,
+            "randomState": 2153,
             "tickCount": 9990,
             "type": "paint"
         },
@@ -4127,272 +4127,272 @@
             "type": "keyPress"
         },
         {
-            "randomState": 2072,
+            "randomState": 2157,
             "tickCount": 10005,
             "type": "paint"
         },
         {
-            "randomState": 2075,
+            "randomState": 2159,
             "tickCount": 10020,
             "type": "paint"
         },
         {
-            "randomState": 2080,
+            "randomState": 2160,
             "tickCount": 10035,
             "type": "paint"
         },
         {
-            "randomState": 2087,
+            "randomState": 2167,
             "tickCount": 10050,
             "type": "paint"
         },
         {
-            "randomState": 2090,
+            "randomState": 2169,
             "tickCount": 10065,
             "type": "paint"
         },
         {
-            "randomState": 2097,
+            "randomState": 2172,
             "tickCount": 10080,
             "type": "paint"
         },
         {
-            "randomState": 2101,
+            "randomState": 2175,
             "tickCount": 10095,
             "type": "paint"
         },
         {
-            "randomState": 2104,
+            "randomState": 2175,
             "tickCount": 10110,
             "type": "paint"
         },
         {
-            "randomState": 2108,
+            "randomState": 2176,
             "tickCount": 10125,
             "type": "paint"
         },
         {
-            "randomState": 2111,
+            "randomState": 2177,
             "tickCount": 10140,
             "type": "paint"
         },
         {
-            "randomState": 2113,
+            "randomState": 2177,
             "tickCount": 10155,
             "type": "paint"
         },
         {
-            "randomState": 2118,
+            "randomState": 2180,
             "tickCount": 10170,
             "type": "paint"
         },
         {
-            "randomState": 2146,
+            "randomState": 2202,
             "tickCount": 10185,
             "type": "paint"
         },
         {
-            "randomState": 2170,
+            "randomState": 2221,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 2179,
+            "randomState": 2224,
             "tickCount": 10215,
             "type": "paint"
         },
         {
-            "randomState": 2184,
+            "randomState": 2231,
             "tickCount": 10230,
             "type": "paint"
         },
         {
-            "randomState": 2190,
+            "randomState": 2234,
             "tickCount": 10245,
             "type": "paint"
         },
         {
-            "randomState": 2194,
+            "randomState": 2236,
             "tickCount": 10260,
             "type": "paint"
         },
         {
-            "randomState": 2197,
+            "randomState": 2241,
             "tickCount": 10275,
             "type": "paint"
         },
         {
-            "randomState": 2199,
+            "randomState": 2245,
             "tickCount": 10290,
             "type": "paint"
         },
         {
-            "randomState": 2200,
+            "randomState": 2245,
             "tickCount": 10305,
             "type": "paint"
         },
         {
-            "randomState": 2202,
+            "randomState": 2247,
             "tickCount": 10320,
             "type": "paint"
         },
         {
-            "randomState": 2202,
+            "randomState": 2247,
             "tickCount": 10335,
             "type": "paint"
         },
         {
-            "randomState": 2202,
+            "randomState": 2249,
             "tickCount": 10350,
             "type": "paint"
         },
         {
-            "randomState": 2203,
+            "randomState": 2250,
             "tickCount": 10365,
             "type": "paint"
         },
         {
-            "randomState": 2206,
+            "randomState": 2251,
             "tickCount": 10380,
             "type": "paint"
         },
         {
-            "randomState": 2209,
+            "randomState": 2253,
             "tickCount": 10395,
             "type": "paint"
         },
         {
-            "randomState": 2212,
+            "randomState": 2254,
             "tickCount": 10410,
             "type": "paint"
         },
         {
-            "randomState": 2214,
+            "randomState": 2256,
             "tickCount": 10425,
             "type": "paint"
         },
         {
-            "randomState": 2220,
+            "randomState": 2258,
             "tickCount": 10440,
             "type": "paint"
         },
         {
-            "randomState": 2220,
+            "randomState": 2261,
             "tickCount": 10455,
             "type": "paint"
         },
         {
-            "randomState": 2223,
+            "randomState": 2267,
             "tickCount": 10470,
             "type": "paint"
         },
         {
-            "randomState": 2226,
+            "randomState": 2270,
             "tickCount": 10485,
             "type": "paint"
         },
         {
-            "randomState": 2226,
+            "randomState": 2273,
             "tickCount": 10500,
             "type": "paint"
         },
         {
-            "randomState": 2228,
+            "randomState": 2276,
             "tickCount": 10515,
             "type": "paint"
         },
         {
-            "randomState": 2230,
+            "randomState": 2279,
             "tickCount": 10530,
             "type": "paint"
         },
         {
-            "randomState": 2232,
+            "randomState": 2289,
             "tickCount": 10545,
             "type": "paint"
         },
         {
-            "randomState": 2237,
+            "randomState": 2296,
             "tickCount": 10560,
             "type": "paint"
         },
         {
-            "randomState": 2240,
+            "randomState": 2300,
             "tickCount": 10575,
             "type": "paint"
         },
         {
-            "randomState": 2243,
+            "randomState": 2305,
             "tickCount": 10590,
             "type": "paint"
         },
         {
-            "randomState": 2247,
+            "randomState": 2312,
             "tickCount": 10605,
             "type": "paint"
         },
         {
-            "randomState": 2255,
+            "randomState": 2315,
             "tickCount": 10620,
             "type": "paint"
         },
         {
-            "randomState": 2258,
+            "randomState": 2318,
             "tickCount": 10635,
             "type": "paint"
         },
         {
-            "randomState": 2262,
+            "randomState": 2338,
             "tickCount": 10650,
             "type": "paint"
         },
         {
-            "randomState": 2265,
+            "randomState": 2340,
             "tickCount": 10665,
             "type": "paint"
         },
         {
-            "randomState": 2268,
+            "randomState": 2345,
             "tickCount": 10680,
             "type": "paint"
         },
         {
-            "randomState": 2270,
+            "randomState": 2348,
             "tickCount": 10695,
             "type": "paint"
         },
         {
-            "randomState": 2270,
+            "randomState": 2351,
             "tickCount": 10710,
             "type": "paint"
         },
         {
-            "randomState": 2273,
+            "randomState": 2356,
             "tickCount": 10725,
             "type": "paint"
         },
         {
-            "randomState": 2277,
+            "randomState": 2361,
             "tickCount": 10740,
             "type": "paint"
         },
         {
-            "randomState": 2283,
+            "randomState": 2367,
             "tickCount": 10755,
             "type": "paint"
         },
         {
-            "randomState": 2287,
+            "randomState": 2371,
             "tickCount": 10770,
             "type": "paint"
         },
         {
-            "randomState": 2289,
+            "randomState": 2378,
             "tickCount": 10785,
             "type": "paint"
         },
         {
-            "randomState": 2293,
+            "randomState": 2384,
             "tickCount": 10800,
             "type": "paint"
         }

--- a/test/Data/issue_1226.json
+++ b/test/Data/issue_1226.json
@@ -57894,17 +57894,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25100,
             "type": "paint"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25200,
             "type": "paint"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25300,
             "type": "paint"
         },
@@ -57915,7 +57915,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25400,
             "type": "paint"
         },
@@ -57926,12 +57926,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25500,
             "type": "paint"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25600,
             "type": "paint"
         },
@@ -57942,7 +57942,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25700,
             "type": "paint"
         },
@@ -57953,17 +57953,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25800,
             "type": "paint"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 25900,
             "type": "paint"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 26000,
             "type": "paint"
         },
@@ -57974,7 +57974,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 26100,
             "type": "paint"
         },
@@ -57985,7 +57985,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1800,
+            "randomState": 1801,
             "tickCount": 26200,
             "type": "paint"
         },
@@ -57996,17 +57996,17 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 1818,
+            "randomState": 1819,
             "tickCount": 26300,
             "type": "paint"
         },
         {
-            "randomState": 1839,
+            "randomState": 1840,
             "tickCount": 26400,
             "type": "paint"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 26500,
             "type": "paint"
         },
@@ -58031,7 +58031,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 26600,
             "type": "paint"
         },
@@ -58396,7 +58396,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 26700,
             "type": "paint"
         },
@@ -59321,7 +59321,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 26800,
             "type": "paint"
         },
@@ -60016,7 +60016,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 26900,
             "type": "paint"
         },
@@ -60501,7 +60501,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 27000,
             "type": "paint"
         },
@@ -60516,7 +60516,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1849,
+            "randomState": 1850,
             "tickCount": 27100,
             "type": "paint"
         },
@@ -60571,7 +60571,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 1850,
+            "randomState": 1851,
             "tickCount": 27200,
             "type": "paint"
         },
@@ -61136,7 +61136,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1850,
+            "randomState": 1851,
             "tickCount": 27300,
             "type": "paint"
         },
@@ -61611,7 +61611,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1850,
+            "randomState": 1851,
             "tickCount": 27400,
             "type": "paint"
         },
@@ -61806,7 +61806,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1850,
+            "randomState": 1851,
             "tickCount": 27500,
             "type": "paint"
         },
@@ -62101,7 +62101,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 1850,
+            "randomState": 1851,
             "tickCount": 27600,
             "type": "paint"
         },
@@ -62122,12 +62122,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 27700,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 27800,
             "type": "paint"
         },
@@ -62142,17 +62142,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 27900,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28000,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28100,
             "type": "paint"
         },
@@ -62167,7 +62167,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28200,
             "type": "paint"
         },
@@ -62178,7 +62178,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28300,
             "type": "paint"
         },
@@ -62193,7 +62193,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28400,
             "type": "paint"
         },
@@ -62228,7 +62228,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28500,
             "type": "paint"
         },
@@ -62263,12 +62263,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28600,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28700,
             "type": "paint"
         },
@@ -62359,7 +62359,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28800,
             "type": "paint"
         },
@@ -62524,7 +62524,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 28900,
             "type": "paint"
         },
@@ -62549,7 +62549,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29000,
             "type": "paint"
         },
@@ -62604,7 +62604,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29100,
             "type": "paint"
         },
@@ -63159,7 +63159,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29200,
             "type": "paint"
         },
@@ -63264,47 +63264,47 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29300,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29400,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29500,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29600,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29700,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29800,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 29900,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 30000,
             "type": "paint"
         },
         {
-            "randomState": 1992,
+            "randomState": 1993,
             "tickCount": 30100,
             "type": "paint"
         },
@@ -63386,7 +63386,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 2072,
+            "randomState": 2071,
             "tickCount": 30700,
             "type": "paint"
         },
@@ -63947,7 +63947,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 2092,
+            "randomState": 2090,
             "tickCount": 30800,
             "type": "paint"
         },
@@ -63968,7 +63968,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 2113,
+            "randomState": 2110,
             "tickCount": 30900,
             "type": "paint"
         },
@@ -64083,7 +64083,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 2136,
+            "randomState": 2133,
             "tickCount": 31000,
             "type": "paint"
         },
@@ -64128,7 +64128,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 2163,
+            "randomState": 2160,
             "tickCount": 31100,
             "type": "paint"
         },
@@ -64333,7 +64333,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 2192,
+            "randomState": 2189,
             "tickCount": 31200,
             "type": "paint"
         },
@@ -64433,7 +64433,7 @@
             "type": "paint"
         },
         {
-            "randomState": 2221,
+            "randomState": 2220,
             "tickCount": 31400,
             "type": "paint"
         },

--- a/test/Data/issue_1251b.json
+++ b/test/Data/issue_1251b.json
@@ -736,12 +736,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 102278,
+            "randomState": 573802,
             "tickCount": 950,
             "type": "paint"
         },
         {
-            "randomState": 292026,
+            "randomState": 197532,
             "tickCount": 1000,
             "type": "paint"
         },
@@ -752,77 +752,77 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 292026,
+            "randomState": 197532,
             "tickCount": 1050,
             "type": "paint"
         },
         {
-            "randomState": 197532,
+            "randomState": 573446,
             "tickCount": 1100,
             "type": "paint"
         },
         {
-            "randomState": 197532,
+            "randomState": 573446,
             "tickCount": 1150,
             "type": "paint"
         },
         {
-            "randomState": 573446,
+            "randomState": 1041111,
             "tickCount": 1200,
             "type": "paint"
         },
         {
-            "randomState": 1044865,
+            "randomState": 1011758,
             "tickCount": 1250,
             "type": "paint"
         },
         {
-            "randomState": 165269,
+            "randomState": 761097,
             "tickCount": 1300,
             "type": "paint"
         },
         {
-            "randomState": 165269,
+            "randomState": 761097,
             "tickCount": 1350,
             "type": "paint"
         },
         {
-            "randomState": 1017740,
+            "randomState": 508953,
             "tickCount": 1400,
             "type": "paint"
         },
         {
-            "randomState": 1028768,
+            "randomState": 836874,
             "tickCount": 1450,
             "type": "paint"
         },
         {
-            "randomState": 1028768,
+            "randomState": 836874,
             "tickCount": 1500,
             "type": "paint"
         },
         {
-            "randomState": 1028768,
+            "randomState": 836874,
             "tickCount": 1550,
             "type": "paint"
         },
         {
-            "randomState": 1028768,
+            "randomState": 836874,
             "tickCount": 1600,
             "type": "paint"
         },
         {
-            "randomState": 1003662,
+            "randomState": 839154,
             "tickCount": 1650,
             "type": "paint"
         },
         {
-            "randomState": 115198,
+            "randomState": 311457,
             "tickCount": 1700,
             "type": "paint"
         },
         {
-            "randomState": 5015,
+            "randomState": 670840,
             "tickCount": 1750,
             "type": "paint"
         },
@@ -833,12 +833,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 5015,
+            "randomState": 670840,
             "tickCount": 1800,
             "type": "paint"
         },
         {
-            "randomState": 5015,
+            "randomState": 830689,
             "tickCount": 1850,
             "type": "paint"
         },
@@ -849,77 +849,77 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 1900,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 1950,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 2000,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 2050,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 2100,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 921101,
             "tickCount": 2150,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 1006100,
             "tickCount": 2200,
             "type": "paint"
         },
         {
-            "randomState": 442248,
+            "randomState": 1006100,
             "tickCount": 2250,
             "type": "paint"
         },
         {
-            "randomState": 117927,
+            "randomState": 528128,
             "tickCount": 2300,
             "type": "paint"
         },
         {
-            "randomState": 117927,
+            "randomState": 528128,
             "tickCount": 2350,
             "type": "paint"
         },
         {
-            "randomState": 960218,
+            "randomState": 528128,
             "tickCount": 2400,
             "type": "paint"
         },
         {
-            "randomState": 960218,
+            "randomState": 528128,
             "tickCount": 2450,
             "type": "paint"
         },
         {
-            "randomState": 960218,
+            "randomState": 687593,
             "tickCount": 2500,
             "type": "paint"
         },
         {
-            "randomState": 960218,
+            "randomState": 687593,
             "tickCount": 2550,
             "type": "paint"
         },
         {
-            "randomState": 960218,
+            "randomState": 687593,
             "tickCount": 2600,
             "type": "paint"
         },
@@ -936,22 +936,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 830689,
+            "randomState": 37446,
             "tickCount": 2650,
             "type": "paint"
         },
         {
-            "randomState": 830689,
+            "randomState": 37446,
             "tickCount": 2700,
             "type": "paint"
         },
         {
-            "randomState": 830689,
+            "randomState": 37446,
             "tickCount": 2750,
             "type": "paint"
         },
         {
-            "randomState": 921101,
+            "randomState": 378844,
             "tickCount": 2800,
             "type": "paint"
         },
@@ -962,32 +962,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 921101,
+            "randomState": 890376,
             "tickCount": 2850,
             "type": "paint"
         },
         {
-            "randomState": 1006100,
+            "randomState": 222218,
             "tickCount": 2900,
             "type": "paint"
         },
         {
-            "randomState": 1006100,
+            "randomState": 222218,
             "tickCount": 2950,
             "type": "paint"
         },
         {
-            "randomState": 687593,
+            "randomState": 794548,
             "tickCount": 3000,
             "type": "paint"
         },
         {
-            "randomState": 687593,
+            "randomState": 794548,
             "tickCount": 3050,
             "type": "paint"
         },
         {
-            "randomState": 836688,
+            "randomState": 776624,
             "tickCount": 3100,
             "type": "paint"
         },
@@ -998,12 +998,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 836688,
+            "randomState": 779230,
             "tickCount": 3150,
             "type": "paint"
         },
         {
-            "randomState": 378844,
+            "randomState": 442591,
             "tickCount": 3200,
             "type": "paint"
         },
@@ -1014,12 +1014,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 979362,
+            "randomState": 316578,
             "tickCount": 3250,
             "type": "paint"
         },
         {
-            "randomState": 979362,
+            "randomState": 316578,
             "tickCount": 3300,
             "type": "paint"
         },
@@ -1030,12 +1030,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 714457,
+            "randomState": 740342,
             "tickCount": 3350,
             "type": "paint"
         },
         {
-            "randomState": 714457,
+            "randomState": 740342,
             "tickCount": 3400,
             "type": "paint"
         },
@@ -1046,37 +1046,37 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 714457,
+            "randomState": 836008,
             "tickCount": 3450,
             "type": "paint"
         },
         {
-            "randomState": 714457,
+            "randomState": 836008,
             "tickCount": 3500,
             "type": "paint"
         },
         {
-            "randomState": 714457,
+            "randomState": 836008,
             "tickCount": 3550,
             "type": "paint"
         },
         {
-            "randomState": 711705,
+            "randomState": 33379,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 418107,
+            "randomState": 331927,
             "tickCount": 3650,
             "type": "paint"
         },
         {
-            "randomState": 418107,
+            "randomState": 331927,
             "tickCount": 3700,
             "type": "paint"
         },
         {
-            "randomState": 687318,
+            "randomState": 131263,
             "tickCount": 3750,
             "type": "paint"
         },
@@ -1087,22 +1087,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 687318,
+            "randomState": 332502,
             "tickCount": 3800,
             "type": "paint"
         },
         {
-            "randomState": 182310,
+            "randomState": 332502,
             "tickCount": 3850,
             "type": "paint"
         },
         {
-            "randomState": 179502,
+            "randomState": 800849,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 179502,
+            "randomState": 800849,
             "tickCount": 3950,
             "type": "paint"
         },
@@ -1113,7 +1113,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 179502,
+            "randomState": 800849,
             "tickCount": 4000,
             "type": "paint"
         },
@@ -1124,22 +1124,22 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 316578,
+            "randomState": 996380,
             "tickCount": 4050,
             "type": "paint"
         },
         {
-            "randomState": 316578,
+            "randomState": 996380,
             "tickCount": 4100,
             "type": "paint"
         },
         {
-            "randomState": 316578,
+            "randomState": 514419,
             "tickCount": 4150,
             "type": "paint"
         },
         {
-            "randomState": 316578,
+            "randomState": 514419,
             "tickCount": 4200,
             "type": "paint"
         },
@@ -1150,7 +1150,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 316578,
+            "randomState": 514419,
             "tickCount": 4250,
             "type": "paint"
         },
@@ -1161,47 +1161,47 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 740342,
+            "randomState": 514419,
             "tickCount": 4300,
             "type": "paint"
         },
         {
-            "randomState": 740342,
+            "randomState": 514419,
             "tickCount": 4350,
             "type": "paint"
         },
         {
-            "randomState": 836008,
+            "randomState": 36119,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 836008,
+            "randomState": 36119,
             "tickCount": 4450,
             "type": "paint"
         },
         {
-            "randomState": 33379,
+            "randomState": 36119,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 331927,
+            "randomState": 132012,
             "tickCount": 4550,
             "type": "paint"
         },
         {
-            "randomState": 331927,
+            "randomState": 833827,
             "tickCount": 4600,
             "type": "paint"
         },
         {
-            "randomState": 156357,
+            "randomState": 513555,
             "tickCount": 4650,
             "type": "paint"
         },
         {
-            "randomState": 131263,
+            "randomState": 513555,
             "tickCount": 4700,
             "type": "paint"
         },
@@ -1212,27 +1212,27 @@
             "type": "keyPress"
         },
         {
-            "randomState": 131263,
+            "randomState": 513555,
             "tickCount": 4750,
             "type": "paint"
         },
         {
-            "randomState": 131263,
+            "randomState": 467230,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 131263,
+            "randomState": 467230,
             "tickCount": 4850,
             "type": "paint"
         },
         {
-            "randomState": 332502,
+            "randomState": 511253,
             "tickCount": 4900,
             "type": "paint"
         },
         {
-            "randomState": 332502,
+            "randomState": 511253,
             "tickCount": 4950,
             "type": "paint"
         },
@@ -1243,32 +1243,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 332502,
+            "randomState": 677708,
             "tickCount": 5000,
             "type": "paint"
         },
         {
-            "randomState": 332502,
+            "randomState": 677708,
             "tickCount": 5050,
             "type": "paint"
         },
         {
-            "randomState": 332502,
+            "randomState": 677708,
             "tickCount": 5100,
             "type": "paint"
         },
         {
-            "randomState": 800849,
+            "randomState": 677708,
             "tickCount": 5150,
             "type": "paint"
         },
         {
-            "randomState": 695840,
+            "randomState": 289433,
             "tickCount": 5200,
             "type": "paint"
         },
         {
-            "randomState": 132012,
+            "randomState": 740057,
             "tickCount": 5250,
             "type": "paint"
         },
@@ -1279,47 +1279,47 @@
             "type": "keyPress"
         },
         {
-            "randomState": 132012,
+            "randomState": 740057,
             "tickCount": 5300,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5350,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5400,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5450,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5500,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5550,
             "type": "paint"
         },
         {
-            "randomState": 400093,
+            "randomState": 740057,
             "tickCount": 5600,
             "type": "paint"
         },
         {
-            "randomState": 220420,
+            "randomState": 712719,
             "tickCount": 5650,
             "type": "paint"
         },
         {
-            "randomState": 220420,
+            "randomState": 712719,
             "tickCount": 5700,
             "type": "paint"
         },
@@ -1330,32 +1330,32 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 802702,
+            "randomState": 2955,
             "tickCount": 5750,
             "type": "paint"
         },
         {
-            "randomState": 802702,
+            "randomState": 686920,
             "tickCount": 5800,
             "type": "paint"
         },
         {
-            "randomState": 802702,
+            "randomState": 675242,
             "tickCount": 5850,
             "type": "paint"
         },
         {
-            "randomState": 53704,
+            "randomState": 124778,
             "tickCount": 5900,
             "type": "paint"
         },
         {
-            "randomState": 513555,
+            "randomState": 124778,
             "tickCount": 5950,
             "type": "paint"
         },
         {
-            "randomState": 513555,
+            "randomState": 522572,
             "tickCount": 6000,
             "type": "paint"
         },
@@ -1366,22 +1366,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 480236,
+            "randomState": 522572,
             "tickCount": 6050,
             "type": "paint"
         },
         {
-            "randomState": 480236,
+            "randomState": 522572,
             "tickCount": 6100,
             "type": "paint"
         },
         {
-            "randomState": 480236,
+            "randomState": 811510,
             "tickCount": 6150,
             "type": "paint"
         },
         {
-            "randomState": 480236,
+            "randomState": 811510,
             "tickCount": 6200,
             "type": "paint"
         },
@@ -1392,27 +1392,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 480236,
+            "randomState": 811510,
             "tickCount": 6250,
             "type": "paint"
         },
         {
-            "randomState": 467230,
+            "randomState": 811510,
             "tickCount": 6300,
             "type": "paint"
         },
         {
-            "randomState": 467230,
+            "randomState": 811510,
             "tickCount": 6350,
             "type": "paint"
         },
         {
-            "randomState": 467230,
+            "randomState": 601625,
             "tickCount": 6400,
             "type": "paint"
         },
         {
-            "randomState": 467230,
+            "randomState": 234683,
             "tickCount": 6450,
             "type": "paint"
         },
@@ -1423,7 +1423,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 467230,
+            "randomState": 234683,
             "tickCount": 6500,
             "type": "paint"
         },
@@ -1434,72 +1434,72 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 511253,
+            "randomState": 18637,
             "tickCount": 6550,
             "type": "paint"
         },
         {
-            "randomState": 511253,
+            "randomState": 18637,
             "tickCount": 6600,
             "type": "paint"
         },
         {
-            "randomState": 677708,
+            "randomState": 787760,
             "tickCount": 6650,
             "type": "paint"
         },
         {
-            "randomState": 965607,
+            "randomState": 861138,
             "tickCount": 6700,
             "type": "paint"
         },
         {
-            "randomState": 965607,
+            "randomState": 861138,
             "tickCount": 6750,
             "type": "paint"
         },
         {
-            "randomState": 965607,
+            "randomState": 267486,
             "tickCount": 6800,
             "type": "paint"
         },
         {
-            "randomState": 965607,
+            "randomState": 267486,
             "tickCount": 6850,
             "type": "paint"
         },
         {
-            "randomState": 791346,
+            "randomState": 860713,
             "tickCount": 6900,
             "type": "paint"
         },
         {
-            "randomState": 791346,
+            "randomState": 860713,
             "tickCount": 6950,
             "type": "paint"
         },
         {
-            "randomState": 791346,
+            "randomState": 530534,
             "tickCount": 7000,
             "type": "paint"
         },
         {
-            "randomState": 791346,
+            "randomState": 530534,
             "tickCount": 7050,
             "type": "paint"
         },
         {
-            "randomState": 791346,
+            "randomState": 530534,
             "tickCount": 7100,
             "type": "paint"
         },
         {
-            "randomState": 846757,
+            "randomState": 530534,
             "tickCount": 7150,
             "type": "paint"
         },
         {
-            "randomState": 745227,
+            "randomState": 1005889,
             "tickCount": 7200,
             "type": "paint"
         },
@@ -1510,12 +1510,12 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 745227,
+            "randomState": 609177,
             "tickCount": 7250,
             "type": "paint"
         },
         {
-            "randomState": 745227,
+            "randomState": 156546,
             "tickCount": 7300,
             "type": "paint"
         },
@@ -1532,37 +1532,37 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 170510,
+            "randomState": 849068,
             "tickCount": 7350,
             "type": "paint"
         },
         {
-            "randomState": 170510,
+            "randomState": 849068,
             "tickCount": 7400,
             "type": "paint"
         },
         {
-            "randomState": 170510,
+            "randomState": 849068,
             "tickCount": 7450,
             "type": "paint"
         },
         {
-            "randomState": 170510,
+            "randomState": 849068,
             "tickCount": 7500,
             "type": "paint"
         },
         {
-            "randomState": 811510,
+            "randomState": 849068,
             "tickCount": 7550,
             "type": "paint"
         },
         {
-            "randomState": 811510,
+            "randomState": 849068,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 601625,
+            "randomState": 1036540,
             "tickCount": 7650,
             "type": "paint"
         },
@@ -1573,17 +1573,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 356920,
+            "randomState": 266634,
             "tickCount": 7700,
             "type": "paint"
         },
         {
-            "randomState": 919346,
+            "randomState": 348597,
             "tickCount": 7750,
             "type": "paint"
         },
         {
-            "randomState": 613697,
+            "randomState": 853839,
             "tickCount": 7800,
             "type": "paint"
         },
@@ -1594,87 +1594,87 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 613697,
+            "randomState": 853839,
             "tickCount": 7850,
             "type": "paint"
         },
         {
-            "randomState": 847433,
+            "randomState": 314396,
             "tickCount": 7900,
             "type": "paint"
         },
         {
-            "randomState": 847433,
+            "randomState": 255354,
             "tickCount": 7950,
             "type": "paint"
         },
         {
-            "randomState": 847433,
+            "randomState": 255354,
             "tickCount": 8000,
             "type": "paint"
         },
         {
-            "randomState": 234683,
+            "randomState": 255354,
             "tickCount": 8050,
             "type": "paint"
         },
         {
-            "randomState": 234683,
+            "randomState": 255354,
             "tickCount": 8100,
             "type": "paint"
         },
         {
-            "randomState": 234683,
+            "randomState": 14196,
             "tickCount": 8150,
             "type": "paint"
         },
         {
-            "randomState": 234683,
+            "randomState": 974403,
             "tickCount": 8200,
             "type": "paint"
         },
         {
-            "randomState": 861138,
+            "randomState": 974403,
             "tickCount": 8250,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 974403,
             "tickCount": 8300,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 974403,
             "tickCount": 8350,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 974403,
             "tickCount": 8400,
             "type": "paint"
         },
         {
-            "randomState": 530534,
+            "randomState": 974403,
             "tickCount": 8450,
             "type": "paint"
         },
         {
-            "randomState": 530534,
+            "randomState": 974403,
             "tickCount": 8500,
             "type": "paint"
         },
         {
-            "randomState": 985739,
+            "randomState": 227790,
             "tickCount": 8550,
             "type": "paint"
         },
         {
-            "randomState": 733035,
+            "randomState": 366984,
             "tickCount": 8600,
             "type": "paint"
         },
         {
-            "randomState": 432712,
+            "randomState": 951440,
             "tickCount": 8650,
             "type": "paint"
         },
@@ -1685,22 +1685,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 432712,
+            "randomState": 951440,
             "tickCount": 8700,
             "type": "paint"
         },
         {
-            "randomState": 432712,
+            "randomState": 951440,
             "tickCount": 8750,
             "type": "paint"
         },
         {
-            "randomState": 432712,
+            "randomState": 951440,
             "tickCount": 8800,
             "type": "paint"
         },
         {
-            "randomState": 432712,
+            "randomState": 951440,
             "tickCount": 8850,
             "type": "paint"
         },
@@ -1711,7 +1711,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 934179,
+            "randomState": 206145,
             "tickCount": 8900,
             "type": "paint"
         },
@@ -1722,12 +1722,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 609177,
+            "randomState": 206145,
             "tickCount": 8950,
             "type": "paint"
         },
         {
-            "randomState": 573797,
+            "randomState": 206145,
             "tickCount": 9000,
             "type": "paint"
         },
@@ -1738,17 +1738,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 573797,
+            "randomState": 206145,
             "tickCount": 9050,
             "type": "paint"
         },
         {
-            "randomState": 165735,
+            "randomState": 889682,
             "tickCount": 9100,
             "type": "paint"
         },
         {
-            "randomState": 165735,
+            "randomState": 496279,
             "tickCount": 9150,
             "type": "paint"
         },
@@ -1759,127 +1759,127 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 798733,
+            "randomState": 871186,
             "tickCount": 9200,
             "type": "paint"
         },
         {
-            "randomState": 156546,
+            "randomState": 871186,
             "tickCount": 9250,
             "type": "paint"
         },
         {
-            "randomState": 156546,
+            "randomState": 871186,
             "tickCount": 9300,
             "type": "paint"
         },
         {
-            "randomState": 156546,
+            "randomState": 832147,
             "tickCount": 9350,
             "type": "paint"
         },
         {
-            "randomState": 156546,
+            "randomState": 832147,
             "tickCount": 9400,
             "type": "paint"
         },
         {
-            "randomState": 156546,
+            "randomState": 832147,
             "tickCount": 9450,
             "type": "paint"
         },
         {
-            "randomState": 241336,
+            "randomState": 613693,
             "tickCount": 9500,
             "type": "paint"
         },
         {
-            "randomState": 270016,
+            "randomState": 613693,
             "tickCount": 9550,
             "type": "paint"
         },
         {
-            "randomState": 270016,
+            "randomState": 613693,
             "tickCount": 9600,
             "type": "paint"
         },
         {
-            "randomState": 849068,
+            "randomState": 623382,
             "tickCount": 9650,
             "type": "paint"
         },
         {
-            "randomState": 849068,
+            "randomState": 623382,
             "tickCount": 9700,
             "type": "paint"
         },
         {
-            "randomState": 1036540,
+            "randomState": 576426,
             "tickCount": 9750,
             "type": "paint"
         },
         {
-            "randomState": 1036540,
+            "randomState": 768395,
             "tickCount": 9800,
             "type": "paint"
         },
         {
-            "randomState": 1036540,
+            "randomState": 793981,
             "tickCount": 9850,
             "type": "paint"
         },
         {
-            "randomState": 266634,
+            "randomState": 411377,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 348597,
+            "randomState": 790342,
             "tickCount": 9950,
             "type": "paint"
         },
         {
-            "randomState": 255354,
+            "randomState": 790342,
             "tickCount": 10000,
             "type": "paint"
         },
         {
-            "randomState": 974403,
+            "randomState": 790342,
             "tickCount": 10050,
             "type": "paint"
         },
         {
-            "randomState": 974403,
+            "randomState": 790342,
             "tickCount": 10100,
             "type": "paint"
         },
         {
-            "randomState": 974403,
+            "randomState": 588835,
             "tickCount": 10150,
             "type": "paint"
         },
         {
-            "randomState": 227790,
+            "randomState": 398926,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 227790,
+            "randomState": 398926,
             "tickCount": 10250,
             "type": "paint"
         },
         {
-            "randomState": 366984,
+            "randomState": 218175,
             "tickCount": 10300,
             "type": "paint"
         },
         {
-            "randomState": 366984,
+            "randomState": 218175,
             "tickCount": 10350,
             "type": "paint"
         },
         {
-            "randomState": 951440,
+            "randomState": 218175,
             "tickCount": 10400,
             "type": "paint"
         },
@@ -1890,12 +1890,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 951440,
+            "randomState": 552989,
             "tickCount": 10450,
             "type": "paint"
         },
         {
-            "randomState": 951440,
+            "randomState": 552989,
             "tickCount": 10500,
             "type": "paint"
         },
@@ -1906,72 +1906,72 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 951440,
+            "randomState": 552989,
             "tickCount": 10550,
             "type": "paint"
         },
         {
-            "randomState": 951440,
+            "randomState": 79538,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 206145,
+            "randomState": 423843,
             "tickCount": 10650,
             "type": "paint"
         },
         {
-            "randomState": 889682,
+            "randomState": 56570,
             "tickCount": 10700,
             "type": "paint"
         },
         {
-            "randomState": 889682,
+            "randomState": 373654,
             "tickCount": 10750,
             "type": "paint"
         },
         {
-            "randomState": 889682,
+            "randomState": 979381,
             "tickCount": 10800,
             "type": "paint"
         },
         {
-            "randomState": 889682,
+            "randomState": 979381,
             "tickCount": 10850,
             "type": "paint"
         },
         {
-            "randomState": 263280,
+            "randomState": 1011840,
             "tickCount": 10900,
             "type": "paint"
         },
         {
-            "randomState": 263280,
+            "randomState": 1011840,
             "tickCount": 10950,
             "type": "paint"
         },
         {
-            "randomState": 263280,
+            "randomState": 1011840,
             "tickCount": 11000,
             "type": "paint"
         },
         {
-            "randomState": 263280,
+            "randomState": 1011840,
             "tickCount": 11050,
             "type": "paint"
         },
         {
-            "randomState": 263280,
+            "randomState": 136216,
             "tickCount": 11100,
             "type": "paint"
         },
         {
-            "randomState": 1001408,
+            "randomState": 161940,
             "tickCount": 11150,
             "type": "paint"
         },
         {
-            "randomState": 70878,
+            "randomState": 406109,
             "tickCount": 11200,
             "type": "paint"
         },
@@ -1982,62 +1982,62 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 70878,
+            "randomState": 353498,
             "tickCount": 11250,
             "type": "paint"
         },
         {
-            "randomState": 70878,
+            "randomState": 353498,
             "tickCount": 11300,
             "type": "paint"
         },
         {
-            "randomState": 70878,
+            "randomState": 353498,
             "tickCount": 11350,
             "type": "paint"
         },
         {
-            "randomState": 70878,
+            "randomState": 353498,
             "tickCount": 11400,
             "type": "paint"
         },
         {
-            "randomState": 70878,
+            "randomState": 353498,
             "tickCount": 11450,
             "type": "paint"
         },
         {
-            "randomState": 871186,
+            "randomState": 353498,
             "tickCount": 11500,
             "type": "paint"
         },
         {
-            "randomState": 832147,
+            "randomState": 407444,
             "tickCount": 11550,
             "type": "paint"
         },
         {
-            "randomState": 832147,
+            "randomState": 407444,
             "tickCount": 11600,
             "type": "paint"
         },
         {
-            "randomState": 613693,
+            "randomState": 170060,
             "tickCount": 11650,
             "type": "paint"
         },
         {
-            "randomState": 613693,
+            "randomState": 170060,
             "tickCount": 11700,
             "type": "paint"
         },
         {
-            "randomState": 613693,
+            "randomState": 972546,
             "tickCount": 11750,
             "type": "paint"
         },
         {
-            "randomState": 613693,
+            "randomState": 972546,
             "tickCount": 11800,
             "type": "paint"
         },
@@ -2048,12 +2048,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 613693,
+            "randomState": 972546,
             "tickCount": 11850,
             "type": "paint"
         },
         {
-            "randomState": 623382,
+            "randomState": 832867,
             "tickCount": 11900,
             "type": "paint"
         },
@@ -2064,7 +2064,7 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 576426,
+            "randomState": 457302,
             "tickCount": 11950,
             "type": "paint"
         },
@@ -2081,27 +2081,27 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 576426,
+            "randomState": 457302,
             "tickCount": 12000,
             "type": "paint"
         },
         {
-            "randomState": 576426,
+            "randomState": 457302,
             "tickCount": 12050,
             "type": "paint"
         },
         {
-            "randomState": 576426,
+            "randomState": 904583,
             "tickCount": 12100,
             "type": "paint"
         },
         {
-            "randomState": 576426,
+            "randomState": 554207,
             "tickCount": 12150,
             "type": "paint"
         },
         {
-            "randomState": 576426,
+            "randomState": 554207,
             "tickCount": 12200,
             "type": "paint"
         },
@@ -2112,17 +2112,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 768395,
+            "randomState": 631223,
             "tickCount": 12250,
             "type": "paint"
         },
         {
-            "randomState": 961747,
+            "randomState": 494882,
             "tickCount": 12300,
             "type": "paint"
         },
         {
-            "randomState": 961747,
+            "randomState": 494882,
             "tickCount": 12350,
             "type": "paint"
         },
@@ -2133,192 +2133,192 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 729004,
+            "randomState": 494882,
             "tickCount": 12400,
             "type": "paint"
         },
         {
-            "randomState": 729004,
+            "randomState": 750886,
             "tickCount": 12450,
             "type": "paint"
         },
         {
-            "randomState": 299723,
+            "randomState": 750886,
             "tickCount": 12500,
             "type": "paint"
         },
         {
-            "randomState": 411377,
+            "randomState": 750886,
             "tickCount": 12550,
             "type": "paint"
         },
         {
-            "randomState": 411377,
+            "randomState": 750886,
             "tickCount": 12600,
             "type": "paint"
         },
         {
-            "randomState": 790342,
+            "randomState": 784493,
             "tickCount": 12650,
             "type": "paint"
         },
         {
-            "randomState": 588835,
+            "randomState": 1036390,
             "tickCount": 12700,
             "type": "paint"
         },
         {
-            "randomState": 588835,
+            "randomState": 1036390,
             "tickCount": 12750,
             "type": "paint"
         },
         {
-            "randomState": 595404,
+            "randomState": 472427,
             "tickCount": 12800,
             "type": "paint"
         },
         {
-            "randomState": 595404,
+            "randomState": 472427,
             "tickCount": 12850,
             "type": "paint"
         },
         {
-            "randomState": 79538,
+            "randomState": 87893,
             "tickCount": 12900,
             "type": "paint"
         },
         {
-            "randomState": 79538,
+            "randomState": 87893,
             "tickCount": 12950,
             "type": "paint"
         },
         {
-            "randomState": 79538,
+            "randomState": 530053,
             "tickCount": 13000,
             "type": "paint"
         },
         {
-            "randomState": 423843,
+            "randomState": 530053,
             "tickCount": 13050,
             "type": "paint"
         },
         {
-            "randomState": 423843,
+            "randomState": 530053,
             "tickCount": 13100,
             "type": "paint"
         },
         {
-            "randomState": 56570,
+            "randomState": 957703,
             "tickCount": 13150,
             "type": "paint"
         },
         {
-            "randomState": 556581,
+            "randomState": 564492,
             "tickCount": 13200,
             "type": "paint"
         },
         {
-            "randomState": 621620,
+            "randomState": 573143,
             "tickCount": 13250,
             "type": "paint"
         },
         {
-            "randomState": 621620,
+            "randomState": 573143,
             "tickCount": 13300,
             "type": "paint"
         },
         {
-            "randomState": 621620,
+            "randomState": 573143,
             "tickCount": 13350,
             "type": "paint"
         },
         {
-            "randomState": 621620,
+            "randomState": 81972,
             "tickCount": 13400,
             "type": "paint"
         },
         {
-            "randomState": 817016,
+            "randomState": 522761,
             "tickCount": 13450,
             "type": "paint"
         },
         {
-            "randomState": 373654,
+            "randomState": 522761,
             "tickCount": 13500,
             "type": "paint"
         },
         {
-            "randomState": 373654,
+            "randomState": 1008623,
             "tickCount": 13550,
             "type": "paint"
         },
         {
-            "randomState": 373654,
+            "randomState": 1008623,
             "tickCount": 13600,
             "type": "paint"
         },
         {
-            "randomState": 1011840,
+            "randomState": 4859,
             "tickCount": 13650,
             "type": "paint"
         },
         {
-            "randomState": 1011840,
+            "randomState": 4859,
             "tickCount": 13700,
             "type": "paint"
         },
         {
-            "randomState": 1011840,
+            "randomState": 35984,
             "tickCount": 13750,
             "type": "paint"
         },
         {
-            "randomState": 1011840,
+            "randomState": 35984,
             "tickCount": 13800,
             "type": "paint"
         },
         {
-            "randomState": 136216,
+            "randomState": 35984,
             "tickCount": 13850,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 812552,
             "tickCount": 13900,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 88537,
             "tickCount": 13950,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 88537,
             "tickCount": 14000,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 88537,
             "tickCount": 14050,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 363052,
             "tickCount": 14100,
             "type": "paint"
         },
         {
-            "randomState": 161940,
+            "randomState": 419202,
             "tickCount": 14150,
             "type": "paint"
         },
         {
-            "randomState": 596454,
+            "randomState": 897450,
             "tickCount": 14200,
             "type": "paint"
         },
         {
-            "randomState": 596454,
+            "randomState": 897450,
             "tickCount": 14250,
             "type": "paint"
         },
@@ -2329,22 +2329,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 596454,
+            "randomState": 897450,
             "tickCount": 14300,
             "type": "paint"
         },
         {
-            "randomState": 596454,
+            "randomState": 897450,
             "tickCount": 14350,
             "type": "paint"
         },
         {
-            "randomState": 414091,
+            "randomState": 897450,
             "tickCount": 14400,
             "type": "paint"
         },
         {
-            "randomState": 492191,
+            "randomState": 272493,
             "tickCount": 14450,
             "type": "paint"
         },
@@ -2355,52 +2355,52 @@
             "type": "keyPress"
         },
         {
-            "randomState": 492191,
+            "randomState": 272493,
             "tickCount": 14500,
             "type": "paint"
         },
         {
-            "randomState": 492191,
+            "randomState": 272493,
             "tickCount": 14550,
             "type": "paint"
         },
         {
-            "randomState": 492191,
+            "randomState": 47248,
             "tickCount": 14600,
             "type": "paint"
         },
         {
-            "randomState": 406109,
+            "randomState": 838932,
             "tickCount": 14650,
             "type": "paint"
         },
         {
-            "randomState": 406109,
+            "randomState": 838932,
             "tickCount": 14700,
             "type": "paint"
         },
         {
-            "randomState": 406109,
+            "randomState": 838932,
             "tickCount": 14750,
             "type": "paint"
         },
         {
-            "randomState": 12480,
+            "randomState": 838932,
             "tickCount": 14800,
             "type": "paint"
         },
         {
-            "randomState": 12480,
+            "randomState": 838932,
             "tickCount": 14850,
             "type": "paint"
         },
         {
-            "randomState": 762267,
+            "randomState": 452370,
             "tickCount": 14900,
             "type": "paint"
         },
         {
-            "randomState": 762267,
+            "randomState": 954883,
             "tickCount": 14950,
             "type": "paint"
         }

--- a/test/Data/issue_1294.json
+++ b/test/Data/issue_1294.json
@@ -709,67 +709,67 @@
     },
     "trace": [
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 50,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 100,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 150,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 200,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 250,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 300,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 350,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 400,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 450,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 500,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 550,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 600,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 650,
             "type": "paint"
         },
@@ -784,7 +784,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 700,
             "type": "paint"
         },
@@ -799,7 +799,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 750,
             "type": "paint"
         },
@@ -814,7 +814,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 800,
             "type": "paint"
         },
@@ -829,7 +829,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 850,
             "type": "paint"
         },
@@ -844,7 +844,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 900,
             "type": "paint"
         },
@@ -859,7 +859,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 950,
             "type": "paint"
         },
@@ -874,7 +874,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1000,
             "type": "paint"
         },
@@ -889,7 +889,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1050,
             "type": "paint"
         },
@@ -904,12 +904,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1150,
             "type": "paint"
         },
@@ -924,7 +924,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1200,
             "type": "paint"
         },
@@ -939,12 +939,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1300,
             "type": "paint"
         },
@@ -959,12 +959,12 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1400,
             "type": "paint"
         },
@@ -979,7 +979,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1450,
             "type": "paint"
         },
@@ -994,7 +994,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1500,
             "type": "paint"
         },
@@ -1009,7 +1009,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1550,
             "type": "paint"
         },
@@ -1024,7 +1024,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1600,
             "type": "paint"
         },
@@ -1039,7 +1039,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1650,
             "type": "paint"
         },
@@ -1054,7 +1054,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1700,
             "type": "paint"
         },
@@ -1069,7 +1069,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1750,
             "type": "paint"
         },
@@ -1084,7 +1084,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1800,
             "type": "paint"
         },
@@ -1099,7 +1099,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1850,
             "type": "paint"
         },
@@ -1114,7 +1114,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1900,
             "type": "paint"
         },
@@ -1129,7 +1129,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1950,
             "type": "paint"
         },
@@ -1144,7 +1144,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2000,
             "type": "paint"
         },
@@ -1159,7 +1159,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2050,
             "type": "paint"
         },
@@ -1174,7 +1174,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2100,
             "type": "paint"
         },
@@ -1189,7 +1189,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2150,
             "type": "paint"
         },
@@ -1204,7 +1204,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2200,
             "type": "paint"
         },
@@ -1219,7 +1219,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2250,
             "type": "paint"
         },
@@ -1234,7 +1234,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2300,
             "type": "paint"
         },
@@ -1249,7 +1249,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2350,
             "type": "paint"
         },
@@ -1264,7 +1264,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2400,
             "type": "paint"
         },
@@ -1279,12 +1279,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2500,
             "type": "paint"
         },
@@ -1299,92 +1299,92 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3400,
             "type": "paint"
         },
@@ -1399,12 +1399,12 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3500,
             "type": "paint"
         },
@@ -1419,7 +1419,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3550,
             "type": "paint"
         },
@@ -1434,7 +1434,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3600,
             "type": "paint"
         },
@@ -1449,7 +1449,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3650,
             "type": "paint"
         },
@@ -1464,7 +1464,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3700,
             "type": "paint"
         },
@@ -1479,7 +1479,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3750,
             "type": "paint"
         },
@@ -1494,7 +1494,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3800,
             "type": "paint"
         },
@@ -1509,7 +1509,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3850,
             "type": "paint"
         },
@@ -1524,7 +1524,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3900,
             "type": "paint"
         },
@@ -1539,7 +1539,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3950,
             "type": "paint"
         },
@@ -1554,17 +1554,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4100,
             "type": "paint"
         },
@@ -1579,12 +1579,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4200,
             "type": "paint"
         },
@@ -1599,7 +1599,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4250,
             "type": "paint"
         },
@@ -1624,7 +1624,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4300,
             "type": "paint"
         },
@@ -1639,7 +1639,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4350,
             "type": "paint"
         },
@@ -1664,7 +1664,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4400,
             "type": "paint"
         },
@@ -1679,7 +1679,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4450,
             "type": "paint"
         },
@@ -1694,12 +1694,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4550,
             "type": "paint"
         },
@@ -1714,7 +1714,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4600,
             "type": "paint"
         },
@@ -1729,7 +1729,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4650,
             "type": "paint"
         },
@@ -1744,7 +1744,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4700,
             "type": "paint"
         },
@@ -1759,7 +1759,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4750,
             "type": "paint"
         },
@@ -1774,7 +1774,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4800,
             "type": "paint"
         },
@@ -1789,7 +1789,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4850,
             "type": "paint"
         },
@@ -1804,7 +1804,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4900,
             "type": "paint"
         },
@@ -1819,7 +1819,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4950,
             "type": "paint"
         },
@@ -1834,7 +1834,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5000,
             "type": "paint"
         },
@@ -1849,7 +1849,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5050,
             "type": "paint"
         },
@@ -1864,7 +1864,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5100,
             "type": "paint"
         },
@@ -1879,22 +1879,22 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5300,
             "type": "paint"
         },
@@ -1909,7 +1909,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5350,
             "type": "paint"
         },
@@ -1924,7 +1924,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5400,
             "type": "paint"
         },
@@ -1939,7 +1939,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5450,
             "type": "paint"
         },
@@ -1954,7 +1954,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5500,
             "type": "paint"
         },
@@ -1969,7 +1969,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5550,
             "type": "paint"
         },
@@ -1984,7 +1984,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5600,
             "type": "paint"
         },
@@ -1999,7 +1999,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5650,
             "type": "paint"
         },
@@ -2014,7 +2014,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5700,
             "type": "paint"
         },
@@ -2029,7 +2029,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5750,
             "type": "paint"
         },
@@ -2044,7 +2044,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5800,
             "type": "paint"
         },
@@ -2059,7 +2059,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5850,
             "type": "paint"
         },
@@ -2074,7 +2074,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5900,
             "type": "paint"
         },
@@ -2089,7 +2089,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 5950,
             "type": "paint"
         },
@@ -2104,7 +2104,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6000,
             "type": "paint"
         },
@@ -2129,12 +2129,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6100,
             "type": "paint"
         },
@@ -2159,7 +2159,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6150,
             "type": "paint"
         },
@@ -2174,7 +2174,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6200,
             "type": "paint"
         },
@@ -2189,7 +2189,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6250,
             "type": "paint"
         },
@@ -2204,7 +2204,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6300,
             "type": "paint"
         },
@@ -2219,7 +2219,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6350,
             "type": "paint"
         },
@@ -2234,7 +2234,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6400,
             "type": "paint"
         },
@@ -2249,7 +2249,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6450,
             "type": "paint"
         },
@@ -2264,7 +2264,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6500,
             "type": "paint"
         },
@@ -2279,7 +2279,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6550,
             "type": "paint"
         },
@@ -2294,7 +2294,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6600,
             "type": "paint"
         },
@@ -2309,7 +2309,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6650,
             "type": "paint"
         },
@@ -2334,7 +2334,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6700,
             "type": "paint"
         },
@@ -2349,7 +2349,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6750,
             "type": "paint"
         },
@@ -2374,12 +2374,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6850,
             "type": "paint"
         },
@@ -2394,7 +2394,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6900,
             "type": "paint"
         },
@@ -2409,7 +2409,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 6950,
             "type": "paint"
         },
@@ -2424,7 +2424,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7000,
             "type": "paint"
         },
@@ -2439,7 +2439,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7050,
             "type": "paint"
         },
@@ -2454,7 +2454,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7100,
             "type": "paint"
         },
@@ -2469,7 +2469,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7150,
             "type": "paint"
         },
@@ -2484,7 +2484,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7200,
             "type": "paint"
         },
@@ -2499,7 +2499,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7250,
             "type": "paint"
         },
@@ -2514,7 +2514,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7300,
             "type": "paint"
         },
@@ -2529,7 +2529,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7350,
             "type": "paint"
         },
@@ -2544,7 +2544,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7400,
             "type": "paint"
         },
@@ -2559,12 +2559,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7500,
             "type": "paint"
         },
@@ -2579,17 +2579,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7650,
             "type": "paint"
         },
@@ -2604,22 +2604,22 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7850,
             "type": "paint"
         },
@@ -2634,22 +2634,22 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 7950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8050,
             "type": "paint"
         },
@@ -2664,7 +2664,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8100,
             "type": "paint"
         },
@@ -2679,7 +2679,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8150,
             "type": "paint"
         },
@@ -2694,7 +2694,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8200,
             "type": "paint"
         },
@@ -2709,7 +2709,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8250,
             "type": "paint"
         },
@@ -2724,7 +2724,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8300,
             "type": "paint"
         },
@@ -2739,7 +2739,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8350,
             "type": "paint"
         },
@@ -2754,7 +2754,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8400,
             "type": "paint"
         },
@@ -2769,7 +2769,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8450,
             "type": "paint"
         },
@@ -2784,7 +2784,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8500,
             "type": "paint"
         },
@@ -2799,7 +2799,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8550,
             "type": "paint"
         },
@@ -2814,7 +2814,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8600,
             "type": "paint"
         },
@@ -2829,7 +2829,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8650,
             "type": "paint"
         },
@@ -2844,7 +2844,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8700,
             "type": "paint"
         },
@@ -2859,7 +2859,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8750,
             "type": "paint"
         },
@@ -2874,7 +2874,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8800,
             "type": "paint"
         },
@@ -2889,7 +2889,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8850,
             "type": "paint"
         },
@@ -2904,7 +2904,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8900,
             "type": "paint"
         },
@@ -2919,7 +2919,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 8950,
             "type": "paint"
         },
@@ -2934,12 +2934,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9050,
             "type": "paint"
         },
@@ -2964,12 +2964,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9150,
             "type": "paint"
         },
@@ -2984,7 +2984,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9200,
             "type": "paint"
         },
@@ -2999,7 +2999,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9250,
             "type": "paint"
         },
@@ -3014,7 +3014,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9300,
             "type": "paint"
         },
@@ -3029,7 +3029,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9350,
             "type": "paint"
         },
@@ -3044,7 +3044,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9400,
             "type": "paint"
         },
@@ -3059,7 +3059,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9450,
             "type": "paint"
         },
@@ -3074,7 +3074,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9500,
             "type": "paint"
         },
@@ -3089,7 +3089,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9550,
             "type": "paint"
         },
@@ -3104,17 +3104,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9700,
             "type": "paint"
         },
@@ -3129,7 +3129,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9750,
             "type": "paint"
         },
@@ -3144,7 +3144,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9800,
             "type": "paint"
         },
@@ -3159,7 +3159,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9850,
             "type": "paint"
         },
@@ -3174,22 +3174,22 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 9950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10050,
             "type": "paint"
         },
@@ -3204,92 +3204,92 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10400,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10500,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 10950,
             "type": "paint"
         },
@@ -3304,47 +3304,47 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11400,
             "type": "paint"
         },
@@ -3359,7 +3359,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11450,
             "type": "paint"
         },
@@ -3374,7 +3374,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11500,
             "type": "paint"
         },
@@ -3389,7 +3389,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11550,
             "type": "paint"
         },
@@ -3404,7 +3404,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11600,
             "type": "paint"
         },
@@ -3419,7 +3419,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11650,
             "type": "paint"
         },
@@ -3434,27 +3434,27 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11900,
             "type": "paint"
         },
@@ -3469,7 +3469,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 11950,
             "type": "paint"
         },
@@ -3484,7 +3484,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12000,
             "type": "paint"
         },
@@ -3499,7 +3499,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12050,
             "type": "paint"
         },
@@ -3514,7 +3514,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12100,
             "type": "paint"
         },
@@ -3529,7 +3529,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12150,
             "type": "paint"
         },
@@ -3544,12 +3544,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12250,
             "type": "paint"
         },
@@ -3564,7 +3564,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12300,
             "type": "paint"
         },
@@ -3579,7 +3579,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12350,
             "type": "paint"
         },
@@ -3614,7 +3614,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12400,
             "type": "paint"
         },
@@ -3629,7 +3629,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12450,
             "type": "paint"
         },
@@ -3644,7 +3644,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12500,
             "type": "paint"
         },
@@ -3659,7 +3659,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12550,
             "type": "paint"
         },
@@ -3674,7 +3674,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12600,
             "type": "paint"
         },
@@ -3689,7 +3689,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12650,
             "type": "paint"
         },
@@ -3704,7 +3704,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12700,
             "type": "paint"
         },
@@ -3719,7 +3719,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12750,
             "type": "paint"
         },
@@ -3734,7 +3734,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12800,
             "type": "paint"
         },
@@ -3749,7 +3749,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12850,
             "type": "paint"
         },
@@ -3764,7 +3764,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12900,
             "type": "paint"
         },
@@ -3779,7 +3779,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 12950,
             "type": "paint"
         },
@@ -3794,47 +3794,47 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13400,
             "type": "paint"
         },
@@ -3849,7 +3849,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13450,
             "type": "paint"
         },
@@ -3864,7 +3864,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13500,
             "type": "paint"
         },
@@ -3879,167 +3879,167 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 13950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14200,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14250,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14400,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14500,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 14950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15150,
             "type": "paint"
         },
@@ -4054,7 +4054,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15200,
             "type": "paint"
         },
@@ -4069,7 +4069,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15250,
             "type": "paint"
         },
@@ -4084,7 +4084,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15300,
             "type": "paint"
         },
@@ -4099,12 +4099,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15400,
             "type": "paint"
         },
@@ -4119,7 +4119,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15450,
             "type": "paint"
         },
@@ -4134,7 +4134,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15500,
             "type": "paint"
         },
@@ -4149,12 +4149,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15600,
             "type": "paint"
         },
@@ -4179,62 +4179,62 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15700,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 15950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16200,
             "type": "paint"
         },
@@ -4249,7 +4249,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16250,
             "type": "paint"
         },
@@ -4284,7 +4284,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16300,
             "type": "paint"
         },
@@ -4299,7 +4299,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16350,
             "type": "paint"
         },
@@ -4314,7 +4314,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16400,
             "type": "paint"
         },
@@ -4329,7 +4329,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16450,
             "type": "paint"
         },
@@ -4344,7 +4344,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16500,
             "type": "paint"
         },
@@ -4359,12 +4359,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16600,
             "type": "paint"
         },
@@ -4379,7 +4379,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16650,
             "type": "paint"
         },
@@ -4394,7 +4394,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16700,
             "type": "paint"
         },
@@ -4409,17 +4409,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16850,
             "type": "paint"
         },
@@ -4434,12 +4434,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 16950,
             "type": "paint"
         },
@@ -4454,37 +4454,37 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 17000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 17050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 17100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 17150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 17200,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17250,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17300,
             "type": "paint"
         },
@@ -4499,7 +4499,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17350,
             "type": "paint"
         },
@@ -4514,32 +4514,32 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17400,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17450,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17500,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17550,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17600,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17650,
             "type": "paint"
         },
@@ -4550,22 +4550,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17700,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17750,
             "type": "paint"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 17800,
             "type": "paint"
         },
         {
-            "randomState": 79,
+            "randomState": 127,
             "tickCount": 17850,
             "type": "paint"
         },
@@ -4576,47 +4576,47 @@
             "type": "keyPress"
         },
         {
-            "randomState": 89,
+            "randomState": 139,
             "tickCount": 17900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17950,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18000,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18050,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18100,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18150,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18200,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18250,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18300,
             "type": "paint"
         }

--- a/test/Data/issue_1708.json
+++ b/test/Data/issue_1708.json
@@ -1226,7 +1226,7 @@
             "type": "paint"
         },
         {
-            "randomState": 192841,
+            "randomState": 529290,
             "tickCount": 13700,
             "type": "paint"
         },
@@ -1251,7 +1251,7 @@
             "type": "paint"
         },
         {
-            "randomState": 50273,
+            "randomState": 220517,
             "tickCount": 14200,
             "type": "paint"
         },
@@ -1262,12 +1262,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 286002,
+            "randomState": 423532,
             "tickCount": 14300,
             "type": "paint"
         },
         {
-            "randomState": 423532,
+            "randomState": 516362,
             "tickCount": 14400,
             "type": "paint"
         },
@@ -1278,17 +1278,17 @@
             "type": "keyPress"
         },
         {
-            "randomState": 138384,
+            "randomState": 514118,
             "tickCount": 14500,
             "type": "paint"
         },
         {
-            "randomState": 514118,
+            "randomState": 987811,
             "tickCount": 14600,
             "type": "paint"
         },
         {
-            "randomState": 514118,
+            "randomState": 987811,
             "tickCount": 14700,
             "type": "paint"
         }

--- a/test/Data/issue_1972.json
+++ b/test/Data/issue_1972.json
@@ -115,7 +115,7 @@
                         "Wizard Ring of Mind Magic",
                         "Brass Ring of Magic [+12]"
                     ],
-                    "hp": 523,
+                    "hp": 693,
                     "intelligence": 109,
                     "luck": 429,
                     "might": 137,
@@ -167,7 +167,7 @@
                         "Brass Ring of Disarming [+8]",
                         "Sapphire Ring of Items [+12]"
                     ],
-                    "hp": 446,
+                    "hp": 681,
                     "intelligence": 141,
                     "luck": 451,
                     "might": 150,
@@ -214,7 +214,7 @@
                         "Wizard Ring of The Troll",
                         "Enchanted Ring of The Moon"
                     ],
-                    "hp": 403,
+                    "hp": 562,
                     "intelligence": 125,
                     "luck": 429,
                     "might": 155,
@@ -289,7 +289,7 @@
                         "Wizards' Platinum Ring",
                         "Dazzling Ring of The Sun"
                     ],
-                    "hp": 84,
+                    "hp": 316,
                     "intelligence": 152,
                     "luck": 460,
                     "might": 129,
@@ -536,582 +536,582 @@
     },
     "trace": [
         {
-            "randomState": 854299,
+            "randomState": 875569,
             "tickCount": 100,
             "type": "paint"
         },
         {
-            "randomState": 854299,
+            "randomState": 875569,
             "tickCount": 200,
             "type": "paint"
         },
         {
-            "randomState": 854299,
+            "randomState": 875569,
             "tickCount": 300,
             "type": "paint"
         },
         {
-            "randomState": 854299,
+            "randomState": 875569,
             "tickCount": 400,
             "type": "paint"
         },
         {
-            "randomState": 854299,
+            "randomState": 875569,
             "tickCount": 500,
             "type": "paint"
         },
         {
-            "randomState": 182310,
+            "randomState": 740342,
             "tickCount": 600,
             "type": "paint"
         },
         {
-            "randomState": 182310,
+            "randomState": 740342,
             "tickCount": 700,
             "type": "paint"
         },
         {
-            "randomState": 460056,
+            "randomState": 53704,
             "tickCount": 800,
             "type": "paint"
         },
         {
-            "randomState": 460056,
+            "randomState": 53704,
             "tickCount": 900,
             "type": "paint"
         },
         {
-            "randomState": 460056,
+            "randomState": 53704,
             "tickCount": 1000,
             "type": "paint"
         },
         {
-            "randomState": 686920,
+            "randomState": 478185,
             "tickCount": 1100,
             "type": "paint"
         },
         {
-            "randomState": 811510,
+            "randomState": 613697,
             "tickCount": 1200,
             "type": "paint"
         },
         {
-            "randomState": 811510,
+            "randomState": 613697,
             "tickCount": 1300,
             "type": "paint"
         },
         {
-            "randomState": 811510,
+            "randomState": 613697,
             "tickCount": 1400,
             "type": "paint"
         },
         {
-            "randomState": 861138,
+            "randomState": 432712,
             "tickCount": 1500,
             "type": "paint"
         },
         {
-            "randomState": 861138,
+            "randomState": 432712,
             "tickCount": 1600,
             "type": "paint"
         },
         {
-            "randomState": 861138,
+            "randomState": 432712,
             "tickCount": 1700,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 443720,
             "tickCount": 1800,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 443720,
             "tickCount": 1900,
             "type": "paint"
         },
         {
-            "randomState": 860713,
+            "randomState": 443720,
             "tickCount": 2000,
             "type": "paint"
         },
         {
-            "randomState": 729004,
+            "randomState": 595404,
             "tickCount": 2100,
             "type": "paint"
         },
         {
-            "randomState": 398926,
+            "randomState": 817016,
             "tickCount": 2200,
             "type": "paint"
         },
         {
-            "randomState": 755492,
+            "randomState": 573143,
             "tickCount": 2300,
             "type": "paint"
         },
         {
-            "randomState": 296404,
+            "randomState": 151996,
             "tickCount": 2400,
             "type": "paint"
         },
         {
-            "randomState": 296404,
+            "randomState": 151996,
             "tickCount": 2500,
             "type": "paint"
         },
         {
-            "randomState": 396886,
+            "randomState": 404446,
             "tickCount": 2600,
             "type": "paint"
         },
         {
-            "randomState": 995020,
+            "randomState": 499791,
             "tickCount": 2700,
             "type": "paint"
         },
         {
-            "randomState": 155009,
+            "randomState": 451105,
             "tickCount": 2800,
             "type": "paint"
         },
         {
-            "randomState": 456863,
+            "randomState": 948836,
             "tickCount": 2900,
             "type": "paint"
         },
         {
-            "randomState": 968233,
+            "randomState": 460188,
             "tickCount": 3000,
             "type": "paint"
         },
         {
-            "randomState": 123121,
+            "randomState": 1041796,
             "tickCount": 3100,
             "type": "paint"
         },
         {
-            "randomState": 340748,
+            "randomState": 190393,
             "tickCount": 3200,
             "type": "paint"
         },
         {
-            "randomState": 687635,
+            "randomState": 839924,
             "tickCount": 3300,
             "type": "paint"
         },
         {
-            "randomState": 687635,
+            "randomState": 839924,
             "tickCount": 3400,
             "type": "paint"
         },
         {
-            "randomState": 765807,
+            "randomState": 606627,
             "tickCount": 3500,
             "type": "paint"
         },
         {
-            "randomState": 105631,
+            "randomState": 248809,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 512343,
+            "randomState": 248809,
             "tickCount": 3700,
             "type": "paint"
         },
         {
-            "randomState": 512343,
+            "randomState": 667385,
             "tickCount": 3800,
             "type": "paint"
         },
         {
-            "randomState": 512343,
+            "randomState": 667385,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 512343,
+            "randomState": 667385,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 834859,
+            "randomState": 300507,
             "tickCount": 4100,
             "type": "paint"
         },
         {
-            "randomState": 712746,
+            "randomState": 68624,
             "tickCount": 4200,
             "type": "paint"
         },
         {
-            "randomState": 526358,
+            "randomState": 207418,
             "tickCount": 4300,
             "type": "paint"
         },
         {
-            "randomState": 526358,
+            "randomState": 207418,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 1675,
+            "randomState": 538820,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 1009776,
+            "randomState": 538820,
             "tickCount": 4600,
             "type": "paint"
         },
         {
-            "randomState": 333690,
+            "randomState": 421023,
             "tickCount": 4700,
             "type": "paint"
         },
         {
-            "randomState": 857890,
+            "randomState": 1009776,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 204584,
+            "randomState": 524782,
             "tickCount": 4900,
             "type": "paint"
         },
         {
-            "randomState": 691646,
+            "randomState": 524782,
             "tickCount": 5000,
             "type": "paint"
         },
         {
-            "randomState": 63408,
+            "randomState": 475841,
             "tickCount": 5100,
             "type": "paint"
         },
         {
-            "randomState": 291151,
+            "randomState": 865404,
             "tickCount": 5200,
             "type": "paint"
         },
         {
-            "randomState": 291151,
+            "randomState": 865404,
             "tickCount": 5300,
             "type": "paint"
         },
         {
-            "randomState": 291151,
+            "randomState": 865404,
             "tickCount": 5400,
             "type": "paint"
         },
         {
-            "randomState": 855760,
+            "randomState": 418652,
             "tickCount": 5500,
             "type": "paint"
         },
         {
-            "randomState": 180478,
+            "randomState": 647264,
             "tickCount": 5600,
             "type": "paint"
         },
         {
-            "randomState": 111375,
+            "randomState": 647264,
             "tickCount": 5700,
             "type": "paint"
         },
         {
-            "randomState": 111375,
+            "randomState": 647264,
             "tickCount": 5800,
             "type": "paint"
         },
         {
-            "randomState": 111375,
+            "randomState": 647264,
             "tickCount": 5900,
             "type": "paint"
         },
         {
-            "randomState": 516727,
+            "randomState": 647264,
             "tickCount": 6000,
             "type": "paint"
         },
         {
-            "randomState": 698706,
+            "randomState": 174795,
             "tickCount": 6100,
             "type": "paint"
         },
         {
-            "randomState": 706963,
+            "randomState": 126509,
             "tickCount": 6200,
             "type": "paint"
         },
         {
-            "randomState": 65581,
+            "randomState": 254514,
             "tickCount": 6300,
             "type": "paint"
         },
         {
-            "randomState": 65581,
+            "randomState": 254514,
             "tickCount": 6400,
             "type": "paint"
         },
         {
-            "randomState": 265104,
+            "randomState": 862830,
             "tickCount": 6500,
             "type": "paint"
         },
         {
-            "randomState": 265104,
+            "randomState": 862830,
             "tickCount": 6600,
             "type": "paint"
         },
         {
-            "randomState": 265104,
+            "randomState": 862830,
             "tickCount": 6700,
             "type": "paint"
         },
         {
-            "randomState": 857484,
+            "randomState": 137952,
             "tickCount": 6800,
             "type": "paint"
         },
         {
-            "randomState": 515639,
+            "randomState": 555496,
             "tickCount": 6900,
             "type": "paint"
         },
         {
-            "randomState": 511898,
+            "randomState": 164002,
             "tickCount": 7000,
             "type": "paint"
         },
         {
-            "randomState": 859812,
+            "randomState": 278167,
             "tickCount": 7100,
             "type": "paint"
         },
         {
-            "randomState": 859812,
+            "randomState": 864421,
             "tickCount": 7200,
             "type": "paint"
         },
         {
-            "randomState": 859812,
+            "randomState": 864421,
             "tickCount": 7300,
             "type": "paint"
         },
         {
-            "randomState": 859812,
+            "randomState": 864421,
             "tickCount": 7400,
             "type": "paint"
         },
         {
-            "randomState": 110760,
+            "randomState": 807367,
             "tickCount": 7500,
             "type": "paint"
         },
         {
-            "randomState": 732060,
+            "randomState": 511898,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 732060,
+            "randomState": 449971,
             "tickCount": 7700,
             "type": "paint"
         },
         {
-            "randomState": 732060,
+            "randomState": 449971,
             "tickCount": 7800,
             "type": "paint"
         },
         {
-            "randomState": 71182,
+            "randomState": 413902,
             "tickCount": 7900,
             "type": "paint"
         },
         {
-            "randomState": 71182,
+            "randomState": 413902,
             "tickCount": 8000,
             "type": "paint"
         },
         {
-            "randomState": 514451,
+            "randomState": 557143,
             "tickCount": 8100,
             "type": "paint"
         },
         {
-            "randomState": 237216,
+            "randomState": 552644,
             "tickCount": 8200,
             "type": "paint"
         },
         {
-            "randomState": 534887,
+            "randomState": 274778,
             "tickCount": 8300,
             "type": "paint"
         },
         {
-            "randomState": 297474,
+            "randomState": 274778,
             "tickCount": 8400,
             "type": "paint"
         },
         {
-            "randomState": 297474,
+            "randomState": 274778,
             "tickCount": 8500,
             "type": "paint"
         },
         {
-            "randomState": 297474,
+            "randomState": 506855,
             "tickCount": 8600,
             "type": "paint"
         },
         {
-            "randomState": 861637,
+            "randomState": 506855,
             "tickCount": 8700,
             "type": "paint"
         },
         {
-            "randomState": 354471,
+            "randomState": 1016948,
             "tickCount": 8800,
             "type": "paint"
         },
         {
-            "randomState": 1036431,
+            "randomState": 704441,
             "tickCount": 8900,
             "type": "paint"
         },
         {
-            "randomState": 998394,
+            "randomState": 728907,
             "tickCount": 9000,
             "type": "paint"
         },
         {
-            "randomState": 97906,
+            "randomState": 483305,
             "tickCount": 9100,
             "type": "paint"
         },
         {
-            "randomState": 651222,
+            "randomState": 338136,
             "tickCount": 9200,
             "type": "paint"
         },
         {
-            "randomState": 651222,
+            "randomState": 338136,
             "tickCount": 9300,
             "type": "paint"
         },
         {
-            "randomState": 970032,
+            "randomState": 338136,
             "tickCount": 9400,
             "type": "paint"
         },
         {
-            "randomState": 755399,
+            "randomState": 184417,
             "tickCount": 9500,
             "type": "paint"
         },
         {
-            "randomState": 487126,
+            "randomState": 201059,
             "tickCount": 9600,
             "type": "paint"
         },
         {
-            "randomState": 691651,
+            "randomState": 254646,
             "tickCount": 9700,
             "type": "paint"
         },
         {
-            "randomState": 691651,
+            "randomState": 802684,
             "tickCount": 9800,
             "type": "paint"
         },
         {
-            "randomState": 691651,
+            "randomState": 802684,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 691651,
+            "randomState": 802684,
             "tickCount": 10000,
             "type": "paint"
         },
         {
-            "randomState": 88744,
+            "randomState": 27219,
             "tickCount": 10100,
             "type": "paint"
         },
         {
-            "randomState": 103304,
+            "randomState": 215960,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 959933,
+            "randomState": 873376,
             "tickCount": 10300,
             "type": "paint"
         },
         {
-            "randomState": 256025,
+            "randomState": 359726,
             "tickCount": 10400,
             "type": "paint"
         },
         {
-            "randomState": 932113,
+            "randomState": 359726,
             "tickCount": 10500,
             "type": "paint"
         },
         {
-            "randomState": 6678,
+            "randomState": 359726,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 6678,
+            "randomState": 359726,
             "tickCount": 10700,
             "type": "paint"
         },
         {
-            "randomState": 1046017,
+            "randomState": 912199,
             "tickCount": 10800,
             "type": "paint"
         },
         {
-            "randomState": 408949,
+            "randomState": 676910,
             "tickCount": 10900,
             "type": "paint"
         },
         {
-            "randomState": 593394,
+            "randomState": 229299,
             "tickCount": 11000,
             "type": "paint"
         },
         {
-            "randomState": 557857,
+            "randomState": 902970,
             "tickCount": 11100,
             "type": "paint"
         },
         {
-            "randomState": 557857,
+            "randomState": 508405,
             "tickCount": 11200,
             "type": "paint"
         },
         {
-            "randomState": 189924,
+            "randomState": 508405,
             "tickCount": 11300,
             "type": "paint"
         },
         {
-            "randomState": 365727,
+            "randomState": 508405,
             "tickCount": 11400,
             "type": "paint"
         },
         {
-            "randomState": 749779,
+            "randomState": 643754,
             "tickCount": 11500,
             "type": "paint"
         },
         {
-            "randomState": 402486,
+            "randomState": 964045,
             "tickCount": 11600,
             "type": "paint"
         }

--- a/test/Data/issue_518.json
+++ b/test/Data/issue_518.json
@@ -2270,447 +2270,447 @@
             "type": "paint"
         },
         {
-            "randomState": 23524,
+            "randomState": 23566,
             "tickCount": 3296,
             "type": "paint"
         },
         {
-            "randomState": 23526,
+            "randomState": 23568,
             "tickCount": 3312,
             "type": "paint"
         },
         {
-            "randomState": 23528,
+            "randomState": 23570,
             "tickCount": 3328,
             "type": "paint"
         },
         {
-            "randomState": 23530,
+            "randomState": 23572,
             "tickCount": 3344,
             "type": "paint"
         },
         {
-            "randomState": 23532,
+            "randomState": 23574,
             "tickCount": 3360,
             "type": "paint"
         },
         {
-            "randomState": 23534,
+            "randomState": 23576,
             "tickCount": 3376,
             "type": "paint"
         },
         {
-            "randomState": 23536,
+            "randomState": 23578,
             "tickCount": 3392,
             "type": "paint"
         },
         {
-            "randomState": 23538,
+            "randomState": 23580,
             "tickCount": 3408,
             "type": "paint"
         },
         {
-            "randomState": 23540,
+            "randomState": 23582,
             "tickCount": 3424,
             "type": "paint"
         },
         {
-            "randomState": 23542,
+            "randomState": 23584,
             "tickCount": 3440,
             "type": "paint"
         },
         {
-            "randomState": 23544,
+            "randomState": 23586,
             "tickCount": 3456,
             "type": "paint"
         },
         {
-            "randomState": 23546,
+            "randomState": 23588,
             "tickCount": 3472,
             "type": "paint"
         },
         {
-            "randomState": 23548,
+            "randomState": 23590,
             "tickCount": 3488,
             "type": "paint"
         },
         {
-            "randomState": 23550,
+            "randomState": 23592,
             "tickCount": 3504,
             "type": "paint"
         },
         {
-            "randomState": 23552,
+            "randomState": 23594,
             "tickCount": 3520,
             "type": "paint"
         },
         {
-            "randomState": 23554,
+            "randomState": 23596,
             "tickCount": 3536,
             "type": "paint"
         },
         {
-            "randomState": 23556,
+            "randomState": 23598,
             "tickCount": 3552,
             "type": "paint"
         },
         {
-            "randomState": 23558,
+            "randomState": 23600,
             "tickCount": 3568,
             "type": "paint"
         },
         {
-            "randomState": 23560,
+            "randomState": 23602,
             "tickCount": 3584,
             "type": "paint"
         },
         {
-            "randomState": 23562,
+            "randomState": 23604,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 23564,
+            "randomState": 23606,
             "tickCount": 3616,
             "type": "paint"
         },
         {
-            "randomState": 23566,
+            "randomState": 23608,
             "tickCount": 3632,
             "type": "paint"
         },
         {
-            "randomState": 23568,
+            "randomState": 23610,
             "tickCount": 3648,
             "type": "paint"
         },
         {
-            "randomState": 23570,
+            "randomState": 23612,
             "tickCount": 3664,
             "type": "paint"
         },
         {
-            "randomState": 23572,
+            "randomState": 23614,
             "tickCount": 3680,
             "type": "paint"
         },
         {
-            "randomState": 23574,
+            "randomState": 23616,
             "tickCount": 3696,
             "type": "paint"
         },
         {
-            "randomState": 23576,
+            "randomState": 23618,
             "tickCount": 3712,
             "type": "paint"
         },
         {
-            "randomState": 23578,
+            "randomState": 23620,
             "tickCount": 3728,
             "type": "paint"
         },
         {
-            "randomState": 23580,
+            "randomState": 23622,
             "tickCount": 3744,
             "type": "paint"
         },
         {
-            "randomState": 23582,
+            "randomState": 23624,
             "tickCount": 3760,
             "type": "paint"
         },
         {
-            "randomState": 23584,
+            "randomState": 23626,
             "tickCount": 3776,
             "type": "paint"
         },
         {
-            "randomState": 23586,
+            "randomState": 23628,
             "tickCount": 3792,
             "type": "paint"
         },
         {
-            "randomState": 23588,
+            "randomState": 23630,
             "tickCount": 3808,
             "type": "paint"
         },
         {
-            "randomState": 23590,
+            "randomState": 23632,
             "tickCount": 3824,
             "type": "paint"
         },
         {
-            "randomState": 23610,
+            "randomState": 23652,
             "tickCount": 3840,
             "type": "paint"
         },
         {
-            "randomState": 23612,
+            "randomState": 23695,
             "tickCount": 3856,
             "type": "paint"
         },
         {
-            "randomState": 23614,
+            "randomState": 23697,
             "tickCount": 3872,
             "type": "paint"
         },
         {
-            "randomState": 23616,
+            "randomState": 23699,
             "tickCount": 3888,
             "type": "paint"
         },
         {
-            "randomState": 23618,
+            "randomState": 23701,
             "tickCount": 3904,
             "type": "paint"
         },
         {
-            "randomState": 23620,
+            "randomState": 23719,
             "tickCount": 3920,
             "type": "paint"
         },
         {
-            "randomState": 23622,
+            "randomState": 23721,
             "tickCount": 3936,
             "type": "paint"
         },
         {
-            "randomState": 23624,
+            "randomState": 23723,
             "tickCount": 3952,
             "type": "paint"
         },
         {
-            "randomState": 23626,
+            "randomState": 23725,
             "tickCount": 3968,
             "type": "paint"
         },
         {
-            "randomState": 23628,
+            "randomState": 23727,
             "tickCount": 3984,
             "type": "paint"
         },
         {
-            "randomState": 23630,
+            "randomState": 23729,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 23632,
+            "randomState": 23731,
             "tickCount": 4016,
             "type": "paint"
         },
         {
-            "randomState": 23634,
+            "randomState": 23733,
             "tickCount": 4032,
             "type": "paint"
         },
         {
-            "randomState": 23636,
+            "randomState": 23738,
             "tickCount": 4048,
             "type": "paint"
         },
         {
-            "randomState": 23638,
+            "randomState": 23740,
             "tickCount": 4064,
             "type": "paint"
         },
         {
-            "randomState": 23640,
+            "randomState": 23742,
             "tickCount": 4080,
             "type": "paint"
         },
         {
-            "randomState": 23642,
+            "randomState": 23744,
             "tickCount": 4096,
             "type": "paint"
         },
         {
-            "randomState": 23644,
+            "randomState": 23746,
             "tickCount": 4112,
             "type": "paint"
         },
         {
-            "randomState": 23646,
+            "randomState": 23748,
             "tickCount": 4128,
             "type": "paint"
         },
         {
-            "randomState": 23648,
+            "randomState": 23750,
             "tickCount": 4144,
             "type": "paint"
         },
         {
-            "randomState": 23650,
+            "randomState": 23752,
             "tickCount": 4160,
             "type": "paint"
         },
         {
-            "randomState": 23652,
+            "randomState": 23754,
             "tickCount": 4176,
             "type": "paint"
         },
         {
-            "randomState": 23654,
+            "randomState": 23756,
             "tickCount": 4192,
             "type": "paint"
         },
         {
-            "randomState": 23656,
+            "randomState": 23758,
             "tickCount": 4208,
             "type": "paint"
         },
         {
-            "randomState": 23658,
+            "randomState": 23760,
             "tickCount": 4224,
             "type": "paint"
         },
         {
-            "randomState": 23660,
+            "randomState": 23762,
             "tickCount": 4240,
             "type": "paint"
         },
         {
-            "randomState": 23662,
+            "randomState": 23764,
             "tickCount": 4256,
             "type": "paint"
         },
         {
-            "randomState": 23664,
+            "randomState": 23766,
             "tickCount": 4272,
             "type": "paint"
         },
         {
-            "randomState": 23669,
+            "randomState": 23771,
             "tickCount": 4288,
             "type": "paint"
         },
         {
-            "randomState": 23671,
+            "randomState": 23773,
             "tickCount": 4304,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4320,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4336,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4352,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4368,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4384,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4416,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4432,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4448,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4464,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4480,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4496,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4512,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4528,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4544,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4560,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4576,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4592,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4608,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4624,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4640,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4656,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4672,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4688,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4704,
             "type": "paint"
         },
@@ -2727,62 +2727,62 @@
             "type": "keyPress"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4720,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4736,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4752,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4768,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4784,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4816,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4832,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4848,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4864,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4880,
             "type": "paint"
         },
         {
-            "randomState": 23854,
+            "randomState": 23956,
             "tickCount": 4896,
             "type": "paint"
         }

--- a/test/Data/issue_573.json
+++ b/test/Data/issue_573.json
@@ -688,42 +688,42 @@
     },
     "trace": [
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 50,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 100,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 150,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 200,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 250,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 300,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 350,
             "type": "paint"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 400,
             "type": "paint"
         },
@@ -738,7 +738,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 450,
             "type": "paint"
         },
@@ -753,7 +753,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 500,
             "type": "paint"
         },
@@ -768,7 +768,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 550,
             "type": "paint"
         },
@@ -783,7 +783,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 600,
             "type": "paint"
         },
@@ -798,7 +798,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 1,
+            "randomState": 28,
             "tickCount": 650,
             "type": "paint"
         },
@@ -813,12 +813,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 700,
             "type": "paint"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 750,
             "type": "paint"
         },
@@ -833,7 +833,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 800,
             "type": "paint"
         },
@@ -848,7 +848,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 850,
             "type": "paint"
         },
@@ -863,7 +863,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 900,
             "type": "paint"
         },
@@ -878,7 +878,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 41,
+            "randomState": 78,
             "tickCount": 950,
             "type": "paint"
         },
@@ -893,7 +893,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1000,
             "type": "paint"
         },
@@ -908,7 +908,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1050,
             "type": "paint"
         },
@@ -923,7 +923,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1100,
             "type": "paint"
         },
@@ -938,7 +938,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1150,
             "type": "paint"
         },
@@ -953,7 +953,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1200,
             "type": "paint"
         },
@@ -968,7 +968,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1250,
             "type": "paint"
         },
@@ -983,7 +983,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1300,
             "type": "paint"
         },
@@ -998,7 +998,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1350,
             "type": "paint"
         },
@@ -1013,7 +1013,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1400,
             "type": "paint"
         },
@@ -1028,7 +1028,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1450,
             "type": "paint"
         },
@@ -1043,7 +1043,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1500,
             "type": "paint"
         },
@@ -1058,7 +1058,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1550,
             "type": "paint"
         },
@@ -1073,7 +1073,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1600,
             "type": "paint"
         },
@@ -1088,7 +1088,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1650,
             "type": "paint"
         },
@@ -1103,7 +1103,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1700,
             "type": "paint"
         },
@@ -1128,7 +1128,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1750,
             "type": "paint"
         },
@@ -1143,7 +1143,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1800,
             "type": "paint"
         },
@@ -1158,7 +1158,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1850,
             "type": "paint"
         },
@@ -1173,7 +1173,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1900,
             "type": "paint"
         },
@@ -1188,12 +1188,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 1950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2000,
             "type": "paint"
         },
@@ -1208,7 +1208,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2050,
             "type": "paint"
         },
@@ -1223,7 +1223,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2100,
             "type": "paint"
         },
@@ -1238,12 +1238,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2200,
             "type": "paint"
         },
@@ -1258,7 +1258,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2250,
             "type": "paint"
         },
@@ -1273,7 +1273,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2300,
             "type": "paint"
         },
@@ -1288,7 +1288,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2350,
             "type": "paint"
         },
@@ -1303,7 +1303,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2400,
             "type": "paint"
         },
@@ -1318,7 +1318,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2450,
             "type": "paint"
         },
@@ -1333,7 +1333,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2500,
             "type": "paint"
         },
@@ -1348,7 +1348,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2550,
             "type": "paint"
         },
@@ -1363,7 +1363,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2600,
             "type": "paint"
         },
@@ -1378,7 +1378,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2650,
             "type": "paint"
         },
@@ -1393,7 +1393,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2700,
             "type": "paint"
         },
@@ -1408,12 +1408,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2800,
             "type": "paint"
         },
@@ -1438,7 +1438,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2850,
             "type": "paint"
         },
@@ -1453,7 +1453,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2900,
             "type": "paint"
         },
@@ -1468,7 +1468,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 2950,
             "type": "paint"
         },
@@ -1483,7 +1483,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3000,
             "type": "paint"
         },
@@ -1498,7 +1498,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3050,
             "type": "paint"
         },
@@ -1513,7 +1513,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3100,
             "type": "paint"
         },
@@ -1528,7 +1528,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3150,
             "type": "paint"
         },
@@ -1543,7 +1543,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3200,
             "type": "paint"
         },
@@ -1558,7 +1558,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3250,
             "type": "paint"
         },
@@ -1573,7 +1573,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3300,
             "type": "paint"
         },
@@ -1588,7 +1588,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3350,
             "type": "paint"
         },
@@ -1603,7 +1603,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3400,
             "type": "paint"
         },
@@ -1618,17 +1618,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3500,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3550,
             "type": "paint"
         },
@@ -1643,17 +1643,17 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3650,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3700,
             "type": "paint"
         },
@@ -1668,52 +1668,52 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3750,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3800,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3850,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 3950,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4050,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4100,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4150,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4200,
             "type": "paint"
         },
@@ -1728,7 +1728,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4250,
             "type": "paint"
         },
@@ -1743,27 +1743,27 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4300,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4350,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4450,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4500,
             "type": "paint"
         },
@@ -1778,12 +1778,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4550,
             "type": "paint"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4600,
             "type": "paint"
         },
@@ -1798,7 +1798,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4650,
             "type": "paint"
         },
@@ -1813,7 +1813,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4700,
             "type": "paint"
         },
@@ -1828,7 +1828,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4750,
             "type": "paint"
         },
@@ -1843,7 +1843,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 53,
+            "randomState": 94,
             "tickCount": 4800,
             "type": "paint"
         },
@@ -1858,7 +1858,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 4850,
             "type": "paint"
         },
@@ -1873,7 +1873,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 4900,
             "type": "paint"
         },
@@ -1888,7 +1888,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 4950,
             "type": "paint"
         },
@@ -1903,7 +1903,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5000,
             "type": "paint"
         },
@@ -1918,7 +1918,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5050,
             "type": "paint"
         },
@@ -1933,7 +1933,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5100,
             "type": "paint"
         },
@@ -1948,7 +1948,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5150,
             "type": "paint"
         },
@@ -1963,7 +1963,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5200,
             "type": "paint"
         },
@@ -1978,7 +1978,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5250,
             "type": "paint"
         },
@@ -1993,7 +1993,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5300,
             "type": "paint"
         },
@@ -2008,7 +2008,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5350,
             "type": "paint"
         },
@@ -2023,7 +2023,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 73,
+            "randomState": 119,
             "tickCount": 5400,
             "type": "paint"
         },
@@ -2038,7 +2038,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 79,
+            "randomState": 127,
             "tickCount": 5450,
             "type": "paint"
         },
@@ -2053,12 +2053,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 89,
+            "randomState": 139,
             "tickCount": 5500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5550,
             "type": "paint"
         },
@@ -2073,7 +2073,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5600,
             "type": "paint"
         },
@@ -2088,7 +2088,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5650,
             "type": "paint"
         },
@@ -2103,12 +2103,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5750,
             "type": "paint"
         },
@@ -2143,7 +2143,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5800,
             "type": "paint"
         },
@@ -2158,7 +2158,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5850,
             "type": "paint"
         },
@@ -2173,17 +2173,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 5950,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6000,
             "type": "paint"
         },
@@ -2198,7 +2198,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6050,
             "type": "paint"
         },
@@ -2213,7 +2213,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6100,
             "type": "paint"
         },
@@ -2228,7 +2228,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6150,
             "type": "paint"
         },
@@ -2253,7 +2253,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6200,
             "type": "paint"
         },
@@ -2268,7 +2268,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6250,
             "type": "paint"
         },
@@ -2283,7 +2283,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6300,
             "type": "paint"
         },
@@ -2298,7 +2298,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6350,
             "type": "paint"
         },
@@ -2313,7 +2313,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6400,
             "type": "paint"
         },
@@ -2328,7 +2328,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6450,
             "type": "paint"
         },
@@ -2343,7 +2343,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6500,
             "type": "paint"
         },
@@ -2358,7 +2358,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6550,
             "type": "paint"
         },
@@ -2373,7 +2373,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6600,
             "type": "paint"
         },
@@ -2388,7 +2388,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6650,
             "type": "paint"
         },
@@ -2403,7 +2403,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6700,
             "type": "paint"
         },
@@ -2418,12 +2418,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6750,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6800,
             "type": "paint"
         },
@@ -2438,12 +2438,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6900,
             "type": "paint"
         },
@@ -2468,7 +2468,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 6950,
             "type": "paint"
         },
@@ -2483,7 +2483,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7000,
             "type": "paint"
         },
@@ -2498,7 +2498,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7050,
             "type": "paint"
         },
@@ -2513,7 +2513,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7100,
             "type": "paint"
         },
@@ -2528,7 +2528,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7150,
             "type": "paint"
         },
@@ -2543,7 +2543,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7200,
             "type": "paint"
         },
@@ -2558,7 +2558,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7250,
             "type": "paint"
         },
@@ -2573,7 +2573,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7300,
             "type": "paint"
         },
@@ -2598,12 +2598,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7350,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7400,
             "type": "paint"
         },
@@ -2618,7 +2618,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7450,
             "type": "paint"
         },
@@ -2633,7 +2633,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7500,
             "type": "paint"
         },
@@ -2648,7 +2648,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7550,
             "type": "paint"
         },
@@ -2663,17 +2663,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7650,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7700,
             "type": "paint"
         },
@@ -2688,12 +2688,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7750,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7800,
             "type": "paint"
         },
@@ -2708,17 +2708,17 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 7950,
             "type": "paint"
         },
@@ -2733,7 +2733,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8000,
             "type": "paint"
         },
@@ -2748,7 +2748,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8050,
             "type": "paint"
         },
@@ -2763,7 +2763,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8100,
             "type": "paint"
         },
@@ -2778,7 +2778,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8150,
             "type": "paint"
         },
@@ -2793,7 +2793,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8200,
             "type": "paint"
         },
@@ -2808,12 +2808,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8250,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8300,
             "type": "paint"
         },
@@ -2828,7 +2828,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8350,
             "type": "paint"
         },
@@ -2843,12 +2843,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8400,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8450,
             "type": "paint"
         },
@@ -2863,12 +2863,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8550,
             "type": "paint"
         },
@@ -2903,7 +2903,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8600,
             "type": "paint"
         },
@@ -2918,7 +2918,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8650,
             "type": "paint"
         },
@@ -2933,7 +2933,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8700,
             "type": "paint"
         },
@@ -2948,7 +2948,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8750,
             "type": "paint"
         },
@@ -2963,7 +2963,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8800,
             "type": "paint"
         },
@@ -2978,7 +2978,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8850,
             "type": "paint"
         },
@@ -2993,7 +2993,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8900,
             "type": "paint"
         },
@@ -3008,7 +3008,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 8950,
             "type": "paint"
         },
@@ -3023,7 +3023,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9000,
             "type": "paint"
         },
@@ -3038,7 +3038,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9050,
             "type": "paint"
         },
@@ -3053,7 +3053,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9100,
             "type": "paint"
         },
@@ -3068,7 +3068,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9150,
             "type": "paint"
         },
@@ -3083,7 +3083,7 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9200,
             "type": "paint"
         },
@@ -3098,7 +3098,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9250,
             "type": "paint"
         },
@@ -3113,12 +3113,12 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9300,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9350,
             "type": "paint"
         },
@@ -3133,7 +3133,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9400,
             "type": "paint"
         },
@@ -3148,7 +3148,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9450,
             "type": "paint"
         },
@@ -3163,12 +3163,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9550,
             "type": "paint"
         },
@@ -3183,7 +3183,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9600,
             "type": "paint"
         },
@@ -3198,7 +3198,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9650,
             "type": "paint"
         },
@@ -3213,7 +3213,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9700,
             "type": "paint"
         },
@@ -3238,67 +3238,67 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9750,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9800,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 9950,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10000,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10050,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10100,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10150,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10250,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10300,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10350,
             "type": "paint"
         },
@@ -3313,32 +3313,32 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10400,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10450,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10550,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10650,
             "type": "paint"
         },
@@ -3353,12 +3353,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10750,
             "type": "paint"
         },
@@ -3383,7 +3383,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10800,
             "type": "paint"
         },
@@ -3398,12 +3398,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10900,
             "type": "paint"
         },
@@ -3418,7 +3418,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 10950,
             "type": "paint"
         },
@@ -3433,7 +3433,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11000,
             "type": "paint"
         },
@@ -3448,7 +3448,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11050,
             "type": "paint"
         },
@@ -3463,7 +3463,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11100,
             "type": "paint"
         },
@@ -3478,7 +3478,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11150,
             "type": "paint"
         },
@@ -3493,7 +3493,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11200,
             "type": "paint"
         },
@@ -3508,7 +3508,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11250,
             "type": "paint"
         },
@@ -3523,7 +3523,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11300,
             "type": "paint"
         },
@@ -3538,7 +3538,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11350,
             "type": "paint"
         },
@@ -3553,7 +3553,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11400,
             "type": "paint"
         },
@@ -3568,7 +3568,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11450,
             "type": "paint"
         },
@@ -3583,7 +3583,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11500,
             "type": "paint"
         },
@@ -3598,7 +3598,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11550,
             "type": "paint"
         },
@@ -3613,7 +3613,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11600,
             "type": "paint"
         },
@@ -3628,7 +3628,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11650,
             "type": "paint"
         },
@@ -3643,12 +3643,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11750,
             "type": "paint"
         },
@@ -3663,12 +3663,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11800,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11850,
             "type": "paint"
         },
@@ -3683,7 +3683,7 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11900,
             "type": "paint"
         },
@@ -3698,7 +3698,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 11950,
             "type": "paint"
         },
@@ -3713,7 +3713,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12000,
             "type": "paint"
         },
@@ -3728,7 +3728,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12050,
             "type": "paint"
         },
@@ -3743,7 +3743,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12100,
             "type": "paint"
         },
@@ -3758,7 +3758,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12150,
             "type": "paint"
         },
@@ -3773,7 +3773,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12200,
             "type": "paint"
         },
@@ -3788,7 +3788,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12250,
             "type": "paint"
         },
@@ -3803,7 +3803,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12300,
             "type": "paint"
         },
@@ -3818,7 +3818,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12350,
             "type": "paint"
         },
@@ -3833,7 +3833,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12400,
             "type": "paint"
         },
@@ -3848,7 +3848,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12450,
             "type": "paint"
         },
@@ -3873,7 +3873,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12500,
             "type": "paint"
         },
@@ -3888,7 +3888,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12550,
             "type": "paint"
         },
@@ -3903,7 +3903,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12600,
             "type": "paint"
         },
@@ -3918,12 +3918,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12650,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12700,
             "type": "paint"
         },
@@ -3958,7 +3958,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12750,
             "type": "paint"
         },
@@ -3973,7 +3973,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12800,
             "type": "paint"
         },
@@ -3988,7 +3988,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12850,
             "type": "paint"
         },
@@ -4013,7 +4013,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12900,
             "type": "paint"
         },
@@ -4028,7 +4028,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 12950,
             "type": "paint"
         },
@@ -4043,7 +4043,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13000,
             "type": "paint"
         },
@@ -4058,7 +4058,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13050,
             "type": "paint"
         },
@@ -4073,7 +4073,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13100,
             "type": "paint"
         },
@@ -4088,7 +4088,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13150,
             "type": "paint"
         },
@@ -4103,7 +4103,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13200,
             "type": "paint"
         },
@@ -4118,7 +4118,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13250,
             "type": "paint"
         },
@@ -4133,7 +4133,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13300,
             "type": "paint"
         },
@@ -4148,7 +4148,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13350,
             "type": "paint"
         },
@@ -4163,7 +4163,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13400,
             "type": "paint"
         },
@@ -4178,7 +4178,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13450,
             "type": "paint"
         },
@@ -4193,7 +4193,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13500,
             "type": "paint"
         },
@@ -4208,7 +4208,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13550,
             "type": "paint"
         },
@@ -4223,7 +4223,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13600,
             "type": "paint"
         },
@@ -4238,7 +4238,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13650,
             "type": "paint"
         },
@@ -4253,7 +4253,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13700,
             "type": "paint"
         },
@@ -4268,7 +4268,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13750,
             "type": "paint"
         },
@@ -4283,7 +4283,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13800,
             "type": "paint"
         },
@@ -4298,7 +4298,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13850,
             "type": "paint"
         },
@@ -4313,7 +4313,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13900,
             "type": "paint"
         },
@@ -4328,7 +4328,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 13950,
             "type": "paint"
         },
@@ -4343,7 +4343,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14000,
             "type": "paint"
         },
@@ -4358,7 +4358,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14050,
             "type": "paint"
         },
@@ -4373,12 +4373,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14100,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14150,
             "type": "paint"
         },
@@ -4393,12 +4393,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14200,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14250,
             "type": "paint"
         },
@@ -4423,7 +4423,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14300,
             "type": "paint"
         },
@@ -4438,7 +4438,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14350,
             "type": "paint"
         },
@@ -4453,7 +4453,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14400,
             "type": "paint"
         },
@@ -4468,7 +4468,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14450,
             "type": "paint"
         },
@@ -4483,7 +4483,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14500,
             "type": "paint"
         },
@@ -4498,7 +4498,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14550,
             "type": "paint"
         },
@@ -4513,7 +4513,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14600,
             "type": "paint"
         },
@@ -4528,7 +4528,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14650,
             "type": "paint"
         },
@@ -4543,7 +4543,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14700,
             "type": "paint"
         },
@@ -4558,7 +4558,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14750,
             "type": "paint"
         },
@@ -4573,7 +4573,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14800,
             "type": "paint"
         },
@@ -4588,7 +4588,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14850,
             "type": "paint"
         },
@@ -4603,7 +4603,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14900,
             "type": "paint"
         },
@@ -4618,7 +4618,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 14950,
             "type": "paint"
         },
@@ -4633,7 +4633,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15000,
             "type": "paint"
         },
@@ -4648,7 +4648,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15050,
             "type": "paint"
         },
@@ -4663,7 +4663,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15100,
             "type": "paint"
         },
@@ -4678,17 +4678,17 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15150,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15200,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15250,
             "type": "paint"
         },
@@ -4703,72 +4703,72 @@
             "type": "mouseButtonRelease"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15300,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15350,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15400,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15450,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15550,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15600,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15650,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15750,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15800,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 15950,
             "type": "paint"
         },
@@ -4783,7 +4783,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16000,
             "type": "paint"
         },
@@ -4798,7 +4798,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16050,
             "type": "paint"
         },
@@ -4813,7 +4813,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16100,
             "type": "paint"
         },
@@ -4828,7 +4828,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16150,
             "type": "paint"
         },
@@ -4843,7 +4843,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16200,
             "type": "paint"
         },
@@ -4858,7 +4858,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16250,
             "type": "paint"
         },
@@ -4873,7 +4873,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16300,
             "type": "paint"
         },
@@ -4888,7 +4888,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16350,
             "type": "paint"
         },
@@ -4903,7 +4903,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16400,
             "type": "paint"
         },
@@ -4918,7 +4918,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16450,
             "type": "paint"
         },
@@ -4933,7 +4933,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16500,
             "type": "paint"
         },
@@ -4948,7 +4948,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16550,
             "type": "paint"
         },
@@ -4963,7 +4963,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16600,
             "type": "paint"
         },
@@ -4978,7 +4978,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16650,
             "type": "paint"
         },
@@ -4993,7 +4993,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16700,
             "type": "paint"
         },
@@ -5008,7 +5008,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16750,
             "type": "paint"
         },
@@ -5023,7 +5023,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16800,
             "type": "paint"
         },
@@ -5038,7 +5038,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16850,
             "type": "paint"
         },
@@ -5053,12 +5053,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 16950,
             "type": "paint"
         },
@@ -5073,7 +5073,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17000,
             "type": "paint"
         },
@@ -5088,7 +5088,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17050,
             "type": "paint"
         },
@@ -5103,12 +5103,12 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17100,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17150,
             "type": "paint"
         },
@@ -5123,7 +5123,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17200,
             "type": "paint"
         },
@@ -5138,7 +5138,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17250,
             "type": "paint"
         },
@@ -5153,7 +5153,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17300,
             "type": "paint"
         },
@@ -5168,7 +5168,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17350,
             "type": "paint"
         },
@@ -5183,42 +5183,42 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17400,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17450,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17550,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17600,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17650,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17750,
             "type": "paint"
         },
@@ -5233,7 +5233,7 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17800,
             "type": "paint"
         },
@@ -5248,52 +5248,52 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17850,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 17950,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18000,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18050,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18100,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18150,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18200,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18250,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18300,
             "type": "paint"
         },
@@ -5308,12 +5308,12 @@
             "type": "mouseButtonPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18350,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18400,
             "type": "paint"
         },
@@ -5338,42 +5338,42 @@
             "type": "mouseMove"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18450,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18500,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18550,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18600,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18650,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18700,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18750,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18800,
             "type": "paint"
         },
@@ -5384,7 +5384,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18850,
             "type": "paint"
         },
@@ -5395,37 +5395,37 @@
             "type": "keyPress"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18900,
             "type": "paint"
         },
         {
-            "randomState": 141,
+            "randomState": 204,
             "tickCount": 18950,
             "type": "paint"
         },
         {
-            "randomState": 146,
+            "randomState": 210,
             "tickCount": 19000,
             "type": "paint"
         },
         {
-            "randomState": 186,
+            "randomState": 260,
             "tickCount": 19050,
             "type": "paint"
         },
         {
-            "randomState": 186,
+            "randomState": 260,
             "tickCount": 19100,
             "type": "paint"
         },
         {
-            "randomState": 186,
+            "randomState": 260,
             "tickCount": 19150,
             "type": "paint"
         },
         {
-            "randomState": 186,
+            "randomState": 260,
             "tickCount": 19200,
             "type": "paint"
         }

--- a/test/Data/issue_774.json
+++ b/test/Data/issue_774.json
@@ -1397,332 +1397,332 @@
             "type": "paint"
         },
         {
-            "randomState": 25884,
+            "randomState": 25931,
             "tickCount": 3300,
             "type": "paint"
         },
         {
-            "randomState": 25886,
+            "randomState": 25933,
             "tickCount": 3325,
             "type": "paint"
         },
         {
-            "randomState": 25888,
+            "randomState": 25935,
             "tickCount": 3350,
             "type": "paint"
         },
         {
-            "randomState": 25890,
+            "randomState": 25937,
             "tickCount": 3375,
             "type": "paint"
         },
         {
-            "randomState": 25892,
+            "randomState": 25939,
             "tickCount": 3400,
             "type": "paint"
         },
         {
-            "randomState": 25894,
+            "randomState": 25941,
             "tickCount": 3425,
             "type": "paint"
         },
         {
-            "randomState": 25896,
+            "randomState": 25943,
             "tickCount": 3450,
             "type": "paint"
         },
         {
-            "randomState": 25916,
+            "randomState": 25963,
             "tickCount": 3475,
             "type": "paint"
         },
         {
-            "randomState": 25918,
+            "randomState": 26011,
             "tickCount": 3500,
             "type": "paint"
         },
         {
-            "randomState": 25920,
+            "randomState": 26013,
             "tickCount": 3525,
             "type": "paint"
         },
         {
-            "randomState": 25922,
+            "randomState": 26015,
             "tickCount": 3550,
             "type": "paint"
         },
         {
-            "randomState": 25924,
+            "randomState": 26017,
             "tickCount": 3575,
             "type": "paint"
         },
         {
-            "randomState": 25926,
+            "randomState": 26019,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 25928,
+            "randomState": 26021,
             "tickCount": 3625,
             "type": "paint"
         },
         {
-            "randomState": 25930,
+            "randomState": 26023,
             "tickCount": 3650,
             "type": "paint"
         },
         {
-            "randomState": 25932,
+            "randomState": 26025,
             "tickCount": 3675,
             "type": "paint"
         },
         {
-            "randomState": 25934,
+            "randomState": 26027,
             "tickCount": 3700,
             "type": "paint"
         },
         {
-            "randomState": 25936,
+            "randomState": 26029,
             "tickCount": 3725,
             "type": "paint"
         },
         {
-            "randomState": 25938,
+            "randomState": 26031,
             "tickCount": 3750,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3775,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3800,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3825,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3850,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3875,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3925,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3950,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 3975,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4025,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4050,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4075,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4100,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4125,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4150,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4175,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4200,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4225,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4250,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4275,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4300,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4325,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4350,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4375,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4425,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4450,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4475,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26234,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4525,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4550,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4575,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4600,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4625,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4650,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4675,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4700,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4725,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4750,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4775,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4825,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4850,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4875,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4900,
             "type": "paint"
         },
         {
-            "randomState": 26141,
+            "randomState": 26237,
             "tickCount": 4925,
             "type": "paint"
         }

--- a/test/Data/pr_1325.json
+++ b/test/Data/pr_1325.json
@@ -767,27 +767,27 @@
             "type": "paint"
         },
         {
-            "randomState": 8246,
+            "randomState": 8295,
             "tickCount": 2900,
             "type": "paint"
         },
         {
-            "randomState": 8246,
+            "randomState": 8295,
             "tickCount": 3000,
             "type": "paint"
         },
         {
-            "randomState": 8246,
+            "randomState": 8301,
             "tickCount": 3100,
             "type": "paint"
         },
         {
-            "randomState": 8246,
+            "randomState": 8301,
             "tickCount": 3200,
             "type": "paint"
         },
         {
-            "randomState": 8246,
+            "randomState": 8304,
             "tickCount": 3300,
             "type": "paint"
         },
@@ -798,12 +798,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 8246,
+            "randomState": 8304,
             "tickCount": 3400,
             "type": "paint"
         },
         {
-            "randomState": 9194,
+            "randomState": 9254,
             "tickCount": 3500,
             "type": "paint"
         },
@@ -814,127 +814,127 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 9392,
+            "randomState": 9452,
             "tickCount": 3600,
             "type": "paint"
         },
         {
-            "randomState": 9590,
+            "randomState": 9650,
             "tickCount": 3700,
             "type": "paint"
         },
         {
-            "randomState": 9788,
+            "randomState": 9848,
             "tickCount": 3800,
             "type": "paint"
         },
         {
-            "randomState": 9986,
+            "randomState": 10046,
             "tickCount": 3900,
             "type": "paint"
         },
         {
-            "randomState": 10184,
+            "randomState": 10244,
             "tickCount": 4000,
             "type": "paint"
         },
         {
-            "randomState": 10382,
+            "randomState": 10442,
             "tickCount": 4100,
             "type": "paint"
         },
         {
-            "randomState": 10580,
+            "randomState": 10640,
             "tickCount": 4200,
             "type": "paint"
         },
         {
-            "randomState": 10778,
+            "randomState": 10838,
             "tickCount": 4300,
             "type": "paint"
         },
         {
-            "randomState": 10976,
+            "randomState": 11036,
             "tickCount": 4400,
             "type": "paint"
         },
         {
-            "randomState": 11174,
+            "randomState": 11234,
             "tickCount": 4500,
             "type": "paint"
         },
         {
-            "randomState": 11372,
+            "randomState": 11432,
             "tickCount": 4600,
             "type": "paint"
         },
         {
-            "randomState": 11570,
+            "randomState": 11630,
             "tickCount": 4700,
             "type": "paint"
         },
         {
-            "randomState": 11768,
+            "randomState": 11828,
             "tickCount": 4800,
             "type": "paint"
         },
         {
-            "randomState": 11966,
+            "randomState": 12026,
             "tickCount": 4900,
             "type": "paint"
         },
         {
-            "randomState": 12164,
+            "randomState": 12224,
             "tickCount": 5000,
             "type": "paint"
         },
         {
-            "randomState": 12362,
+            "randomState": 12422,
             "tickCount": 5100,
             "type": "paint"
         },
         {
-            "randomState": 12560,
+            "randomState": 12620,
             "tickCount": 5200,
             "type": "paint"
         },
         {
-            "randomState": 12758,
+            "randomState": 12818,
             "tickCount": 5300,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12896,
             "tickCount": 5400,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12922,
             "tickCount": 5500,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12922,
             "tickCount": 5600,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12924,
             "tickCount": 5700,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12924,
             "tickCount": 5800,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12925,
             "tickCount": 5900,
             "type": "paint"
         },
         {
-            "randomState": 12848,
+            "randomState": 12925,
             "tickCount": 6000,
             "type": "paint"
         },
@@ -945,12 +945,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 12848,
+            "randomState": 12925,
             "tickCount": 6100,
             "type": "paint"
         },
         {
-            "randomState": 14596,
+            "randomState": 14606,
             "tickCount": 6200,
             "type": "paint"
         },
@@ -961,132 +961,132 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 14702,
+            "randomState": 14712,
             "tickCount": 6300,
             "type": "paint"
         },
         {
-            "randomState": 14808,
+            "randomState": 14818,
             "tickCount": 6400,
             "type": "paint"
         },
         {
-            "randomState": 14914,
+            "randomState": 14924,
             "tickCount": 6500,
             "type": "paint"
         },
         {
-            "randomState": 15020,
+            "randomState": 15030,
             "tickCount": 6600,
             "type": "paint"
         },
         {
-            "randomState": 15126,
+            "randomState": 15136,
             "tickCount": 6700,
             "type": "paint"
         },
         {
-            "randomState": 15232,
+            "randomState": 15242,
             "tickCount": 6800,
             "type": "paint"
         },
         {
-            "randomState": 15338,
+            "randomState": 15348,
             "tickCount": 6900,
             "type": "paint"
         },
         {
-            "randomState": 15444,
+            "randomState": 15454,
             "tickCount": 7000,
             "type": "paint"
         },
         {
-            "randomState": 15550,
+            "randomState": 15560,
             "tickCount": 7100,
             "type": "paint"
         },
         {
-            "randomState": 15656,
+            "randomState": 15666,
             "tickCount": 7200,
             "type": "paint"
         },
         {
-            "randomState": 15762,
+            "randomState": 15772,
             "tickCount": 7300,
             "type": "paint"
         },
         {
-            "randomState": 15868,
+            "randomState": 15878,
             "tickCount": 7400,
             "type": "paint"
         },
         {
-            "randomState": 15974,
+            "randomState": 15984,
             "tickCount": 7500,
             "type": "paint"
         },
         {
-            "randomState": 16080,
+            "randomState": 16090,
             "tickCount": 7600,
             "type": "paint"
         },
         {
-            "randomState": 16186,
+            "randomState": 16196,
             "tickCount": 7700,
             "type": "paint"
         },
         {
-            "randomState": 16292,
+            "randomState": 16302,
             "tickCount": 7800,
             "type": "paint"
         },
         {
-            "randomState": 16398,
+            "randomState": 16408,
             "tickCount": 7900,
             "type": "paint"
         },
         {
-            "randomState": 16504,
+            "randomState": 16514,
             "tickCount": 8000,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16569,
             "tickCount": 8100,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8200,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8300,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8400,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8500,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8600,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8700,
             "type": "paint"
         },
         {
-            "randomState": 16565,
+            "randomState": 16575,
             "tickCount": 8800,
             "type": "paint"
         },
@@ -1097,7 +1097,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 16565,
+            "randomState": 16578,
             "tickCount": 8900,
             "type": "paint"
         },
@@ -1108,132 +1108,132 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 17341,
+            "randomState": 17354,
             "tickCount": 9000,
             "type": "paint"
         },
         {
-            "randomState": 17367,
+            "randomState": 17380,
             "tickCount": 9100,
             "type": "paint"
         },
         {
-            "randomState": 17393,
+            "randomState": 17406,
             "tickCount": 9200,
             "type": "paint"
         },
         {
-            "randomState": 17419,
+            "randomState": 17432,
             "tickCount": 9300,
             "type": "paint"
         },
         {
-            "randomState": 17445,
+            "randomState": 17458,
             "tickCount": 9400,
             "type": "paint"
         },
         {
-            "randomState": 17471,
+            "randomState": 17484,
             "tickCount": 9500,
             "type": "paint"
         },
         {
-            "randomState": 17497,
+            "randomState": 17510,
             "tickCount": 9600,
             "type": "paint"
         },
         {
-            "randomState": 17523,
+            "randomState": 17536,
             "tickCount": 9700,
             "type": "paint"
         },
         {
-            "randomState": 17549,
+            "randomState": 17562,
             "tickCount": 9800,
             "type": "paint"
         },
         {
-            "randomState": 17575,
+            "randomState": 17588,
             "tickCount": 9900,
             "type": "paint"
         },
         {
-            "randomState": 17601,
+            "randomState": 17614,
             "tickCount": 10000,
             "type": "paint"
         },
         {
-            "randomState": 17627,
+            "randomState": 17640,
             "tickCount": 10100,
             "type": "paint"
         },
         {
-            "randomState": 17653,
+            "randomState": 17666,
             "tickCount": 10200,
             "type": "paint"
         },
         {
-            "randomState": 17679,
+            "randomState": 17692,
             "tickCount": 10300,
             "type": "paint"
         },
         {
-            "randomState": 17705,
+            "randomState": 17718,
             "tickCount": 10400,
             "type": "paint"
         },
         {
-            "randomState": 17731,
+            "randomState": 17744,
             "tickCount": 10500,
             "type": "paint"
         },
         {
-            "randomState": 17757,
+            "randomState": 17770,
             "tickCount": 10600,
             "type": "paint"
         },
         {
-            "randomState": 17783,
+            "randomState": 17796,
             "tickCount": 10700,
             "type": "paint"
         },
         {
-            "randomState": 17809,
+            "randomState": 17822,
             "tickCount": 10800,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17834,
             "tickCount": 10900,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11000,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11100,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11200,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11300,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11400,
             "type": "paint"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11500,
             "type": "paint"
         },
@@ -1244,12 +1244,12 @@
             "type": "keyPress"
         },
         {
-            "randomState": 17824,
+            "randomState": 17840,
             "tickCount": 11600,
             "type": "paint"
         },
         {
-            "randomState": 20476,
+            "randomState": 20493,
             "tickCount": 11700,
             "type": "paint"
         },
@@ -1260,117 +1260,117 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 20502,
+            "randomState": 20519,
             "tickCount": 11800,
             "type": "paint"
         },
         {
-            "randomState": 20528,
+            "randomState": 20545,
             "tickCount": 11900,
             "type": "paint"
         },
         {
-            "randomState": 20554,
+            "randomState": 20571,
             "tickCount": 12000,
             "type": "paint"
         },
         {
-            "randomState": 20580,
+            "randomState": 20597,
             "tickCount": 12100,
             "type": "paint"
         },
         {
-            "randomState": 20606,
+            "randomState": 20623,
             "tickCount": 12200,
             "type": "paint"
         },
         {
-            "randomState": 20632,
+            "randomState": 20649,
             "tickCount": 12300,
             "type": "paint"
         },
         {
-            "randomState": 20658,
+            "randomState": 20675,
             "tickCount": 12400,
             "type": "paint"
         },
         {
-            "randomState": 20684,
+            "randomState": 20701,
             "tickCount": 12500,
             "type": "paint"
         },
         {
-            "randomState": 20710,
+            "randomState": 20727,
             "tickCount": 12600,
             "type": "paint"
         },
         {
-            "randomState": 20736,
+            "randomState": 20753,
             "tickCount": 12700,
             "type": "paint"
         },
         {
-            "randomState": 20762,
+            "randomState": 20779,
             "tickCount": 12800,
             "type": "paint"
         },
         {
-            "randomState": 20788,
+            "randomState": 20805,
             "tickCount": 12900,
             "type": "paint"
         },
         {
-            "randomState": 20814,
+            "randomState": 20831,
             "tickCount": 13000,
             "type": "paint"
         },
         {
-            "randomState": 20840,
+            "randomState": 20857,
             "tickCount": 13100,
             "type": "paint"
         },
         {
-            "randomState": 20866,
+            "randomState": 20883,
             "tickCount": 13200,
             "type": "paint"
         },
         {
-            "randomState": 20892,
+            "randomState": 20909,
             "tickCount": 13300,
             "type": "paint"
         },
         {
-            "randomState": 20918,
+            "randomState": 20935,
             "tickCount": 13400,
             "type": "paint"
         },
         {
-            "randomState": 20944,
+            "randomState": 20961,
             "tickCount": 13500,
             "type": "paint"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 13600,
             "type": "paint"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 13700,
             "type": "paint"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 13800,
             "type": "paint"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 13900,
             "type": "paint"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 14000,
             "type": "paint"
         },
@@ -1381,7 +1381,7 @@
             "type": "keyPress"
         },
         {
-            "randomState": 20965,
+            "randomState": 20980,
             "tickCount": 14100,
             "type": "paint"
         },
@@ -1392,127 +1392,127 @@
             "type": "keyRelease"
         },
         {
-            "randomState": 21717,
+            "randomState": 21732,
             "tickCount": 14200,
             "type": "paint"
         },
         {
-            "randomState": 21719,
+            "randomState": 21734,
             "tickCount": 14300,
             "type": "paint"
         },
         {
-            "randomState": 21721,
+            "randomState": 21736,
             "tickCount": 14400,
             "type": "paint"
         },
         {
-            "randomState": 21723,
+            "randomState": 21738,
             "tickCount": 14500,
             "type": "paint"
         },
         {
-            "randomState": 21725,
+            "randomState": 21740,
             "tickCount": 14600,
             "type": "paint"
         },
         {
-            "randomState": 21727,
+            "randomState": 21742,
             "tickCount": 14700,
             "type": "paint"
         },
         {
-            "randomState": 21729,
+            "randomState": 21744,
             "tickCount": 14800,
             "type": "paint"
         },
         {
-            "randomState": 21731,
+            "randomState": 21746,
             "tickCount": 14900,
             "type": "paint"
         },
         {
-            "randomState": 21733,
+            "randomState": 21748,
             "tickCount": 15000,
             "type": "paint"
         },
         {
-            "randomState": 21735,
+            "randomState": 21750,
             "tickCount": 15100,
             "type": "paint"
         },
         {
-            "randomState": 21737,
+            "randomState": 21752,
             "tickCount": 15200,
             "type": "paint"
         },
         {
-            "randomState": 21739,
+            "randomState": 21754,
             "tickCount": 15300,
             "type": "paint"
         },
         {
-            "randomState": 21741,
+            "randomState": 21756,
             "tickCount": 15400,
             "type": "paint"
         },
         {
-            "randomState": 21743,
+            "randomState": 21758,
             "tickCount": 15500,
             "type": "paint"
         },
         {
-            "randomState": 21745,
+            "randomState": 21760,
             "tickCount": 15600,
             "type": "paint"
         },
         {
-            "randomState": 21747,
+            "randomState": 21762,
             "tickCount": 15700,
             "type": "paint"
         },
         {
-            "randomState": 21749,
+            "randomState": 21764,
             "tickCount": 15800,
             "type": "paint"
         },
         {
-            "randomState": 21751,
+            "randomState": 21766,
             "tickCount": 15900,
             "type": "paint"
         },
         {
-            "randomState": 21753,
+            "randomState": 21768,
             "tickCount": 16000,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16100,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16200,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16300,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16400,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16500,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16600,
             "type": "paint"
         },
@@ -1529,22 +1529,22 @@
             "type": "keyPress"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16700,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16800,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 16900,
             "type": "paint"
         },
         {
-            "randomState": 21762,
+            "randomState": 21774,
             "tickCount": 17000,
             "type": "paint"
         }


### PR DESCRIPTION
Cherry-picked from #2540, which bundled six unrelated changes. The other five have since landed separately in #2544, #2545, #2546 and #2547, so this is the last one left. It is also the commit @captainurist flagged as the one he was unsure about.

Opening it for discussion rather than as a merge candidate. Please read the next section first.

## This is not ready to merge as it stands

Review turned up a correctness problem that the test suite does not catch.

**The `continue` this PR deletes is the fix for #518.** `git log -S` traces it to `1ded531fbbc`, whose commit message is literally "fix #518", and which introduced `armageddonForceCount` in the same change. Issue #518 is titled "Armageddon yeets the actors way too far into the sky & actors take stops when falling down", and that title is still sitting in the test at `test/Bin/GameTest/GameTests_0500.cpp:96`.

The recovery path re-exposes that bug one frame later:

1. The new block sets `aiState = Standing` and `currentActionLength = 0_ticks` at `Actor.cpp:2541`.
2. On the next frame the actor is no longer `Stunned`, so it skips the new block. `currentActionTime < currentActionLength` is false at `Actor.cpp:2551`, so it does not `continue`.
3. It reaches `Actor::AI_StandOrBored` at `Actor.cpp:2558`. Both `AI_Stand` (`Actor.cpp:1008-1010`) and the Fidgeting branch of `AI_Bored` (`Actor.cpp:1732-1734`) zero `velocity.x`, `velocity.y` and `velocity.z`.

So a recovered actor has its velocity zeroed one frame after recovery. In mid-air that stops a falling actor dead, which is exactly the symptom of #518 and #774. The block carefully avoids `AI_StandOrBored` on the recovery frame and then walks straight into it on the following one.

A contributing factor is that the armageddon panic block at `Outdoor.cpp:1671-1679` assigns `aiState = Stunned` without setting `currentActionTime` or `currentActionLength`. `Actor::AI_Stun` sets both at `Actor.cpp:1695-1698`. That is why `currentActionLength` is left at a stale value and collapses to zero once the recovery path runs.

## Why CI passing does not clear it

`Issue518` only asserts `actor.pos.z < 3500`. Zeroing velocity makes actors land lower, so the assertion still holds.

`Issue774` had its assertion inverted by this very commit:

```cpp
EXPECT_TRUE(act.aiState != Stunned || act.aiState == Dead);
```

`Dead` is `0x5` and `Stunned` is `0x8`, so the second disjunct is unreachable and the whole expression reduces to `aiState != Stunned`. The regression guard for #774 has been replaced by an assertion of the opposite property. Neither test can detect the regression described above.

## Other findings

- #920 is not fixed for turn-based mode. `UpdateActorAI` returns early at `Actor.cpp:2492-2494`, and the non-queued loop in `TurnEngine.cpp:257-275` only recovers `Dying` and states 12 through 18. `Stunned` is `0x8` and matches neither branch.
- No new test was added for #2003 or #920. The commit only edits existing tests.
- Three assertions unrelated to stun were loosened alongside the retrace. `Pr1325` goes from `>= +4` vials to `>= +1` while the troll death count stays at exactly `+84`, and `Issue1972` party damage goes from `<= -700` to `<= -100` even though its own comment says it exists as a retrace tripwire. The `meteorCount` change from 24 to 12 was pre-announced by the old comment and looks fine.
- The comment on the new block states that vanilla skipped stunned actors entirely. OpenEnroth added that skip in 2023, so the attribution is backwards.

## What a real fix needs

Either gate recovery on the actor being grounded, or stop `AI_Stand` and `AI_Bored` from cancelling an airborne actor's velocity. The outdoor code computes `uIsAboveFloor` as a local inside `UpdateActors_ODM` and it is not available in `UpdateActorAI`, so exposing it is a design decision rather than a small edit. That is why this PR stops here instead of guessing.

## What is in this branch

- `c2f17aaa253` is the cherry-pick of `050595d63e7e`, with Alistair-Afton's authorship preserved.
- `db223a06a90` ports it to current master, which renamed `pEventTimer` to `gameTimer`. Without it the tree does not compile.

Verified locally against master `22e3cdf63bb`: `check_style` clean, and `Run_GameTest_Headless_Parallel` green at 364/364 with no trace desync, so the retraced traces from July still replay. Unit tests show 399 passing with 10 `StackTrace.*` failures that are environmental in my container, since `libdw` is missing there and that binary does not link the changed code at all.

Fixes #2003
Fixes #920
