### PR TITLE
Ignore the Claude worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ local.properties
 # .claude
 .claude/settings.local.json
 .claude/plans
+.claude/worktrees/


### PR DESCRIPTION
Claude Code puts its git worktrees under `.claude/worktrees`. Nothing in the repo ignored them. They stayed out of `git status` only because the harness writes the path into `.git/info/exclude` on its own.

That file is per-clone and never committed, so the exclusion did not survive a fresh clone and did not reach anyone else running Claude Code on the project.

The `.claude` section of `.gitignore` already draws the line between the shared config we track (`CLAUDE.md`, `skills/`) and the machine-local state we do not (`settings.local.json`, `plans`). Worktrees are machine-local, so this puts them with the latter.

One line, no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)