### PR TITLE
Enable bugprone-multi-level-implicit-pointer-conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: >
   -bugprone-integer-division,
   -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
-  -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,
   -bugprone-raw-memory-call-on-non-trivial-type,

--- a/src/Library/Platform/Sdl/SdlOpenGLContext.cpp
+++ b/src/Library/Platform/Sdl/SdlOpenGLContext.cpp
@@ -36,7 +36,7 @@ void SdlOpenGLContext::swapBuffers() {
 }
 
 void *SdlOpenGLContext::nativeHandle() {
-    return &_context;
+    return _context;
 }
 
 void *SdlOpenGLContext::getProcAddress(const char *name) {


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

The single finding is a real bug. `SdlOpenGLContext::nativeHandle` returned `&_context`, the address of its own member, so callers got an `SDL_GLContextState **` dressed up as a `void *`. The commit that added it wrote the neighbouring `SdlWindow::nativeHandle` as a plain `return _window`, which is what this one should have been.

The value goes to `ImGui_ImplSDL3_InitForOpenGL`, which stores it as the main viewport's `GLContext`. Nothing dereferences it today, the paths that would are guarded either by `WindowOwned`, which is false for the main viewport, or by secondary viewport creation, which needs `ImGuiConfigFlags_ViewportsEnable` and we never set it. So the bug is latent rather than visible.
