### PR TITLE
Fix and test #1290

### DIFF
--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -281,10 +281,6 @@ class GameConfig : public Config {
             "Don't let eradicated characters drink potions. In vanilla a potion dropped on an eradicated "
             "character's portrait is drunk normally."};
 
-        Bool ClickableAccuracyWell = {this, "clickable_accuracy_well", true,
-            "Allow mouse interaction with the Accuracy well in Harmondale. In vanilla it only responds to Space. "
-            "Applied when the map loads."};
-
         Bool AttackPreferencesIncludePromotions = {this, "attack_preferences_include_promotions", true,
             "Monster attack preferences for a class also match its promotions, so a monster that hunts clerics "
             "also hunts priests. In vanilla only the base class matches."};

--- a/src/Application/GameConfig.h
+++ b/src/Application/GameConfig.h
@@ -281,6 +281,10 @@ class GameConfig : public Config {
             "Don't let eradicated characters drink potions. In vanilla a potion dropped on an eradicated "
             "character's portrait is drunk normally."};
 
+        Bool ClickableAccuracyWell = {this, "clickable_accuracy_well", true,
+            "Allow mouse interaction with the Accuracy well in Harmondale. In vanilla it only responds to Space. "
+            "Applied when the map loads."};
+
         Bool AttackPreferencesIncludePromotions = {this, "attack_preferences_include_promotions", true,
             "Monster attack preferences for a class also match its promotions, so a monster that hunts clerics "
             "also hunts priests. In vanilla only the base class matches."};

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -592,6 +592,14 @@ void DoPrepareWorld(bool bLoading, int _1_fullscreen_loading_2_box) {
             if (actor.monsterInfo.spell2Id == SPELL_SPIRIT_SPIRIT_LASH)
                 actor.monsterInfo.spell2Id = SPELL_SPIRIT_BLESS;
 
+    // OE fix - the Accuracy well's face is missing FACE_CLICKABLE in map data, so the mouse can't reach it.
+    // TODO(captainurist): move to patched data tables.
+    if (engine->_currentLoadedMapId == MAP_HARMONDALE)
+        for (BSPModel &model : pOutdoor->pBModels)
+            for (BLVFace &face : model.faces)
+                if (face.eventId == 228) // The Accuracy well, "+2 Accuracy (Permanent)" in out02.evt.
+                    face.attributes |= FACE_CLICKABLE;
+
     bDialogueUI_InitializeActor_NPC_ID = 0;
     engine->_pendingTransition.reset();
     onMapLoad();

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -510,21 +510,6 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
 
     reconstruct(delta, this);
 
-    if (engine->_currentLoadedMapId == MAP_HARMONDALE) {
-        // TODO(captainurist): move to patched data tables.
-        for (BSPModel &model : pBModels) {
-            for (BLVFace &face : model.faces) {
-                if (face.eventId == 228) {
-                    if (engine->config->gameplay.ClickableAccuracyWell.value()) {
-                        face.attributes |= FACE_CLICKABLE;
-                    } else {
-                        face.attributes &= ~FACE_CLICKABLE; // Override the bit restored from a save as well.
-                    }
-                }
-            }
-        }
-    }
-
     if (respawnTimed || respawnInitial)
         ddm.lastRespawnDay = days_played;
     if (respawnTimed)

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -510,6 +510,21 @@ void OutdoorLocation::Load(std::string_view filename, int days_played, int respa
 
     reconstruct(delta, this);
 
+    if (engine->_currentLoadedMapId == MAP_HARMONDALE) {
+        // TODO(captainurist): move to patched data tables.
+        for (BSPModel &model : pBModels) {
+            for (BLVFace &face : model.faces) {
+                if (face.eventId == 228) {
+                    if (engine->config->gameplay.ClickableAccuracyWell.value()) {
+                        face.attributes |= FACE_CLICKABLE;
+                    } else {
+                        face.attributes &= ~FACE_CLICKABLE; // Override the bit restored from a save as well.
+                    }
+                }
+            }
+        }
+    }
+
     if (respawnTimed || respawnInitial)
         ddm.lastRespawnDay = days_played;
     if (respawnTimed)

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -14,6 +14,8 @@
 #include "Engine/Objects/NPC.h"
 #include "Engine/Objects/SpriteObject.h"
 #include "Engine/Graphics/Indoor.h"
+#include "Engine/Graphics/Camera.h"
+#include "Engine/Graphics/Vis.h"
 #include "Engine/Graphics/Image.h"
 #include "Engine/AssetsManager.h"
 #include "Engine/Party.h"
@@ -516,6 +518,45 @@ GAME_TEST(Issues, Issue1282) {
     test.playTraceFromTestData("issue_1282.mm7", "issue_1282.json");
     EXPECT_EQ(itemTape, tape(false, true));
     EXPECT_EQ(totalObjectsTape.delta(), -1);
+}
+
+GAME_TEST(Issues, Issue1290) {
+    // Bug: the Harmondale Accuracy well's interactive face was missing its clickable flag.
+    for (bool savedOption : {false, true}) {
+        test.prepareForNextTest();
+        engine->config->debug.NoActors.setValue(true);
+        engine->config->gameplay.ClickableAccuracyWell.setValue(savedOption);
+        game.startNewGame();
+        game.teleportTo(MAP_HARMONDALE, Vec3f(-8864, 17936, 384), 90);
+        pParty->_viewPitch = -256; // Look down into the well, within the mouse-look pitch range.
+        game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
+        game.tick();
+        ASSERT_EQ(pOutdoor->face(Pid::odmFace(97, 10)).Clickable(), savedOption);
+        Blob savedGame = game.saveGame(); // Save before drinking, the bonus is once per character.
+
+        for (bool enabled : {false, true}) {
+            engine->config->gameplay.ClickableAccuracyWell.setValue(enabled);
+            game.loadGame(savedGame);
+            ASSERT_TRUE(pParty->hasActiveCharacter());
+            ASSERT_EQ(pParty->activeCharacterIndex(), 1);
+            ASSERT_EQ(pParty->pPickedItem.itemId, ITEM_NULL);
+            ASSERT_FALSE(pParty->pCharacters[0]._characterEventBits[2]);
+            const BLVFace &well = pOutdoor->face(Pid::odmFace(97, 10));
+            ASSERT_EQ(well.eventId, 228);
+            EXPECT_EQ(well.Clickable(), enabled);
+
+            Vec3f waterPoint(-8864, 18072, 392);
+            Vec2f screenPos = pCamera3D->Project(pCamera3D->ViewTransform(&waterPoint));
+            game.moveMouse(screenPos.x, screenPos.y);
+            game.tick();
+            ASSERT_EQ(engine->PickMouseForTargeting().pid, Pid::odmFace(97, 10));
+            ASSERT_LT(engine->PickMouseForTargeting().depth, engine->config->gameplay.MouseInteractionDepth.value());
+            int accuracy = pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY];
+            game.pressAndReleaseButton(PlatformMouseButton::BUTTON_LEFT, screenPos.x, screenPos.y);
+            game.tick();
+            EXPECT_EQ(pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY], accuracy + (enabled ? 2 : 0));
+        }
+    }
 }
 
 GAME_TEST(Issues, Issue1294_1389) {

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -521,42 +521,37 @@ GAME_TEST(Issues, Issue1282) {
 }
 
 GAME_TEST(Issues, Issue1290) {
-    // Bug: the Harmondale Accuracy well's interactive face was missing its clickable flag.
-    for (bool savedOption : {false, true}) {
-        test.prepareForNextTest();
-        engine->config->debug.NoActors.setValue(true);
-        engine->config->gameplay.ClickableAccuracyWell.setValue(savedOption);
-        game.startNewGame();
-        game.teleportTo(MAP_HARMONDALE, Vec3f(-8864, 17936, 384), 90);
-        pParty->_viewPitch = -256; // Look down into the well, within the mouse-look pitch range.
-        game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_1);
-        game.tick();
-        ASSERT_EQ(pOutdoor->face(Pid::odmFace(97, 10)).Clickable(), savedOption);
-        Blob savedGame = game.saveGame(); // Save before drinking, the bonus is once per character.
+    // Can't interact with the Accuracy well in Harmondale with the mouse.
+    auto statusTape = tapes.statusBar();
+    Pid wellFace = Pid::odmFace(97, 10);
 
-        for (bool enabled : {false, true}) {
-            engine->config->gameplay.ClickableAccuracyWell.setValue(enabled);
-            game.loadGame(savedGame);
-            ASSERT_TRUE(pParty->hasActiveCharacter());
-            ASSERT_EQ(pParty->activeCharacterIndex(), 1);
-            ASSERT_EQ(pParty->pPickedItem.itemId, ITEM_NULL);
-            ASSERT_FALSE(pParty->pCharacters[0]._characterEventBits[2]);
-            const BLVFace &well = pOutdoor->face(Pid::odmFace(97, 10));
-            ASSERT_EQ(well.eventId, 228);
-            EXPECT_EQ(well.Clickable(), enabled);
+    engine->config->debug.NoActors.setValue(true);
+    game.startNewGame();
+    test.startTaping();
+    game.teleportTo(MAP_HARMONDALE, Vec3f(-8864, 17936, 384), 90);
+    pParty->_viewPitch = -256; // Look down into the well, within the mouse-look pitch range.
+    game.tick();
 
-            Vec3f waterPoint(-8864, 18072, 392);
-            Vec2f screenPos = pCamera3D->Project(pCamera3D->ViewTransform(&waterPoint));
-            game.moveMouse(screenPos.x, screenPos.y);
-            game.tick();
-            ASSERT_EQ(engine->PickMouseForTargeting().pid, Pid::odmFace(97, 10));
-            ASSERT_LT(engine->PickMouseForTargeting().depth, engine->config->gameplay.MouseInteractionDepth.value());
-            int accuracy = pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY];
-            game.pressAndReleaseButton(PlatformMouseButton::BUTTON_LEFT, screenPos.x, screenPos.y);
-            game.tick();
-            EXPECT_EQ(pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY], accuracy + (enabled ? 2 : 0));
-        }
-    }
+    const BLVFace &well = pOutdoor->face(wellFace);
+    ASSERT_EQ(well.eventId, 228);
+    ASSERT_EQ(pParty->activeCharacterIndex(), 1);
+    ASSERT_FALSE(pParty->pCharacters[0]._characterEventBits[2]); // The well's once-per-character bit.
+    ASSERT_EQ(pParty->pPickedItem.itemId, ITEM_NULL); // A held item is dropped instead of interacting.
+    EXPECT_TRUE(well.Clickable());
+
+    Vec3f waterPoint(-8864, 18072, 392);
+    Vec2f screenPos = pCamera3D->Project(pCamera3D->ViewTransform(&waterPoint));
+    game.moveMouse(screenPos.x, screenPos.y);
+    game.tick();
+    Vis_PIDAndDepth picked = engine->PickMouseForTargeting();
+    ASSERT_EQ(picked.pid, wellFace);
+    ASSERT_LT(picked.depth, engine->config->gameplay.MouseInteractionDepth.value());
+
+    int accuracy = pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY];
+    game.pressAndReleaseButton(BUTTON_LEFT, screenPos.x, screenPos.y);
+    game.tick(3);
+    EXPECT_EQ(pParty->pCharacters[0]._stats[ATTRIBUTE_ACCURACY], accuracy + 2);
+    EXPECT_CONTAINS(statusTape, "+2 Accuracy (Permanent)");
 }
 
 GAME_TEST(Issues, Issue1294_1389) {


### PR DESCRIPTION
The Harmondale Accuracy well's face carries event 228 but no clickable attribute in MM7's map data, so clicking it reports "Nothing here". The Space path never looks at that attribute, which is why only the mouse was affected.

Set the attribute on map load, in `DoPrepareWorld` next to the other per-map data fixes. It runs after the save delta is reconstructed, which matters because face attributes are persisted in the ddm. The game test clicks the actual well and checks both the +2 Accuracy reward and the status bar text. `EngineController::teleportTo` gains an optional view pitch for it.

Implemented and tested with AI assistance. Fixes #1290.
