### PR TITLE
Enable bugprone-raw-memory-call-on-non-trivial-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,
-  -bugprone-raw-memory-call-on-non-trivial-type,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
   -bugprone-std-namespace-modification,

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1125,7 +1125,6 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
     int v9;                // edi@5
     int v10;               // eax@7
     SpriteFrame *v11;      // eax@7
-    Particle_sw particle;  // [sp+Ch] [bp-A0h]@3
     BillboardFlags v30;               // [sp+8Ch] [bp-20h]@7
 
     if (pLevelDecorations[uDecorationID].uFlags & LEVEL_DECORATION_INVISIBLE)
@@ -1135,7 +1134,7 @@ void IndoorLocation::PrepareDecorationsRenderList_BLV(unsigned int uDecorationID
 
     if (decoration->uFlags & DECORATION_DESC_EMITS_FIRE) {
         // TODO(pskelton): common emit fire code
-        memset(&particle, 0, sizeof(Particle_sw));  // fire,  like at the Pit's tavern
+        Particle_sw particle; // Fire, like at the Pit's tavern.
         particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
         particle.uDiffuse = colorTable.OrangeyRed;
         particle.x = (double)pLevelDecorations[uDecorationID].vPosition.x;

--- a/src/Engine/Graphics/Renderer/BaseRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/BaseRenderer.cpp
@@ -146,7 +146,6 @@ void BaseRenderer::PrepareDecorationsRenderList_ODM() {
     SpriteFrame *frame;     // eax@9
     int v13;                // ecx@9
     Color color;
-    Particle_sw local_0;    // [sp+Ch] [bp-98h]@7
     BillboardFlags v38;                // [sp+88h] [bp-1Ch]@9
 
     for (unsigned int i = 0; i < pLevelDecorations.size(); ++i) {
@@ -239,7 +238,7 @@ void BaseRenderer::PrepareDecorationsRenderList_ODM() {
                 }
             } else {
                 // Emit fire particles.
-                memset(&local_0, 0, sizeof(Particle_sw));
+                Particle_sw local_0;
                 local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
                 local_0.uDiffuse = colorTable.OrangeyRed;
                 local_0.x = static_cast<float>(pLevelDecorations[i].vPosition.x);

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -115,7 +115,6 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
 
 static void createSpriteTrailParticle(Vec3f pos, ObjectDescFlags flags) {
     Particle_sw particle;
-    memset(&particle, 0, sizeof(Particle_sw));
     particle.x = pos.x;
     particle.y = pos.y;
     particle.z = pos.z;

--- a/src/Engine/SpellFxRenderer.cpp
+++ b/src/Engine/SpellFxRenderer.cpp
@@ -334,7 +334,6 @@ void SpellFxRenderer::_4A73AA_hanging_trace_particles___like_fire_strike_ice_bla
     float x;              // [sp+78h] [bp+8h]@2
 
     thisspellfxrend = this;
-    memset(&local_0, 0, sizeof(Particle_sw));
     v5 = a2;
     v6 = a2->field_54;
     if (v6) {
@@ -395,7 +394,6 @@ void SpellFxRenderer::_4A75CC_single_spell_collision_particle(
     signed int v5;        // edi@1
     Particle_sw local_0;  // [sp+8h] [bp-68h]@1
 
-    memset(&local_0, 0, sizeof(Particle_sw));
     local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.x = (float)a1->vPosition.x;
     local_0.y = (float)a1->vPosition.y;
@@ -500,7 +498,6 @@ void SpellFxRenderer::
     float uDiffusea;      // [sp+78h] [bp+Ch]@1
     float uTextureIDa;    // [sp+7Ch] [bp+10h]@1
 
-    memset(&local_0, 0, sizeof(Particle_sw));
     local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.x = (float)a1->vPosition.x;
     v5 = a1->vPosition.z;
@@ -620,7 +617,6 @@ void SpellFxRenderer::AddProjectile(SpriteObject *a2, int a3,
 void SpellFxRenderer::sparklesOnActorAfterItCastsBuff(Actor *pActor, Color uDiffuse) {
     Particle_sw particle;
 
-    memset(&particle, 0, sizeof(Particle_sw));
     particle.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Ascending;
     particle.timeToLive = Duration::randomRealtimeSeconds(vrng, 1, 2);
     particle.texture = this->effpar02;
@@ -648,7 +644,6 @@ void SpellFxRenderer::_4A7F74(int x, int y, int z) {
     double v12;           // [sp+78h] [bp-8h]@1
     float z1;             // [sp+88h] [bp+8h]@2
 
-    memset(&local_0, 0, sizeof(local_0));
     local_0.type = ParticleType_Bitmap | ParticleType_Rotating | ParticleType_Dropping;
     local_0.uDiffuse = colorTable.MediumGrey;
     local_0.particle_size = 1.0;


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

All eight findings are `memset` on a `Particle_sw`. That type is not trivially default constructible because every member has a default initializer, and those defaults are all zero, `ParticleType_Invalid` is 0, `Color` and `Duration` zero themselves and the texture pointer is null. So declaring the particle already does exactly what the memset did, and the memset was only adding undefined behaviour on top.

Six of them sit right after the declaration and simply go. The other two had the declaration hoisted to the top of the function in the old decompiled style, and in `BaseRenderer` that put it outside the loop, so there the memset really was resetting state on each iteration and deleting it alone would have been wrong. Both of those declarations move down into the branch that fills them in.
