### PR TITLE
Map data and table move to Engine/Data and Engine/Tables

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1128,22 +1128,22 @@ void Game::processQueuedMessages() {
                     // Was this, which made exactly zero sense:
                     // if (mapIdx == MAP_INVALID)
                     //    mapIdx = static_cast<MAP_TYPE>(grng->random(pMapStats->uNumMaps + 1));
-                    MapData *pMapInfo = &mapTable[mapIdx];
+                    MapData *mapData = &pMapTable->pInfos[mapIdx];
 
                     // Encounters when resting
-                    if ((grng->random(100) + 1) <= pMapInfo->encounterChance && !engine->config->debug.NoActors.value()) {
+                    if ((grng->random(100) + 1) <= mapData->encounterChance && !engine->config->debug.NoActors.value()) {
                         int encRand = grng->random(100) + 1;
                         int encIndex = 0; // 1-3 index for which monster to spawn
 
-                        if (encRand <= pMapInfo->encounter1Chance) {
+                        if (encRand <= mapData->encounter1Chance) {
                             encIndex = 1;
-                        } else if (encRand <= (pMapInfo->encounter1Chance + pMapInfo->encounter2Chance)) {
+                        } else if (encRand <= (mapData->encounter1Chance + mapData->encounter2Chance)) {
                             encIndex = 2;
                         } else {
                             encIndex = 3;
                         }
 
-                        if (!SpawnEncounterMonsters(pMapInfo, encIndex))
+                        if (!SpawnEncounterMonsters(mapData, encIndex))
                             encIndex = 0;
 
                         if (encIndex) {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -47,7 +47,8 @@
 #include "Engine/Spells/SpellEnumFunctions.h"
 #include "Engine/Timer.h"
 #include "Engine/TurnEngine/TurnEngine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/MapEnumFunctions.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "GUI/GUIButton.h"
 #include "GUI/GUIWindow.h"
@@ -1127,7 +1128,7 @@ void Game::processQueuedMessages() {
                     // Was this, which made exactly zero sense:
                     // if (mapIdx == MAP_INVALID)
                     //    mapIdx = static_cast<MAP_TYPE>(grng->random(pMapStats->uNumMaps + 1));
-                    MapInfo *pMapInfo = &pMapStats->pInfos[mapIdx];
+                    MapData *pMapInfo = &mapTable[mapIdx];
 
                     // Encounters when resting
                     if ((grng->random(100) + 1) <= pMapInfo->encounterChance && !engine->config->debug.NoActors.value()) {

--- a/src/Bin/CodeGen/CodeGen.cpp
+++ b/src/Bin/CodeGen/CodeGen.cpp
@@ -154,29 +154,31 @@ std::string mapIdEnumName(const MapData &mapData) {
 }
 
 int runMapIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    initializeMaps(resourceManager->eventsData("MapStats.txt"));
+    MapTable mapTable;
+    mapTable.Initialize(resourceManager->eventsData("MapStats.txt"));
 
     CodeGenMap map;
     map.insert(MAP_INVALID, "INVALID", "");
 
-    for (MapId i : mapTable.indices())
-        map.insert(i, mapIdEnumName(mapTable[i]), "");
+    for (MapId i : mapTable.pInfos.indices())
+        map.insert(i, mapIdEnumName(mapTable.pInfos[i]), "");
 
     map.dump(stdout, "MAP_");
     return 0;
 }
 
-const MapData &mapDataByFileName(std::string_view fileName) {
-    auto pos = std::find_if(mapTable.begin(), mapTable.end(), [&] (const MapData &mapData) {
+const MapData &mapInfoByFileName(const MapTable &mapTable, std::string_view fileName) {
+    auto pos = std::find_if(mapTable.pInfos.begin(), mapTable.pInfos.end(), [&] (const MapData &mapData) {
         return ascii::noCaseEquals(mapData.fileName, fileName);
     });
-    if (pos == mapTable.end())
+    if (pos == mapTable.pInfos.end())
         throw Exception("Unrecognized map '{}'", fileName);
     return *pos;
 }
 
 int runBeaconsCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    initializeMaps(resourceManager->eventsData("MapStats.txt"));
+    MapTable mapTable;
+    mapTable.Initialize(resourceManager->eventsData("MapStats.txt"));
 
     LodReader gamesLod(dfs->read("data/games.lod"));
     std::vector<std::string> fileNames = gamesLod.ls();
@@ -186,14 +188,15 @@ int runBeaconsCodeGen(const CodeGenOptions &options, ResourceManager *resourceMa
         if (!fileName.ends_with(".odm") && !fileName.ends_with(".blv"))
             continue; // Not a level file.
 
-        fmt::println("    {{MAP_{}, {}}},", mapIdEnumName(mapDataByFileName(fileName)), i);
+        fmt::println("    {{MAP_{}, {}}},", mapIdEnumName(mapInfoByFileName(mapTable, fileName)), i);
     }
 
     return 0;
 }
 
 int runHouseIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    initializeMaps(resourceManager->eventsData("MapStats.txt"));
+    MapTable mapTable;
+    mapTable.Initialize(resourceManager->eventsData("MapStats.txt"));
 
     initializeHouses(resourceManager->eventsData("2dEvents.txt"));
 
@@ -204,7 +207,7 @@ int runHouseIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceMa
         if (!fileName.ends_with(".odm") && !fileName.ends_with(".blv"))
             continue; // Not a level file.
 
-        std::string mapName = mapIdEnumName(mapDataByFileName(fileName));
+        std::string mapName = mapIdEnumName(mapInfoByFileName(mapTable, fileName));
         EvtProgram eventMap = EvtProgram::load(resourceManager->eventsData(fileName.substr(0, fileName.size() - 4) + ".evt"));
 
         for (const EventTrigger &trigger : eventMap.enumerateTriggers(EVENT_SpeakInHouse)) {
@@ -392,10 +395,11 @@ int runBountyHuntCodeGen(const CodeGenOptions &options, ResourceManager *resourc
 }
 
 int runMusicCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    initializeMaps(resourceManager->eventsData("MapStats.txt"));
+    MapTable mapTable;
+    mapTable.Initialize(resourceManager->eventsData("MapStats.txt"));
 
     std::map<MusicId, std::vector<std::string>> mapNamesByMusicId, mapEnumNamesByMusicId;
-    for (const MapData &info : mapTable) {
+    for (const MapData &info : mapTable.pInfos) {
         mapNamesByMusicId[info.musicId].push_back(info.name);
         mapEnumNamesByMusicId[info.musicId].push_back(mapIdEnumName(info));
     }

--- a/src/Bin/CodeGen/CodeGen.cpp
+++ b/src/Bin/CodeGen/CodeGen.cpp
@@ -23,7 +23,7 @@
 #include "Engine/Objects/MonsterEnumFunctions.h"
 #include "Engine/Snapshots/TableSerialization.h"
 #include "Engine/Resources/ResourceManager.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/mm7_data.h"
 
@@ -146,39 +146,37 @@ int runItemIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceMan
     return 0;
 }
 
-std::string mapIdEnumName(const MapInfo &mapInfo) {
-    std::string result = toUpperCaseEnum(mapInfo.name);
+std::string mapIdEnumName(const MapData &mapData) {
+    std::string result = toUpperCaseEnum(mapData.name);
     if (result.starts_with("THE_"))
         result = result.substr(4);
     return result;
 }
 
 int runMapIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    MapStats mapStats;
-    mapStats.Initialize(resourceManager->eventsData("MapStats.txt"));
+    initializeMaps(resourceManager->eventsData("MapStats.txt"));
 
     CodeGenMap map;
     map.insert(MAP_INVALID, "INVALID", "");
 
-    for (MapId i : mapStats.pInfos.indices())
-        map.insert(i, mapIdEnumName(mapStats.pInfos[i]), "");
+    for (MapId i : mapTable.indices())
+        map.insert(i, mapIdEnumName(mapTable[i]), "");
 
     map.dump(stdout, "MAP_");
     return 0;
 }
 
-const MapInfo &mapInfoByFileName(const MapStats &mapStats, std::string_view fileName) {
-    auto pos = std::find_if(mapStats.pInfos.begin(), mapStats.pInfos.end(), [&] (const MapInfo &mapInfo) {
-        return ascii::noCaseEquals(mapInfo.fileName, fileName);
+const MapData &mapDataByFileName(std::string_view fileName) {
+    auto pos = std::find_if(mapTable.begin(), mapTable.end(), [&] (const MapData &mapData) {
+        return ascii::noCaseEquals(mapData.fileName, fileName);
     });
-    if (pos == mapStats.pInfos.end())
+    if (pos == mapTable.end())
         throw Exception("Unrecognized map '{}'", fileName);
     return *pos;
 }
 
 int runBeaconsCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    MapStats mapStats;
-    mapStats.Initialize(resourceManager->eventsData("MapStats.txt"));
+    initializeMaps(resourceManager->eventsData("MapStats.txt"));
 
     LodReader gamesLod(dfs->read("data/games.lod"));
     std::vector<std::string> fileNames = gamesLod.ls();
@@ -188,15 +186,14 @@ int runBeaconsCodeGen(const CodeGenOptions &options, ResourceManager *resourceMa
         if (!fileName.ends_with(".odm") && !fileName.ends_with(".blv"))
             continue; // Not a level file.
 
-        fmt::println("    {{MAP_{}, {}}},", mapIdEnumName(mapInfoByFileName(mapStats, fileName)), i);
+        fmt::println("    {{MAP_{}, {}}},", mapIdEnumName(mapDataByFileName(fileName)), i);
     }
 
     return 0;
 }
 
 int runHouseIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    MapStats mapStats;
-    mapStats.Initialize(resourceManager->eventsData("MapStats.txt"));
+    initializeMaps(resourceManager->eventsData("MapStats.txt"));
 
     initializeHouses(resourceManager->eventsData("2dEvents.txt"));
 
@@ -207,7 +204,7 @@ int runHouseIdCodeGen(const CodeGenOptions &options, ResourceManager *resourceMa
         if (!fileName.ends_with(".odm") && !fileName.ends_with(".blv"))
             continue; // Not a level file.
 
-        std::string mapName = mapIdEnumName(mapInfoByFileName(mapStats, fileName));
+        std::string mapName = mapIdEnumName(mapDataByFileName(fileName));
         EvtProgram eventMap = EvtProgram::load(resourceManager->eventsData(fileName.substr(0, fileName.size() - 4) + ".evt"));
 
         for (const EventTrigger &trigger : eventMap.enumerateTriggers(EVENT_SpeakInHouse)) {
@@ -395,11 +392,10 @@ int runBountyHuntCodeGen(const CodeGenOptions &options, ResourceManager *resourc
 }
 
 int runMusicCodeGen(const CodeGenOptions &options, ResourceManager *resourceManager) {
-    MapStats mapStats;
-    mapStats.Initialize(resourceManager->eventsData("MapStats.txt"));
+    initializeMaps(resourceManager->eventsData("MapStats.txt"));
 
     std::map<MusicId, std::vector<std::string>> mapNamesByMusicId, mapEnumNamesByMusicId;
-    for (const MapInfo &info : mapStats.pInfos) {
+    for (const MapData &info : mapTable) {
         mapNamesByMusicId[info.musicId].push_back(info.name);
         mapEnumNamesByMusicId[info.musicId].push_back(mapIdEnumName(info));
     }

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -10,7 +10,6 @@ set(ENGINE_SOURCES
         GpuHints.cpp
         Localization.cpp
         MapEnums.cpp
-        MapInfo.cpp
         Party.cpp
         PartyEnums.cpp
         PartyPlacement.cpp
@@ -36,7 +35,6 @@ set(ENGINE_HEADERS
         Localization.h
         LocationInfo.h
         MapEnums.h
-        MapInfo.h
         Party.h
         PartyEnums.h
         PartyPlacement.h

--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -6,7 +6,7 @@
 
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/mm7_data.h"
 
 #include "Media/Audio/AudioPlayer.h"
@@ -103,7 +103,7 @@ EventTraceGameState EngineTraceStateAccessor::makeGameState() {
     };
 
     EventTraceGameState result;
-    result.locationName = ascii::toLower(pMapStats->pInfos[engine->_currentLoadedMapId].fileName);
+    result.locationName = ascii::toLower(mapTable[engine->_currentLoadedMapId].fileName);
     result.partyPosition = pParty->pos.toInt();
     for (const Character &character : pParty->pCharacters) {
         EventTraceCharacterState &traceCharacter = result.characters.emplace_back();

--- a/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
+++ b/src/Engine/Components/Trace/EngineTraceStateAccessor.cpp
@@ -103,7 +103,7 @@ EventTraceGameState EngineTraceStateAccessor::makeGameState() {
     };
 
     EventTraceGameState result;
-    result.locationName = ascii::toLower(mapTable[engine->_currentLoadedMapId].fileName);
+    result.locationName = ascii::toLower(pMapTable->pInfos[engine->_currentLoadedMapId].fileName);
     result.partyPosition = pParty->pos.toInt();
     for (const Character &character : pParty->pCharacters) {
         EventTraceCharacterState &traceCharacter = result.characters.emplace_back();

--- a/src/Engine/Data/CMakeLists.txt
+++ b/src/Engine/Data/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ENGINE_DATA_HEADERS
         HouseEnums.h
         IconFrameData.h
         ItemData.h
+        MapData.h
         OverlayData.h
         PortraitFrameData.h
         SoundEnums.h

--- a/src/Engine/Data/MapData.h
+++ b/src/Engine/Data/MapData.h
@@ -1,19 +1,13 @@
 #pragma once
 
 #include <cstdint>
-#include <array>
 #include <string>
 
-#include "Engine/Data/SoundEnums.h"
+#include "SoundEnums.h"
 
-#include "Utility/IndexedArray.h"
+#include "Engine/MapEnums.h"
 
-#include "MapEnumFunctions.h"
-#include "MapEnums.h"
-
-class Blob;
-
-struct MapInfo {
+struct MapData {
     std::string name; // Display name, e.g. "The Tularean Forest".
     std::string fileName; // E.g. "out02.odm".
     std::string encounter1MonsterInternalName; //
@@ -50,11 +44,3 @@ struct MapInfo {
     char field_42 = 0;
     char field_43 = 0;
 };
-
-struct MapStats {
-    void Initialize(const Blob &mapStats);
-    MapId GetMapInfo(std::string_view Str2);
-    IndexedArray<MapInfo, MAP_FIRST, MAP_LAST> pInfos;
-};
-
-extern MapStats *pMapStats;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -68,7 +68,8 @@
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/AttackList.h"
 #include "Engine/Resources/ResourceManager.h"
-#include "Engine/MapInfo.h"
+#include "Engine/MapEnumFunctions.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/Resources/LOD.h"
 
@@ -701,8 +702,7 @@ void Engine::MM7_Initialize() {
 void Engine::SecondaryInitialization() {
     mouse->Initialize();
 
-    pMapStats = new MapStats();
-    pMapStats->Initialize(engine->resources()->eventsData("MapStats.txt"));
+    initializeMaps(engine->resources()->eventsData("MapStats.txt"));
 
     pMonsterStats = new MonsterStats();
     pMonsterStats->Initialize(engine->resources()->eventsData("monsters.txt"));
@@ -1438,7 +1438,7 @@ void initLevelStrings(const Blob &blob) {
 }
 
 void loadMapEventsAndStrings(MapId mapid) {
-    std::string mapName = pMapStats->pInfos[mapid].fileName;
+    std::string mapName = mapTable[mapid].fileName;
     std::string mapNameWithoutExt = mapName.substr(0, mapName.rfind('.'));
 
     initLevelStrings(engine->resources()->eventsData(fmt::format("{}.str", mapNameWithoutExt)));
@@ -1481,6 +1481,6 @@ void TeleportToNWCDungeon() {
 
     // start tranistion to dungeon
     pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_Fullscreen);
-    startMapTransition(MapDestination(pMapStats->GetMapInfo("nwc.blv"), MAP_START_POINT_PARTY));
+    startMapTransition(MapDestination(mapIdByFileName("nwc.blv"), MAP_START_POINT_PARTY));
     current_screen_type = SCREEN_GAME;
 }

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -702,7 +702,8 @@ void Engine::MM7_Initialize() {
 void Engine::SecondaryInitialization() {
     mouse->Initialize();
 
-    initializeMaps(engine->resources()->eventsData("MapStats.txt"));
+    pMapTable = new MapTable();
+    pMapTable->Initialize(engine->resources()->eventsData("MapStats.txt"));
 
     pMonsterStats = new MonsterStats();
     pMonsterStats->Initialize(engine->resources()->eventsData("monsters.txt"));
@@ -1438,7 +1439,7 @@ void initLevelStrings(const Blob &blob) {
 }
 
 void loadMapEventsAndStrings(MapId mapid) {
-    std::string mapName = mapTable[mapid].fileName;
+    std::string mapName = pMapTable->pInfos[mapid].fileName;
     std::string mapNameWithoutExt = mapName.substr(0, mapName.rfind('.'));
 
     initLevelStrings(engine->resources()->eventsData(fmt::format("{}.str", mapNameWithoutExt)));
@@ -1481,6 +1482,6 @@ void TeleportToNWCDungeon() {
 
     // start tranistion to dungeon
     pGameLoadingUI_ProgressBar->Initialize(GUIProgressBar::TYPE_Fullscreen);
-    startMapTransition(MapDestination(mapIdByFileName("nwc.blv"), MAP_START_POINT_PARTY));
+    startMapTransition(MapDestination(pMapTable->GetMapInfo("nwc.blv"), MAP_START_POINT_PARTY));
     current_screen_type = SCREEN_GAME;
 }

--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -21,7 +21,7 @@
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Spells/Spells.h"
 #include "Engine/Engine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "Media/Audio/AudioPlayer.h"
 #include "Media/MediaPlayer.h"
@@ -89,7 +89,7 @@ void spawnMonsters(int16_t typeindex, int16_t level, int count,
 
     AIDirection direction;
     int oldNumActors = pActors.size();
-    SpawnEncounter(&pMapStats->pInfos[engine->_currentLoadedMapId], &pSpawnPoint, 0, count, 0);
+    SpawnEncounter(&mapTable[engine->_currentLoadedMapId], &pSpawnPoint, 0, count, 0);
     Actor::GetDirectionInfo(pos, pParty->pos + Vec3f(0, 0, pParty->eyeLevel), &direction);
     for (int i = oldNumActors; i < pActors.size(); ++i) {
         pActors[i].PrepareSprites(0);
@@ -124,7 +124,7 @@ static tl::generator<Character &> iterateCharacters(EvtTargetCharacter who, Rand
 static MapDestination moveToMapDestination(const EvtInstruction &ir) {
     const auto &descr = ir.data.move_map_descr;
 
-    MapId map = !ir.str.starts_with('0') && !ir.str.empty() ? pMapStats->GetMapInfo(ir.str) : MAP_INVALID;
+    MapId map = !ir.str.starts_with('0') && !ir.str.empty() ? mapIdByFileName(ir.str) : MAP_INVALID;
     if (descr.x || descr.y || descr.z)
         return MapDestination(map, PartyPlacement(Vec3f(descr.x, descr.y, descr.z),
                                                   descr.yaw != -1 ? (descr.yaw & TrigLUT.uDoublePiMask) : -1, descr.pitch, descr.zspeed));

--- a/src/Engine/Evt/EvtInterpreter.cpp
+++ b/src/Engine/Evt/EvtInterpreter.cpp
@@ -89,7 +89,7 @@ void spawnMonsters(int16_t typeindex, int16_t level, int count,
 
     AIDirection direction;
     int oldNumActors = pActors.size();
-    SpawnEncounter(&mapTable[engine->_currentLoadedMapId], &pSpawnPoint, 0, count, 0);
+    SpawnEncounter(&pMapTable->pInfos[engine->_currentLoadedMapId], &pSpawnPoint, 0, count, 0);
     Actor::GetDirectionInfo(pos, pParty->pos + Vec3f(0, 0, pParty->eyeLevel), &direction);
     for (int i = oldNumActors; i < pActors.size(); ++i) {
         pActors[i].PrepareSprites(0);
@@ -124,7 +124,7 @@ static tl::generator<Character &> iterateCharacters(EvtTargetCharacter who, Rand
 static MapDestination moveToMapDestination(const EvtInstruction &ir) {
     const auto &descr = ir.data.move_map_descr;
 
-    MapId map = !ir.str.starts_with('0') && !ir.str.empty() ? mapIdByFileName(ir.str) : MAP_INVALID;
+    MapId map = !ir.str.starts_with('0') && !ir.str.empty() ? pMapTable->GetMapInfo(ir.str) : MAP_INVALID;
     if (descr.x || descr.y || descr.z)
         return MapDestination(map, PartyPlacement(Vec3f(descr.x, descr.y, descr.z),
                                                   descr.yaw != -1 ? (descr.yaw & TrigLUT.uDoublePiMask) : -1, descr.pitch, descr.zspeed));

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -37,7 +37,8 @@
 #include "Engine/Timer.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/MapEnumFunctions.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/LOD.h"
 #include "Engine/SaveLoad.h"
 
@@ -296,7 +297,7 @@ void IndoorLocation::Load(std::string_view filename, int num_days_played, int re
             if (dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)
                 respawn_interval_days = 0x1BAF800;
 
-            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && pMapStats->GetMapInfo(filename) != MAP_CASTLE_HARMONDALE)
+            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && mapIdByFileName(filename) != MAP_CASTLE_HARMONDALE)
                 respawnTimed = true;
         } catch (const Exception &e) {
             MM_ERROR("Failed to load '{}', respawning location: {}", dlv_filename, e.what());
@@ -878,7 +879,7 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     assert(isMapIndoor(mapid));
 
     unsigned int respawn_interval;  // ebx@1
-    MapInfo *map_info;              // edi@9
+    MapData *map_info;              // edi@9
     bool v28;                       // zf@81
     bool alertStatus;                        // [sp+404h] [bp-10h]@1
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
@@ -898,9 +899,9 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
 
-    mapFilename = pMapStats->pInfos[mapid].fileName;
-    map_info = &pMapStats->pInfos[mapid];
-    respawn_interval = pMapStats->pInfos[mapid].respawnIntervalDays;
+    mapFilename = mapTable[mapid].fileName;
+    map_info = &mapTable[mapid];
+    respawn_interval = mapTable[mapid].respawnIntervalDays;
     alertStatus = GetAlertStatus();
 
 
@@ -1730,7 +1731,7 @@ int CalcDistPointToLine(int x1, int y1, int x2, int y2, int x3, int y3) {
 }
 
 //----- (0045063B) --------------------------------------------------------
-int SpawnEncounterMonsters(MapInfo *map_info, int enc_index) {
+int SpawnEncounterMonsters(MapData *map_info, int enc_index) {
     // creates random spawn point for encounter
     bool failed_point = false;
     float angle_from_party;
@@ -1832,7 +1833,7 @@ int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f p
     return a1.Create(0, 0, 0, 0);
 }
 
-void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *spawn) {
+void SpawnRandomTreasure(MapData *mapInfo, SpawnPoint *spawn) {
     assert(spawn->type == OBJECT_Sprite);
 
     SpriteObject spawnedObject;

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -297,7 +297,7 @@ void IndoorLocation::Load(std::string_view filename, int num_days_played, int re
             if (dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)
                 respawn_interval_days = 0x1BAF800;
 
-            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && mapIdByFileName(filename) != MAP_CASTLE_HARMONDALE)
+            if (!respawnInitial && num_days_played - delta.header.info.lastRespawnDay >= respawn_interval_days && pMapTable->GetMapInfo(filename) != MAP_CASTLE_HARMONDALE)
                 respawnTimed = true;
         } catch (const Exception &e) {
             MM_ERROR("Failed to load '{}', respawning location: {}", dlv_filename, e.what());
@@ -879,7 +879,7 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     assert(isMapIndoor(mapid));
 
     unsigned int respawn_interval;  // ebx@1
-    MapData *map_info;              // edi@9
+    MapData *mapData;              // edi@9
     bool v28;                       // zf@81
     bool alertStatus;                        // [sp+404h] [bp-10h]@1
     bool indoor_was_respawned = true;                      // [sp+40Ch] [bp-8h]@1
@@ -899,9 +899,9 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
     //pPaletteManager->RecalculateAll();
     pParty->_delayedReactionTimer = 0_ticks;
 
-    mapFilename = mapTable[mapid].fileName;
-    map_info = &mapTable[mapid];
-    respawn_interval = mapTable[mapid].respawnIntervalDays;
+    mapFilename = pMapTable->pInfos[mapid].fileName;
+    mapData = &pMapTable->pInfos[mapid];
+    respawn_interval = pMapTable->pInfos[mapid].respawnIntervalDays;
     alertStatus = GetAlertStatus();
 
 
@@ -917,9 +917,9 @@ void loadAndPrepareBLV(MapId mapid, bool bLoading) {
         for (unsigned i = 0; i < pIndoor->pSpawnPoints.size(); ++i) {
             auto spawn = &pIndoor->pSpawnPoints[i];
             if (spawn->type == OBJECT_Actor)
-                SpawnEncounter(map_info, spawn, 0, 0, 0);
+                SpawnEncounter(mapData, spawn, 0, 0, 0);
             else
-                SpawnRandomTreasure(map_info, spawn);
+                SpawnRandomTreasure(mapData, spawn);
         }
         RespawnGlobalDecorations();
     }
@@ -1731,7 +1731,7 @@ int CalcDistPointToLine(int x1, int y1, int x2, int y2, int x3, int y3) {
 }
 
 //----- (0045063B) --------------------------------------------------------
-int SpawnEncounterMonsters(MapData *map_info, int enc_index) {
+int SpawnEncounterMonsters(MapData *mapData, int enc_index) {
     // creates random spawn point for encounter
     bool failed_point = false;
     float angle_from_party;
@@ -1813,7 +1813,7 @@ int SpawnEncounterMonsters(MapData *map_info, int enc_index) {
     if (failed_point) {
         return false;
     } else {
-        SpawnEncounter(map_info, &enc_spawn_point, 0, 0, 1);
+        SpawnEncounter(mapData, &enc_spawn_point, 0, 0, 1);
     }
 
     return enc_index;
@@ -1833,14 +1833,14 @@ int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f p
     return a1.Create(0, 0, 0, 0);
 }
 
-void SpawnRandomTreasure(MapData *mapInfo, SpawnPoint *spawn) {
+void SpawnRandomTreasure(MapData *mapData, SpawnPoint *spawn) {
     assert(spawn->type == OBJECT_Sprite);
 
     SpriteObject spawnedObject;
     spawnedObject.containing_item.Reset();
 
     int typeRandom = grng->random(100);
-    ItemTreasureLevel levelRandom = grng->randomSample(RemapTreasureLevel(spawn->treasureLevel, mapInfo->mapTreasureLevel));
+    ItemTreasureLevel levelRandom = grng->randomSample(RemapTreasureLevel(spawn->treasureLevel, mapData->mapTreasureLevel));
     if (levelRandom != ITEM_TREASURE_LEVEL_7) {
         // TODO(pskelton): configurable thresholds for treasure
         // [0, 20) -- nothing

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -322,9 +322,9 @@ void PrepareDrawLists_BLV();
  * @offset 0x460A78
  */
 void loadAndPrepareBLV(MapId mapid, bool bLoading);
-int SpawnEncounterMonsters(MapData *a1, int a2);
+int SpawnEncounterMonsters(MapData *mapData, int encIndex);
 int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f pos, uint16_t facing);
-void SpawnRandomTreasure(MapData *mapInfo, SpawnPoint *a2);
+void SpawnRandomTreasure(MapData *mapData, SpawnPoint *spawn);
 
 void FindBillboardsLightLevels_BLV();
 

--- a/src/Engine/Graphics/Indoor.h
+++ b/src/Engine/Graphics/Indoor.h
@@ -23,7 +23,7 @@
 
 struct BspRenderer;
 struct IndoorLocation;
-struct MapInfo;
+struct MapData;
 
 struct BSPNode {
     int uFront;
@@ -322,9 +322,9 @@ void PrepareDrawLists_BLV();
  * @offset 0x460A78
  */
 void loadAndPrepareBLV(MapId mapid, bool bLoading);
-int SpawnEncounterMonsters(MapInfo *a1, int a2);
+int SpawnEncounterMonsters(MapData *a1, int a2);
 int DropTreasureAt(ItemTreasureLevel trs_level, RandomItemType trs_type, Vec3f pos, uint16_t facing);
-void SpawnRandomTreasure(MapInfo *mapInfo, SpawnPoint *a2);
+void SpawnRandomTreasure(MapData *mapInfo, SpawnPoint *a2);
 
 void FindBillboardsLightLevels_BLV();
 

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -38,7 +38,8 @@
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/BspRenderer.h"
-#include "Engine/MapInfo.h"
+#include "Engine/MapEnumFunctions.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/LOD.h"
 #include "Engine/SaveLoad.h"
 #include "Engine/Seasons.h"
@@ -1742,7 +1743,7 @@ void UpdateActors_ODM() {
 static void loadAndPrepareODMInternal(MapId mapid) {
     assert(isMapOutdoor(mapid));
 
-    MapInfo *map_info;
+    MapData *map_info;
     bool outdoor_was_respawned;
     unsigned int respawn_interval = 0;
     std::string mapFilename;
@@ -1752,8 +1753,8 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     // thisa = (ODMRenderParams *)1;
     GetAlertStatus(); // Result unused.
     pParty->_delayedReactionTimer = 0_ticks;
-    mapFilename = pMapStats->pInfos[mapid].fileName;
-    map_info = &pMapStats->pInfos[mapid];
+    mapFilename = mapTable[mapid].fileName;
+    map_info = &mapTable[mapid];
     respawn_interval = map_info->respawnIntervalDays;
 
     pOutdoor->weather.flags &= ~MAP_WEATHER_FOGGY;

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -1743,7 +1743,7 @@ void UpdateActors_ODM() {
 static void loadAndPrepareODMInternal(MapId mapid) {
     assert(isMapOutdoor(mapid));
 
-    MapData *map_info;
+    MapData *mapData;
     bool outdoor_was_respawned;
     unsigned int respawn_interval = 0;
     std::string mapFilename;
@@ -1753,9 +1753,9 @@ static void loadAndPrepareODMInternal(MapId mapid) {
     // thisa = (ODMRenderParams *)1;
     GetAlertStatus(); // Result unused.
     pParty->_delayedReactionTimer = 0_ticks;
-    mapFilename = mapTable[mapid].fileName;
-    map_info = &mapTable[mapid];
-    respawn_interval = map_info->respawnIntervalDays;
+    mapFilename = pMapTable->pInfos[mapid].fileName;
+    mapData = &pMapTable->pInfos[mapid];
+    respawn_interval = mapData->respawnIntervalDays;
 
     pOutdoor->weather.flags &= ~MAP_WEATHER_FOGGY;
     pOutdoor->Initialize(mapFilename, pParty->GetPlayingTime().toDays() + 1, respawn_interval, &outdoor_was_respawned);
@@ -1771,9 +1771,9 @@ static void loadAndPrepareODMInternal(MapId mapid) {
             SpawnPoint *spawn = &pOutdoor->pSpawnPoints[i];
 
             if (spawn->type == OBJECT_Actor)
-                SpawnEncounter(map_info, spawn, 0, 0, 0);
+                SpawnEncounter(mapData, spawn, 0, 0, 0);
             else
-                SpawnRandomTreasure(map_info, spawn);
+                SpawnRandomTreasure(mapData, spawn);
         }
         RespawnGlobalDecorations();
     }

--- a/src/Engine/LocationInfo.h
+++ b/src/Engine/LocationInfo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// TODO(captainurist): we also have MapInfo, rename this into something more sane with Map- prefix.
+// TODO(captainurist): we also have MapData, rename this into something more sane with Map- prefix.
 struct LocationInfo {
     int respawnCount = 0; // Number of times a location was respawned, including the initial spawn.
     int lastRespawnDay = 0; // Day of the last respawn (days since GameTime zero to last respawn).

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1096,7 +1096,7 @@ void Actor::ApplyFineForKillingPeasant(unsigned int uActorID) {
     if ((engine->_currentLoadedMapId == MAP_DEYJA || engine->_currentLoadedMapId == MAP_PIT) && pParty->isPartyGood())
         return;
 
-    pParty->uFine += 100 * (mapTable[engine->_currentLoadedMapId].baseStealingFine +
+    pParty->uFine += 100 * (pMapTable->pInfos[engine->_currentLoadedMapId].baseStealingFine +
                             pActors[uActorID].monsterInfo.level +
                             pParty->GetPartyReputation());
     if (pParty->uFine < 0)
@@ -1237,7 +1237,7 @@ void Actor::StealFrom(unsigned int uActorID) {
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
         if (engine->_currentLoadedMapId != MAP_INVALID)
-            v4 = mapTable[engine->_currentLoadedMapId].baseStealingFine;
+            v4 = pMapTable->pInfos[engine->_currentLoadedMapId].baseStealingFine;
         v6 = &currentLocationInfo();
         pPlayer->StealFromActor(uActorID, v4, v6->reputation++);
         v8 = pPlayer->GetAttackRecoveryTime(false);
@@ -4197,7 +4197,7 @@ void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Durati
 }
 
 //----- (0044F57C) --------------------------------------------------------
-void SpawnEncounter(MapData *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro) {
+void SpawnEncounter(MapData *mapData, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro) {
     assert(spawn->type == OBJECT_Actor);
 
     char v8;               // zf@5
@@ -4212,46 +4212,46 @@ void SpawnEncounter(MapData *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int
     int monsterCategoryOddsSet = 0;
     switch (spawn->monsterIndex - 1) {
         case 0:
-            monsterCategoryOddsSet = pMapInfo->Dif_M1;
-            NumToSpawn = pMapInfo->encounter1MinCount + grng->random(pMapInfo->encounter1MaxCount - pMapInfo->encounter1MinCount + 1);
-            baseInternalName = pMapInfo->encounter1MonsterInternalName;
+            monsterCategoryOddsSet = mapData->Dif_M1;
+            NumToSpawn = mapData->encounter1MinCount + grng->random(mapData->encounter1MaxCount - mapData->encounter1MinCount + 1);
+            baseInternalName = mapData->encounter1MonsterInternalName;
             break;
         case 1:
-            monsterCategoryOddsSet = pMapInfo->Dif_M2;
-            NumToSpawn = pMapInfo->encounter2MinCount + grng->random(pMapInfo->encounter2MaxCount - pMapInfo->encounter2MinCount + 1);
-            baseInternalName = pMapInfo->encounter2MonsterInternalName;
+            monsterCategoryOddsSet = mapData->Dif_M2;
+            NumToSpawn = mapData->encounter2MinCount + grng->random(mapData->encounter2MaxCount - mapData->encounter2MinCount + 1);
+            baseInternalName = mapData->encounter2MonsterInternalName;
             break;
         case 2:
-            monsterCategoryOddsSet = pMapInfo->Dif_M3;
-            NumToSpawn = pMapInfo->encounter3MinCount + grng->random(pMapInfo->encounter3MaxCount - pMapInfo->encounter3MinCount + 1);
-            baseInternalName = pMapInfo->encounter3MonsterInternalName;
+            monsterCategoryOddsSet = mapData->Dif_M3;
+            NumToSpawn = mapData->encounter3MinCount + grng->random(mapData->encounter3MaxCount - mapData->encounter3MinCount + 1);
+            baseInternalName = mapData->encounter3MonsterInternalName;
             break;
         case 3:
-            baseInternalName = pMapInfo->encounter1MonsterInternalName + " A";
+            baseInternalName = mapData->encounter1MonsterInternalName + " A";
             break;
         case 4:
-            baseInternalName = pMapInfo->encounter2MonsterInternalName + " A";
+            baseInternalName = mapData->encounter2MonsterInternalName + " A";
             break;
         case 5:
-            baseInternalName = pMapInfo->encounter3MonsterInternalName + " A";
+            baseInternalName = mapData->encounter3MonsterInternalName + " A";
             break;
         case 6:
-            baseInternalName = pMapInfo->encounter1MonsterInternalName + " B";
+            baseInternalName = mapData->encounter1MonsterInternalName + " B";
             break;
         case 7:
-            baseInternalName = pMapInfo->encounter2MonsterInternalName + " B";
+            baseInternalName = mapData->encounter2MonsterInternalName + " B";
             break;
         case 8:
-            baseInternalName = pMapInfo->encounter3MonsterInternalName + " B";
+            baseInternalName = mapData->encounter3MonsterInternalName + " B";
             break;
         case 9:
-            baseInternalName = pMapInfo->encounter1MonsterInternalName + " C";
+            baseInternalName = mapData->encounter1MonsterInternalName + " C";
             break;
         case 10:
-            baseInternalName = pMapInfo->encounter2MonsterInternalName + " C";
+            baseInternalName = mapData->encounter2MonsterInternalName + " C";
             break;
         case 11:
-            baseInternalName = pMapInfo->encounter3MonsterInternalName + " C";
+            baseInternalName = mapData->encounter3MonsterInternalName + " C";
             break;
         default:
             return;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -33,7 +33,7 @@
 #include "Engine/Tables/HostilityTable.h"
 #include "Engine/Timer.h"
 #include "Engine/TurnEngine/TurnEngine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "GUI/UI/UIGame.h"
 #include "GUI/UI/UIStatusBar.h"
@@ -1096,7 +1096,7 @@ void Actor::ApplyFineForKillingPeasant(unsigned int uActorID) {
     if ((engine->_currentLoadedMapId == MAP_DEYJA || engine->_currentLoadedMapId == MAP_PIT) && pParty->isPartyGood())
         return;
 
-    pParty->uFine += 100 * (pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine +
+    pParty->uFine += 100 * (mapTable[engine->_currentLoadedMapId].baseStealingFine +
                             pActors[uActorID].monsterInfo.level +
                             pParty->GetPartyReputation());
     if (pParty->uFine < 0)
@@ -1237,7 +1237,7 @@ void Actor::StealFrom(unsigned int uActorID) {
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
         if (engine->_currentLoadedMapId != MAP_INVALID)
-            v4 = pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine;
+            v4 = mapTable[engine->_currentLoadedMapId].baseStealingFine;
         v6 = &currentLocationInfo();
         pPlayer->StealFromActor(uActorID, v4, v6->reputation++);
         v8 = pPlayer->GetAttackRecoveryTime(false);
@@ -4197,7 +4197,7 @@ void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Durati
 }
 
 //----- (0044F57C) --------------------------------------------------------
-void SpawnEncounter(MapInfo *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro) {
+void SpawnEncounter(MapData *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro) {
     assert(spawn->type == OBJECT_Actor);
 
     char v8;               // zf@5

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -21,7 +21,7 @@
 class Actor;
 class Vis;
 struct SpawnPoint;
-struct MapInfo;
+struct MapData;
 
 struct stru319 {
     int which_player_to_attack(Actor *pActor);
@@ -280,7 +280,7 @@ void npcSetItem(int npc, ItemId item, int a3);
 void toggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag, bool bValue);
 bool Detect_Between_Objects(Pid uObjID, Pid uObj2ID);
 void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Duration duration);
-void SpawnEncounter(MapInfo *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro);
+void SpawnEncounter(MapData *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro);
 /**
  * @offset 0x438F8F
  */

--- a/src/Engine/Objects/Actor.h
+++ b/src/Engine/Objects/Actor.h
@@ -280,7 +280,7 @@ void npcSetItem(int npc, ItemId item, int a3);
 void toggleActorGroupFlag(unsigned int uGroupID, ActorAttribute uFlag, bool bValue);
 bool Detect_Between_Objects(Pid uObjID, Pid uObj2ID);
 void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Duration duration);
-void SpawnEncounter(MapData *pMapInfo, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro);
+void SpawnEncounter(MapData *mapData, SpawnPoint *spawn, int monsterCatMod, int countOverride, int aggro);
 /**
  * @offset 0x438F8F
  */

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -17,7 +17,6 @@
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
 #include "Engine/Random/Random.h"
 #include "Engine/Objects/Actor.h"
 #include "Engine/Objects/ObjectList.h"

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -21,7 +21,7 @@
 #include "Engine/Graphics/Sprites.h"
 #include "Engine/Tables/ItemTable.h"
 #include "Engine/Party.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Tables/ChestTable.h"
 
 #include "GUI/UI/UIChest.h"
@@ -62,7 +62,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
         return false;
     flag_shout = false;
     if (chest->Trapped() && engine->_currentLoadedMapId != MAP_INVALID) {
-        if (pParty->activeCharacter().GetDisarmTrap() < 2 * pMapStats->pInfos[engine->_currentLoadedMapId].disarmDifficulty) {
+        if (pParty->activeCharacter().GetDisarmTrap() < 2 * mapTable[engine->_currentLoadedMapId].disarmDifficulty) {
             pSpriteID[0] = SPRITE_TRAP_FIRE;
             pSpriteID[1] = SPRITE_TRAP_LIGHTNING;
             pSpriteID[2] = SPRITE_TRAP_COLD;
@@ -322,7 +322,7 @@ void Chest::GrabItem(bool all) {  // new function to grab items from chest using
 }
 
 void GenerateItemsInChest() {
-    MapInfo *currMapInfo = &pMapStats->pInfos[engine->_currentLoadedMapId];
+    MapData *currMapInfo = &mapTable[engine->_currentLoadedMapId];
     for (int i = 0; i < 20; ++i) {
         for (InventoryEntry entry : vChests[i].inventory.entries()) {
             if (!isRandomItem(entry->itemId))

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -62,7 +62,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
         return false;
     flag_shout = false;
     if (chest->Trapped() && engine->_currentLoadedMapId != MAP_INVALID) {
-        if (pParty->activeCharacter().GetDisarmTrap() < 2 * mapTable[engine->_currentLoadedMapId].disarmDifficulty) {
+        if (pParty->activeCharacter().GetDisarmTrap() < 2 * pMapTable->pInfos[engine->_currentLoadedMapId].disarmDifficulty) {
             pSpriteID[0] = SPRITE_TRAP_FIRE;
             pSpriteID[1] = SPRITE_TRAP_LIGHTNING;
             pSpriteID[2] = SPRITE_TRAP_COLD;
@@ -322,14 +322,14 @@ void Chest::GrabItem(bool all) {  // new function to grab items from chest using
 }
 
 void GenerateItemsInChest() {
-    MapData *currMapInfo = &mapTable[engine->_currentLoadedMapId];
+    MapData *mapData = &pMapTable->pInfos[engine->_currentLoadedMapId];
     for (int i = 0; i < 20; ++i) {
         for (InventoryEntry entry : vChests[i].inventory.entries()) {
             if (!isRandomItem(entry->itemId))
                 continue;
 
             ItemTreasureLevel resultTreasureLevel = grng->randomSample(
-                RemapTreasureLevel(randomItemTreasureLevel(entry->itemId), currMapInfo->mapTreasureLevel));
+                RemapTreasureLevel(randomItemTreasureLevel(entry->itemId), mapData->mapTreasureLevel));
 
             if (resultTreasureLevel == ITEM_TREASURE_LEVEL_7) {
                 // TODO(captainurist): GenerateArtifact calls Reset on failure, this messes up inventory state. Rewrite properly.

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -511,14 +511,14 @@ LABEL_25:
 }
 
 void SpriteObject::explosionTraps() {
-    MapData *pMapInfo = &mapTable[engine->_currentLoadedMapId];
+    MapData *mapData = &pMapTable->pInfos[engine->_currentLoadedMapId];
     int dir_x = pParty->pos.x - this->vPosition.x;
     int dir_y = pParty->pos.y - this->vPosition.y;
     int dir_z = pParty->pos.z + pParty->eyeLevel - this->vPosition.z;
     if (Vec3i(dir_x, dir_y, dir_z).octagonalLength() <= 768) {
         int trapDamage = 5;
-        if (pMapInfo->trapDamageD20DiceCount) {
-            trapDamage += grng->randomDice(pMapInfo->trapDamageD20DiceCount, 20);
+        if (mapData->trapDamageD20DiceCount) {
+            trapDamage += grng->randomDice(mapData->trapDamageD20DiceCount, 20);
         }
         DamageType pDamageType;
         switch (this->spriteId) {

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -11,7 +11,7 @@
 #include "Engine/Party.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/AttackList.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "Engine/Random/Random.h"
 
@@ -511,7 +511,7 @@ LABEL_25:
 }
 
 void SpriteObject::explosionTraps() {
-    MapInfo *pMapInfo = &pMapStats->pInfos[engine->_currentLoadedMapId];
+    MapData *pMapInfo = &mapTable[engine->_currentLoadedMapId];
     int dir_x = pParty->pos.x - this->vPosition.x;
     int dir_y = pParty->pos.y - this->vPosition.y;
     int dir_z = pParty->pos.z + pParty->eyeLevel - this->vPosition.z;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -23,7 +23,7 @@
 #include "Engine/Tables/PortraitFrameTable.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/AssetsManager.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "GUI/GUIWindow.h"
 #include "GUI/GUIMessageQueue.h"
@@ -174,7 +174,7 @@ bool Party::checkPartyPerceptionAgainstCurrentMap() {
                 maxPerception = playerPerception;
         }
     }
-    return maxPerception >= 2 * pMapStats->pInfos[engine->_currentLoadedMapId].perceptionDifficulty;
+    return maxPerception >= 2 * mapTable[engine->_currentLoadedMapId].perceptionDifficulty;
 }
 
 int Party::canActCount() const {

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -174,7 +174,7 @@ bool Party::checkPartyPerceptionAgainstCurrentMap() {
                 maxPerception = playerPerception;
         }
     }
-    return maxPerception >= 2 * mapTable[engine->_currentLoadedMapId].perceptionDifficulty;
+    return maxPerception >= 2 * pMapTable->pInfos[engine->_currentLoadedMapId].perceptionDifficulty;
 }
 
 int Party::canActCount() const {

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -14,7 +14,7 @@
 #include "Engine/Resources/LOD.h"
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Timer.h"
 #include "Engine/TurnEngine/TurnEngine.h"
 
@@ -112,7 +112,7 @@ void loadGame(std::string_view fileName) {
 
     // TODO(captainurist): the start point is a placeholder, the save carries the party's position and the loaders
     //                     skip placement when loading. MapDestination has no way to say that.
-    engine->_pendingTransition = MapDestination(pMapStats->GetMapInfo(state.header.locationName), MAP_START_POINT_PARTY);
+    engine->_pendingTransition = MapDestination(mapIdByFileName(state.header.locationName), MAP_START_POINT_PARTY);
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
 
@@ -128,7 +128,7 @@ void loadGame(std::string_view fileName) {
 }
 
 std::pair<SaveGameHeader, Blob> createSaveData(bool resetWorld, std::string_view title) {
-    std::string currentMapName = pMapStats->pInfos[engine->_currentLoadedMapId].fileName;
+    std::string currentMapName = mapTable[engine->_currentLoadedMapId].fileName;
 
     // Populate SaveGameState from global variables.
     SaveGame state;

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -112,7 +112,7 @@ void loadGame(std::string_view fileName) {
 
     // TODO(captainurist): the start point is a placeholder, the save carries the party's position and the loaders
     //                     skip placement when loading. MapDestination has no way to say that.
-    engine->_pendingTransition = MapDestination(mapIdByFileName(state.header.locationName), MAP_START_POINT_PARTY);
+    engine->_pendingTransition = MapDestination(pMapTable->GetMapInfo(state.header.locationName), MAP_START_POINT_PARTY);
 
     dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_SKIP_WORLD_UPDATE;
 
@@ -128,7 +128,7 @@ void loadGame(std::string_view fileName) {
 }
 
 std::pair<SaveGameHeader, Blob> createSaveData(bool resetWorld, std::string_view title) {
-    std::string currentMapName = mapTable[engine->_currentLoadedMapId].fileName;
+    std::string currentMapName = pMapTable->pInfos[engine->_currentLoadedMapId].fileName;
 
     // Populate SaveGameState from global variables.
     SaveGame state;

--- a/src/Engine/Tables/CMakeLists.txt
+++ b/src/Engine/Tables/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ENGINE_TABLES_SOURCES
         HouseTable.cpp
         IconFrameTable.cpp
         ItemTable.cpp
+        MapTable.cpp
         MerchantTable.cpp
         MessageScrollTable.cpp
         NPCTable.cpp
@@ -30,6 +31,7 @@ set(ENGINE_TABLES_HEADERS
         HouseTable.h
         IconFrameTable.h
         ItemTable.h
+        MapTable.h
         MerchantTable.h
         MessageScrollTable.h
         NPCTable.h

--- a/src/Engine/Tables/MapTable.cpp
+++ b/src/Engine/Tables/MapTable.cpp
@@ -1,5 +1,6 @@
-#include "MapInfo.h"
+#include "MapTable.h"
 
+#include <cassert>
 #include <array>
 #include <map>
 #include <string>
@@ -12,9 +13,9 @@
 #include "Utility/String/Split.h"
 #include "Utility/String/Transformations.h"
 
-MapStats *pMapStats;
+IndexedArray<MapData, MAP_FIRST, MAP_LAST> mapTable;
 
-void MapStats::Initialize(const Blob &mapStats) {
+void initializeMaps(const Blob &maps) {
     // mapstats.txt table structure: map id | name (localized) | file name | ... |
     //                               map designer (set only in mm6, not used) | dev notes | parent map (not used).
     static const std::map<std::string, uint8_t, ascii::NoCaseLess> eaxEnvMap = {
@@ -58,10 +59,10 @@ void MapStats::Initialize(const Blob &mapStats) {
         }
     };
 
-    for (std::string_view line : split(mapStats.str()).by("\r\n").drop(3).skip("")) {
+    for (std::string_view line : split(maps.str()).by("\r\n").drop(3).skip("")) {
         std::array<std::string_view, 30> tokens = split(line).by('\t');
         MapId mapId = static_cast<MapId>(fromString<int>(tokens[0]));
-        MapInfo &info = pInfos[mapId];
+        MapData &info = mapTable[mapId];
         info.name = unquote(tokens[1]);
         info.fileName = ascii::toLower(unquote(tokens[2]));
         info.numResets = fromString<int>(tokens[3]);
@@ -91,14 +92,12 @@ void MapStats::Initialize(const Blob &mapStats) {
     }
 }
 
-MapId MapStats::GetMapInfo(std::string_view Str2) {
-    std::string map_name = ascii::toLower(Str2);
+MapId mapIdByFileName(std::string_view fileName) {
+    std::string mapName = ascii::toLower(fileName);
 
-    for (MapId i : pInfos.indices()) {
-        if (pInfos[i].fileName == map_name) {
+    for (MapId i : mapTable.indices())
+        if (mapTable[i].fileName == mapName)
             return i;
-        }
-    }
 
     assert(false);
     return MAP_INVALID;

--- a/src/Engine/Tables/MapTable.cpp
+++ b/src/Engine/Tables/MapTable.cpp
@@ -13,9 +13,9 @@
 #include "Utility/String/Split.h"
 #include "Utility/String/Transformations.h"
 
-IndexedArray<MapData, MAP_FIRST, MAP_LAST> mapTable;
+MapTable *pMapTable;
 
-void initializeMaps(const Blob &maps) {
+void MapTable::Initialize(const Blob &mapStats) {
     // mapstats.txt table structure: map id | name (localized) | file name | ... |
     //                               map designer (set only in mm6, not used) | dev notes | parent map (not used).
     static const std::map<std::string, uint8_t, ascii::NoCaseLess> eaxEnvMap = {
@@ -59,10 +59,10 @@ void initializeMaps(const Blob &maps) {
         }
     };
 
-    for (std::string_view line : split(maps.str()).by("\r\n").drop(3).skip("")) {
+    for (std::string_view line : split(mapStats.str()).by("\r\n").drop(3).skip("")) {
         std::array<std::string_view, 30> tokens = split(line).by('\t');
         MapId mapId = static_cast<MapId>(fromString<int>(tokens[0]));
-        MapData &info = mapTable[mapId];
+        MapData &info = pInfos[mapId];
         info.name = unquote(tokens[1]);
         info.fileName = ascii::toLower(unquote(tokens[2]));
         info.numResets = fromString<int>(tokens[3]);
@@ -92,13 +92,15 @@ void initializeMaps(const Blob &maps) {
     }
 }
 
-MapId mapIdByFileName(std::string_view fileName) {
+MapId MapTable::GetMapInfo(std::string_view fileName) {
     std::string mapName = ascii::toLower(fileName);
 
-    for (MapId i : mapTable.indices())
-        if (mapTable[i].fileName == mapName)
+    for (MapId i : pInfos.indices()) {
+        if (pInfos[i].fileName == mapName) {
             return i;
+        }
+    }
 
-    assert(false);
+    assert(false); // TODO(captainurist): GUIWindow_IndoorEntryExit checks the result against MAP_INVALID, so this assert or that check is wrong.
     return MAP_INVALID;
 }

--- a/src/Engine/Tables/MapTable.h
+++ b/src/Engine/Tables/MapTable.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string_view>
+
+#include "Engine/Data/MapData.h"
+#include "Engine/MapEnums.h"
+
+#include "Utility/IndexedArray.h"
+
+class Blob;
+
+void initializeMaps(const Blob &maps);
+
+/**
+ * @param fileName                      Map file name, e.g. "out02.odm", case-insensitive.
+ * @return                              Id of the map with the given file name, or `MAP_INVALID` if there is no such
+ *                                      map.
+ */
+MapId mapIdByFileName(std::string_view fileName);
+
+extern IndexedArray<MapData, MAP_FIRST, MAP_LAST> mapTable;

--- a/src/Engine/Tables/MapTable.h
+++ b/src/Engine/Tables/MapTable.h
@@ -9,13 +9,10 @@
 
 class Blob;
 
-void initializeMaps(const Blob &maps);
+struct MapTable {
+    void Initialize(const Blob &mapStats);
+    MapId GetMapInfo(std::string_view fileName);
+    IndexedArray<MapData, MAP_FIRST, MAP_LAST> pInfos;
+};
 
-/**
- * @param fileName                      Map file name, e.g. "out02.odm", case-insensitive.
- * @return                              Id of the map with the given file name, or `MAP_INVALID` if there is no such
- *                                      map.
- */
-MapId mapIdByFileName(std::string_view fileName);
-
-extern IndexedArray<MapData, MAP_FIRST, MAP_LAST> mapTable;
+extern MapTable *pMapTable;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -26,7 +26,7 @@
 #include "Engine/Tables/AwardTable.h"
 #include "Engine/Tables/IconFrameTable.h"
 #include "Engine/Timer.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "GUI/GUIButton.h"
 #include "GUI/GUIFont.h"
@@ -878,7 +878,7 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, NPCData *np
                 break;
             case 23:
                 if (engine->_currentLoadedMapId != MAP_INVALID)
-                    result += pMapStats->pInfos[engine->_currentLoadedMapId].name;
+                    result += mapTable[engine->_currentLoadedMapId].name;
                 else
                     result += localization->str(LSTR_UNKNOWN);
                 break;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -878,7 +878,7 @@ std::string BuildDialogueString(std::string_view str, int uPlayerID, NPCData *np
                 break;
             case 23:
                 if (engine->_currentLoadedMapId != MAP_INVALID)
-                    result += mapTable[engine->_currentLoadedMapId].name;
+                    result += pMapTable->pInfos[engine->_currentLoadedMapId].name;
                 else
                     result += localization->str(LSTR_UNKNOWN);
                 break;

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -6,7 +6,7 @@
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
 #include "Engine/AssetsManager.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Engine.h"
 #include "Engine/mm7_data.h"
 
@@ -93,7 +93,7 @@ void GUIWindow_CalendarBook::Update() {
 
     std::string pMapName = "Unknown";
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        pMapName = pMapStats->pInfos[engine->_currentLoadedMapId].name;
+        pMapName = mapTable[engine->_currentLoadedMapId].name;
     }
 
     str = fmt::format("{}\t100:\t110{}", localization->str(LSTR_LOCATION), pMapName);

--- a/src/GUI/UI/Books/CalendarBook.cpp
+++ b/src/GUI/UI/Books/CalendarBook.cpp
@@ -93,7 +93,7 @@ void GUIWindow_CalendarBook::Update() {
 
     std::string pMapName = "Unknown";
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        pMapName = mapTable[engine->_currentLoadedMapId].name;
+        pMapName = pMapTable->pInfos[engine->_currentLoadedMapId].name;
     }
 
     str = fmt::format("{}\t100:\t110{}", localization->str(LSTR_LOCATION), pMapName);

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -113,7 +113,7 @@ void GUIWindow_LloydsBook::Update() {
         if (pPlayer->vBeacons[beaconId]) {
             LloydBeacon &beacon = pPlayer->vBeacons[beaconId].value();
             render->DrawQuad2D(beacon.image, {lloydsBeaconsPreviewXs[beaconId], lloydsBeaconsPreviewYs[beaconId]});
-            std::string Str = mapTable[beacon.mapId].name;
+            std::string Str = pMapTable->pInfos[beacon.mapId].name;
             int pTextHeight = assets->pFontBookLloyds->CalcTextHeight(Str, pWindow.w, 0);
             pWindow.y -= 6 + pTextHeight;
             DrawTitleText(assets->pFontBookLloyds.get(), 0, 0, colorTable.Black, Str, 3, pWindow);
@@ -153,17 +153,17 @@ void GUIWindow_LloydsBook::hintBeaconSlot(int beaconId) {
     LloydBeacon &beacon = *character.vBeacons[beaconId];
     if (_recallingBeacon) {
         if (beacon.uBeaconTime) {
-            std::string mapName = mapTable[beacon.mapId].name;
+            std::string mapName = pMapTable->pInfos[beacon.mapId].name;
             engine->_statusBar->setPermanent(LSTR_RECALL_TO_S, mapName);
         }
     } else {
         std::string mapName = "Not in Map Stats";
         if (engine->_currentLoadedMapId != MAP_INVALID) {
-            mapName = mapTable[engine->_currentLoadedMapId].name;
+            mapName = pMapTable->pInfos[engine->_currentLoadedMapId].name;
         }
 
         if (beacon.uBeaconTime) {
-            std::string mapName2 = mapTable[beacon.mapId].name;
+            std::string mapName2 = pMapTable->pInfos[beacon.mapId].name;
             engine->_statusBar->setPermanent(LSTR_SET_S_OVER_S, mapName, mapName2);
         } else {
             engine->_statusBar->setPermanent(LSTR_SET_TO_S, mapName);

--- a/src/GUI/UI/Books/LloydsBook.cpp
+++ b/src/GUI/UI/Books/LloydsBook.cpp
@@ -10,7 +10,7 @@
 #include "Engine/Evt/Processor.h"
 #include "Engine/Spells/Spells.h"
 #include "Engine/TurnEngine/TurnEngine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 
 #include "GUI/GUIButton.h"
 #include "GUI/GUIFont.h"
@@ -113,7 +113,7 @@ void GUIWindow_LloydsBook::Update() {
         if (pPlayer->vBeacons[beaconId]) {
             LloydBeacon &beacon = pPlayer->vBeacons[beaconId].value();
             render->DrawQuad2D(beacon.image, {lloydsBeaconsPreviewXs[beaconId], lloydsBeaconsPreviewYs[beaconId]});
-            std::string Str = pMapStats->pInfos[beacon.mapId].name;
+            std::string Str = mapTable[beacon.mapId].name;
             int pTextHeight = assets->pFontBookLloyds->CalcTextHeight(Str, pWindow.w, 0);
             pWindow.y -= 6 + pTextHeight;
             DrawTitleText(assets->pFontBookLloyds.get(), 0, 0, colorTable.Black, Str, 3, pWindow);
@@ -153,17 +153,17 @@ void GUIWindow_LloydsBook::hintBeaconSlot(int beaconId) {
     LloydBeacon &beacon = *character.vBeacons[beaconId];
     if (_recallingBeacon) {
         if (beacon.uBeaconTime) {
-            std::string mapName = pMapStats->pInfos[beacon.mapId].name;
+            std::string mapName = mapTable[beacon.mapId].name;
             engine->_statusBar->setPermanent(LSTR_RECALL_TO_S, mapName);
         }
     } else {
         std::string mapName = "Not in Map Stats";
         if (engine->_currentLoadedMapId != MAP_INVALID) {
-            mapName = pMapStats->pInfos[engine->_currentLoadedMapId].name;
+            mapName = mapTable[engine->_currentLoadedMapId].name;
         }
 
         if (beacon.uBeaconTime) {
-            std::string mapName2 = pMapStats->pInfos[beacon.mapId].name;
+            std::string mapName2 = mapTable[beacon.mapId].name;
             engine->_statusBar->setPermanent(LSTR_SET_S_OVER_S, mapName, mapName2);
         } else {
             engine->_statusBar->setPermanent(LSTR_SET_TO_S, mapName);

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -15,7 +15,7 @@
 #include "Engine/Graphics/Image.h"
 #include "Engine/Localization.h"
 #include "Engine/Party.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Engine.h"
 
 #include "GUI/GUIButton.h"
@@ -139,7 +139,7 @@ void GUIWindow_MapBook::Update() {
 
     Recti map_window = pViewport;
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapStats->pInfos[engine->_currentLoadedMapId].name, 3, map_window);
+        DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, mapTable[engine->_currentLoadedMapId].name, 3, map_window);
     }
 
     auto party_coordinates = localization->format(LSTR_X_D_Y_D, static_cast<int>(pParty->pos.x), static_cast<int>(pParty->pos.y));

--- a/src/GUI/UI/Books/MapBook.cpp
+++ b/src/GUI/UI/Books/MapBook.cpp
@@ -139,7 +139,7 @@ void GUIWindow_MapBook::Update() {
 
     Recti map_window = pViewport;
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, mapTable[engine->_currentLoadedMapId].name, 3, map_window);
+        DrawTitleText(assets->pFontBookTitle.get(), -14, 12, ui_book_map_title_color, pMapTable->pInfos[engine->_currentLoadedMapId].name, 3, map_window);
     }
 
     auto party_coordinates = localization->format(LSTR_X_D_Y_D, static_cast<int>(pParty->pos.x), static_cast<int>(pParty->pos.y));

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -12,7 +12,7 @@
 #include "Engine/TurnEngine/TurnEngine.h"
 #include "Engine/Evt/Processor.h"
 #include "Engine/Spells/Spells.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Graphics/Viewport.h"
 
 #include "GUI/GUIMessageQueue.h"
@@ -212,5 +212,5 @@ void GUIWindow_TownPortalBook::hintTown(int townId) {
         return;
     }
 
-    engine->_statusBar->setPermanent(LSTR_TOWN_PORTAL_TO_S, pMapStats->pInfos[townPortalList[townId].mapInfoID].name);
+    engine->_statusBar->setPermanent(LSTR_TOWN_PORTAL_TO_S, mapTable[townPortalList[townId].mapInfoID].name);
 }

--- a/src/GUI/UI/Books/TownPortalBook.cpp
+++ b/src/GUI/UI/Books/TownPortalBook.cpp
@@ -212,5 +212,5 @@ void GUIWindow_TownPortalBook::hintTown(int townId) {
         return;
     }
 
-    engine->_statusBar->setPermanent(LSTR_TOWN_PORTAL_TO_S, mapTable[townPortalList[townId].mapInfoID].name);
+    engine->_statusBar->setPermanent(LSTR_TOWN_PORTAL_TO_S, pMapTable->pInfos[townPortalList[townId].mapInfoID].name);
 }

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -1097,7 +1097,7 @@ void GUIWindow_Shop::houseScreenClick() {
             int stealDifficulty = 0;
             int fine;
             if (engine->_currentLoadedMapId != MAP_INVALID) {
-                stealDifficulty = mapTable[engine->_currentLoadedMapId].baseStealingFine;
+                stealDifficulty = pMapTable->pInfos[engine->_currentLoadedMapId].baseStealingFine;
             }
             int partyReputation = pParty->GetPartyReputation();
             if (isStealingModeActive()) {

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -13,7 +13,7 @@
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/LocationFunctions.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Objects/Item.h"
 #include "Engine/Party.h"
 #include "Engine/PriceCalculator.h"
@@ -1097,7 +1097,7 @@ void GUIWindow_Shop::houseScreenClick() {
             int stealDifficulty = 0;
             int fine;
             if (engine->_currentLoadedMapId != MAP_INVALID) {
-                stealDifficulty = pMapStats->pInfos[engine->_currentLoadedMapId].baseStealingFine;
+                stealDifficulty = mapTable[engine->_currentLoadedMapId].baseStealingFine;
             }
             int partyReputation = pParty->GetPartyReputation();
             if (isStealingModeActive()) {

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -17,7 +17,7 @@
 #include "Engine/PriceCalculator.h"
 #include "Engine/Graphics/Camera.h"
 #include "Engine/Objects/NPC.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
 
@@ -127,7 +127,7 @@ void GUIWindow_Transport::mainDialogue() {
 
         if (routeActive && (transportSchedule[schedule_id].uQuestBit == QBIT_INVALID || pParty->_questBits[transportSchedule[schedule_id].uQuestBit])) {
             int travel_time = getTravelTimeTransportDays(schedule_id);
-            optionsText.push_back(localization->format(LSTR_D_DAYS_TO_S, travel_time, pMapStats->pInfos[transportSchedule[schedule_id].uMapInfoID].name));
+            optionsText.push_back(localization->format(LSTR_D_DAYS_TO_S, travel_time, mapTable[transportSchedule[schedule_id].uMapInfoID].name));
             hasActiveRoute = true;
         } else {
             optionsText.push_back("");

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -127,7 +127,7 @@ void GUIWindow_Transport::mainDialogue() {
 
         if (routeActive && (transportSchedule[schedule_id].uQuestBit == QBIT_INVALID || pParty->_questBits[transportSchedule[schedule_id].uQuestBit])) {
             int travel_time = getTravelTimeTransportDays(schedule_id);
-            optionsText.push_back(localization->format(LSTR_D_DAYS_TO_S, travel_time, mapTable[transportSchedule[schedule_id].uMapInfoID].name));
+            optionsText.push_back(localization->format(LSTR_D_DAYS_TO_S, travel_time, pMapTable->pInfos[transportSchedule[schedule_id].uMapInfoID].name));
             hasActiveRoute = true;
         } else {
             optionsText.push_back("");

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -671,7 +671,7 @@ std::string GameUI_GetMinimapHintText() {
         if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = mapTable[engine->_currentLoadedMapId].name;
+            result = pMapTable->pInfos[engine->_currentLoadedMapId].name;
     } else {
         for (BSPModel &model : pOutdoor->pBModels) {
             v7 = Vec2i((int)model.boundingCenter.x - global_coord_X,
@@ -693,7 +693,7 @@ std::string GameUI_GetMinimapHintText() {
         if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = mapTable[engine->_currentLoadedMapId].name;
+            result = pMapTable->pInfos[engine->_currentLoadedMapId].name;
         return result;
     }
     return result;

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -26,7 +26,8 @@
 #include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/MapEnumFunctions.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Objects/Actor.h"
 #include "Engine/Objects/Chest.h"
 #include "Engine/Objects/ObjectList.h"
@@ -670,7 +671,7 @@ std::string GameUI_GetMinimapHintText() {
         if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = pMapStats->pInfos[engine->_currentLoadedMapId].name;
+            result = mapTable[engine->_currentLoadedMapId].name;
     } else {
         for (BSPModel &model : pOutdoor->pBModels) {
             v7 = Vec2i((int)model.boundingCenter.x - global_coord_X,
@@ -692,7 +693,7 @@ std::string GameUI_GetMinimapHintText() {
         if (engine->_currentLoadedMapId == MAP_INVALID)
             result = "No Maze Info for this maze on file!";
         else
-            result = pMapStats->pInfos[engine->_currentLoadedMapId].name;
+            result = mapTable[engine->_currentLoadedMapId].name;
         return result;
     }
     return result;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -16,7 +16,7 @@
 #include "Engine/Graphics/Image.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Party.h"
 #include "Engine/PriceCalculator.h"
 #include "Engine/Graphics/Viewport.h"
@@ -426,7 +426,7 @@ void prepareHouse(HouseId house) {
 
             HouseNpcDesc desc;
             desc.type = HOUSE_TRANSITION;
-            desc.label = localization->format(LSTR_ENTER_S, pMapStats->pInfos[id].name);
+            desc.label = localization->format(LSTR_ENTER_S, mapTable[id].name);
             desc.icon = assets->getImage_ColorKey(pHouse_ExitPictures[static_cast<int>(id)]);
             desc.targetMapID = id;
 
@@ -700,11 +700,11 @@ void GUIWindow_House::houseNPCDialogue() {
         MapId id = houseNpcs[currentHouseNpc].targetMapID;
         house_window.x = 493;
         house_window.w = 126;
-        DrawTitleText(assets->pFontCreate.get(), 0, 2, colorTable.White, pMapStats->pInfos[id].name, 3, house_window);
+        DrawTitleText(assets->pFontCreate.get(), 0, 2, colorTable.White, mapTable[id].name, 3, house_window);
         house_window.x = SIDE_TEXT_BOX_POS_X;
         house_window.w = SIDE_TEXT_BOX_WIDTH;
         if (pTransitionStrings[std::to_underlying(id)].empty()) { // TODO(captainurist): this is a weird access into pTransitionStrings, investigate & add docs
-            auto str = localization->format(LSTR_ENTER_S, pMapStats->pInfos[id].name);
+            auto str = localization->format(LSTR_ENTER_S, mapTable[id].name);
             DrawTitleText(assets->pFontCreate.get(), 0, (212 - assets->pFontCreate->CalcTextHeight(str, house_window.w, 0)) / 2 + 101, colorTable.White, str, 3, house_window);
             return;
         }
@@ -902,7 +902,7 @@ void GUIWindow_House::houseDialogManager() {
                 int yPos = 0;
                 switch (houseNpcs[i].type) {
                   case HOUSE_TRANSITION:
-                    pTitleText = pMapStats->pInfos[houseNpcs[i].targetMapID].name;
+                    pTitleText = mapTable[houseNpcs[i].targetMapID].name;
                     yPos = 94 * i + SIDE_TEXT_BOX_POS_Y;
                     break;
                   case HOUSE_PROPRIETOR:

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -426,7 +426,7 @@ void prepareHouse(HouseId house) {
 
             HouseNpcDesc desc;
             desc.type = HOUSE_TRANSITION;
-            desc.label = localization->format(LSTR_ENTER_S, mapTable[id].name);
+            desc.label = localization->format(LSTR_ENTER_S, pMapTable->pInfos[id].name);
             desc.icon = assets->getImage_ColorKey(pHouse_ExitPictures[static_cast<int>(id)]);
             desc.targetMapID = id;
 
@@ -700,11 +700,11 @@ void GUIWindow_House::houseNPCDialogue() {
         MapId id = houseNpcs[currentHouseNpc].targetMapID;
         house_window.x = 493;
         house_window.w = 126;
-        DrawTitleText(assets->pFontCreate.get(), 0, 2, colorTable.White, mapTable[id].name, 3, house_window);
+        DrawTitleText(assets->pFontCreate.get(), 0, 2, colorTable.White, pMapTable->pInfos[id].name, 3, house_window);
         house_window.x = SIDE_TEXT_BOX_POS_X;
         house_window.w = SIDE_TEXT_BOX_WIDTH;
         if (pTransitionStrings[std::to_underlying(id)].empty()) { // TODO(captainurist): this is a weird access into pTransitionStrings, investigate & add docs
-            auto str = localization->format(LSTR_ENTER_S, mapTable[id].name);
+            auto str = localization->format(LSTR_ENTER_S, pMapTable->pInfos[id].name);
             DrawTitleText(assets->pFontCreate.get(), 0, (212 - assets->pFontCreate->CalcTextHeight(str, house_window.w, 0)) / 2 + 101, colorTable.White, str, 3, house_window);
             return;
         }
@@ -902,7 +902,7 @@ void GUIWindow_House::houseDialogManager() {
                 int yPos = 0;
                 switch (houseNpcs[i].type) {
                   case HOUSE_TRANSITION:
-                    pTitleText = mapTable[houseNpcs[i].targetMapID].name;
+                    pTitleText = pMapTable->pInfos[houseNpcs[i].targetMapID].name;
                     yPos = 94 * i + SIDE_TEXT_BOX_POS_Y;
                     break;
                   case HOUSE_PROPRIETOR:

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -12,7 +12,7 @@
 #include "Engine/AssetsManager.h"
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/Snapshots/CompositeSnapshots.h"
 
@@ -167,7 +167,7 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
 
         // Draw map name
         GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
-                                 pMapStats->pInfos[pMapStats->GetMapInfo(slot.header.locationName)].name, 3, titleRect);
+                                 mapTable[mapIdByFileName(slot.header.locationName)].name, 3, titleRect);
 
         // Draw date
         CivilTime time = slot.header.playingTime.toCivilTime();

--- a/src/GUI/UI/UISaveLoad.cpp
+++ b/src/GUI/UI/UISaveLoad.cpp
@@ -167,7 +167,7 @@ void GUIWindow_SaveLoad::drawSaveLoad() {
 
         // Draw map name
         GUIWindow::DrawTitleText(assets->pFontSmallnum.get(), 0, 0, colorTable.White,
-                                 mapTable[mapIdByFileName(slot.header.locationName)].name, 3, titleRect);
+                                 pMapTable->pInfos[pMapTable->GetMapInfo(slot.header.locationName)].name, 3, titleRect);
 
         // Draw date
         CivilTime time = slot.header.playingTime.toCivilTime();

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -11,7 +11,7 @@
 #include "Engine/Graphics/Renderer/Renderer.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/Localization.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Party.h"
 #include "Engine/Timer.h"
 #include "Engine/Tables/TransitionTable.h"
@@ -96,7 +96,7 @@ GUIWindow_Travel::GUIWindow_Travel() : GUIWindow_Transition(WINDOW_Travel, SCREE
     transition_ui_icon = assets->getImage_Solid("outside");
 
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        hint = localization->format(LSTR_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);
+        hint = localization->format(LSTR_LEAVE_S, mapTable[engine->_currentLoadedMapId].name);
     } else {
         hint = localization->str(LSTR_EXIT_DIALOGUE);
     }
@@ -116,18 +116,18 @@ void GUIWindow_Travel::Update() {
         Recti travel_window = pPrimaryWindow->frameRect;
         travel_window.x = 493;
         travel_window.w = 126;
-        DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, pMapStats->pInfos[destinationMap].name, 3, travel_window);
+        DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, mapTable[destinationMap].name, 3, travel_window);
         travel_window.x = SIDE_TEXT_BOX_POS_X;
         travel_window.w = SIDE_TEXT_BOX_WIDTH;
 
         std::string str;
         if (getTravelTime() == 1) {
-            str = localization->format(LSTR_IT_WILL_TAKE_D_DAY_TO_CROSS_TO_S, 1, pMapStats->pInfos[destinationMap].name);
+            str = localization->format(LSTR_IT_WILL_TAKE_D_DAY_TO_CROSS_TO_S, 1, mapTable[destinationMap].name);
         } else {
-            str = localization->format(LSTR_IT_WILL_TAKE_D_DAYS_TO_TRAVEL_TO_S, getTravelTime(), pMapStats->pInfos[destinationMap].name);
+            str = localization->format(LSTR_IT_WILL_TAKE_D_DAYS_TO_TRAVEL_TO_S, getTravelTime(), mapTable[destinationMap].name);
         }
         str += "\n \n";
-        str += localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_1, pMapStats->pInfos[engine->_currentLoadedMapId].name);
+        str += localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_1, mapTable[engine->_currentLoadedMapId].name);
 
         DrawTitleText(assets->pFontCreate.get(), 0, (212 - assets->pFontCreate->CalcTextHeight(str, travel_window.w, 0)) / 2 + 101, colorTable.White, str, 3, travel_window);
     }
@@ -152,10 +152,10 @@ GUIWindow_IndoorEntryExit::GUIWindow_IndoorEntryExit(HouseId transitionHouse, un
 
         std::string destMap = std::string(locationName);
         if (locationName[0] == '0') {
-            destMap = pMapStats->pInfos[engine->_currentLoadedMapId].fileName;
+            destMap = mapTable[engine->_currentLoadedMapId].fileName;
         }
-        if (pMapStats->GetMapInfo(destMap) != MAP_INVALID) {
-            hint = localization->format(LSTR_ENTER_S, pMapStats->pInfos[pMapStats->GetMapInfo(destMap)].name);
+        if (mapIdByFileName(destMap) != MAP_INVALID) {
+            hint = localization->format(LSTR_ENTER_S, mapTable[mapIdByFileName(destMap)].name);
         } else {
             hint = localization->str(LSTR_EXIT_DIALOGUE);
             if (transitionHouse != HOUSE_INVALID && pAnimatedRooms[houseTable[transitionHouse].uAnimationID].uRoomSoundId)
@@ -167,7 +167,7 @@ GUIWindow_IndoorEntryExit::GUIWindow_IndoorEntryExit(HouseId transitionHouse, un
             _transitionStringId = getSpecialTransferMessageIndex(locationName);
     } else if (!getSpecialTransferMessageIndex(locationName)) { // transfer to outdoors - no special message
         if (engine->_currentLoadedMapId != MAP_INVALID) {
-            hint = localization->format(LSTR_LEAVE_S, pMapStats->pInfos[engine->_currentLoadedMapId].name);
+            hint = localization->format(LSTR_LEAVE_S, mapTable[engine->_currentLoadedMapId].name);
         } else {
             hint = localization->str(LSTR_EXIT_DIALOGUE);
         }
@@ -190,13 +190,13 @@ void GUIWindow_IndoorEntryExit::Update() {
 
     MapId map_id = engine->_currentLoadedMapId;
     if (pMovie_Track || getSpecialTransferMessageIndex(_mapName)) {
-        map_id = pMapStats->GetMapInfo(_mapName);
+        map_id = mapIdByFileName(_mapName);
     }
 
     Recti transition_window = pPrimaryWindow->frameRect;
     transition_window.x = 493;
     transition_window.w = 126;
-    DrawTitleText(assets->pFontCreate.get(), 0, 5, colorTable.White, pMapStats->pInfos[map_id].name, 3, transition_window);
+    DrawTitleText(assets->pFontCreate.get(), 0, 5, colorTable.White, mapTable[map_id].name, 3, transition_window);
     transition_window.x = SIDE_TEXT_BOX_POS_X;
     transition_window.w = SIDE_TEXT_BOX_WIDTH;
 
@@ -204,7 +204,7 @@ void GUIWindow_IndoorEntryExit::Update() {
         unsigned int vertMargin = (212 - assets->pFontCreate->CalcTextHeight(pTransitionStrings[_transitionStringId], transition_window.w, 0)) / 2 + 101;
         DrawTitleText(assets->pFontCreate.get(), 0, vertMargin, colorTable.White, pTransitionStrings[_transitionStringId], 3, transition_window);
     } else if (map_id != MAP_INVALID) {
-        std::string str = localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_2, pMapStats->pInfos[map_id].name);
+        std::string str = localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_2, mapTable[map_id].name);
         unsigned int vertMargin = (212 - assets->pFontCreate->CalcTextHeight(str, transition_window.w, 0)) / 2 + 101;
         DrawTitleText(assets->pFontCreate.get(), 0, vertMargin, colorTable.White, str, 3, transition_window);
     } else {

--- a/src/GUI/UI/UITransition.cpp
+++ b/src/GUI/UI/UITransition.cpp
@@ -96,7 +96,7 @@ GUIWindow_Travel::GUIWindow_Travel() : GUIWindow_Transition(WINDOW_Travel, SCREE
     transition_ui_icon = assets->getImage_Solid("outside");
 
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        hint = localization->format(LSTR_LEAVE_S, mapTable[engine->_currentLoadedMapId].name);
+        hint = localization->format(LSTR_LEAVE_S, pMapTable->pInfos[engine->_currentLoadedMapId].name);
     } else {
         hint = localization->str(LSTR_EXIT_DIALOGUE);
     }
@@ -116,18 +116,18 @@ void GUIWindow_Travel::Update() {
         Recti travel_window = pPrimaryWindow->frameRect;
         travel_window.x = 493;
         travel_window.w = 126;
-        DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, mapTable[destinationMap].name, 3, travel_window);
+        DrawTitleText(assets->pFontCreate.get(), 0, 4, colorTable.White, pMapTable->pInfos[destinationMap].name, 3, travel_window);
         travel_window.x = SIDE_TEXT_BOX_POS_X;
         travel_window.w = SIDE_TEXT_BOX_WIDTH;
 
         std::string str;
         if (getTravelTime() == 1) {
-            str = localization->format(LSTR_IT_WILL_TAKE_D_DAY_TO_CROSS_TO_S, 1, mapTable[destinationMap].name);
+            str = localization->format(LSTR_IT_WILL_TAKE_D_DAY_TO_CROSS_TO_S, 1, pMapTable->pInfos[destinationMap].name);
         } else {
-            str = localization->format(LSTR_IT_WILL_TAKE_D_DAYS_TO_TRAVEL_TO_S, getTravelTime(), mapTable[destinationMap].name);
+            str = localization->format(LSTR_IT_WILL_TAKE_D_DAYS_TO_TRAVEL_TO_S, getTravelTime(), pMapTable->pInfos[destinationMap].name);
         }
         str += "\n \n";
-        str += localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_1, mapTable[engine->_currentLoadedMapId].name);
+        str += localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_1, pMapTable->pInfos[engine->_currentLoadedMapId].name);
 
         DrawTitleText(assets->pFontCreate.get(), 0, (212 - assets->pFontCreate->CalcTextHeight(str, travel_window.w, 0)) / 2 + 101, colorTable.White, str, 3, travel_window);
     }
@@ -152,10 +152,10 @@ GUIWindow_IndoorEntryExit::GUIWindow_IndoorEntryExit(HouseId transitionHouse, un
 
         std::string destMap = std::string(locationName);
         if (locationName[0] == '0') {
-            destMap = mapTable[engine->_currentLoadedMapId].fileName;
+            destMap = pMapTable->pInfos[engine->_currentLoadedMapId].fileName;
         }
-        if (mapIdByFileName(destMap) != MAP_INVALID) {
-            hint = localization->format(LSTR_ENTER_S, mapTable[mapIdByFileName(destMap)].name);
+        if (pMapTable->GetMapInfo(destMap) != MAP_INVALID) {
+            hint = localization->format(LSTR_ENTER_S, pMapTable->pInfos[pMapTable->GetMapInfo(destMap)].name);
         } else {
             hint = localization->str(LSTR_EXIT_DIALOGUE);
             if (transitionHouse != HOUSE_INVALID && pAnimatedRooms[houseTable[transitionHouse].uAnimationID].uRoomSoundId)
@@ -167,7 +167,7 @@ GUIWindow_IndoorEntryExit::GUIWindow_IndoorEntryExit(HouseId transitionHouse, un
             _transitionStringId = getSpecialTransferMessageIndex(locationName);
     } else if (!getSpecialTransferMessageIndex(locationName)) { // transfer to outdoors - no special message
         if (engine->_currentLoadedMapId != MAP_INVALID) {
-            hint = localization->format(LSTR_LEAVE_S, mapTable[engine->_currentLoadedMapId].name);
+            hint = localization->format(LSTR_LEAVE_S, pMapTable->pInfos[engine->_currentLoadedMapId].name);
         } else {
             hint = localization->str(LSTR_EXIT_DIALOGUE);
         }
@@ -190,13 +190,13 @@ void GUIWindow_IndoorEntryExit::Update() {
 
     MapId map_id = engine->_currentLoadedMapId;
     if (pMovie_Track || getSpecialTransferMessageIndex(_mapName)) {
-        map_id = mapIdByFileName(_mapName);
+        map_id = pMapTable->GetMapInfo(_mapName);
     }
 
     Recti transition_window = pPrimaryWindow->frameRect;
     transition_window.x = 493;
     transition_window.w = 126;
-    DrawTitleText(assets->pFontCreate.get(), 0, 5, colorTable.White, mapTable[map_id].name, 3, transition_window);
+    DrawTitleText(assets->pFontCreate.get(), 0, 5, colorTable.White, pMapTable->pInfos[map_id].name, 3, transition_window);
     transition_window.x = SIDE_TEXT_BOX_POS_X;
     transition_window.w = SIDE_TEXT_BOX_WIDTH;
 
@@ -204,7 +204,7 @@ void GUIWindow_IndoorEntryExit::Update() {
         unsigned int vertMargin = (212 - assets->pFontCreate->CalcTextHeight(pTransitionStrings[_transitionStringId], transition_window.w, 0)) / 2 + 101;
         DrawTitleText(assets->pFontCreate.get(), 0, vertMargin, colorTable.White, pTransitionStrings[_transitionStringId], 3, transition_window);
     } else if (map_id != MAP_INVALID) {
-        std::string str = localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_2, mapTable[map_id].name);
+        std::string str = localization->format(LSTR_DO_YOU_WISH_TO_LEAVE_S_2, pMapTable->pInfos[map_id].name);
         unsigned int vertMargin = (212 - assets->pFontCreate->CalcTextHeight(str, transition_window.w, 0)) / 2 + 101;
         DrawTitleText(assets->pFontCreate.get(), 0, vertMargin, colorTable.White, str, 3, transition_window);
     } else {

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -462,7 +462,7 @@ void AudioPlayer::UpdateVolumeFromConfig() {
 
 void PlayLevelMusic() {
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        pAudioPlayer->MusicPlayTrack(mapTable[engine->_currentLoadedMapId].musicId);
+        pAudioPlayer->MusicPlayTrack(pMapTable->pInfos[engine->_currentLoadedMapId].musicId);
     }
 }
 

--- a/src/Media/Audio/AudioPlayer.cpp
+++ b/src/Media/Audio/AudioPlayer.cpp
@@ -15,7 +15,7 @@
 #include "Engine/Spells/Spells.h"
 #include "Engine/Party.h"
 #include "Engine/Engine.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Resources/EngineFileSystem.h"
 #include "Engine/EngineCallObserver.h"
 
@@ -462,7 +462,7 @@ void AudioPlayer::UpdateVolumeFromConfig() {
 
 void PlayLevelMusic() {
     if (engine->_currentLoadedMapId != MAP_INVALID) {
-        pAudioPlayer->MusicPlayTrack(pMapStats->pInfos[engine->_currentLoadedMapId].musicId);
+        pAudioPlayer->MusicPlayTrack(mapTable[engine->_currentLoadedMapId].musicId);
     }
 }
 

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -896,7 +896,7 @@ GAME_TEST(Issues, Issue2341) {
 GAME_TEST(Prs, Pr2354) {
     // Verify that all levels (indoor & outdoor) and their default deltas can be deserialized and reconstructed.
     for (MapId mapId : allMaps()) {
-        std::string_view fileName = mapTable[mapId].fileName;
+        std::string_view fileName = pMapTable->pInfos[mapId].fileName;
         std::string_view baseName = fileName.substr(0, fileName.size() - 4);
 
         if (isMapIndoor(mapId)) {

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -9,7 +9,7 @@
 #include "Engine/MapEnumFunctions.h"
 #include "Engine/mm7_data.h"
 #include "Engine/MapEnums.h"
-#include "Engine/MapInfo.h"
+#include "Engine/Tables/MapTable.h"
 #include "Engine/Party.h"
 #include "Engine/Graphics/DecalBuilder.h"
 #include "Engine/Graphics/Image.h"
@@ -896,7 +896,7 @@ GAME_TEST(Issues, Issue2341) {
 GAME_TEST(Prs, Pr2354) {
     // Verify that all levels (indoor & outdoor) and their default deltas can be deserialized and reconstructed.
     for (MapId mapId : allMaps()) {
-        std::string_view fileName = pMapStats->pInfos[mapId].fileName;
+        std::string_view fileName = mapTable[mapId].fileName;
         std::string_view baseName = fileName.substr(0, fileName.size() - 4);
 
         if (isMapIndoor(mapId)) {


### PR DESCRIPTION
A mechanical move. `MapInfo` becomes `MapData` in `Engine/Data`, and `MapStats` becomes `MapTable` in `Engine/Tables`. The table keeps its shape, so `Initialize`, `GetMapInfo`, `pInfos` and the `pMapTable` global pointer are all as they were. Converting it to the free function plus global array that the other text tables use is left for a follow-up. Variables that spelled the old type name follow it to `mapData`.

Five files were reaching `MapEnumFunctions.h` through `MapInfo.h` and now include it directly, and `Character.cpp` included `MapInfo.h` without using anything from it.

`GetMapInfo` asserts on a miss while `GUIWindow_IndoorEntryExit` tests its result against `MAP_INVALID` and handles the miss. Both predate this PR and only one can be right, so the assert carries a TODO now.
