### PR TITLE
Enable bugprone-inc-dec-in-conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   -bugprone-empty-catch,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
-  -bugprone-inc-dec-in-conditions,
   -bugprone-incorrect-roundings,
   -bugprone-integer-division,
   -bugprone-invalid-enum-default-initialization,

--- a/src/Library/Color/Color.h
+++ b/src/Library/Color/Color.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <string_view>
 
 #include "Library/Serialization/SerializationFwd.h"
 
@@ -107,11 +108,10 @@ struct fmt::formatter<ColorTag> {
     constexpr auto parse(format_parse_context &ctx) {
         // Require {::} format spec. What's special about it is that it will fail for other types, so can only be used
         // for ColorTag. Also makes it easier to distinguish color tags in the format string.
-        auto pos = ctx.begin();
-        auto end = ctx.end();
-        if (pos == end || *pos != ':' || ++pos == end || *pos != '}')
+        std::string_view spec(ctx.begin(), ctx.end());
+        if (!spec.starts_with(":}"))
             fmt::report_error("ColorTag needs {::} format specifier");
-        return pos; // pos points to '}'
+        return ctx.begin() + 1; // Points to '}'.
     }
 
     auto format(const ColorTag &tag, format_context &ctx) const {

--- a/src/Library/Color/Tests/Color_ut.cpp
+++ b/src/Library/Color/Tests/Color_ut.cpp
@@ -14,7 +14,6 @@ UNIT_TEST(Color, Tags) {
     EXPECT_THROW((void) fmt::format(fmt::runtime("{: }"), colorTable.Anakiwa.tag()), std::exception);
     EXPECT_THROW((void) fmt::format(fmt::runtime("{:_}"), colorTable.Anakiwa.tag()), std::exception);
     EXPECT_THROW((void) fmt::format(fmt::runtime("{:!}"), colorTable.Anakiwa.tag()), std::exception);
-    // Truncated spec, the parser must stop at the end of the format string instead of reading past it.
     EXPECT_THROW((void) fmt::format(fmt::runtime("{::"), colorTable.Anakiwa.tag()), std::exception);
 
     EXPECT_EQ(fmt::format("{::}", colorTable.White.tag()), "\f65535");

--- a/src/Library/Color/Tests/Color_ut.cpp
+++ b/src/Library/Color/Tests/Color_ut.cpp
@@ -14,6 +14,8 @@ UNIT_TEST(Color, Tags) {
     EXPECT_THROW((void) fmt::format(fmt::runtime("{: }"), colorTable.Anakiwa.tag()), std::exception);
     EXPECT_THROW((void) fmt::format(fmt::runtime("{:_}"), colorTable.Anakiwa.tag()), std::exception);
     EXPECT_THROW((void) fmt::format(fmt::runtime("{:!}"), colorTable.Anakiwa.tag()), std::exception);
+    // Truncated spec, the parser must stop at the end of the format string instead of reading past it.
+    EXPECT_THROW((void) fmt::format(fmt::runtime("{::"), colorTable.Anakiwa.tag()), std::exception);
 
     EXPECT_EQ(fmt::format("{::}", colorTable.White.tag()), "\f65535");
     EXPECT_EQ(fmt::format("{::}", colorTable.Black.tag()), "\f00000");


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

`bugprone-inc-dec-in-conditions` has a single finding, the `ColorTag` format spec parser in `Library/Color/Color.h`. It incremented the parse iterator inside a short-circuited condition chain and then returned that same iterator, so what the function returns depended on how far the chain got before it bailed out.

The chain accepted precisely the specs starting with `:}`, so it now says that directly and the increment is gone. I also added a test for a truncated spec, that is the boundary the rewrite touched and nothing covered it.
