### PR TITLE
Enable bugprone-assignment-in-if-condition

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: >
   -*,
   bugprone-*,
-  -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
   -bugprone-derived-method-shadowing-base-method,
   -bugprone-easily-swappable-parameters,

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -4184,12 +4184,13 @@ void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Durati
     actor->UpdateAnimation();
 
     int sectorId = pIndoor->GetSector(actor->pos);
-    int zlevel;
-    int zdiff;
-    if (uCurrentlyLoadedLevelType == LEVEL_OUTDOOR ||
-            sectorId == partySectorId &&
-            (zlevel = BLV_GetFloorLevel(actor->pos, sectorId), zlevel != -30000) &&
-            (zdiff = std::abs(zlevel - pParty->pos.z), zdiff <= 1024)) {
+    bool positionValid = uCurrentlyLoadedLevelType == LEVEL_OUTDOOR;
+    if (!positionValid && sectorId == partySectorId) {
+        int zlevel = BLV_GetFloorLevel(actor->pos, sectorId);
+        positionValid = zlevel != -30000 && std::abs(zlevel - pParty->pos.z) <= 1024;
+    }
+
+    if (positionValid) {
         actor->summonerId = Pid(OBJECT_Character, spell_power);
 
         actor->buffs[ACTOR_BUFF_SUMMONED].Apply(pParty->GetPlayingTime() + duration,

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -1643,11 +1643,14 @@ Duration Character::GetAttackRecoveryTime(bool attackUsesBow) const {
         weapon_recovery = base_recovery_times_per_weapon_type[weapon->skill()];
     } else if (IsUnarmed() && getActualSkillValue(SKILL_UNARMED).level() > 0) {
         weapon_recovery = base_recovery_times_per_weapon_type[SKILL_UNARMED];
-    } else if (weapon = inventory.functionalEntry(ITEM_SLOT_MAIN_HAND)) {
-        if (weapon->isWand()) {
-            weapon_recovery = pSpellDatas[spellForWand(weapon->itemId)].recovery_per_skill[MASTERY_EXPERT];
-        } else {
-            weapon_recovery = base_recovery_times_per_weapon_type[weapon->skill()];
+    } else {
+        weapon = inventory.functionalEntry(ITEM_SLOT_MAIN_HAND);
+        if (weapon) {
+            if (weapon->isWand()) {
+                weapon_recovery = pSpellDatas[spellForWand(weapon->itemId)].recovery_per_skill[MASTERY_EXPERT];
+            } else {
+                weapon_recovery = base_recovery_times_per_weapon_type[weapon->skill()];
+            }
         }
     }
 

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -728,11 +728,11 @@ std::pair<int, int> MonsterPopup_Draw(unsigned int uActorID, Recti* pWindow) {
     bool showCurrentHp = monster_full_informations || pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE].Active();
 
     if (pParty->hasActiveCharacter()) {
-        int skill_points = 0;
         Mastery skill_mastery = MASTERY_NONE;
         CombinedSkillValue idMonsterSkill = pParty->activeCharacter().getActualSkillValue(SKILL_MONSTER_ID);
+        int skill_points = idMonsterSkill.level();
 
-        if ((skill_points = idMonsterSkill.level()) > 0) {
+        if (skill_points > 0) {
             skill_mastery = idMonsterSkill.mastery();
             if (skill_mastery == MASTERY_NOVICE) {
                 if (skill_points + 10 >= monsterInfo.level) {
@@ -1147,7 +1147,9 @@ void CharacterUI_StatsTab_ShowHint() {
                         pHourWord = localization->str(LSTR_HOUR);
                     else
                         pHourWord = localization->str(LSTR_HOURS);
-                    if (!d.days || (pDayWord = localization->str(LSTR_DAY_CAPITALIZED), d.days > 1))
+                    if (d.days && d.days <= 1)
+                        pDayWord = localization->str(LSTR_DAY_CAPITALIZED);
+                    else
                         pDayWord = localization->str(LSTR_DAYS);
                     str += fmt::format("{} {}, {} {}", d.days, pDayWord, d.hours, pHourWord);
                 }

--- a/src/Library/Fsm/Fsm.cpp
+++ b/src/Library/Fsm/Fsm.cpp
@@ -22,8 +22,8 @@ void Fsm::update() {
 }
 
 void Fsm::_goToState(std::string_view stateName) {
-    FsmStateEntry *nextState = nullptr;
-    if (!(nextState = _getStateByName(stateName))) {
+    FsmStateEntry *nextState = _getStateByName(stateName);
+    if (!nextState) {
         throw Exception("Cannot jump to state [{}]. The state does not exist.", stateName);
     }
 


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`. Six findings across four files, all of them assignments hoisted out of the condition they sat in.

`Fsm::_goToState` and the monster popup were plain, the value just moves into the declaration. The day suffix in the stats hint was a comma operator that assigned in one branch and let the body overwrite it in another, it now mirrors the hour suffix right above it. `GetAttackRecoveryTime` reads the weapon after the chain, so the assignment stays and only the test moves out.

The summon check in `Actor` was the awkward one. It computed a floor level and a delta with comma operators inside a short-circuited chain, so those two calls only ran when the level was indoor and the sector matched. The rewrite keeps that order and scopes both values to the block that uses them.
