### PR TITLE
Log an invalid face event id at warning level

### DIFF
--- a/src/Engine/Evt/Processor.cpp
+++ b/src/Engine/Evt/Processor.cpp
@@ -164,7 +164,7 @@ void eventProcessor(int eventId, Pid targetObj, bool canShowMessages, int startS
     }
 
     if (!interpreter.isValid()) {
-        MM_INFO("Face has invalid event ID");
+        MM_WARNING("Face has invalid event ID");
         engine->_statusBar->nothingHere();
         return;
     }


### PR DESCRIPTION
A face whose event id does not resolve is a data problem worth noticing in the log, and info level buried it among routine messages. This raises the "Face has invalid event ID" message to warning level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)