### PR TITLE
Enable bugprone-unused-local-non-trivial-variable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,7 +28,6 @@ Checks: >
   -bugprone-throwing-static-initialization,
   -bugprone-unchecked-optional-access,
   -bugprone-unchecked-string-to-number-conversion,
-  -bugprone-unused-local-non-trivial-variable,
   -bugprone-use-after-move
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(src|test)/'

--- a/src/Bin/LodTool/LodTool.cpp
+++ b/src/Bin/LodTool/LodTool.cpp
@@ -141,7 +141,6 @@ int runDump(const LodToolOptions &options) {
         fmt::println("Size{}: {}", isCompressed ? " (uncompressed)" : "", data.size());
         fmt::println("Data{}:", isCompressed ? " (uncompressed)" : "");
 
-        std::string line;
         for (size_t offset = 0; offset < data.size(); offset += 16) {
             std::string_view chunk = data.str().substr(offset, 16);
 


### PR DESCRIPTION
Takes one check off the exclusion list in `.clang-tidy` and turns it on.

I swept all 28 excluded checks over the 408 linted translation units to find the cheapest one. This check has exactly one finding, an `std::string` in LodTool's dump path that is declared and then never touched, so the fix is to delete it. Worth noting that the check works off an allowlist of types rather than a blocklist, covering mutexes, futures, strings, streams, regexes, bitsets and paths, so RAII guards such as `lock_guard` will not start failing builds.

Verified with `check_tidy`, `check_style`, unit tests and headless game tests.
