### PR TITLE
Clean up the GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Grouped so that an update round lands as a single pull request.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -107,8 +107,13 @@ jobs:
           echo "MATRIX_CCACHE_SIZE=$ccache_size" >> "$GITHUB_ENV"
           echo "MATRIX_CMAKE_ARGS=$cmake_args" >> "$GITHUB_ENV"
 
-          # PR builds pass an empty release tag, which must not leave a doubled underscore in the file names.
-          echo "RELEASE_SUFFIX=${RELEASE_TAG:+_$RELEASE_TAG}_${{matrix.configuration}}_$architecture" >> "$GITHUB_ENV"
+          # PR builds pass an empty release tag, which must not leave a doubled underscore in the file name.
+          release_suffix="${RELEASE_TAG:+_$RELEASE_TAG}_${{matrix.configuration}}_$architecture"
+          if [ "$platform" = "android" ]; then
+            echo "RELEASE_FILE=dist/Android$release_suffix.apk" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_FILE=$RUNNER_OS$release_suffix.zip" >> "$GITHUB_ENV"
+          fi
         env:
           RELEASE_TAG: '${{inputs.releaseTag}}'
 
@@ -282,9 +287,9 @@ jobs:
         run: |
           mkdir -p dist
           if [ "$MATRIX_CONFIGURATION" = "Debug" ]; then
-            cp android/openenroth/build/outputs/apk/debug/openenroth-debug.apk "dist/Android$RELEASE_SUFFIX.apk"
+            cp android/openenroth/build/outputs/apk/debug/openenroth-debug.apk "$RELEASE_FILE"
           else
-            cp android/openenroth/build/outputs/apk/release/openenroth-release.apk "dist/Android$RELEASE_SUFFIX.apk"
+            cp android/openenroth/build/outputs/apk/release/openenroth-release.apk "$RELEASE_FILE"
           fi
 
       - name: '[darwin] Prepare files for release'
@@ -316,24 +321,16 @@ jobs:
         uses: thedoctor0/zip-release@0.7.6
         with:
           type: zip
-          filename: ${{runner.os}}${{env.RELEASE_SUFFIX}}.zip
+          filename: ${{env.RELEASE_FILE}}
           path: dist
 
-      - name: '[darwin/windows/linux] Publish release'
-        if: env.MATRIX_PLATFORM != 'android' && env.MATRIX_SANITIZERS == '' && inputs.releaseTag != ''
+      - name: 'Publish release'
+        if: env.MATRIX_SANITIZERS == '' && inputs.releaseTag != ''
         uses: softprops/action-gh-release@v3.0.3
         with:
           prerelease: true
           tag_name: '${{inputs.releaseTag}}'
-          files: ${{runner.os}}${{env.RELEASE_SUFFIX}}.zip
-
-      - name: '[android] Publish release'
-        if: env.MATRIX_PLATFORM == 'android' && inputs.releaseTag != ''
-        uses: softprops/action-gh-release@v3.0.3
-        with:
-          prerelease: true
-          tag_name: '${{inputs.releaseTag}}'
-          files: dist/Android${{env.RELEASE_SUFFIX}}.apk
+          files: ${{env.RELEASE_FILE}}
 
       - name: '[darwin] Check dependencies'
         if: env.MATRIX_PLATFORM == 'darwin'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request: null
+  pull_request:
   workflow_dispatch:
     inputs:
       myCommit:
@@ -26,13 +26,10 @@ on:
         required: false
         default: ''
         type: string
-  release:
-    types:
-      - published
 
 # A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
-  group: build-all-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{github.workflow}}-${{github.event.pull_request.number || github.run_id}}
   cancel-in-progress: true
 
 env:
@@ -45,6 +42,10 @@ env:
   # would fail the sanitizer build long before it reaches our code. Many of our own game tests leak too.
   ASAN_OPTIONS: detect_leaks=0
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_all:
     timeout-minutes: 60
@@ -55,7 +56,7 @@ jobs:
           - Debug
           - RelWithDebInfo
         # Build android_universal on releases, per-ABI on PR
-        target: >- 
+        target: >-
           ${{fromJSON(
             inputs.releaseTag != ''
               && '["windows_x86","windows_x86_64","darwin_arm64","darwin_x86_64","linux_x86","linux_x86_64","android_universal"]'
@@ -71,16 +72,12 @@ jobs:
         startsWith(matrix.target, 'darwin_')  && 'macos-15'     ||
         'ubuntu-26.04'
       }}
-    defaults:
-      run:
-        shell: bash
     steps:
       - name: 'Initialize matrix vars'
         run: |
-          set -euo pipefail
           echo "MATRIX_CONFIGURATION=${{matrix.configuration}}" >> "$GITHUB_ENV"
           echo "MATRIX_TARGET=${{matrix.target}}" >> "$GITHUB_ENV"
-          
+
           configuration="${{matrix.configuration}}"
           case "$configuration" in
             ASan) build_type=Debug;            sanitizers=address;;
@@ -101,7 +98,7 @@ jobs:
             android_x86_64)     platform=android; architecture=x86_64;      ccache_architecture=universal; ccache_size=800M;  cmake_args="";;
             *) echo "Unknown target: $target" >&2; exit 1;;
           esac
-          
+
           echo "MATRIX_BUILD_TYPE=$build_type" >> "$GITHUB_ENV"
           echo "MATRIX_SANITIZERS=$sanitizers" >> "$GITHUB_ENV"
           echo "MATRIX_PLATFORM=$platform" >> "$GITHUB_ENV"
@@ -109,6 +106,11 @@ jobs:
           echo "MATRIX_CCACHE_ARCHITECTURE=$ccache_architecture" >> "$GITHUB_ENV"
           echo "MATRIX_CCACHE_SIZE=$ccache_size" >> "$GITHUB_ENV"
           echo "MATRIX_CMAKE_ARGS=$cmake_args" >> "$GITHUB_ENV"
+
+          # PR builds pass an empty release tag, which must not leave a doubled underscore in the file names.
+          echo "RELEASE_SUFFIX=${RELEASE_TAG:+_$RELEASE_TAG}_${{matrix.configuration}}_$architecture" >> "$GITHUB_ENV"
+        env:
+          RELEASE_TAG: '${{inputs.releaseTag}}'
 
       - name: '[linux/android] Configure fast APT mirror'
         if: env.MATRIX_PLATFORM == 'linux' || env.MATRIX_PLATFORM == 'android'
@@ -121,7 +123,7 @@ jobs:
           xcode-version: 16.3
 
       - name: 'Checkout'
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v7.0.1
         with:
           submodules: recursive
           ref: '${{inputs.myCommit}}'
@@ -130,7 +132,7 @@ jobs:
       - name: '[android] Decode keystore'
         if: env.MATRIX_PLATFORM == 'android' && env.SECRETS_KEYSTORE != ''
         id: decode_keystore
-        uses: timheuer/base64-to-file@v1.2.4
+        uses: timheuer/base64-to-file@v2
         with:
           fileName: android_keystore.jks
           encodedString: '${{env.SECRETS_KEYSTORE}}'
@@ -146,7 +148,7 @@ jobs:
       # We need gcc-multilib for host-side tools (luajit's buildvm) when building for armeabi-v7a. Why? No idea.
       - name: '[android] Install dependencies'
         if: env.MATRIX_PLATFORM == 'android'
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
           attempt_delay: 5000
@@ -158,14 +160,14 @@ jobs:
 
       - name: '[android] Setup Java'
         if: env.MATRIX_PLATFORM == 'android'
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v6.0.0
         with:
           distribution: temurin
-          java-version: 17.0.6
+          java-version: 17
 
       - name: '[linux] Install dependencies'
         if: env.MATRIX_PLATFORM == 'linux'
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
           attempt_delay: 5000
@@ -196,15 +198,15 @@ jobs:
       - name: '[darwin/windows/linux] Restore data cache'
         if: env.MATRIX_PLATFORM != 'android'
         id: restore_data_cache
-        uses: actions/cache/restore@v4.2.4
+        uses: actions/cache/restore@v6.1.0
         with:
           path: |
             OpenEnroth_GameData
           key: data-cache
           enableCrossOsArchive: ${{env.MATRIX_PLATFORM == 'windows'}}
 
-      - name: 'Run ccache'
-        uses: hendrikmuhs/ccache-action@v1.2.18
+      - name: 'Set up ccache'
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: '${{env.MATRIX_PLATFORM}}-${{env.MATRIX_CONFIGURATION}}-${{env.MATRIX_CCACHE_ARCHITECTURE}}'
           verbose: 2
@@ -213,7 +215,7 @@ jobs:
 
       - name: 'Record build start time'
         run: |
-          echo "BUILD_START_TIME=$(date +%s)" >> $GITHUB_ENV
+          echo "BUILD_START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: '[windows] Configure ccache'
         if: env.MATRIX_PLATFORM == 'windows'
@@ -233,7 +235,7 @@ jobs:
 
       - name: '[android] Build'
         if: env.MATRIX_PLATFORM == 'android'
-        uses: burrunan/gradle-cache-action@v3.0.1
+        uses: burrunan/gradle-cache-action@v3.0.3
         with:
           build-root-directory: android
           job-id: android-${{env.MATRIX_CONFIGURATION == 'RelWithDebInfo' && 'Release' || env.MATRIX_CONFIGURATION}}
@@ -274,9 +276,20 @@ jobs:
         run: |
           find android/openenroth/build/outputs/apk
 
+      # PR builds get no keystore, and an unsigned release apk is written under a different name.
+      - name: '[android] Prepare files for release'
+        if: env.MATRIX_PLATFORM == 'android' && inputs.releaseTag != ''
+        run: |
+          mkdir -p dist
+          if [ "$MATRIX_CONFIGURATION" = "Debug" ]; then
+            cp android/openenroth/build/outputs/apk/debug/openenroth-debug.apk "dist/Android$RELEASE_SUFFIX.apk"
+          else
+            cp android/openenroth/build/outputs/apk/release/openenroth-release.apk "dist/Android$RELEASE_SUFFIX.apk"
+          fi
+
       - name: '[darwin] Prepare files for release'
         if: env.MATRIX_PLATFORM == 'darwin'
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
           attempt_delay: 5000
@@ -295,7 +308,7 @@ jobs:
       - name: '[linux] Prepare files for release'
         if: env.MATRIX_PLATFORM == 'linux' && env.MATRIX_SANITIZERS == ''
         run: |
-          mkdir dist
+          mkdir -p dist
           cp build/src/Bin/OpenEnroth/OpenEnroth dist/
 
       - name: '[darwin/windows/linux] Zip folder for release'
@@ -303,27 +316,24 @@ jobs:
         uses: thedoctor0/zip-release@0.7.6
         with:
           type: zip
-          filename: ${{runner.os}}_${{inputs.releaseTag}}_${{env.MATRIX_CONFIGURATION}}_${{env.MATRIX_ARCHITECTURE}}.zip
+          filename: ${{runner.os}}${{env.RELEASE_SUFFIX}}.zip
           path: dist
 
       - name: '[darwin/windows/linux] Publish release'
         if: env.MATRIX_PLATFORM != 'android' && env.MATRIX_SANITIZERS == '' && inputs.releaseTag != ''
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3.0.3
         with:
           prerelease: true
           tag_name: '${{inputs.releaseTag}}'
-          files: |
-            ${{runner.os}}_${{inputs.releaseTag}}_${{env.MATRIX_CONFIGURATION}}_${{env.MATRIX_ARCHITECTURE}}.zip
+          files: ${{runner.os}}${{env.RELEASE_SUFFIX}}.zip
 
       - name: '[android] Publish release'
         if: env.MATRIX_PLATFORM == 'android' && inputs.releaseTag != ''
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3.0.3
         with:
           prerelease: true
           tag_name: '${{inputs.releaseTag}}'
-          files: |
-            android/openenroth/build/outputs/apk/debug/openenroth-debug.apk
-            android/openenroth/build/outputs/apk/release/openenroth-release.apk
+          files: dist/Android${{env.RELEASE_SUFFIX}}.apk
 
       - name: '[darwin] Check dependencies'
         if: env.MATRIX_PLATFORM == 'darwin'

--- a/.github/workflows/build_data_cache.yml
+++ b/.github/workflows/build_data_cache.yml
@@ -6,8 +6,13 @@ on:
     - cron: "16 * * * *"
   workflow_dispatch: # Allow to manually run a workflow
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_data_cache:
+    timeout-minutes: 60
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
@@ -15,27 +20,30 @@ jobs:
         configuration: [Release]
         architecture: [x64]
     steps:
-    - name: Check for data cache
-      id: check-for-data-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          OpenEnroth_GameData
-        key: data-cache
+      - name: Check for data cache
+        id: check-for-data-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: |
+            OpenEnroth_GameData
+          key: data-cache
+          lookup-only: true
 
-    - name: Checkout private data
-      if: steps.check-for-data-cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: OpenEnroth/OpenEnroth_GameData
-        path: OpenEnroth_GameData
-        lfs: 'true' # .vid files are stored in LFS.
-        token: '${{secrets.DATA_ACCESS_TOKEN}}'
+      - name: Checkout private data
+        if: steps.check-for-data-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: OpenEnroth/OpenEnroth_GameData
+          path: OpenEnroth_GameData
+          lfs: 'true' # .vid files are stored in LFS.
+          token: '${{secrets.DATA_ACCESS_TOKEN}}'
+          # Persisted credentials land in the checked out tree, and the step below caches that tree.
+          persist-credentials: false
 
-    - name: Cache data
-      if: steps.check-for-data-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: |
-          OpenEnroth_GameData
-        key: data-cache
+      - name: Cache data
+        if: steps.check-for-data-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: |
+            OpenEnroth_GameData
+          key: data-cache

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -17,71 +17,55 @@ on:
 env:
   TAG_NAME: nightly
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  advanceNightlyTag:
+  advance_nightly_tag:
     name: Advance Nightly
+    timeout-minutes: 60
     runs-on: ubuntu-26.04
     outputs:
-      tagName: ${{steps.outputReleaseTag.outputs.tagName }}
+      tagName: ${{steps.output_release_tag.outputs.tagName}}
+    env:
+      GH_TOKEN: '${{secrets.GITHUB_TOKEN}}'
+      GH_REPO: '${{github.repository}}'
     steps:
+      # A dispatch can ask for a commit other than the one that triggered the run, and the tag has to follow it.
       - name: Advance nightly tag
-        uses: actions/github-script@v3
-        with:
-          github-token: '${{secrets.GITHUB_TOKEN}}'
-          script: |
-            try {
-                await github.git.deleteRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: "tags/nightly"
-                })
-            } catch (e) {
-              console.log("The nightly tag doesn't exist yet: " + e)
-            }
-            await github.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/nightly",
-              sha: context.sha
-            })
-
-      - name: Sleep for 10 seconds
-        run: sleep 10s
-        shell: bash
-
-      - name: Get latest release
-        id: latest_release
-        uses: kaliber5/action-get-release@v1
-        with:
-          token: '${{ github.token }}'
-          tag_name: nightly
-          draft: true
-
-      - name: Publish release
-        uses: eregon/publish-release@v1
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        with:
-          release_id: '${{ steps.latest_release.outputs.id }}'
-
-      - name: Output Release Tag
-        id: outputReleaseTag
+          NIGHTLY_SHA: '${{inputs.myCommit || github.sha}}'
         run: |
-          echo "tagName=${{env.TAG_NAME}}" >> "$GITHUB_OUTPUT"
+          if ! gh api --method PATCH "repos/$GH_REPO/git/refs/tags/$TAG_NAME" -f sha="$NIGHTLY_SHA" -F force=true; then
+            gh api --method POST "repos/$GH_REPO/git/refs" -f ref="refs/tags/$TAG_NAME" -f sha="$NIGHTLY_SHA"
+          fi
 
+      - name: Publish nightly release
+        run: |
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+            gh release edit "$TAG_NAME" --draft=false --prerelease
+          else
+            gh release create "$TAG_NAME" --prerelease --title "$TAG_NAME" --notes 'Nightly build.'
+          fi
+
+      - name: Output release tag
+        id: output_release_tag
+        run: |
+          echo "tagName=$TAG_NAME" >> "$GITHUB_OUTPUT"
 
   build_all:
-    needs: advanceNightlyTag
+    needs: advance_nightly_tag
     uses: ./.github/workflows/build_all.yml
     secrets: inherit
     with:
-      releaseTag: '${{needs.advanceNightlyTag.outputs.tagName}}'
+      releaseTag: '${{needs.advance_nightly_tag.outputs.tagName}}'
       myCommit: '${{inputs.myCommit}}'
 
   build_linux_flatpak:
-    needs: advanceNightlyTag
+    needs: advance_nightly_tag
     uses: ./.github/workflows/linux_flatpak.yml
     secrets: inherit
     with:
-      releaseTag: '${{needs.advanceNightlyTag.outputs.tagName}}'
+      releaseTag: '${{needs.advance_nightly_tag.outputs.tagName}}'
       myCommit: '${{inputs.myCommit}}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint
 
 on:
-  pull_request: null
-  push: null
+  pull_request:
+  push:
   workflow_dispatch:
     inputs:
       myCommit:
@@ -10,13 +10,10 @@ on:
         required: false
         default: ''
         type: string
-  release:
-    types:
-      - published
 
 # A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
-  group: lint-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{github.workflow}}-${{github.event.pull_request.number || github.run_id}}
   cancel-in-progress: true
 
 env:
@@ -24,12 +21,17 @@ env:
   CLANG_TIDY_VERSION: '22.1.8'
   DOXYGEN_VERSION: '1.9.5'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
+    timeout-minutes: 60
     runs-on: ubuntu-26.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v7.0.1
         with:
           submodules: recursive
           ref: '${{inputs.myCommit}}'
@@ -44,7 +46,7 @@ jobs:
       # The configure step resolves OpenGL, so the GL development files have to be there.
       # The shader checks run glslangValidator, which comes from glslang-tools.
       - name: Install dependencies
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3.8.0
         with:
           attempt_limit: 3
           attempt_delay: 5000
@@ -95,25 +97,18 @@ jobs:
           ninja check_tidy
 
       # The shader and doxygen checks need no build tree, so they run regardless of how the configure went.
-      - name: Check OpenGL 4.1 (Core) shaders
+      - name: Check shaders
         if: '!cancelled()'
         run: |
-          for shader in resources/shaders/*.vert resources/shaders/*.frag; do
-            echo "Checking $shader..."
-            ./scripts/check_shader.sh "$shader" "410 core"
-          done
-
-      - name: Check OpenGL ES 3.2 shaders
-        if: '!cancelled()'
-        run: |
-          for shader in resources/shaders/*.vert resources/shaders/*.frag; do
-            echo "Checking $shader..."
-            ./scripts/check_shader.sh "$shader" "320 es"
+          for glsl_version in "410 core" "320 es"; do
+            for shader in resources/shaders/*.vert resources/shaders/*.frag; do
+              echo "Checking $shader against GLSL $glsl_version..."
+              ./scripts/check_shader.sh "$shader" "$glsl_version"
+            done
           done
 
       # Doxyfile sets WARN_AS_ERROR, so generating the docs is the check.
       - name: Check doxygen
         if: '!cancelled()'
         run: |
-          export PROJECT_NUMBER="$(git describe --always --tags --dirty)"
           "$HOME/doxygen/doxygen" Doxyfile

--- a/.github/workflows/linux_flatpak.yml
+++ b/.github/workflows/linux_flatpak.yml
@@ -1,7 +1,7 @@
 name: Linux (Flatpak)
 
 on:
-  pull_request: null
+  pull_request:
   workflow_dispatch:
     inputs:
       myCommit:
@@ -26,22 +26,23 @@ on:
         required: false
         default: ''
         type: string
-  release:
-    types:
-      - published
 
 # A new push into a PR auto-cancels the run for the previous one. Master and nightly unaffected.
 concurrency:
-  group: linux-flatpak-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{github.workflow}}-${{github.event.pull_request.number || github.run_id}}
   cancel-in-progress: true
 
 env:
   CCACHE_COMPILERCHECK: content
-    
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_flatpak_bundle:
     timeout-minutes: 60
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
       options: --privileged
@@ -54,46 +55,53 @@ jobs:
           - x86_64
 
     steps:
-    - name: make ccache dir
-      run: |
-        mkdir -p .ccache
-        cd .ccache
-        echo "CCACHE_DIR=$PWD" >> $GITHUB_ENV
-        
-    - name: Checkout
-      uses: actions/checkout@v5.0.0
-      with:
-        submodules: recursive
-        ref: '${{inputs.myCommit}}'
-          
-    - name: Run ccache
-      uses: hendrikmuhs/ccache-action@v1.2.18
-      with:
-        key: 'linux-flatpak-${{matrix.configuration}}-${{matrix.architecture}}'
-        verbose: 2
-        max-size: 400M
-        save: ${{github.event_name != 'pull_request'}}
-        
-    - name: Run Flatpak build
-      uses: flatpak/flatpak-github-actions/flatpak-builder@dcbd3a30d991a38708c318d17f5352cc1268c215
-      with:
-        run-tests: true
-        bundle: io.github.openenroth.openenroth_${{inputs.releaseTag}}_${{matrix.configuration}}_${{matrix.architecture}}.flatpak
-        manifest-path: distribution/linux/flatpak/dev.io.github.openenroth.openenroth.yml
-        arch: ${{matrix.architecture}}
-        verbose: true
-        cache: true
-        restore-cache: false
-        upload-artifact: false
+      - name: make ccache dir
+        run: |
+          mkdir -p .ccache
+          cd .ccache
+          echo "CCACHE_DIR=$PWD" >> "$GITHUB_ENV"
 
-    - name: Publish release
-      if: inputs.releaseTag != ''
-      uses: softprops/action-gh-release@v2.0.8
-      with:
-        prerelease: true
-        tag_name: '${{inputs.releaseTag}}'
-        files: io.github.openenroth.openenroth_${{inputs.releaseTag}}_${{matrix.configuration}}_${{matrix.architecture}}.flatpak
+      - name: Compose bundle name
+        env:
+          RELEASE_TAG: '${{inputs.releaseTag}}'
+        run: |
+          # PR builds pass an empty release tag, which must not leave a doubled underscore in the name.
+          echo "BUNDLE_NAME=io.github.openenroth.openenroth${RELEASE_TAG:+_$RELEASE_TAG}_${{matrix.configuration}}_${{matrix.architecture}}.flatpak" >> "$GITHUB_ENV"
 
-    - name: Cleanup ccache
-      run: |
-        ccache -c
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          submodules: recursive
+          ref: '${{inputs.myCommit}}'
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.24
+        with:
+          key: 'linux-flatpak-${{matrix.configuration}}-${{matrix.architecture}}'
+          verbose: 2
+          max-size: 400M
+          save: ${{github.event_name != 'pull_request'}}
+
+      - name: Run Flatpak build
+        uses: flatpak/flatpak-github-actions/flatpak-builder@79327416609af08178ad73b352877e51450790b3 # v6.8
+        with:
+          run-tests: true
+          bundle: ${{env.BUNDLE_NAME}}
+          manifest-path: distribution/linux/flatpak/dev.io.github.openenroth.openenroth.yml
+          arch: ${{matrix.architecture}}
+          verbose: true
+          cache: true
+          restore-cache: false
+          upload-artifact: false
+
+      - name: Publish release
+        if: inputs.releaseTag != ''
+        uses: softprops/action-gh-release@v3.0.3
+        with:
+          prerelease: true
+          tag_name: '${{inputs.releaseTag}}'
+          files: ${{env.BUNDLE_NAME}}
+
+      - name: Cleanup ccache
+        run: |
+          ccache -c


### PR DESCRIPTION
Follows a review of the workflow files.

The one real bug: `build_data_cache` checked out the private data repo with credential persistence left on, so the token was sitting in `OpenEnroth_GameData/.git/config` when the next step cached that directory, and every PR run restores that cache. Fixed with `persist-credentials: false`. **The `DATA_ACCESS_TOKEN` should be rotated and the current `data-cache` entry deleted**, since the existing cache was built on 2025-10-12 and still carries whatever token was in use then.

The nightly tag advance went through `actions/github-script@v3`, `kaliber5/action-get-release`, an archived `eregon/publish-release` and a `sleep 10s`. That is `gh` now, and the tag follows `myCommit` rather than always landing on the branch head.

Everything else is consistency and version work: one 60 minute timeout and one bash default per workflow, uniform indentation and `${{x}}` spelling, concurrency groups prefixed with the workflow name, current action versions with `wretry` pinned off `master`, a `dependabot.yml` to keep them current, and one shared suffix for release file names so the android apks are named like everything else and an empty tag stops doubling an underscore. The dead `release: published` trigger is gone, it could only ever run builds whose upload steps were all gated off.

Two things I deliberately did not do. `Cleanup ccache` still has no `if: always()`: it evicts everything the build did not touch, so running it after a failure would throw away entries a successful build would have kept. And doxygen stays on 1.9.5, since `WARN_AS_ERROR` is on and a jump to 1.18 needs its own pass.

Note that `build_release.yml` and `build_data_cache.yml` are not exercised by PR CI.
