### PR TITLE
Drop the unused inside_game_viewport flag from DrawMessageBox

### DIFF
--- a/src/Application/GameStates/LoadStep2State.cpp
+++ b/src/Application/GameStates/LoadStep2State.cpp
@@ -47,7 +47,7 @@ void LoadStep2State::_drawMM7CopyrightWindow() {
     window.h = assets->pFontSmallnum->CalcTextHeight(localization->str(LSTR_1999_THE_3DO_COMPANY_ALL_RIGHTS_RESERVED), window.w, 24);
     window.h += 2 * assets->pFontSmallnum->GetHeight() + 24;
     window.y = 470 - window.h;
-    GUIWindow::DrawMessageBox(0, window, "");
+    GUIWindow::DrawMessageBox(window, "");
 
     window.w -= 28;
     window.x += 12;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -200,49 +200,37 @@ GUIButton *GUIWindow::GetControl(unsigned int uID) {
 }
 
 // TODO(pskelton): this function may modify frameRect - extract out
-void GUIWindow::DrawMessageBox(bool inside_game_viewport, Recti& frameRect, std::string sHint) {
+void GUIWindow::DrawMessageBox(Recti& frameRect, std::string sHint) {
     // TODO(pskelton): Derived Messagebox types for different kinds of popup boxes
     if (engine->callObserver) {
         engine->callObserver->notify(CALL_DRAW_MESSAGE_BOX, sHint);
     }
 
-    int x = 0;
-    int y = 0;
-    int z, w;
-    if (inside_game_viewport) {
-        x = pViewport.x;
-        z = pViewport.x + pViewport.w - 1;
-        y = pViewport.y;
-        w = pViewport.y + pViewport.h - 1;
-    } else {
-        Sizei renDims = render->GetRenderDimensions();
-        z = renDims.w;
-        w = renDims.h;
-    }
+    Sizei renDims = render->GetRenderDimensions();
 
     Pointi cursor = EngineIocContainer::ResolveMouse()->position();
-    if (frameRect.x >= x) {
-        if (frameRect.w + frameRect.x > z) {
-            frameRect.x = z - frameRect.w;
+    if (frameRect.x >= 0) {
+        if (frameRect.w + frameRect.x > renDims.w) {
+            frameRect.x = renDims.w - frameRect.w;
             frameRect.y = cursor.y + 30;
         }
     } else {
-        frameRect.x = x;
+        frameRect.x = 0;
         frameRect.y = cursor.y + 30;
     }
 
-    if (frameRect.y >= y) {
-        if (frameRect.y + frameRect.h > w) {
+    if (frameRect.y >= 0) {
+        if (frameRect.y + frameRect.h > renDims.h) {
             frameRect.y = cursor.y - frameRect.h - 30;
         }
     } else {
         frameRect.y = cursor.y + 30;
     }
-    if (frameRect.y < y) {
-        frameRect.y = y;
+    if (frameRect.y < 0) {
+        frameRect.y = 0;
     }
-    if (frameRect.x < x) {
-        frameRect.x = x;
+    if (frameRect.x < 0) {
+        frameRect.x = 0;
     }
 
     Recti current_window = frameRect;

--- a/src/GUI/GUIWindow.h
+++ b/src/GUI/GUIWindow.h
@@ -83,8 +83,7 @@ class GUIWindow {
     static void DrawFlashingInputCursor(int uX, int uY, GUIFont *a2, Recti frameRect);
     static void DrawShops_next_generation_time_string(Duration time, Recti frameRect);
     // TODO(pskelton): string_view or ref?
-    // TODO(pskelton): inside_game_viewport used anywhere?
-    static void DrawMessageBox(bool inside_game_viewport, Recti& frameRect, std::string hint);
+    static void DrawMessageBox(Recti& frameRect, std::string hint);
 
     /**
      * Draws the dialogue panel with background, e.g. for showing Arcomage rules in a tavern. Automatically switches

--- a/src/GUI/UI/UIGameOver.cpp
+++ b/src/GUI/UI/UIGameOver.cpp
@@ -32,7 +32,7 @@ void GUIWindow_GameOver::Update() {
     // draw pop up box
     if (_showPopUp) {
         Recti popupRect(120, 140, 400, 100);
-        DrawMessageBox(0, popupRect, fmt::format("{}\n \n{}", sHint, localization->str(LSTR_PRESS_ESCAPE)));
+        DrawMessageBox(popupRect, fmt::format("{}\n \n{}", sHint, localization->str(LSTR_PRESS_ESCAPE)));
     }
 }
 

--- a/src/GUI/UI/UIMessageScroll.cpp
+++ b/src/GUI/UI/UIMessageScroll.cpp
@@ -30,7 +30,7 @@ void GUIWindow_MessageScroll::Update() {
         v0 = 479 - a1.frameRect.y;
         a1.frameRect.h = 479 - a1.frameRect.y;
     }
-    GUIWindow::DrawMessageBox(0, a1.frameRect, a1.sHint);
+    GUIWindow::DrawMessageBox(a1.frameRect, a1.sHint);
     a1.frameRect.x += 12;
     a1.frameRect.w -= 28;
     a1.frameRect.y += 12;

--- a/src/GUI/UI/UIPartyCreation.cpp
+++ b/src/GUI/UI/UIPartyCreation.cpp
@@ -560,7 +560,7 @@ void GUIWindow_PartyCreation::Update() {
     if (errorMessageExpireTime > animTimer->time()) {
         auto& sHint = pBonusNum < 0 ? localization->str(LSTR_YOU_CANT_SPEND_MORE_THAN_50_POINTS) : localization->str(LSTR_CREATE_PARTY_CANNOT_BE_COMPLETED_UNLESS);
         Recti popupRect(170, 140, 300, 100);
-        DrawMessageBox(0, popupRect, sHint);
+        DrawMessageBox(popupRect, sHint);
     }
 
     // force draw so overlays dont get muddled

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -246,7 +246,7 @@ static void CharacterUI_DrawTooltip(std::string_view title, std::string_view con
 
     Recti popup_window(128, pt.y + 30, 384, 256);
     popup_window.h = assets->pFontSmallnum->CalcTextHeight(content, popup_window.w, 24) + 2 * assets->pFontLucida->GetHeight() + 24;
-    GUIWindow::DrawMessageBox(0, popup_window, "");
+    GUIWindow::DrawMessageBox(popup_window, "");
 
     popup_window.x += 12;
     popup_window.w -= 28;
@@ -390,7 +390,7 @@ void GameUI_DrawItemInfo(Item *inspect_item) {
     }
 
     if (inspect_item->IsBroken()) {
-        GUIWindow::DrawMessageBox(0, iteminfo_window, "");
+        GUIWindow::DrawMessageBox(iteminfo_window, "");
         render->SetUIClipRect(Recti(
             iteminfo_window.x + 12, iteminfo_window.y + 12,
             iteminfo_window.w - 24, iteminfo_window.h - 24));
@@ -414,7 +414,7 @@ void GameUI_DrawItemInfo(Item *inspect_item) {
     }
 
     if (!inspect_item->IsIdentified()) {
-        GUIWindow::DrawMessageBox(0, iteminfo_window, "");
+        GUIWindow::DrawMessageBox(iteminfo_window, "");
         render->SetUIClipRect(Recti(
             iteminfo_window.x + 12, iteminfo_window.y + 12,
             iteminfo_window.w - 24, iteminfo_window.h - 24));
@@ -541,7 +541,7 @@ void GameUI_DrawItemInfo(Item *inspect_item) {
     // flush draw before starting popup window
     render->DrawTwodVerts();
 
-    GUIWindow::DrawMessageBox(0, iteminfo_window, "");
+    GUIWindow::DrawMessageBox(iteminfo_window, "");
     render->SetUIClipRect(Recti(
         iteminfo_window.x + 12, iteminfo_window.y + 12,
         iteminfo_window.w - 24, iteminfo_window.h - 24));
@@ -1300,7 +1300,7 @@ void DrawSpellDescriptionPopup(SpellId spell_id) {
     if (frameRect.h < 150)
         frameRect.h = 150;
     frameRect.w = pViewport.w;
-    GUIWindow::DrawMessageBox(false, frameRect, "");
+    GUIWindow::DrawMessageBox(frameRect, "");
     frameRect.w -= 12;
     frameRect.h -= 12;
     GUIWindow::DrawTitleText(
@@ -1367,7 +1367,7 @@ static void drawBuffPopupWindow() {
 
     frameRect.h = assets->pFontArrus->GetHeight() + 72;
     frameRect.h += (stringCount - 1) * assets->pFontArrus->GetHeight();
-    GUIWindow::DrawMessageBox(0, frameRect, "");
+    GUIWindow::DrawMessageBox(frameRect, "");
     GUIWindow::DrawTitleText(assets->pFontArrus.get(), 0, 12, colorTable.White, localization->str(LSTR_ACTIVE_PARTY_SPELLS), 3, frameRect);
     if (!stringCount) {
         GUIWindow::DrawTitleText(assets->pFontComic.get(), 0, 40, colorTable.White, localization->str(LSTR_NONE), 3, frameRect);
@@ -1423,7 +1423,7 @@ void showSpellbookInfo(ItemId spellbook) {
         popup.h = 150;
     }
     popup.w = pViewport.w;
-    GUIWindow::DrawMessageBox(false, popup, "");
+    GUIWindow::DrawMessageBox(popup, "");
     popup.w -= 12;
     popup.h -= 12;
     GUIWindow::DrawTitleText(assets->pFontArrus.get(), 0x78u, 0xCu, colorTable.PaleCanary, pSpellStats->pInfos[spell].name, 3u, popup);
@@ -1640,7 +1640,7 @@ void GameUI_CharacterQuickRecord_Draw(Recti window, int characterIndex) {
             ++numActivePlayerBuffs;
 
     window.h = ((assets->pFontArrus->GetHeight() + 162) + ((numActivePlayerBuffs - 1) * assets->pFontArrus->GetHeight()));
-    GUIWindow::DrawMessageBox(0, window, "");
+    GUIWindow::DrawMessageBox(window, "");
 
     if (player->IsEradicated()) {
         v13 = game_ui_player_face_eradicated;
@@ -1728,7 +1728,7 @@ void GameUI_DrawNPCPopup(int _this) {  // PopupWindowForBenefitAndJoinText
                 if (popup_window.h < 130)
                     popup_window.h = 130;
                 popup_window.w = 400;
-                GUIWindow::DrawMessageBox(0, popup_window, "");
+                GUIWindow::DrawMessageBox(popup_window, "");
                 auto tex_name = fmt::format("NPC{:03}", pNPC->portraitId);
                 render->DrawQuad2D(assets->getImage_ColorKey(tex_name),
                                    {popup_window.x + 22, popup_window.y + 36});
@@ -1758,7 +1758,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                     popup_window.x = pX + 30;
                 else
                     popup_window.x = pX - 414;
-                GUIWindow::DrawMessageBox(0, popup_window, localization->format(
+                GUIWindow::DrawMessageBox(popup_window, localization->format(
                     LSTR_S_IS_IN_NO_CONDITION_TO_S,
                     pParty->activeCharacter().name,
                     localization->str(LSTR_IDENTIFY_ITEMS)));
@@ -1800,7 +1800,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                     }
                 } else {  // minimap zone
                     Recti popupRect(130, 140, 256, 64);
-                    GUIWindow::DrawMessageBox(0, popupRect, GameUI_GetMinimapHintText());
+                    GUIWindow::DrawMessageBox(popupRect, GameUI_GetMinimapHintText());
                 }
             } else {  // game zone
                 Recti popup_window(pX - 350, 40, 320, 320);
@@ -1815,7 +1815,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                     auto [w, h] = MonsterPopup_Draw(pointedObject.id(), nullptr);
                     popup_window.w = w;
                     popup_window.h = h;
-                    GUIWindow::DrawMessageBox(0, popup_window, "");
+                    GUIWindow::DrawMessageBox(popup_window, "");
                     MonsterPopup_Draw(pointedObject.id(), &popup_window);
                 }
                 if (pointedObject.type() == OBJECT_Sprite) {
@@ -1834,7 +1834,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
             auto hint = GetMapBookHintText(mousePos.x, mousePos.y);
             if (!hint.empty()) {
                 Recti popupRect(pX + 5, pY + 5, (assets->pFontArrus->GetLineWidth(hint) + 32) + 0.5f, 64);
-                GUIWindow::DrawMessageBox(0, popupRect, hint);
+                GUIWindow::DrawMessageBox(popupRect, hint);
             }
             break;
         }
@@ -1956,7 +1956,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
                     assets->pFontSmallnum->CalcTextHeight(
                         sHint, popup_window.w, 24) +
                     2 * assets->pFontLucida->GetHeight() + 24;
-                GUIWindow::DrawMessageBox(0, popup_window, "");
+                GUIWindow::DrawMessageBox(popup_window, "");
                 popup_window.x += 12;
                 popup_window.w -= 24;
                 popup_window.y += 12;
@@ -2055,7 +2055,7 @@ void Inventory_ItemPopupAndAlchemy() {
         } else {
             frameRect.x = pX - 414;
         }
-        GUIWindow::DrawMessageBox(0, frameRect, hint_reference);
+        GUIWindow::DrawMessageBox(frameRect, hint_reference);
         return;
     }
 


### PR DESCRIPTION
`GUIWindow::DrawMessageBox` took a leading `bool inside_game_viewport` that chose whether the popup was clamped to the game viewport or to the whole screen. All 19 call sites passed `0` or `false`, so the viewport branch never ran. This drops the parameter and answers the `TODO(pskelton): inside_game_viewport used anywhere?` above the declaration.

With the flag gone the origin is always zero and the bounds are always the render dimensions, so the `z` and `w` locals fold back into the `Sizei` they were read from. Every remaining clamp is the same comparison against the same value it had before, and `pViewport` keeps its other 185 users elsewhere.

No behaviour change. The game tests record `CALL_DRAW_MESSAGE_BOX` tapes, so the popup path is covered, and all 364 pass.
