### PR TITLE
Rename the got-hit state from Stunned to InPain

### DIFF
--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1672,7 +1672,7 @@ void UpdateActors_ODM() {
             actor.velocity.x += grng->random(100) - 50;
             actor.velocity.y += grng->random(100) - 50;
             actor.velocity.z += grng->random(100) - 20;
-            actor.aiState = Stunned;
+            actor.aiState = InPain;
             actor.yawAngle += grng->random(32) - 16;
             actor.UpdateAnimation();
         }

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1656,8 +1656,8 @@ char Actor::_4031C1_update_job_never_gets_called(
 }
 
 //----- (004030AD) --------------------------------------------------------
-void Actor::AI_Stun(unsigned int uActorID, Pid edx0,
-                    int stunRegardlessOfState) {
+void Actor::AI_Pain(unsigned int uActorID, Pid edx0,
+                    int painRegardlessOfState) {
     Duration v7;      // ax@16
     AIDirection a3;  // [sp+Ch] [bp-40h]@16
 
@@ -1671,8 +1671,8 @@ void Actor::AI_Stun(unsigned int uActorID, Pid edx0,
         pActors[uActorID].buffs[ACTOR_BUFF_CHARM].Reset();
     if (pActors[uActorID].buffs[ACTOR_BUFF_AFRAID].Active())
         pActors[uActorID].buffs[ACTOR_BUFF_AFRAID].Reset();
-    if (stunRegardlessOfState ||
-        (pActors[uActorID].aiState != Stunned &&
+    if (painRegardlessOfState ||
+        (pActors[uActorID].aiState != InPain &&
          pActors[uActorID].aiState != AttackingRanged1 &&
          pActors[uActorID].aiState != AttackingRanged2 &&
          pActors[uActorID].aiState != AttackingRanged3 &&
@@ -1685,9 +1685,9 @@ void Actor::AI_Stun(unsigned int uActorID, Pid edx0,
                  ->pSpriteSFrames[pActors[uActorID].spriteIds[ANIM_GotHit]]
                  .animationLength;
         pActors[uActorID].currentActionTime = 0_ticks;
-        pActors[uActorID].aiState = Stunned;
+        pActors[uActorID].aiState = InPain;
         pActors[uActorID].currentActionLength = v7;
-        Actor::playSound(uActorID, ACTOR_STUNNED_SOUND);
+        Actor::playSound(uActorID, ACTOR_PAIN_SOUND);
         pActors[uActorID].UpdateAnimation();
     }
 }
@@ -2030,7 +2030,7 @@ void Actor::AI_Pursue3(unsigned int uActorID, Pid a2,
     v6->pitchAngle = v16;
     v6->aiState = Pursuing;
     if (vrng->random(100) < 2) {
-        Actor::playSound(uActorID, ACTOR_STUNNED_SOUND);
+        Actor::playSound(uActorID, ACTOR_PAIN_SOUND);
     }
     v6->UpdateAnimation();
 }
@@ -2205,7 +2205,7 @@ void Actor::UpdateAnimation() {
             attributes |= ACTOR_ANIMATION;
             break;
 
-        case Stunned:
+        case InPain:
             currentActionAnimation = ANIM_GotHit;
             attributes |= ACTOR_ANIMATION;
             break;
@@ -2336,7 +2336,7 @@ void Actor::ActorDamageFromMonster(Pid attacker_id,
                 pActors[actor_id].hp -= finalDmg;
                 if (finalDmg) {
                     if (pActors[actor_id].hp > 0)
-                        Actor::AI_Stun(actor_id, attacker_id, 0);
+                        Actor::AI_Pain(actor_id, attacker_id, 0);
                     else
                         Actor::Die(actor_id);
                     Actor::AggroSurroundingPeasants(actor_id, 0);
@@ -2348,7 +2348,7 @@ void Actor::ActorDamageFromMonster(Pid attacker_id,
                     }
                     Actor::AddOnDamageOverlay(actor_id, 1, finalDmg);
                 } else {
-                    Actor::AI_Stun(actor_id, attacker_id, 0);
+                    Actor::AI_Pain(actor_id, attacker_id, 0);
                 }
                 return;
             }
@@ -2524,7 +2524,7 @@ void Actor::UpdateActorAI() {
 
         // If actor is stunned: skip - vanilla bug that causes stunned background actors to recover to idle motions
         // Most apparent during armageddon spell, falling background actors will occasionally hover to perform action
-        if (pActor->aiState == AIState::Stunned)
+        if (pActor->aiState == AIState::InPain)
             continue;
 
         // Calculate RecoveryTime
@@ -2616,12 +2616,12 @@ void Actor::UpdateActorAI() {
         AIState uAIState = pActor->aiState;
 
          // TODO(captainurist): this check makes no sense, it fails only for monsters that are:
-        // stunned && non-friendly && recovering && far from target && don't have missile attack. Seriously?
+        // in pain && non-friendly && recovering && far from target && don't have missile attack. Seriously?
         if (pActor->monsterInfo.hostilityType == HOSTILITY_FRIENDLY ||
             pActor->monsterInfo.recoveryTime > 0_ticks ||
             radiusMultiplier * meleeRange < pDir->uDistance ||
             uAIState != Pursuing && uAIState != Standing && uAIState != Tethered && uAIState != Fidgeting && pActor->monsterInfo.attack1MissileType == MONSTER_PROJECTILE_NONE ||
-            uAIState != Stunned) {
+            uAIState != InPain) {
             if (pActor->currentActionTime < pActor->currentActionLength) {
                 continue;
             } else if (pActor->aiState == AttackingMelee) {
@@ -3149,7 +3149,7 @@ int Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster, const V
         return 0;
     }
     if (pMonster->hp > 0) {
-        Actor::AI_Stun(uActorID_Monster, a1, 0);
+        Actor::AI_Pain(uActorID_Monster, a1, 0);
         Actor::AggroSurroundingPeasants(uActorID_Monster, 1);
         if (engine->config->settings.ShowHits.value()) {
             if (projectileSprite)
@@ -4507,7 +4507,7 @@ void ItemDamageFromActor(Pid uObjID, unsigned int uActorID, const Vec3f &pVeloci
 
                 if (damage > 0) {
                     if (pActors[uActorID].hp > 0)
-                        Actor::AI_Stun(uActorID, uObjID, 0);
+                        Actor::AI_Pain(uActorID, uObjID, 0);
                     else
                         Actor::Die(uActorID);
 
@@ -4519,7 +4519,7 @@ void ItemDamageFromActor(Pid uObjID, unsigned int uActorID, const Vec3f &pVeloci
                     }
                     Actor::AddOnDamageOverlay(uActorID, 1, damage);
                 } else {
-                    Actor::AI_Stun(uActorID, uObjID, 0);
+                    Actor::AI_Pain(uActorID, uObjID, 0);
                 }
             }
         }

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -122,7 +122,7 @@ class Actor {
     static void resurrect(unsigned int uActorID);
     static void AI_Bored(unsigned int uActorID, Pid uObjID,
                          AIDirection *a4);
-    static void AI_Stun(unsigned int uActorID, Pid edx0, int arg0);
+    static void AI_Pain(unsigned int uActorID, Pid edx0, int arg0);
     static char _4031C1_update_job_never_gets_called(unsigned int uActorID,
                                                      signed int a2, int a3);
     static void AI_RandomMove(unsigned int uActor_id, Pid uTarget_id,

--- a/src/Engine/Objects/ActorEnums.h
+++ b/src/Engine/Objects/ActorEnums.h
@@ -62,7 +62,7 @@ enum class AIState : uint16_t {
     Dead = 0x5,
     Pursuing = 0x6,
     Fleeing = 0x7,
-    Stunned = 0x8,
+    InPain = 0x8,
     Fidgeting = 0x9,
     Interacting = 10,
     Removed = 11,
@@ -120,7 +120,7 @@ MM_DECLARE_OPERATORS_FOR_FLAGS(ActorAttributes)
 enum class ActorSound {
     ACTOR_ATTACK_SOUND = 0,
     ACTOR_DEATH_SOUND = 1,
-    ACTOR_STUNNED_SOUND = 2,
+    ACTOR_PAIN_SOUND = 2,
     ACTOR_BORED_SOUND = 3,
 
     ACTOR_SOUND_FIRST = ACTOR_ATTACK_SOUND,

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -5870,7 +5870,7 @@ void DamageCharacterFromMonster(Pid uObjID, ActorAbility dmgSource, signed int t
                 actorPtr->hp -= reflectedDamage;
                 if (reflectedDamage >= 0) {
                     if (actorPtr->hp >= 1) {
-                        Actor::AI_Stun(uActorID, Pid(OBJECT_Character, targetchar), 0);  // todo extract this branch to a function
+                        Actor::AI_Pain(uActorID, Pid(OBJECT_Character, targetchar), 0);  // todo extract this branch to a function
                                     // once Actor::functions are changed to
                                     // nonstatic actor functions
                         Actor::AggroSurroundingPeasants(uActorID, 1);
@@ -6038,7 +6038,7 @@ void DamageCharacterFromMonster(Pid uObjID, ActorAbility dmgSource, signed int t
 
                     if (recvdMagicDmg >= 0) {
                         if (actorPtr->hp >= 1) {
-                            Actor::AI_Stun(uActorID, Pid(OBJECT_Character, targetchar), 0);
+                            Actor::AI_Pain(uActorID, Pid(OBJECT_Character, targetchar), 0);
                             Actor::AggroSurroundingPeasants(uActorID, 1);
                         } else {
                             // actor killed by retaliation

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -883,7 +883,7 @@ void armageddonProgress() {
             actor.hp -= incomingDamage;
 
             if (actor.hp >= 0) {
-                Actor::AI_Stun(actor.id, Pid::character(0), 0);
+                Actor::AI_Pain(actor.id, Pid::character(0), 0);
             } else {
                 Actor::Die(actor.id);
                 if (actor.monsterInfo.exp) {

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -385,7 +385,7 @@ void stru262_TurnBased::NextTurn() {
         if (pQueue[i].uPackedID.type() == OBJECT_Actor) {
             monster_id = pQueue[i].uPackedID.id();
             if ((pActors[monster_id].aiState == Dying) ||
-                (pActors[monster_id].aiState == Stunned) ||
+                (pActors[monster_id].aiState == InPain) ||
                 (pActors[monster_id].aiState == AttackingMelee) ||
                 (pActors[monster_id].aiState == AttackingRanged1) ||
                 (pActors[monster_id].aiState == AttackingRanged2) ||
@@ -402,7 +402,7 @@ void stru262_TurnBased::NextTurn() {
                     pActors[monster_id].currentActionLength = 0_ticks;
                     pActors[monster_id].UpdateAnimation();
                 } else {
-                    if (pActors[monster_id].aiState == Stunned)  // Stunned
+                    if (pActors[monster_id].aiState == InPain)
                         Actor::AI_StandOrBored(
                             monster_id,
                             ai_near_actors_targets_pid[monster_id], 32_ticks, 0);
@@ -603,7 +603,7 @@ void stru262_TurnBased::AIAttacks(unsigned int queue_index) {
                         pActors[actor_id].aiState = Dead;
                         pActors[actor_id].UpdateAnimation();
                         break;
-                    case Stunned:
+                    case InPain:
                         Actor::AI_Stand(actor_id, ai_near_actors_targets_pid[actor_id], 0_ticks, &a4);
                         break;
                     case AttackingRanged2:

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -654,8 +654,8 @@ GAME_TEST(Issues, Issue415a) {
 
     EXPECT_EQ(hpTape.slice(0).delta(), -60); // Armageddon damage at GM is 60.
     EXPECT_EQ(hpTape.slice(1).delta(), 0); // The stoned titan is unfazed.
-    EXPECT_CONTAINS(stateTape.slice(0), AIState::Stunned); // Armageddon knockback should also affect paralyzed monsters.
-    EXPECT_MISSES(stateTape.slice(1), AIState::Stunned); // But not the stoned ones.
+    EXPECT_CONTAINS(stateTape.slice(0), AIState::InPain); // Armageddon knockback should also affect paralyzed monsters.
+    EXPECT_MISSES(stateTape.slice(1), AIState::InPain); // But not the stoned ones.
     EXPECT_EQ(paralyzedTape, tape(true)); // Stayed paralyzed the whole time.
     EXPECT_EQ(stonedTape, tape(true)); // Stayed stoned the whole time.
 }

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -680,7 +680,7 @@ GAME_TEST(Issues, Issue774) {
     test.playTraceFromTestData("issue_774.mm7", "issue_774.json");
     for (auto &act : pActors) {
         if (!(act.attributes & ACTOR_FULL_AI_STATE))
-            EXPECT_TRUE(act.aiState == Stunned || act.aiState == Dead);
+            EXPECT_TRUE(act.aiState == InPain || act.aiState == Dead);
     }
 }
 


### PR DESCRIPTION
`AIState::Stunned` is the state an actor is in while its pain animation plays after any damaging hit it survives. That's what `Actor::AI_Stun` sets, from party hits, monster hits, projectile impacts and armageddon's damage tick, and what armageddon's push sets directly. Neither of the things a player would call a stun lives there: a Master mace hit adds attack recovery time in `DamageMonsterFromParty`, and paralysis is a buff. So the state is `InPain`, the function `AI_Pain` and the sound `ACTOR_PAIN_SOUND`. Real stuns keep their names.

Pure rename, no behaviour change, and saves store the numeric value so nothing on disk moves. #2694 gets rebased on top once this is in.
