### PR TITLE
Enable bugprone-crtp-constructor-accessibility

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: >
   bugprone-*,
   -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
-  -bugprone-crtp-constructor-accessibility,
   -bugprone-derived-method-shadowing-base-method,
   -bugprone-easily-swappable-parameters,
   -bugprone-empty-catch,

--- a/src/Utility/View.h
+++ b/src/Utility/View.h
@@ -113,6 +113,9 @@ class ResizeView {
  */
 template<class Derived>
 class ViewInterface : public std::ranges::view_interface<Derived> {
+    ViewInterface() = default; // Private, so that passing the wrong type as Derived doesn't compile.
+    friend Derived;
+
     [[nodiscard]] Derived &derived() { return static_cast<Derived &>(*this); }
 
  public:


### PR DESCRIPTION
Takes a third check off the exclusion list in `.clang-tidy`.

`bugprone-crtp-constructor-accessibility` has a single finding, `ViewInterface` in `Utility/View.h`. Its implicit default constructor was public, so a class could derive from `ViewInterface<SomethingElse>` and still be constructed. That is not merely untidy, `derived()` does `static_cast<Derived &>(*this)`, so the mismatch would have been undefined behaviour at the first call. Making the constructor private and befriending `Derived` turns it into a compile error instead.

Checked both directions with a throwaway translation unit. `struct Wrong : ViewInterface<Other> {}` compiles against master and fails with `use of deleted function` after the change. `SplitView` is the only real deriver and it is unaffected.
