### PR TITLE
Enable bugprone-use-after-move

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,8 +18,7 @@ Checks: >
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-switch-missing-default-case,
   -bugprone-throwing-static-initialization,
-  -bugprone-unchecked-optional-access,
-  -bugprone-use-after-move
+  -bugprone-unchecked-optional-access
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(src|test)/'
 ExcludeHeaderFilterRegex: '/thirdparty/' # Submodules have src and test dirs of their own.

--- a/src/Library/FileSystem/Dump/FileSystemDump.h
+++ b/src/Library/FileSystem/Dump/FileSystemDump.h
@@ -28,7 +28,7 @@ struct FileSystemDumpEntry {
 
     FileSystemDumpEntry(std::string_view path, FileType type, Blob content = {}): path(path), type(type), content(std::move(content)) {
         assert(type == FILE_REGULAR || type == FILE_DIRECTORY);
-        assert(content.empty() || type == FILE_REGULAR);
+        assert(this->content.empty() || type == FILE_REGULAR);
     }
 
     FileSystemDumpEntry(std::string_view path, FileType type, std::string content) : path(path), type(type) {

--- a/src/Library/Platform/Application/PlatformIntrospection.h
+++ b/src/Library/Platform/Application/PlatformIntrospection.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cassert>
-#include <utility>
 #include <type_traits>
 
 #include "Library/Platform/Proxy/ProxyWindow.h"
@@ -18,12 +17,12 @@ class PlatformIntrospection {
     static void visit(T *component, Callable &&callable) {
         int count = 0;
         // Using += instead of one big expression to get deterministic call order.
-        count += visitInternal<ProxyPlatform>(component, std::forward<Callable>(callable));
-        count += visitInternal<ProxyEventLoop>(component, std::forward<Callable>(callable));
-        count += visitInternal<ProxyWindow>(component, std::forward<Callable>(callable));
-        count += visitInternal<ProxyOpenGLContext>(component, std::forward<Callable>(callable));
-        count += visitInternal<PlatformEventFilter>(component, std::forward<Callable>(callable));
-        count += visitInternal<PlatformApplicationAware>(component, std::forward<Callable>(callable));
+        count += visitInternal<ProxyPlatform>(component, callable);
+        count += visitInternal<ProxyEventLoop>(component, callable);
+        count += visitInternal<ProxyWindow>(component, callable);
+        count += visitInternal<ProxyOpenGLContext>(component, callable);
+        count += visitInternal<PlatformEventFilter>(component, callable);
+        count += visitInternal<PlatformApplicationAware>(component, callable);
         assert(count > 0); // Must derive from at least one of the supported types.
         (void) count;
     }

--- a/src/Library/Platform/Application/PlatformIntrospection.h
+++ b/src/Library/Platform/Application/PlatformIntrospection.h
@@ -14,7 +14,7 @@
 class PlatformIntrospection {
  public:
     template<class T, class Callable>
-    static void visit(T *component, Callable &&callable) {
+    static void visit(T *component, const Callable &callable) {
         int count = 0;
         // Using += instead of one big expression to get deterministic call order.
         count += visitInternal<ProxyPlatform>(component, callable);
@@ -29,7 +29,7 @@ class PlatformIntrospection {
 
  private:
     template<class Installable, class T, class Callable>
-    static bool visitInternal(T *component, Callable &&callable) {
+    static bool visitInternal(T *component, const Callable &callable) {
         if constexpr (std::is_base_of_v<Installable, T>) {
             callable(static_cast<Installable *>(component));
             return true;


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

One of the six findings is a real bug. In the `Blob` constructor of `FileSystemDumpEntry` the parameter shadows the member, so once the member init list had moved the parameter, the body assert was reading the moved-from parameter and was always true. It now checks the member. No unit or game test trips it, so the invariant did hold, the assert just was not testing it. The `std::string` overload right below already gets this right by asserting before the move.

The other five are the same `std::forward` repeated across six calls in `PlatformIntrospection::visit`. `visitInternal` only calls the callable and never moves from it, so forwarding it six times said nothing, and passing an lvalue says what is meant. Both call sites pass plain capturing lambdas, whose `operator()` is not ref-qualified, so this is behaviour-identical. That leaves `<utility>` unused, so it goes too.
