### PR TITLE
Move LocationInfo out of Engine/Graphics

### DIFF
--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -34,6 +34,7 @@ set(ENGINE_HEADERS
         EngineGlobals.h
         EngineIocContainer.h
         Localization.h
+        LocationInfo.h
         MapEnums.h
         MapInfo.h
         Party.h

--- a/src/Engine/Graphics/CMakeLists.txt
+++ b/src/Engine/Graphics/CMakeLists.txt
@@ -44,7 +44,6 @@ set(ENGINE_GRAPHICS_HEADERS
         Lighting.h
         LightsStack.h
         LocationFunctions.h
-        LocationInfo.h
         MapWeather.h
         Outdoor.h
         Overlays.h

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -10,6 +10,7 @@
 #include "Engine/mm7_data.h"
 #include "Engine/EngineIocContainer.h"
 #include "Engine/SpawnPoint.h"
+#include "Engine/LocationInfo.h"
 
 #include "Core/Time/Time.h"
 
@@ -17,7 +18,6 @@
 #include "Library/Geometry/Plane.h"
 #include "Library/Geometry/BBox.h"
 
-#include "LocationInfo.h"
 #include "LocationFunctions.h"
 #include "FaceEnums.h"
 

--- a/src/Engine/Graphics/LocationFunctions.h
+++ b/src/Engine/Graphics/LocationFunctions.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "Engine/MapEnums.h"
-
-#include "LocationInfo.h"
+#include "Engine/LocationInfo.h"
 
 // TODO(captainurist): move to Engine/ and drop the Location- prefix, should be MapSmth.
 

--- a/src/Engine/Graphics/Outdoor.h
+++ b/src/Engine/Graphics/Outdoor.h
@@ -7,13 +7,13 @@
 #include "Engine/SpawnPoint.h"
 #include "Engine/MapEnums.h"
 #include "Engine/PartyPlacement.h"
+#include "Engine/LocationInfo.h"
 
 #include "Core/Time/Time.h"
 
 #include "Library/Color/Color.h"
 
 #include "BSPModel.h"
-#include "LocationInfo.h"
 #include "MapWeather.h"
 #include "LocationFunctions.h"
 #include "OutdoorTerrain.h"

--- a/src/Engine/LocationInfo.h
+++ b/src/Engine/LocationInfo.h
@@ -1,7 +1,6 @@
 #pragma once
 
 // TODO(captainurist): we also have MapInfo, rename this into something more sane with Map- prefix.
-// TODO(captainurist): this isn't graphics, it belongs in Engine/ rather than Engine/Graphics/.
 struct LocationInfo {
     int respawnCount = 0; // Number of times a location was respawned, including the initial spawn.
     int lastRespawnDay = 0; // Day of the last respawn (days since GameTime zero to last respawn).

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -10,7 +10,7 @@
 
 #include "Engine/Localization.h"
 #include "Engine/PriceCalculator.h"
-#include "Engine/Graphics/LocationInfo.h"
+#include "Engine/LocationInfo.h"
 #include "Engine/Graphics/LocationFunctions.h"
 #include "Engine/Spells/CastSpellInfo.h"
 #include "Engine/Party.h"


### PR DESCRIPTION
`LocationInfo` holds a respawn count, the last respawn day, party reputation and an alert flag. None of that is graphics, and the header said so itself in a `TODO(captainurist)`. It moves to `src/Engine/`, both CMakeLists follow, and the four includers update.

Two of those includers had it in their local relative include group, since it used to be a sibling header. It is lifted into their `Engine/` group instead of being left where a reader would not expect it.

The other TODO in the file, asking for a `Map-` prefix so the type is not confused with `MapInfo`, is a separate naming question and stays put.
