### PR TITLE
Ignore bazel's convenience symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ build
 build_*
 build-*
 
+# Convenience symlinks that bazel drops at the workspace root
+bazel-*
+
 # Scratch dir for local experiments
 tmp
 


### PR DESCRIPTION
Running bazel drops `bazel-bin`, `bazel-out`, `bazel-testlogs` and a `bazel-<dirname>` symlink at the workspace root, and they linger after switching to a branch without bazel. This ignores them next to the other build output folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)