### PR TITLE
Enable bugprone-invalid-enum-default-initialization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,6 @@ Checks: >
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-incorrect-roundings,
   -bugprone-integer-division,
-  -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -512,10 +512,10 @@ void SpellStats::Initialize(const Blob &spells) {
         pInfos[uSpellID].pExpertSkillDesc = unquote(tokens[7]);
         pInfos[uSpellID].pMasterSkillDesc = unquote(tokens[8]);
         pInfos[uSpellID].pGrandmasterSkillDesc = unquote(tokens[9]);
-        pSpellDatas[uSpellID].flags |= tokens[10].contains('m') || tokens[10].contains('M') ? SPELL_CASTABLE_BY_MONSTER : SpellFlag();
-        pSpellDatas[uSpellID].flags |= tokens[10].contains('e') || tokens[10].contains('E') ? SPELL_CASTABLE_BY_EVENT : SpellFlag();
-        pSpellDatas[uSpellID].flags |= tokens[10].contains('c') || tokens[10].contains('C') ? SPELL_SHIFT_CLICK_CASTABLE : SpellFlag();
-        pSpellDatas[uSpellID].flags |= tokens[10].contains('x') || tokens[10].contains('X') ? SPELL_FLAG_8 : SpellFlag();
+        pSpellDatas[uSpellID].flags |= tokens[10].contains('m') || tokens[10].contains('M') ? SPELL_CASTABLE_BY_MONSTER : SpellFlags();
+        pSpellDatas[uSpellID].flags |= tokens[10].contains('e') || tokens[10].contains('E') ? SPELL_CASTABLE_BY_EVENT : SpellFlags();
+        pSpellDatas[uSpellID].flags |= tokens[10].contains('c') || tokens[10].contains('C') ? SPELL_SHIFT_CLICK_CASTABLE : SpellFlags();
+        pSpellDatas[uSpellID].flags |= tokens[10].contains('x') || tokens[10].contains('X') ? SPELL_FLAG_8 : SpellFlags();
     }
 
     // Patch SPELL_SHIFT_CLICK_CASTABLE flags that are bogus in vanilla spells.txt. See issues #1494, #1495, #1496.


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

All four findings are the same pattern in the spells.txt parser. `SpellFlag` values start at `0x1` and there is no zero enumerator, so `SpellFlag()` was building an enum value that no enumerator names.

The empty case of those ternaries wants the flag set rather than the enum, and `SpellFlags()` is a genuine empty set. `Flags` converts from the enum implicitly, so the other branch of each ternary still compiles unchanged.
