### PR TITLE
Document the brace rules in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -94,8 +94,9 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* A control statement doesn't need braces when its body is a single statement that isn't itself a control statement, or a control statement that carries no braces. This applies recursively.
+* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that isn't itself a control statement, or a control statement that carries no braces. This applies recursively.
 * An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to.
+* A `do`/`while` loop always braces its body.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -95,7 +95,7 @@ Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
 * A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces on every control statement wrapping it.
-* An `if` that has an `else` braces every body in the chain, `else if` arms included. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
+* An `if` with an `else` braces all of its bodies. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
 * A `do`/`while`, a `switch` and a `try`/`catch` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* An `if`, a `for` or a `while` doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces all the way out.
+* An `if`, a `for` or a `while` doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces all the way up.
 * An `if` with an `else` braces all of its bodies. A lone `if` doesn't have to. When an `else` holds nothing but an `if`, write `} else if (...) {`.
 * A `do`/`while`, a `switch` and a `try`/`catch` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,8 +94,8 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* Braces around a body are optional when the body is a single statement, and when the body is a nested `if`, `for` or `while` that carries no braces itself. So `for (...) if (...) doSomething();` needs no braces at all.
-* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`, while an `if`/`else` pair also forces braces on the `for` around it.
+* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies at every level, so `for (...) for (...) if (...) doSomething();` needs no braces at all.
+* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`. An `if`/`else` pair can't, and because it carries braces it forces braces on every loop around it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* A body needs no braces when it is a single statement, or when it is an `if`, `for` or `while` that needs no braces by this same rule. So `for (...) for (...) if (...) doSomething();` carries no braces at any level, and neither does the same chain with more loops in it.
+* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies recursively, so `for (...) for (...) if (...) doSomething();` needs no braces at all.
 * An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`. An `if`/`else` pair can't, and because it carries braces it forces braces on every loop around it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -95,7 +95,7 @@ Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
 * An `if`, a `for` or a `while` doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces all the way out.
-* An `if` with an `else` braces all of its bodies. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
+* An `if` with an `else` braces all of its bodies. A lone `if` doesn't have to. When an `else` holds nothing but an `if`, write `} else if (...) {`.
 * A `do`/`while`, a `switch` and a `try`/`catch` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,14 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies recursively, and the bodies don't have to be on one line:
-  ```
-  for (...)
-      for (...)
-          for (...)
-              if (...)
-                  doSomething();
-  ```
+* A control statement doesn't need braces when its body is a single statement that isn't itself a control statement, or a control statement that carries no braces. This applies recursively.
 * An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -96,7 +96,7 @@ Code formatting:
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
 * A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces on every control statement wrapping it.
 * An `if` that has an `else` braces every body in the chain, `else if` arms included. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
-* A `do`/`while`, a `switch` and a `try` always brace their bodies.
+* A `do`/`while`, a `switch` and a `try`/`catch` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,6 +94,8 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
+* Braces around a body are optional when the body is a single statement, and when the body is a nested `if`, `for` or `while` that carries no braces itself. So `for (...) if (...) doSomething();` needs no braces at all.
+* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`, while an `if`/`else` pair also forces braces on the `for` around it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,9 +94,9 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that isn't itself a control statement, or is a control statement that carries no braces. This applies recursively.
-* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to.
-* A `do`/`while` loop always braces its body.
+* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces on every control statement wrapping it.
+* An `if` that has an `else` braces every body in the chain, `else if` arms included. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
+* A `do`/`while`, a `switch` and a `try` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,8 +94,15 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies recursively, so `for (...) for (...) if (...) doSomething();` needs no braces at all.
-* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`. An `if`/`else` pair can't, and because it carries braces it forces braces on every loop around it.
+* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies recursively, and the bodies don't have to be on one line:
+  ```
+  for (...)
+      for (...)
+          for (...)
+              if (...)
+                  doSomething();
+  ```
+* An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.
 * In header files, use an additional `private:` label before listing all class fields at the end of the class declaration.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that isn't itself a control statement, or a control statement that carries no braces. This applies recursively.
+* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that isn't itself a control statement, or is a control statement that carries no braces. This applies recursively.
 * An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to.
 * A `do`/`while` loop always braces its body.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* A control statement (`if`, `for`, `while`) doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces on every control statement wrapping it.
+* An `if`, a `for` or a `while` doesn't need braces when its body is a single statement that carries no braces itself. This applies recursively, so a brace at any depth forces braces all the way out.
 * An `if` with an `else` braces all of its bodies. A lone `if` doesn't have to. Write `} else if (...) {`, never an `if` nested inside a braced `else`.
 * A `do`/`while`, a `switch` and a `try`/`catch` always brace their bodies.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -94,7 +94,7 @@ Naming:
 Code formatting:
 * Lines are at most 200 columns, `check_style` enforces it. Prefer ~120, but readability wins over the number: a long line is fine, ugly wrapping isn't. Applies to all file types, not just C++. Don't wrap at 80!
 * Comments stay within 120 columns, the 200 limit is for code. The exception is a trailing comment, it's part of the code line it's on and only needs to fit in 200 together with it.
-* Braces around a body are optional when the body is a single statement, and when the body is an `if`, `for` or `while` that carries no braces itself. This applies at every level, so `for (...) for (...) if (...) doSomething();` needs no braces at all.
+* A body needs no braces when it is a single statement, or when it is an `if`, `for` or `while` that needs no braces by this same rule. So `for (...) for (...) if (...) doSomething();` carries no braces at any level, and neither does the same chain with more loops in it.
 * An `if` that has an `else` always braces both bodies. A lone `if` doesn't have to, so a braceless `if` can be the body of a braceless `for`. An `if`/`else` pair can't, and because it carries braces it forces braces on every loop around it.
 * `*` and `&` in type declarations should be preceded by a space. So it's `char *string`, and not `char* string`.
 * Sort method definitions in `.cpp` files in the same order as they appear in the `.h` file.


### PR DESCRIPTION
The coding style section said nothing about braces, and neither cpplint nor clang-tidy check them, so the convention only ever showed up in review comments.

Two bullets in the Code formatting section now spell it out. A body can go without braces when it's a single statement or a braceless nested control statement, and an `if` with an `else` always braces both bodies, which in turn forces braces on any loop wrapping it.