### PR TITLE
Use length() at the call sites where it keeps the tests green

### DIFF
--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1766,7 +1766,7 @@ int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
             for (BSPModel &model : pOutdoor->pBModels) {
                 dist_y = enc_spawn_point.position.y - model.boundingCenter.y;
                 dist_x = enc_spawn_point.position.x - model.boundingCenter.x;
-                if (Vec2i(dist_x, dist_y).octagonalLength() < model.boundingRadius + 256) {
+                if (Vec2i(dist_x, dist_y).length() < model.boundingRadius + 256) {
                     not_in_model = 1;
                     break;
                 }

--- a/src/Engine/Graphics/Lighting.cpp
+++ b/src/Engine/Graphics/Lighting.cpp
@@ -120,7 +120,7 @@ int GetLightLevelAtPoint(unsigned int uBaseLightLevel, int uSectorID, float x, f
             if (distY <= light_radius) {
                 distZ = std::abs(p->vPosition.z - z);
                 if (distZ <= light_radius) {
-                    approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).octagonalLength();
+                    approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).length();
                     if (approx_distance < light_radius)
                         //* ORIGONAL */lightlevel += ((uint64_t)(30i64 *(signed int)(approx_distance << 16) / light_radius) >> 16) - 30;
                         lightlevel += static_cast<int> (30 * approx_distance / light_radius) - 30;
@@ -144,7 +144,7 @@ int GetLightLevelAtPoint(unsigned int uBaseLightLevel, int uSectorID, float x, f
                     if (distY <= light_radius) {
                         distZ = std::abs(this_light->vPosition.z - z);
                         if (distZ <= light_radius) {
-                            approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).octagonalLength();
+                            approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).length();
                             if (approx_distance < light_radius)
                                 lightlevel += static_cast<int> (30 * approx_distance / light_radius) - 30;
                         }
@@ -165,7 +165,7 @@ int GetLightLevelAtPoint(unsigned int uBaseLightLevel, int uSectorID, float x, f
             if (distY <= light_radius) {
                 distZ = std::abs(p->vPosition.z - z);
                 if (distZ <= light_radius) {
-                    approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).octagonalLength();
+                    approx_distance = Vec3i(static_cast<int>(distX), static_cast<int>(distY), static_cast<int>(distZ)).length();
                     if (approx_distance < light_radius)
                         lightlevel += static_cast<int> (30 * approx_distance / light_radius) - 30;
                 }

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -308,7 +308,7 @@ void OpenGLRenderer::DrawProjectile(float srcX, float srcY, float srcworldview, 
 
     int xDifference = static_cast<int>(std::round(dstX - srcX));
     int yDifference = static_cast<int>(std::round(dstY - srcY));
-    int distapprox = Vec2i(xDifference, yDifference).octagonalLength();
+    int distapprox = Vec2i(xDifference, yDifference).length();
 
     float v16 = 1.0f / (float)distapprox;
     float srcxmod = (float)yDifference * v16 * srcfovoworldview;

--- a/src/Engine/Graphics/Vis.cpp
+++ b/src/Engine/Graphics/Vis.cpp
@@ -300,10 +300,9 @@ void Vis::PickIndoorFaces_Mouse(float fDepth, const Vec3f &rayOrigin, const Vec3
 }
 
 bool IsBModelVisible(BSPModel *model, int reachable_depth, bool *reachable) {
-    // approx distance - for reachable checks
     float rayx = model->boundingCenter.x - pCamera3D->vCameraPos.x;
     float rayy = model->boundingCenter.y - pCamera3D->vCameraPos.y;
-    int dist = Vec2i(static_cast<int>(rayx), static_cast<int>(rayy)).octagonalLength();
+    int dist = Vec2i(static_cast<int>(rayx), static_cast<int>(rayy)).length();
     *reachable = false;
     if (dist < model->boundingRadius + reachable_depth) *reachable = true;
 

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -719,6 +719,7 @@ void Actor::AggroSurroundingPeasants(unsigned int uActorID, int a2) {
             int deltaX = actor->pos.x - victim->pos.x;
             int deltaY = actor->pos.y - victim->pos.y;
             int deltaZ = actor->pos.z - victim->pos.z;
+            // TODO(captainurist): use length() here and retrace
             if (Vec3i(deltaX, deltaY, deltaZ).octagonalLength() < 4096) {
                 actor->monsterInfo.hostilityType =
                     HOSTILITY_LONG;
@@ -3021,7 +3022,7 @@ int Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster, const V
             int d1 = pParty->pos.x - projectileSprite->vPosition.x;
             int d2 = pParty->pos.y - projectileSprite->vPosition.y;
             int d3 = pParty->pos.z - projectileSprite->vPosition.z;
-            v61 = Vec3i(d1, d2, d3).octagonalLength();
+            v61 = Vec3i(d1, d2, d3).length();
 
             if (v61 >= 5120 && !(pMonster->attributes & ACTOR_FULL_AI_STATE))  // 0x400
                 return 0;
@@ -3460,7 +3461,7 @@ bool CheckActors_proximity() {
         for_x = actor.pos.x - pParty->pos.x;
         for_y = actor.pos.y - pParty->pos.y;
         for_z = actor.pos.z - pParty->pos.z;
-        if (Vec3i(for_x, for_y, for_z).octagonalLength() < distance) {
+        if (Vec3i(for_x, for_y, for_z).length() < distance) {
             if (actor.aiState != Dead) {
                 if (actor.aiState != Dying &&
                     actor.aiState != Removed &&
@@ -3859,6 +3860,7 @@ void Actor::MakeActorAIList_ODM() {
         int delta_y = pParty->pos.y - actor.pos.y;
         int delta_z = pParty->pos.z - actor.pos.z;
 
+        // TODO(captainurist): use length() here and retrace
         int distance = Vec3i(delta_x, delta_y, delta_z).octagonalLength() - actor.radius;
         if (distance < 0)
             distance = 0;
@@ -3913,6 +3915,7 @@ int Actor::MakeActorAIList_BLV() {
         int delta_y = pParty->pos.y - actor.pos.y;
         int delta_z = pParty->pos.z - actor.pos.z;
 
+        // TODO(captainurist): use length() here and retrace
         int distance = Vec3i(delta_x, delta_y, delta_z).octagonalLength() - actor.radius;
         if (distance < 0)
             distance = 0;

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -515,7 +515,7 @@ void SpriteObject::explosionTraps() {
     int dir_x = pParty->pos.x - this->vPosition.x;
     int dir_y = pParty->pos.y - this->vPosition.y;
     int dir_z = pParty->pos.z + pParty->eyeLevel - this->vPosition.z;
-    if (Vec3i(dir_x, dir_y, dir_z).octagonalLength() <= 768) {
+    if (Vec3i(dir_x, dir_y, dir_z).length() <= 768) {
         int trapDamage = 5;
         if (pMapInfo->trapDamageD20DiceCount) {
             trapDamage += grng->randomDice(pMapInfo->trapDamageD20DiceCount, 20);

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -986,7 +986,7 @@ size_t Party::immolationAffectedActors(int *affected, size_t affectedArrSize, si
         int x = pActors[i].pos.x - this->pos.x;
         int y = pActors[i].pos.y - this->pos.y;
         int z = pActors[i].pos.z - this->pos.z;
-        if (Vec3i(x, y, z).octagonalLength() <= effectRange) {
+        if (Vec3i(x, y, z).length() <= effectRange) {
             if (pActors[i].aiState != Dead && pActors[i].aiState != Dying &&
                 pActors[i].aiState != Removed &&
                 pActors[i].aiState != Disabled &&

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -336,7 +336,7 @@ std::string GetMapBookHintText(int mouse_x, int mouse_y) {
         !pOutdoor->pBModels.empty()) {
         for (BSPModel &model : pOutdoor->pBModels) {
             if (Vec2i((int)model.boundingCenter.x - global_coord_X,
-                      (int)model.boundingCenter.y - global_coord_Y).octagonalLength() < model.boundingRadius) {
+                      (int)model.boundingCenter.y - global_coord_Y).length() < model.boundingRadius) {
                 for (BLVFace &face : model.faces) {
                     if (face.eventId) {
                         if (!(face.attributes & FACE_HAS_HINT)) {

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -674,7 +674,7 @@ std::string GameUI_GetMinimapHintText() {
     } else {
         for (BSPModel &model : pOutdoor->pBModels) {
             v7 = Vec2i((int)model.boundingCenter.x - global_coord_X,
-                       (int)model.boundingCenter.y - global_coord_Y).octagonalLength();
+                       (int)model.boundingCenter.y - global_coord_Y).length();
             if (v7 < 2 * model.boundingRadius) {
                 for (BLVFace &face : model.faces) {
                     if (face.eventId) {


### PR DESCRIPTION
Each of the fifteen `octagonalLength` call sites was replaced with `length()` on its own and run through the game tests. Twelve keep the whole suite green and are converted here. The three that do not are the actor AI range checks in `Actor.cpp`, breaking 2, 84 and 17 tests respectively, so those keep the approximation and carry a TODO.

Worth a reviewer's eye. A green suite does not prove a converted site is inert, it only says nothing recorded depends on it. The octagonal norm sits within about six percent of the true length in two dimensions and nine in three, in either direction depending on the angle, so the immolation radius in `Party.cpp` and the trap radius in `SpriteObject.cpp` do change behaviour that no trace exercises.