### PR TITLE
Enable bugprone-incorrect-roundings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   -bugprone-empty-catch,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
-  -bugprone-incorrect-roundings,
   -bugprone-integer-division,
   -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1833,7 +1833,7 @@ void UI_OnMouseRightClick(Pointi mousePos) {
 
             auto hint = GetMapBookHintText(mousePos.x, mousePos.y);
             if (!hint.empty()) {
-                Recti popupRect(pX + 5, pY + 5, (assets->pFontArrus->GetLineWidth(hint) + 32) + 0.5f, 64);
+                Recti popupRect(pX + 5, pY + 5, assets->pFontArrus->GetLineWidth(hint) + 32, 64);
                 GUIWindow::DrawMessageBox(popupRect, hint);
             }
             break;

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -403,7 +403,7 @@ class Movie : public IMovie {
         playback_time += std::chrono::duration_cast<std::chrono::milliseconds>(diff).count();
         start_time = current_time;
 
-        int desired_frame_number = static_cast<int>(std::lround(playback_time / video.frame_len));
+        int desired_frame_number = std::round(playback_time / video.frame_len);
         if (last_resampled_frame_num == desired_frame_number) {
             return Blob::share(video.last_frame);
         }

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <deque>
 #include <map>
 #include <memory>
@@ -402,7 +403,7 @@ class Movie : public IMovie {
         playback_time += std::chrono::duration_cast<std::chrono::milliseconds>(diff).count();
         start_time = current_time;
 
-        int desired_frame_number = (int)((playback_time / video.frame_len) + 0.5);
+        int desired_frame_number = static_cast<int>(std::lround(playback_time / video.frame_len));
         if (last_resampled_frame_num == desired_frame_number) {
             return Blob::share(video.last_frame);
         }


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

Two findings, and they turned out to need different fixes. The one in `UIPopup` is a no-op, `GetLineWidth` returns an `int` and `Recti` takes `int`, so the `+ 0.5f` only turns the sum into a float that truncates straight back to where it started.

The one in `MediaPlayer` is a genuine round to nearest on a double quotient. Both operands are non-negative, `playback_time` starts at zero and accumulates millisecond deltas and `frame_len` comes from the stream time base, so `std::lround` gives the same answer for every input that can reach it.
