### PR TITLE
Rewrite the comment rules around what actually gets deleted

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,9 +12,11 @@ Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your c
 
 *NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.
 
-Before every commit, re-read the code comments in the diff against the Comments section, as a separate pass. You *MUST* do this - the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
+Before every commit, do a deletion pass over the comments in the diff, as a separate step. For each added comment ask whether it describes the code or defends the change, and delete the ones that defend it. You *MUST* do this, the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
 
 *NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call.
+
+The commit message is where the reasoning lives. Say what was wrong and why this is the fix, in a paragraph. Every "why" you were tempted to put in a comment goes here instead.
 
 Keep pull request descriptions short - a few sentences on what was done and how, and that's it. Two or three paragraphs at most, humans don't want to read an essay. The evidence you gathered along the way belongs in a comment on the PR if it belongs anywhere.
 
@@ -22,18 +24,16 @@ Put the `🤖 Human Needed` label on every pull request you open, once its CI is
 
 # Comments
 
-Keep comments terse - prefer a single trailing comment over a multi-line block, and never write comments explaining what you *didn't* do.
+The default is no comment. Write one where the code can't say it, a non-obvious runtime or domain fact, a hidden dependency, a value that looks wrong and isn't. Most comments in this codebase are a single trailing line, match that.
 
-Explanations live where the logic lives. A comment that explains a statement sits on that statement, inside the function. If it's about returning, it sits where the function returns. If it's about why this particular call happens here, it sits at that call site. The doxygen block above a function is for callers only - what it does, what goes in, what comes out - never a walkthrough of the body.
+A comment describes the code. It *NEVER* defends the change. If a sentence says why the diff is right, what would break without this line, or what the test would catch, it's commit message material and it doesn't go in the source. "Nothing else would notice", "this is what catches", "so that we" are the tells, delete the sentence.
 
-Every sentence in a comment must say something not already said by the code, the names, or the previous sentence. No pointers to other comments - state the fact or delete the sentence. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
+Every sentence in a comment must say something the code, the names and the previous sentence don't. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 
-Any comment on a function, class, struct or table that's longer than a trailing one-liner is a doxygen block. Every doxygen block on a function *MUST* carry a `@param` tag for each parameter and a `@return` tag if the function returns something. A prose-only block isn't finished. Descriptions start at column 41, like the rest of the codebase.
+Explanations live where the logic lives. A comment about a statement is a trailing comment on that statement. A comment about a return sits at the return. A comment about a call sits at the call. The doxygen block above a function is for callers only, what goes in and what comes out, never a walkthrough of the body.
 
-An invariant is an assert, not a comment. If you're about to write a comment saying what must be true at this point in the code, write an `assert` instead.
+Public functions, classes, structs and tables get a doxygen block, with a `@param` tag for each parameter and a `@return` tag if there's a result. Descriptions start at column 41. Helpers and test functions don't get one, a trailing line inside the body does the job.
 
-Comments in production code should say how the present code works, and only where the workings are non-trivial. *NEVER* narrate past bugs there - the reader needs the current invariant, not the history.
+An invariant is an assert, not a comment.
 
-Comments in tests are the opposite. State the bug that the test guards against, otherwise it's unclear why the test exists, and someone will eventually delete it as redundant.
-
-When you do write about a past bug, spell out that it *was* a bug and name it. "We used to keep the old buffer" reads like a reasonable choice that happened to change. "This used to be a heap buffer overflow" doesn't.
+Production code never narrates past bugs. A test does the opposite, it says in one line which bug it guards against, and calls it a bug. "We used to keep the old buffer" reads like a choice. "This used to be a heap buffer overflow" doesn't.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,7 @@ Put the `🤖 Human Needed` label on every pull request you open, once its CI is
 
 The default is no comment. Write one only for what the code can't say: a non-obvious runtime or domain fact, a hidden dependency, or a value that looks wrong but isn't. Most comments in this codebase are one line, and usually trail the code they're about, match that.
 
-A comment describes the code. It *NEVER* defends the change. The tell is what the sentence is about. A sentence about the game, the data, the platform or a library describes. A sentence about this diff, this test, the suite or what else would notice defends, and so does one about what you didn't do. Delete it, it's commit message material. Defending sentences tend to arrive as a result clause ("X, so Y", "so that"), a claim about what else exists ("nothing else", "the only one"), a counterfactual ("would break", "would pass") or "this is what". "Because" is fine when a fact about the world follows it.
+A comment describes the code. It *NEVER* defends the change. The tell is what the sentence is about. A sentence about the game, the data, the platform or a library describes. A sentence about this diff, this test, the suite or what else would notice defends, and so does one about what you didn't do. Delete it, it's commit message material. "Because" is fine when a fact about the world follows it.
 
 Every sentence in a comment must say something the code, the names and the previous sentence don't. A comment that repeats the name next to it goes. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,9 +26,9 @@ Put the `🤖 Human Needed` label on every pull request you open, once its CI is
 
 The default is no comment. Write one only for what the code can't say: a non-obvious runtime or domain fact, a hidden dependency, or a value that looks wrong but isn't. Most comments in this codebase are one line, and usually trail the code they're about, match that.
 
-A comment describes the code. It *NEVER* defends the change. The tell is what the sentence is about. A sentence about the game, the data, the platform or a library describes. A sentence about this diff, this test, the suite or what else would notice defends, and so does one about what you didn't do. Delete it, it's commit message material. "Because" is fine when a fact about the world follows it.
+A comment describes the code. It *NEVER* defends the change. A sentence about the game, the data, the platform or a library describes. A sentence about this diff defends, and so does one about what you didn't do. Delete it, it's commit message material. "Because" is fine when a fact about the world follows it.
 
-Every sentence in a comment must say something the code, the names and the previous sentence don't. A comment that repeats the name next to it goes. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
+Every sentence in a comment must say something the code, the names and the previous sentence don't. A comment that repeats the name next to it is not needed. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 
 Explanations live where the logic lives. A comment about a statement is a trailing comment on that statement. A comment about a return sits at the return. A comment about a call sits at the call. The doxygen block above a function is for callers only, what it does, what goes in and what comes out, never a walkthrough of the body.
 
@@ -36,4 +36,4 @@ A function, class, struct, enum or table whose name doesn't say it all gets a do
 
 An invariant is an assert, not a comment.
 
-Production code never narrates past bugs. A test does the opposite, its first line names the bug it guards against, as the symptom. "Gold piles are generated with 0 gold" is the shape. What the test would catch, or what else would catch it, is the defending shape from above. When a comment does mention a past bug, say it was a bug. "We used to keep the old buffer" reads like a choice. "This used to be a heap buffer overflow" doesn't.
+Production code never narrates past bugs. A test does the opposite, its first line names the bug it guards against. "Gold piles were generated with 0 gold" is the shape. When a comment does mention a past bug, say it was a bug. "We used to keep the old buffer" reads like a choice. "This used to be a heap buffer overflow" doesn't.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,9 +24,9 @@ Put the `🤖 Human Needed` label on every pull request you open, once its CI is
 
 # Comments
 
-The default is no comment. Write one where the code can't say it, a non-obvious runtime or domain fact, a hidden dependency, a value that looks wrong and isn't. Most comments in this codebase are a single trailing line, match that.
+The default is no comment. Write one only for what the code can't say: a non-obvious runtime or domain fact, a hidden dependency, or a value that looks wrong but isn't. Most comments in this codebase are a single trailing line, match that.
 
-A comment describes the code. It *NEVER* defends the change. If a sentence says why the diff is right, what would break without this line, or what the test would catch, it's commit message material and it doesn't go in the source. "Nothing else would notice", "this is what catches", "so that we" are the tells, delete the sentence.
+A comment describes the code. It *NEVER* defends the change. If a sentence says why the diff is right, what would break without this line, or what the test would catch, it's commit message material and it doesn't go in the source. The tells are a result clause ("X, so Y", "so that"), a claim about what else exists ("nothing else", "the only one"), a counterfactual ("would break", "would pass") and a justification of a choice ("because", "this is what"). A sentence built on one of these defends the change, delete it.
 
 Every sentence in a comment must say something the code, the names and the previous sentence don't. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,11 +12,11 @@ Build `Run_UnitTest` and `Run_GameTest_Headless_Parallel` targets to test your c
 
 *NEVER* claim anything about game data or runtime behaviour that you haven't checked. OpenEnroth targets MM6, MM7 and MM8, so a claim about the data means all three were scanned. Go the extra mile when scanning data, and say what you checked - "no shipped record does this" means MM6, MM7 and MM8 scripts were all read, and if one of them wasn't, say which.
 
-Before every commit, do a deletion pass over the comments in the diff, as a separate step. For each added comment ask whether it describes the code or defends the change, and delete the ones that defend it. You *MUST* do this, the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
+Before every commit, do a deletion pass over the comments in the diff, as a separate step. For each added comment ask whether it describes the code or defends the change, and delete the ones that defend it. Then check what's left against the Comments section. You *MUST* do this, the review rounds exist for design questions, not for comment cleanup you could have caught yourself.
 
 *NEVER* amend a commit or rewrite pushed history unless explicitly asked to. Fixes go on top as new commits with their own messages, and squashing is the human's call.
 
-The commit message is where the reasoning lives. Say what was wrong and why this is the fix, in a paragraph. Every "why" you were tempted to put in a comment goes here instead.
+The commit message is where the reasoning lives. Say what was wrong and why this is the fix, in a paragraph. Every "why" about the diff that you were tempted to put in a comment goes here instead. A "why" about the game or the platform stays in the source, see Comments.
 
 Keep pull request descriptions short - a few sentences on what was done and how, and that's it. Two or three paragraphs at most, humans don't want to read an essay. The evidence you gathered along the way belongs in a comment on the PR if it belongs anywhere.
 
@@ -24,16 +24,16 @@ Put the `🤖 Human Needed` label on every pull request you open, once its CI is
 
 # Comments
 
-The default is no comment. Write one only for what the code can't say: a non-obvious runtime or domain fact, a hidden dependency, or a value that looks wrong but isn't. Most comments in this codebase are a single trailing line, match that.
+The default is no comment. Write one only for what the code can't say: a non-obvious runtime or domain fact, a hidden dependency, or a value that looks wrong but isn't. Most comments in this codebase are one line, and usually trail the code they're about, match that.
 
-A comment describes the code. It *NEVER* defends the change. If a sentence says why the diff is right, what would break without this line, or what the test would catch, it's commit message material and it doesn't go in the source. The tells are a result clause ("X, so Y", "so that"), a claim about what else exists ("nothing else", "the only one"), a counterfactual ("would break", "would pass") and a justification of a choice ("because", "this is what"). A sentence built on one of these defends the change, delete it.
+A comment describes the code. It *NEVER* defends the change. The tell is what the sentence is about. A sentence about the game, the data, the platform or a library describes. A sentence about this diff, this test, the suite or what else would notice defends, and so does one about what you didn't do. Delete it, it's commit message material. Defending sentences tend to arrive as a result clause ("X, so Y", "so that"), a claim about what else exists ("nothing else", "the only one"), a counterfactual ("would break", "would pass") or "this is what". "Because" is fine when a fact about the world follows it.
 
-Every sentence in a comment must say something the code, the names and the previous sentence don't. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
+Every sentence in a comment must say something the code, the names and the previous sentence don't. A comment that repeats the name next to it goes. If a call site needs a comment to be readable, fix the code instead. An enum parameter reads at the call site. A bool doesn't.
 
-Explanations live where the logic lives. A comment about a statement is a trailing comment on that statement. A comment about a return sits at the return. A comment about a call sits at the call. The doxygen block above a function is for callers only, what goes in and what comes out, never a walkthrough of the body.
+Explanations live where the logic lives. A comment about a statement is a trailing comment on that statement. A comment about a return sits at the return. A comment about a call sits at the call. The doxygen block above a function is for callers only, what it does, what goes in and what comes out, never a walkthrough of the body.
 
-Public functions, classes, structs, enums and tables get a doxygen block, with a `@param` tag for each parameter and a `@return` tag if there's a result. Descriptions start at column 41. Helpers and test functions get no block, a trailing line inside the body does the job. Either way, a comment above a declaration is a doxygen block or nothing. A `//` line above a function is never right, it either grows into the block or moves inside the body. A `TODO` is a note, not a description, and may stay where it is.
+A function, class, struct, enum or table whose name doesn't say it all gets a doxygen block, with a `@param` tag for each parameter and a `@return` tag if there's a result. The text after a tag starts at column 41. A name that says it all gets nothing, `isOpen()` needs no block. A test, and the helpers next to it, get no block, a `//` line at the top of the body does the job. A comment above a declaration is a doxygen block or nothing, a `//` line you'd write there either grows into the block or moves inside the body. Existing `//----- (0x...)` offset markers stay, see `HACKING.md`. A `TODO(name)` above a declaration is fine, it says what's left to do and nothing else.
 
 An invariant is an assert, not a comment.
 
-Production code never narrates past bugs. A test does the opposite, it says in one line which bug it guards against, and calls it a bug. "We used to keep the old buffer" reads like a choice. "This used to be a heap buffer overflow" doesn't.
+Production code never narrates past bugs. A test does the opposite, its first line names the bug it guards against, as the symptom. "Gold piles are generated with 0 gold" is the shape. What the test would catch, or what else would catch it, is the defending shape from above. When a comment does mention a past bug, say it was a bug. "We used to keep the old buffer" reads like a choice. "This used to be a heap buffer overflow" doesn't.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,7 +32,7 @@ Every sentence in a comment must say something the code, the names and the previ
 
 Explanations live where the logic lives. A comment about a statement is a trailing comment on that statement. A comment about a return sits at the return. A comment about a call sits at the call. The doxygen block above a function is for callers only, what goes in and what comes out, never a walkthrough of the body.
 
-Public functions, classes, structs and tables get a doxygen block, with a `@param` tag for each parameter and a `@return` tag if there's a result. Descriptions start at column 41. Helpers and test functions don't get one, a trailing line inside the body does the job.
+Public functions, classes, structs, enums and tables get a doxygen block, with a `@param` tag for each parameter and a `@return` tag if there's a result. Descriptions start at column 41. Helpers and test functions get no block, a trailing line inside the body does the job. Either way, a comment above a declaration is a doxygen block or nothing. A `//` line above a function is never right, it either grows into the block or moves inside the body. A `TODO` is a note, not a description, and may stay where it is.
 
 An invariant is an assert, not a comment.
 


### PR DESCRIPTION
The Comments section in CLAUDE.md grew to 346 words over five revisions while the same review corrections kept coming. Most deleted comments had one shape, a sentence defending the change instead of describing the code, and two of the rules were manufacturing what got deleted. The doxygen mandate on every function pushed helpers into tagged blocks, and the test rule licensed the "nothing else would notice" sentences.

This rewrite opens with no comment as the default, names the change-defending shape and its tells, scopes doxygen blocks to public declarations, turns the pre-commit re-read into a deletion pass, and names the commit message as the home for the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)