### PR TITLE
Own pCamera3D, pOverlayTable and viewparams with unique_ptr

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -408,7 +408,7 @@ Engine::Engine(std::shared_ptr<GameConfig> config, OverlaySystem &overlaySystem)
 
     uNumStationaryLights_in_pStationaryLightsStack = 0;
 
-    pCamera3D = new Camera3D;
+    pCamera3D = std::make_unique<Camera3D>();
 
     keyboardInputHandler = ::keyboardInputHandler;
     keyboardActionMapping = ::keyboardActionMapping;
@@ -419,7 +419,7 @@ Engine::Engine(std::shared_ptr<GameConfig> config, OverlaySystem &overlaySystem)
 //----- (0044E7F3) --------------------------------------------------------
 Engine::~Engine() {
     delete gameTimer;
-    delete pCamera3D;
+    pCamera3D.reset();
     pAudioPlayer.reset();
 }
 
@@ -678,8 +678,8 @@ void Engine::MM7_Initialize() {
     pMonsterList = new MonsterList;
     deserialize(engine->resources()->eventsData("dmonlist.bin"), pMonsterList);
 
-    pOverlayTable = new OverlayTable;
-    deserialize(engine->resources()->eventsData("doverlay.bin"), pOverlayTable);
+    pOverlayTable = std::make_unique<OverlayTable>();
+    deserialize(engine->resources()->eventsData("doverlay.bin"), pOverlayTable.get());
 
     pSoundList = new SoundList;
     deserialize(engine->resources()->eventsData("dsounds.bin"), pSoundList);
@@ -782,7 +782,7 @@ void Engine::Initialize() {
 
 //----- (00466082) --------------------------------------------------------
 void MM6_Initialize() {
-    viewparams = new ViewingParams;
+    viewparams = std::make_unique<ViewingParams>();
     pAudioPlayer = std::make_unique<AudioPlayer>();
 
     pODMRenderParams = new ODMRenderParams;

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -1,6 +1,7 @@
 #include "Engine/Graphics/Camera.h"
 
 #include <cmath>
+#include <memory>
 
 #include "Engine/Engine.h"
 
@@ -10,7 +11,7 @@
 
 #include "Engine/Graphics/ClippingFunctions.h"
 
-Camera3D *pCamera3D = new Camera3D;
+std::unique_ptr<Camera3D> pCamera3D = std::make_unique<Camera3D>();
 
 //----- (0043643E) --------------------------------------------------------
 float Camera3D::GetMouseInfoDepth() {

--- a/src/Engine/Graphics/Camera.cpp
+++ b/src/Engine/Graphics/Camera.cpp
@@ -11,7 +11,7 @@
 
 #include "Engine/Graphics/ClippingFunctions.h"
 
-std::unique_ptr<Camera3D> pCamera3D = std::make_unique<Camera3D>();
+std::unique_ptr<Camera3D> pCamera3D;
 
 //----- (0043643E) --------------------------------------------------------
 float Camera3D::GetMouseInfoDepth() {

--- a/src/Engine/Graphics/Camera.h
+++ b/src/Engine/Graphics/Camera.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <array>
+#include <memory>
 
 #include <glm/glm.hpp>
 
@@ -97,4 +98,4 @@ struct Camera3D {
     float GetFarClip() const;
 };
 
-extern Camera3D *pCamera3D;
+extern std::unique_ptr<Camera3D> pCamera3D;

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -1,6 +1,7 @@
 #include "Viewport.h"
 
 #include <algorithm>
+#include <memory>
 
 #include "Engine/Engine.h"
 #include "Engine/Evt/Processor.h"
@@ -25,7 +26,7 @@
 #include "Media/Audio/AudioPlayer.h"
 
 Recti pViewport;
-ViewingParams *viewparams = new ViewingParams;
+std::unique_ptr<ViewingParams> viewparams = std::make_unique<ViewingParams>();
 
 //----- (00443219) --------------------------------------------------------
 void ViewingParams::MapViewUp() {

--- a/src/Engine/Graphics/Viewport.cpp
+++ b/src/Engine/Graphics/Viewport.cpp
@@ -26,7 +26,7 @@
 #include "Media/Audio/AudioPlayer.h"
 
 Recti pViewport;
-std::unique_ptr<ViewingParams> viewparams = std::make_unique<ViewingParams>();
+std::unique_ptr<ViewingParams> viewparams;
 
 //----- (00443219) --------------------------------------------------------
 void ViewingParams::MapViewUp() {

--- a/src/Engine/Graphics/Viewport.h
+++ b/src/Engine/Graphics/Viewport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include "Library/Color/Color.h"
 #include "Library/Geometry/Rect.h"
@@ -41,4 +42,4 @@ struct ViewingParams {
     Color pPalette[256] {};
 };
 
-extern ViewingParams *viewparams;
+extern std::unique_ptr<ViewingParams> viewparams;

--- a/src/Engine/Tables/OverlayTable.cpp
+++ b/src/Engine/Tables/OverlayTable.cpp
@@ -1,8 +1,10 @@
 #include "Engine/Tables/OverlayTable.h"
 
+#include <memory>
+
 #include "Engine/Graphics/Sprites.h"
 
-OverlayTable *pOverlayTable = new OverlayTable;
+std::unique_ptr<OverlayTable> pOverlayTable = std::make_unique<OverlayTable>();
 
 //----- (00458D97) --------------------------------------------------------
 void OverlayTable::initializeSprites() {

--- a/src/Engine/Tables/OverlayTable.cpp
+++ b/src/Engine/Tables/OverlayTable.cpp
@@ -4,7 +4,7 @@
 
 #include "Engine/Graphics/Sprites.h"
 
-std::unique_ptr<OverlayTable> pOverlayTable = std::make_unique<OverlayTable>();
+std::unique_ptr<OverlayTable> pOverlayTable;
 
 //----- (00458D97) --------------------------------------------------------
 void OverlayTable::initializeSprites() {

--- a/src/Engine/Tables/OverlayTable.h
+++ b/src/Engine/Tables/OverlayTable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "Engine/Data/OverlayData.h"
@@ -10,4 +11,4 @@ struct OverlayTable {
     std::vector<OverlayData> overlays;
 };
 
-extern OverlayTable *pOverlayTable;
+extern std::unique_ptr<OverlayTable> pOverlayTable;


### PR DESCRIPTION
`pCamera3D`, `pOverlayTable` and `viewparams` were each allocated twice, once at static init in their own translation unit and again in `Engine.cpp`. The second allocation orphaned the first object, and LeakSanitizer reported all three on every run, 1260 bytes in 3 allocations.

Making them `unique_ptr` frees the first object on reassignment and spells out the ownership, matching `pAudioPlayer` which is already a `unique_ptr` global. `Engine::~Engine` used to `delete pCamera3D` and leave the pointer dangling, it now resets it. Only the `deserialize` call for `pOverlayTable` needed a `.get()`, every other use goes through `operator->`.
