### PR TITLE
Exclude the stack overflow test helper from ASan instrumentation

### DIFF
--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -190,9 +190,9 @@ MM_NOINLINE void stackTraceTrapFunction() {
 
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
-MM_NO_SANITIZE_ADDRESS MM_NOINLINE int stackTraceOverflowFunction(int depth) {
-    // MM_NO_SANITIZE_ADDRESS above is needed because an instrumented prologue calls __asan_stack_malloc, and
-    // that allocator's own frame hits the guard page in some runs, putting libasan on top of the trace.
+MM_NOASAN MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    // MM_NOASAN above is needed because an instrumented prologue calls __asan_stack_malloc, and that
+    // allocator's own frame hits the guard page in some runs, putting libasan on top of the trace.
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     stackTraceOverflowEscape = pad; // Address taken, so the pad keeps its size at -O2 and the recursion can't be folded into a loop.
     pad[0] = static_cast<char>(depth);

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -190,7 +190,9 @@ MM_NOINLINE void stackTraceTrapFunction() {
 
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
-MM_NO_SANITIZE_ADDRESS MM_NOINLINE int stackTraceOverflowFunction(int depth) { // Or ASan's prologue call to __asan_stack_malloc faults inside the allocator, putting libasan on top of the trace.
+MM_NO_SANITIZE_ADDRESS MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+    // MM_NO_SANITIZE_ADDRESS above is needed because an instrumented prologue calls __asan_stack_malloc, and
+    // that allocator's own frame hits the guard page in some runs, putting libasan on top of the trace.
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     stackTraceOverflowEscape = pad; // Address taken, so the pad keeps its size at -O2 and the recursion can't be folded into a loop.
     pad[0] = static_cast<char>(depth);

--- a/src/Library/StackTrace/Tests/StackTrace_ut.cpp
+++ b/src/Library/StackTrace/Tests/StackTrace_ut.cpp
@@ -190,7 +190,7 @@ MM_NOINLINE void stackTraceTrapFunction() {
 
 static volatile char *volatile stackTraceOverflowEscape; // Never read, the pad below is stored here so it exists.
 
-MM_NOINLINE int stackTraceOverflowFunction(int depth) {
+MM_NO_SANITIZE_ADDRESS MM_NOINLINE int stackTraceOverflowFunction(int depth) { // Or ASan's prologue call to __asan_stack_malloc faults inside the allocator, putting libasan on top of the trace.
     volatile char pad[1024]; // Big frames overflow fast, and the volatile writes keep the endless recursion out of UB land.
     stackTraceOverflowEscape = pad; // Address taken, so the pad keeps its size at -O2 and the recursion can't be folded into a loop.
     pad[0] = static_cast<char>(depth);

--- a/src/Utility/Attributes.h
+++ b/src/Utility/Attributes.h
@@ -12,12 +12,12 @@
 #endif
 
 /**
- * @def MM_NO_SANITIZE_ADDRESS
+ * @def MM_NOASAN
  *
  * Excludes a function from AddressSanitizer instrumentation, and is inert in builds that don't enable it.
  */
 #ifdef _MSC_VER
-#   define MM_NO_SANITIZE_ADDRESS __declspec(no_sanitize_address)
+#   define MM_NOASAN __declspec(no_sanitize_address)
 #else
-#   define MM_NO_SANITIZE_ADDRESS [[gnu::no_sanitize_address]]
+#   define MM_NOASAN [[gnu::no_sanitize_address]]
 #endif

--- a/src/Utility/Attributes.h
+++ b/src/Utility/Attributes.h
@@ -10,3 +10,14 @@
 #else
 #   define MM_NOINLINE [[gnu::noinline]]
 #endif
+
+/**
+ * @def MM_NO_SANITIZE_ADDRESS
+ *
+ * Excludes a function from AddressSanitizer instrumentation, and is inert in builds that don't enable it.
+ */
+#ifdef _MSC_VER
+#   define MM_NO_SANITIZE_ADDRESS __declspec(no_sanitize_address)
+#else
+#   define MM_NO_SANITIZE_ADDRESS [[gnu::no_sanitize_address]]
+#endif


### PR DESCRIPTION
`StackTrace.StackOverflowIsTraced` flakes in the ASan job. ASan instruments the recursing helper's prologue with a call to `__asan_stack_malloc`, and that allocator has a frame of its own, so the guard page is hit either in the helper or one call deeper inside libasan. Which of the two it is depends on where the death test child's stack started, so frame 0 comes back as libasan often enough to red unrelated PRs.

`MM_NO_SANITIZE_ADDRESS` on the helper leaves its own frame as the only thing that can fault. Everything else in the file stays instrumented.

Locally the test failed 14 out of 300 runs before this change and 0 out of 300 after.
