### PR TITLE
Fix the portrait click test, it used a circle for an oval

### DIFF
--- a/src/GUI/GUIButton.cpp
+++ b/src/GUI/GUIButton.cpp
@@ -1,5 +1,6 @@
 #include "GUI/GUIButton.h"
 
+#include <cassert>
 #include <vector>
 
 #include "Engine/Graphics/Renderer/Renderer.h"
@@ -99,6 +100,8 @@ bool GUIButton::Contains(Pointi position) {
 }
 
 bool GUIButton::containsOval(Pointi position) const {
+    assert(uButtonType == BUTTON_TYPE_CHARACTER);
+
     if (rect.isEmpty())
         return false;
 

--- a/src/GUI/GUIButton.cpp
+++ b/src/GUI/GUIButton.cpp
@@ -97,3 +97,12 @@ bool GUIButton::Contains(unsigned int x, unsigned int y) {
 bool GUIButton::Contains(Pointi position) {
     return rect.contains(position);
 }
+
+bool GUIButton::containsOval(Pointi position) const {
+    if (rect.isEmpty())
+        return false;
+
+    int dx = position.x - rect.x;
+    int dy = position.y - rect.y;
+    return 1.0 * dx * dx / (rect.w * rect.w) + 1.0 * dy * dy / (rect.h * rect.h) < 1.0;
+}

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -19,6 +19,17 @@ class GUIButton {
     void DrawLabel(std::string_view text, GUIFont *font, Color color, Color shadowColor = colorTable.Black);
     bool Contains(unsigned int x, unsigned int y);
     bool Contains(Pointi position);
+
+    /**
+     * Hit test for `BUTTON_TYPE_CHARACTER` buttons, which are ovals rather than rectangles. `rect` is not a
+     * rectangle for these - `rect.x` and `rect.y` are the center of the oval, and `rect.w` and `rect.h` are its
+     * semi-axes.
+     *
+     * @param position                  Point to test.
+     * @return                          Whether the point is inside the oval.
+     */
+    bool containsOval(Pointi position) const;
+
     void Release();
 
     std::string id = {}; // Button id, so that buttons can be referenced from tests.

--- a/src/GUI/GUIButton.h
+++ b/src/GUI/GUIButton.h
@@ -21,9 +21,8 @@ class GUIButton {
     bool Contains(Pointi position);
 
     /**
-     * Hit test for `BUTTON_TYPE_CHARACTER` buttons, which are ovals rather than rectangles. `rect` is not a
-     * rectangle for these - `rect.x` and `rect.y` are the center of the oval, and `rect.w` and `rect.h` are its
-     * semi-axes.
+     * Hit test for `BUTTON_TYPE_CHARACTER` buttons. `rect` holds an oval for these, `rect.x` and `rect.y` are its
+     * center and `rect.w` and `rect.h` its semi-axes.
      *
      * @param position                  Point to test.
      * @return                          Whether the point is inside the oval.

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -1017,26 +1017,14 @@ void GameUI_WritePointedObjectStatusString() {
                             }
                             break;
                         case BUTTON_TYPE_CHARACTER:  // hovering over portraits
-                            if (!pButton->rect.isEmpty()) {
-                                int distW = mousePos.x - pButton->rect.x;
-                                int distY = mousePos.y - pButton->rect.y;
+                            if (pButton->containsOval(mousePos)) {
+                                engine->_statusBar->setPermanent(pButton->label);  // for character name
+                                pMessageType2 = (UIMessageType)pButton->uData;
+                                if (pMessageType2 != 0)
+                                    GameUI_handleHintMessage(pMessageType2, pButton->msg_param);
 
-                                double ratioX =
-                                    1.0 * (distW * distW) /
-                                    (pButton->rect.w * pButton->rect.w);
-                                double ratioY =
-                                    1.0 * (distY * distY) /
-                                    (pButton->rect.h * pButton->rect.h);
-
-                                if (ratioX + ratioY < 1.0) {
-                                    engine->_statusBar->setPermanent(pButton->label);  // for character name
-                                    pMessageType2 = (UIMessageType)pButton->uData;
-                                    if (pMessageType2 != 0)
-                                        GameUI_handleHintMessage(pMessageType2, pButton->msg_param);
-
-                                    uLastPointedObjectID = Pid::dummy();
-                                    return;
-                                }
+                                uLastPointedObjectID = Pid::dummy();
+                                return;
                             }
                             break;
                         case BUTTON_TYPE_SKILLS:  // hovering over buttons
@@ -1127,24 +1115,13 @@ void GameUI_WritePointedObjectStatusString() {
                         }
                         break;
                     case BUTTON_TYPE_CHARACTER:  // hovering over portraits
-                        if (!pButton->rect.isEmpty()) {
-                            int distW = mousePos.x - pButton->rect.x;
-                            int distY = mousePos.y - pButton->rect.y;
-
-                            double ratioX = 1.0 * (distW * distW) /
-                                            (pButton->rect.w * pButton->rect.w);
-                            double ratioY =
-                                1.0 * (distY * distY) /
-                                (pButton->rect.h * pButton->rect.h);
-
-                            if (ratioX + ratioY < 1.0) {
-                                engine->_statusBar->setPermanent(pButton->label);  // for character name
-                                pMessageType2 = (UIMessageType)pButton->uData;
-                                if (pMessageType2 != 0)
-                                    GameUI_handleHintMessage(pMessageType2, pButton->msg_param);
-                                uLastPointedObjectID = Pid::dummy();
-                                return;
-                            }
+                        if (pButton->containsOval(mousePos)) {
+                            engine->_statusBar->setPermanent(pButton->label);  // for character name
+                            pMessageType2 = (UIMessageType)pButton->uData;
+                            if (pMessageType2 != 0)
+                                GameUI_handleHintMessage(pMessageType2, pButton->msg_param);
+                            uLastPointedObjectID = Pid::dummy();
+                            return;
                         }
                         break;
                     case BUTTON_TYPE_SKILLS:

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -249,11 +249,8 @@ void Io::Mouse::UI_OnMouseLeftClick(bool isDoubleClick) {
                         }
                         continue;
                     }
-                    if (control->uButtonType == BUTTON_TYPE_CHARACTER) {  // adventurers portraits click (circular button)
-                        // TODO(captainurist): actual shape is oval, this check is bugged.
-                        int dx = x - control->rect.x;
-                        int dy = y - control->rect.y;
-                        if (std::sqrt((double)(dx * dx + dy * dy)) < (double)control->rect.w) {
+                    if (control->uButtonType == BUTTON_TYPE_CHARACTER) {  // adventurers portraits click (oval button)
+                        if (control->containsOval(Pointi(x, y))) {
                             control->field_2C_is_pushed = true;
                             engine->_messageQueue->clear();
                             engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);

--- a/src/Io/Mouse.cpp
+++ b/src/Io/Mouse.cpp
@@ -249,8 +249,8 @@ void Io::Mouse::UI_OnMouseLeftClick(bool isDoubleClick) {
                         }
                         continue;
                     }
-                    if (control->uButtonType == BUTTON_TYPE_CHARACTER) {  // adventurers portraits click (oval button)
-                        if (control->containsOval(Pointi(x, y))) {
+                    if (control->uButtonType == BUTTON_TYPE_CHARACTER) {  // adventurers portraits click
+                        if (control->containsOval(mousePos)) {
                             control->field_2C_is_pushed = true;
                             engine->_messageQueue->clear();
                             engine->_messageQueue->addMessageCurrentFrame(control->msg, control->msg_param, 0);

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1688,3 +1688,18 @@ GAME_TEST(Prs, Pr2615d) {
     game.tick(3);
     EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_RED_APPLE); // The tree handed over an apple.
 }
+
+GAME_TEST(Prs, Pr2717) {
+    // Clicking the top or the bottom of a party portrait did nothing. A portrait is an oval with semi-axes 32 and
+    // 41, but the click test used the circle of radius 32 inscribed in it, so a nine pixel band at each end lit up
+    // on hover and then swallowed the click.
+    game.startNewGame();
+
+    pParty->setActiveCharacterIndex(1);
+    ASSERT_EQ(pParty->pCharacters[1].timeToRecovery, Duration()); // Portrait clicks do nothing while recovering.
+
+    game.pressAndReleaseButton(BUTTON_LEFT, 177, 460); // 36 pixels below the center of the second portrait.
+    game.tick();
+
+    EXPECT_EQ(pParty->activeCharacterIndex(), 2);
+}

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -1691,12 +1691,12 @@ GAME_TEST(Prs, Pr2615d) {
 
 GAME_TEST(Prs, Pr2717) {
     // Clicking the top or the bottom of a party portrait did nothing. A portrait is an oval with semi-axes 32 and
-    // 41, but the click test used the circle of radius 32 inscribed in it, so a nine pixel band at each end lit up
-    // on hover and then swallowed the click.
+    // 41, but the click test used the circle of radius 32 inscribed in it, so a nine pixel band at each end showed
+    // the character in the status bar on hover and then swallowed the click.
     game.startNewGame();
 
     pParty->setActiveCharacterIndex(1);
-    ASSERT_EQ(pParty->pCharacters[1].timeToRecovery, Duration()); // Portrait clicks do nothing while recovering.
+    ASSERT_EQ(pParty->pCharacters[1].timeToRecovery, 0_ticks); // Portrait clicks do nothing while recovering.
 
     game.pressAndReleaseButton(BUTTON_LEFT, 177, 460); // 36 pixels below the center of the second portrait.
     game.tick();


### PR DESCRIPTION
`BUTTON_TYPE_CHARACTER` buttons are ovals rather than rectangles, and `rect` holds that oval in a peculiar way. `rect.x` and `rect.y` are the center and `rect.w` and `rect.h` are the semi-axes. The click test in `Mouse.cpp` measured the distance from the center and compared it against `rect.w` alone, which is the circle inscribed in that oval rather than the oval itself.

The four party portraits are 32 by 41, so a nine pixel band at the top and at the bottom of each one lit up on hover and then did nothing when clicked. The two hover tests already had the ellipse right and were verbatim copies of each other, so all three sites call a single `GUIButton::containsOval` now. The targeting portraits in `UISpell.cpp` are round, which is why the bug never showed there.

`Prs.Pr2717` clicks 36 pixels below the center of the second portrait and checks that the character gets selected. It fails on master.
