### PR TITLE
Enable bugprone-misplaced-widening-cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks: >
   -bugprone-integer-division,
   -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
-  -bugprone-misplaced-widening-cast,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -2335,5 +2335,5 @@ uint64_t GetExperienceRequiredForLevel(int level) {
     int effectiveLevel = 0;
     for (int i = 0; i < level; ++i)
         effectiveLevel += i + 1;
-    return (uint64_t)(1000 * effectiveLevel);
+    return 1000ULL * effectiveLevel;
 }


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

`bugprone-misplaced-widening-cast` has a single finding. `GetExperienceRequiredForLevel` computed `1000 * effectiveLevel` in `int` and only widened the product to `uint64_t` afterwards, so the multiplication overflowed from level 2072 up. The experience tooltip walks its level variable as far as 10000, so the argument does reach that range. Widening before the multiply covers every input the callers can produce, because `effectiveLevel` itself stays inside `int` until level 65535.

No test comes with this. The function is file-local to `UIPopup.cpp` and there is no test target for GUI. Verified with `check_tidy`, `check_style`, unit tests and headless game tests.
