### PR TITLE
Enable bugprone-unchecked-string-to-number-conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,6 @@ Checks: >
   -bugprone-switch-missing-default-case,
   -bugprone-throwing-static-initialization,
   -bugprone-unchecked-optional-access,
-  -bugprone-unchecked-string-to-number-conversion,
   -bugprone-use-after-move
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(src|test)/'

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -1,5 +1,6 @@
 #include "GUIFont.h"
 
+#include <cstdlib>
 #include <sstream>
 #include <memory>
 #include <algorithm>
@@ -16,7 +17,7 @@ static Color parseColorTag(const char *tag, const Color &defaultColor) {
     char color_code[20];
     strncpy(color_code, tag, 5);
     color_code[5] = 0;
-    int color16 = atoi(color_code);
+    int color16 = static_cast<int>(std::strtol(color_code, nullptr, 10));
     if (color16 == 0) {
         return defaultColor; // Back to default color.
     } else {
@@ -295,7 +296,7 @@ std::string GUIFont::WrapText(std::string_view inString, int width, int uX, bool
                 char digits[4];
                 strncpy(digits, &inString[i + 1], 3);
                 digits[3] = 0;
-                lineWidth = atoi(digits) + uX;
+                lineWidth = static_cast<int>(std::strtol(digits, nullptr, 10)) + uX;
                 i += 3;
                 break;
             }
@@ -392,7 +393,7 @@ void GUIFont::DrawText(const Recti &rect, Pointi position, Color defaultColor, s
             strncpy(Dest, &string_base[i + 1], 3);
             Dest[3] = 0;
             i += 3;
-            left_margin = atoi(Dest);
+            left_margin = static_cast<int>(std::strtol(Dest, nullptr, 10));
             out_x = position.x + rect.x + left_margin;
             break;
         case '\n': // New line.
@@ -413,7 +414,7 @@ void GUIFont::DrawText(const Recti &rect, Pointi position, Color defaultColor, s
             strncpy(Dest, &string_base[i + 1], 3);
             Dest[3] = 0;
             i += 3;
-            left_margin = atoi(Dest);
+            left_margin = static_cast<int>(std::strtol(Dest, nullptr, 10));
             out_x = rect.x + rect.w - 1 - GetLineWidth(&string_base[i]) - left_margin;
             out_y = position.y + rect.y;
             if (maxY != 0) {
@@ -531,7 +532,7 @@ std::string GUIFont::FitTwoFontStringInWindow(std::string_view inString, GUIFont
                 char digits[4];
                 strncpy(digits, &inString[i + 1], 3);
                 digits[3] = 0;
-                lineWidth = atoi(digits) + x;
+                lineWidth = static_cast<int>(std::strtol(digits, nullptr, 10)) + x;
                 i += 3;
                 break;
             }

--- a/src/GUI/GUIFont.cpp
+++ b/src/GUI/GUIFont.cpp
@@ -17,7 +17,7 @@ static Color parseColorTag(const char *tag, const Color &defaultColor) {
     char color_code[20];
     strncpy(color_code, tag, 5);
     color_code[5] = 0;
-    int color16 = static_cast<int>(std::strtol(color_code, nullptr, 10));
+    int color16 = std::strtol(color_code, nullptr, 10);
     if (color16 == 0) {
         return defaultColor; // Back to default color.
     } else {
@@ -296,7 +296,7 @@ std::string GUIFont::WrapText(std::string_view inString, int width, int uX, bool
                 char digits[4];
                 strncpy(digits, &inString[i + 1], 3);
                 digits[3] = 0;
-                lineWidth = static_cast<int>(std::strtol(digits, nullptr, 10)) + uX;
+                lineWidth = std::strtol(digits, nullptr, 10) + uX;
                 i += 3;
                 break;
             }
@@ -393,7 +393,7 @@ void GUIFont::DrawText(const Recti &rect, Pointi position, Color defaultColor, s
             strncpy(Dest, &string_base[i + 1], 3);
             Dest[3] = 0;
             i += 3;
-            left_margin = static_cast<int>(std::strtol(Dest, nullptr, 10));
+            left_margin = std::strtol(Dest, nullptr, 10);
             out_x = position.x + rect.x + left_margin;
             break;
         case '\n': // New line.
@@ -414,7 +414,7 @@ void GUIFont::DrawText(const Recti &rect, Pointi position, Color defaultColor, s
             strncpy(Dest, &string_base[i + 1], 3);
             Dest[3] = 0;
             i += 3;
-            left_margin = static_cast<int>(std::strtol(Dest, nullptr, 10));
+            left_margin = std::strtol(Dest, nullptr, 10);
             out_x = rect.x + rect.w - 1 - GetLineWidth(&string_base[i]) - left_margin;
             out_y = position.y + rect.y;
             if (maxY != 0) {
@@ -532,7 +532,7 @@ std::string GUIFont::FitTwoFontStringInWindow(std::string_view inString, GUIFont
                 char digits[4];
                 strncpy(digits, &inString[i + 1], 3);
                 digits[3] = 0;
-                lineWidth = static_cast<int>(std::strtol(digits, nullptr, 10)) + x;
+                lineWidth = std::strtol(digits, nullptr, 10) + x;
                 i += 3;
                 break;
             }

--- a/src/GUI/UI/Houses/Bank.cpp
+++ b/src/GUI/UI/Houses/Bank.cpp
@@ -1,5 +1,6 @@
 #include "Bank.h"
 
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -43,7 +44,7 @@ void GUIWindow_Bank::putGoldDialogue() {
         return;
     }
     if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-        int sum = atoi(keyboardInputHandler->GetTextInput().c_str());
+        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
         if (sum <= 0) {
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
             return;
@@ -83,7 +84,7 @@ void GUIWindow_Bank::getGoldDialogue() {
         return;
     } else if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
         keyboard_input_status = WINDOW_INPUT_NONE;
-        int sum = atoi(keyboardInputHandler->GetTextInput().c_str());
+        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
         if (sum <= 0) {
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
             return;

--- a/src/GUI/UI/Houses/Bank.cpp
+++ b/src/GUI/UI/Houses/Bank.cpp
@@ -44,7 +44,7 @@ void GUIWindow_Bank::putGoldDialogue() {
         return;
     }
     if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
+        int sum = std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10);
         if (sum <= 0) {
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
             return;
@@ -84,7 +84,7 @@ void GUIWindow_Bank::getGoldDialogue() {
         return;
     } else if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
         keyboard_input_status = WINDOW_INPUT_NONE;
-        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
+        int sum = std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10);
         if (sum <= 0) {
             engine->_messageQueue->addMessageCurrentFrame(UIMSG_Escape, 1, 0);
             return;

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -1,6 +1,7 @@
 #include "TownHall.h"
 
 #include <cassert>
+#include <cstdlib>
 #include <vector>
 #include <string>
 
@@ -68,7 +69,7 @@ void GUIWindow_TownHall::payFineDialogue() {
         DrawFlashingInputCursor(assets->pFontArrus->GetLineWidth(keyboardInputHandler->GetTextInput()) / 2 + 80, 185, assets->pFontArrus.get(), townHall_window);
         return;
     } else if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-        int sum = atoi(keyboardInputHandler->GetTextInput().c_str());
+        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
         if (sum > 0) {
             int party_gold = pParty->GetGold();
             if (sum > party_gold) {

--- a/src/GUI/UI/Houses/TownHall.cpp
+++ b/src/GUI/UI/Houses/TownHall.cpp
@@ -69,7 +69,7 @@ void GUIWindow_TownHall::payFineDialogue() {
         DrawFlashingInputCursor(assets->pFontArrus->GetLineWidth(keyboardInputHandler->GetTextInput()) / 2 + 80, 185, assets->pFontArrus.get(), townHall_window);
         return;
     } else if (keyboard_input_status == WINDOW_INPUT_CONFIRMED) {
-        int sum = static_cast<int>(std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10));
+        int sum = std::strtol(keyboardInputHandler->GetTextInput().c_str(), nullptr, 10);
         if (sum > 0) {
             int party_gold = pParty->GetGold();
             if (sum > party_gold) {


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

All eight findings are `atoi`, five parsing font markup and three parsing the gold amount the player types in a bank or town hall.

Every one of them leans on `atoi` returning 0 for input it cannot parse. That zero is what makes `parseColorTag` fall back to the default color and what makes the bank reject a nonsense amount. `std::strtol` parses the same leading digits and returns the same 0, so behaviour is unchanged, and unlike `atoi` it is defined rather than undefined when the number does not fit.

Tightening these into real error handling would change what the game does with malformed input, which is a separate decision, so it is left alone here.
