### PR TITLE
Make the active character index 0-based

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -260,8 +260,6 @@ void Game::closeTargetedSpellWindow() {
 void Game::onEscape() {
     closeTargetedSpellWindow();
 
-    // if ((signed int)pParty->activeCharacterIndex() < 1 || (signed int)pParty->activeCharacterIndex() > 4)
-
     pParty->switchToNextActiveCharacter();  // always check this - could leave
                                            // shops with characters who couldnt
                                            // act sctive
@@ -516,10 +514,10 @@ void Game::processQueuedMessages() {
                         if (current_screen_type < SCREEN_64) {
                             switch (current_screen_type) {
                                 case SCREEN_CASTING:
-                                    if (enchantingActiveCharacter) {
+                                    if (enchantingActiveCharacter != -1) {
                                         pParty->setActiveCharacterIndex(enchantingActiveCharacter);
                                         pParty->switchToNextActiveCharacter();
-                                        enchantingActiveCharacter = 0;
+                                        enchantingActiveCharacter = -1;
                                         if (pParty->bTurnBasedModeOn) {
                                             pTurnEngine->ApplyPlayerAction();
                                         }
@@ -954,7 +952,7 @@ void Game::processQueuedMessages() {
                 if (!pParty->hasActiveCharacter() || pParty->activeCharacter().timeToRecovery) {
                     continue;
                 }
-                pushSpellOrRangedAttack(pParty->activeCharacter().uQuickSpell, pParty->activeCharacterIndex() - 1,
+                pushSpellOrRangedAttack(pParty->activeCharacter().uQuickSpell, pParty->activeCharacterIndex(),
                                         CombinedSkillValue::none(), ON_CAST_AutoTarget);
                 continue;
             }
@@ -1253,7 +1251,7 @@ void Game::processQueuedMessages() {
                         current_screen_type = SCREEN_GAME;
                         // Processing must happen on next frame because need to close spell book and update
                         // drawing object list which is used to count actors for some spells
-                        engine->_messageQueue->addMessageNextFrame(UIMSG_CastSpellFromBook, std::to_underlying(selectedSpell), pParty->activeCharacterIndex() - 1);
+                        engine->_messageQueue->addMessageNextFrame(UIMSG_CastSpellFromBook, std::to_underlying(selectedSpell), pParty->activeCharacterIndex());
                     } else {
                         spellbookSelectedSpell = selectedSpell;
                     }
@@ -1675,7 +1673,7 @@ void Game::gameLoop() {
                                        // 0, 0x180u);//(pCharacterBuffs[0], 0, 384)
                     character.health = 1;
                 }
-                pParty->setActiveCharacterIndex(1);
+                pParty->setActiveCharacterIndex(0);
 
                 if (pParty->_questBits[QBIT_ESCAPED_EMERALD_ISLE]) {
                     pParty->pos = Vec3f(-17331, 12547, 465); // respawn in harmondale

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -179,10 +179,10 @@ void EngineController::goToInventory(int characterIndex) {
 
     goToGame();
 
-    if (pParty->activeCharacterIndex() != characterIndex) {
+    if (pParty->activeCharacterIndex() != characterIndex - 1) {
         pressAndReleaseKey(platformKeyForDigit(characterIndex));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex)
+        if (pParty->activeCharacterIndex() != characterIndex - 1)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 
@@ -367,10 +367,10 @@ void EngineController::castSpell(int characterIndex, SpellId spell) {
     if (GetCurrentMenuID() != MENU_NONE)
         throw Exception("Can't cast a spell from the main menu");
 
-    if (pParty->activeCharacterIndex() != characterIndex) {
+    if (pParty->activeCharacterIndex() != characterIndex - 1) {
         pressAndReleaseKey(platformKeyForDigit(characterIndex));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex)
+        if (pParty->activeCharacterIndex() != characterIndex - 1)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 
@@ -394,10 +394,10 @@ void EngineController::castQuickSpell(int characterIndex, SpellId spell) {
     if (GetCurrentMenuID() != MENU_NONE)
         throw Exception("Can't cast a spell from the main menu");
 
-    if (pParty->activeCharacterIndex() != characterIndex) {
+    if (pParty->activeCharacterIndex() != characterIndex - 1) {
         pressAndReleaseKey(platformKeyForDigit(characterIndex));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex)
+        if (pParty->activeCharacterIndex() != characterIndex - 1)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 

--- a/src/Engine/Components/Control/EngineController.cpp
+++ b/src/Engine/Components/Control/EngineController.cpp
@@ -175,14 +175,14 @@ void EngineController::goToGame() {
 }
 
 void EngineController::goToInventory(int characterIndex) {
-    assert(characterIndex >= 1 && characterIndex <= 4);
+    assert(characterIndex >= 0 && characterIndex < std::ssize(pParty->pCharacters));
 
     goToGame();
 
-    if (pParty->activeCharacterIndex() != characterIndex - 1) {
-        pressAndReleaseKey(platformKeyForDigit(characterIndex));
+    if (pParty->activeCharacterIndex() != characterIndex) {
+        pressAndReleaseKey(platformKeyForDigit(characterIndex + 1));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex - 1)
+        if (pParty->activeCharacterIndex() != characterIndex)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 
@@ -361,16 +361,16 @@ void EngineController::teleportTo(MapId map, Vec3f position, int viewYaw) {
 }
 
 void EngineController::castSpell(int characterIndex, SpellId spell) {
-    assert(characterIndex >= 1 && characterIndex <= 4);
+    assert(characterIndex >= 0 && characterIndex < std::ssize(pParty->pCharacters));
 
     goToGame();
     if (GetCurrentMenuID() != MENU_NONE)
         throw Exception("Can't cast a spell from the main menu");
 
-    if (pParty->activeCharacterIndex() != characterIndex - 1) {
-        pressAndReleaseKey(platformKeyForDigit(characterIndex));
+    if (pParty->activeCharacterIndex() != characterIndex) {
+        pressAndReleaseKey(platformKeyForDigit(characterIndex + 1));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex - 1)
+        if (pParty->activeCharacterIndex() != characterIndex)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 
@@ -388,20 +388,20 @@ void EngineController::castSpell(int characterIndex, SpellId spell) {
 }
 
 void EngineController::castQuickSpell(int characterIndex, SpellId spell) {
-    assert(characterIndex >= 1 && characterIndex <= 4);
+    assert(characterIndex >= 0 && characterIndex < std::ssize(pParty->pCharacters));
 
     goToGame();
     if (GetCurrentMenuID() != MENU_NONE)
         throw Exception("Can't cast a spell from the main menu");
 
-    if (pParty->activeCharacterIndex() != characterIndex - 1) {
-        pressAndReleaseKey(platformKeyForDigit(characterIndex));
+    if (pParty->activeCharacterIndex() != characterIndex) {
+        pressAndReleaseKey(platformKeyForDigit(characterIndex + 1));
         tick(1);
-        if (pParty->activeCharacterIndex() != characterIndex - 1)
+        if (pParty->activeCharacterIndex() != characterIndex)
             throw Exception("Couldn't activate character #{}", characterIndex);
     }
 
-    Character &character = pParty->pCharacters[characterIndex - 1];
+    Character &character = pParty->pCharacters[characterIndex];
     SpellId oldQuickSpell = character.uQuickSpell;
     character.uQuickSpell = spell;
     pressAndReleaseKey(PlatformKey::KEY_S);

--- a/src/Engine/Components/Control/EngineController.h
+++ b/src/Engine/Components/Control/EngineController.h
@@ -154,7 +154,7 @@ class EngineController {
      * Casts a spell through the quick spell mechanism. Unlike `castSpell`, quick spells don't open the targeting
      * interface, and just auto-target the closest actor.
      *
-     * @param characterIndex            1-based index of the casting character.
+     * @param characterIndex            0-based index of the casting character.
      * @param spell                     Spell to cast.
      */
     void castQuickSpell(int characterIndex, SpellId spell);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1145,7 +1145,7 @@ void _494035_timed_effects__water_walking_damage__etc(Duration dt) {
         }
 
         if (!pBuff->isGM) {
-            if (!pParty->pCharacters[pBuff->caster - 1].CanAct()) {
+            if (!pParty->pCharacters[pBuff->caster].CanAct()) {
                 pBuff->Reset();
                 if (buffIdx == PARTY_BUFF_FLY) {
                     pParty->bFlying = false;
@@ -1265,7 +1265,7 @@ void RegeneratePartyHealthMana() {
     // GM does not drain
     if (!engine->config->debug.AllMagic.value() && pParty->FlyActive() && !pParty->pPartyBuffs[PARTY_BUFF_FLY].isGM) {
         if (pParty->bFlying) {
-            int caster = pParty->pPartyBuffs[PARTY_BUFF_FLY].caster - 1;
+            int caster = pParty->pPartyBuffs[PARTY_BUFF_FLY].caster;
             pParty->pCharacters[caster].mana = std::max(0, pParty->pCharacters[caster].mana - ticks5);
         }
     }
@@ -1274,7 +1274,7 @@ void RegeneratePartyHealthMana() {
     // GM does not drain
     if (!engine->config->debug.AllMagic.value() && pParty->WaterWalkActive() && !pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGM) {
         if (pParty->uFlags & PARTY_FLAG_STANDING_ON_WATER) {
-            int caster = pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].caster - 1;
+            int caster = pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].caster;
 
             int ticksW = ticks5;
             // Vanilla bug: Water Walk drains mana with the same speed as Fly.

--- a/src/Engine/Graphics/Outdoor.cpp
+++ b/src/Engine/Graphics/Outdoor.cpp
@@ -919,7 +919,7 @@ void ODM_ProcessPartyActions() {
         waterWalkActive = true;
         engine->_persistentVariables.decorVars[20 * pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].overlayId + 119] |= 1;
         if (!pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGM &&
-            pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].caster - 1].mana <= 0)
+            pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].caster].mana <= 0)
             waterWalkActive = false;
     }
 
@@ -1003,7 +1003,7 @@ void ODM_ProcessPartyActions() {
                 pParty->bFlying = false;
                 if (engine->IsUnderwater() ||
                     pParty->pPartyBuffs[PARTY_BUFF_FLY].isGM ||
-                    (pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_FLY].caster - 1].mana > 0 || engine->config->debug.AllMagic.value())) {
+                    (pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_FLY].caster].mana > 0 || engine->config->debug.AllMagic.value())) {
                     if (pParty->sPartySavedFlightZ < engine->config->gameplay.MaxFlightHeight.value() || partyNotTouchingFloor) {
                         pParty->bFlying = true;
                         pParty->velocity.z = 0;
@@ -1218,7 +1218,7 @@ void ODM_ProcessPartyActions() {
             pParty->bFlying = false;
             if (engine->IsUnderwater() ||
                 pParty->pPartyBuffs[PARTY_BUFF_FLY].isGM ||
-                (pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_FLY].caster - 1].mana > 0 || engine->config->debug.AllMagic.value())) {
+                (pParty->pCharacters[pParty->pPartyBuffs[PARTY_BUFF_FLY].caster].mana > 0 || engine->config->debug.AllMagic.value())) {
                 partyOldFlightZ = pParty->pos.z;
                 partyInputSpeed.z = -pParty->walkSpeed * 4;
                 pParty->bFlying = true;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -1227,7 +1227,7 @@ void Actor::StealFrom(unsigned int uActorID) {
     LocationInfo *v6;  // esi@4
     Duration v8;              // [sp+8h] [bp-4h]@6
 
-    pPlayer = &pParty->pCharacters[pParty->activeCharacterIndex() - 1];
+    pPlayer = &pParty->pCharacters[pParty->activeCharacterIndex()];
     if (pPlayer->CanAct()) {
         CastSpellInfoHelpers::cancelSpellCastInProgress();
         if (engine->_currentLoadedMapId != MAP_INVALID)

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -289,7 +289,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.OrangeyRed);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -424,7 +424,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_SHIELD].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_SHIELD].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, -1);
             // Spell sound was missing from before
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -447,7 +447,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_STONESKIN].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_STONESKIN].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.Cioccolato);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -470,7 +470,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_BLESS].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_BLESS].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -493,7 +493,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_FATE].Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), masteryLevel, spellPower, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_FATE].Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), masteryLevel, spellPower, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -517,7 +517,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_HEROISM].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_HEROISM].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.RioGrande);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -525,7 +525,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
         case SPELL_BODY_HAMMERHANDS:
             // TODO(Nik-RE-dev): calculation of duration is strange
             actorPtr->buffs[ACTOR_BUFF_HAMMERHANDS]
-                .Apply(pParty->GetPlayingTime() + Duration::fromHours(realPoints), masteryLevel, realPoints, 0, 0);
+                .Apply(pParty->GetPlayingTime() + Duration::fromHours(realPoints), masteryLevel, realPoints, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.JazzberryJam);
             pAudioPlayer->playSound(SOUND_51heroism03, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -582,7 +582,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_DAY_OF_PROTECTION].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, spellPower, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_DAY_OF_PROTECTION].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, spellPower, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.White);
             pAudioPlayer->playSpellSound(uSpellID, false, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -606,7 +606,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     break;
             }
 
-            actorPtr->buffs[ACTOR_BUFF_HOUR_OF_POWER].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_HOUR_OF_POWER].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, realPoints + 5, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.White);
             pAudioPlayer->playSound(SOUND_9armageddon01, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -677,7 +677,7 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                     assert(false);
                     break;
             }
-            actorPtr->buffs[ACTOR_BUFF_PAIN_REFLECTION].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, 0);
+            actorPtr->buffs[ACTOR_BUFF_PAIN_REFLECTION].Apply(pParty->GetPlayingTime() + spellLength, masteryLevel, 0, 0, -1);
             spell_fx_renderer->sparklesOnActorAfterItCastsBuff(actorPtr, colorTable.MediumGrey);
             pAudioPlayer->playSound(SOUND_Sacrifice2, SOUND_MODE_PID, Pid(OBJECT_Actor, uActorID));
             break;
@@ -3184,7 +3184,7 @@ int Actor::DamageMonsterFromParty(Pid a1, unsigned int uActorID_Monster, const V
     if (hit_will_paralyze && pMonster->CanAct() &&
         pMonster->DoesDmgTypeDoDamage(DAMAGE_EARTH)) {
         CombinedSkillValue maceSkill = character->getActualSkillValue(SKILL_MACE);
-        pMonster->buffs[ACTOR_BUFF_PARALYZED].Apply(pParty->GetPlayingTime() + Duration::fromMinutes(maceSkill.level()), maceSkill.mastery(), 0, 0, 0);
+        pMonster->buffs[ACTOR_BUFF_PARALYZED].Apply(pParty->GetPlayingTime() + Duration::fromMinutes(maceSkill.level()), maceSkill.mastery(), 0, 0, -1);
         if (engine->config->settings.ShowHits.value()) {
             engine->_statusBar->setEvent(LSTR_S_PARALYZES_S, character->name, pMonster->GetDisplayName());
         }
@@ -4186,7 +4186,7 @@ void Spawn_Light_Elemental(int spell_power, Mastery caster_skill_mastery, Durati
         actor->summonerId = Pid(OBJECT_Character, spell_power);
 
         actor->buffs[ACTOR_BUFF_SUMMONED].Apply(pParty->GetPlayingTime() + duration,
-                                                caster_skill_mastery, spell_power, 0, 0);
+                                                caster_skill_mastery, spell_power, 0, -1);
     } else {
         actor->Remove();
     }

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6123,14 +6123,6 @@ void Character::OnInventoryLeftClick() {
             InventoryEntry enchantedItemPos = inventory.entry(inventoryPos);
 
             if (enchantedItemPos) {
-                /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
-                    *0x7Fu;
-                    *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                    *pParty->activeCharacterIndex() - 1;
-                    *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-                    *enchantedItemPos - 1;
-                    *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-                    *invMatrixIndex;*/
                 CastSpellInfo* pSpellInfo;
                 pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
                 pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -3125,36 +3125,36 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
 
             case ITEM_POTION_HASTE:
                 if (!playerAffected->conditions.has(CONDITION_WEAK)) {
-                    playerAffected->pCharacterBuffs[CHARACTER_BUFF_HASTE].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, 0);
+                    playerAffected->pCharacterBuffs[CHARACTER_BUFF_HASTE].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, -1);
                 }
                 break;
 
             case ITEM_POTION_HEROISM:
-                playerAffected->pCharacterBuffs[CHARACTER_BUFF_HEROISM].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, 0);
+                playerAffected->pCharacterBuffs[CHARACTER_BUFF_HEROISM].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, -1);
                 break;
 
             case ITEM_POTION_BLESS:
-                playerAffected->pCharacterBuffs[CHARACTER_BUFF_BLESS].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, 0);
+                playerAffected->pCharacterBuffs[CHARACTER_BUFF_BLESS].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, -1);
                 break;
 
             case ITEM_POTION_PRESERVATION:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_PRESERVATION].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_SHIELD:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_SHIELD].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_STONESKIN:
-                playerAffected->pCharacterBuffs[CHARACTER_BUFF_STONESKIN].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, 0);
+                playerAffected->pCharacterBuffs[CHARACTER_BUFF_STONESKIN].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, -1);
                 break;
 
             case ITEM_POTION_WATER_BREATHING:
-                playerAffected->pCharacterBuffs[CHARACTER_BUFF_WATER_WALK].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, 0);
+                playerAffected->pCharacterBuffs[CHARACTER_BUFF_WATER_WALK].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER, 5, 0, -1);
                 // Drink potion reaction was missing
                 break;
 
@@ -3173,37 +3173,37 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             case ITEM_POTION_MIGHT_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_STRENGTH].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_INTELLECT_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_INTELLIGENCE].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_PERSONALITY_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_PERSONALITY].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_ENDURANCE_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_ENDURANCE].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_SPEED_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_SPEED].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_ACCURACY_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_ACCURACY].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_CURE_PARALYSIS:
@@ -3236,43 +3236,43 @@ void Character::useItem(int targetCharacter, bool isPortraitClick) {
             case ITEM_POTION_LUCK_BOOST:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_LUCK].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_FIRE_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_FIRE].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_AIR_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_AIR].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_WATER_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_WATER].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_EARTH_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_EARTH].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_MIND_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_MIND].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_BODY_RESISTANCE:
                 // mastery was NONE
                 playerAffected->pCharacterBuffs[CHARACTER_BUFF_RESIST_BODY].Apply(pParty->GetPlayingTime() + buffDuration, MASTERY_MASTER,
-                        potionStrength * 3, 0, 0);
+                        potionStrength * 3, 0, -1);
                 break;
 
             case ITEM_POTION_STONE_TO_FLESH:

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -2018,7 +2018,7 @@ void Character::SetRecoveryTime(Duration rec) {
     if (rec > timeToRecovery) timeToRecovery = rec;
 
     if (pParty->hasActiveCharacter() && &pParty->activeCharacter() == this &&
-        !enchantingActiveCharacter)
+        enchantingActiveCharacter == -1)
         pParty->switchToNextActiveCharacter();
 }
 
@@ -5707,7 +5707,7 @@ void Character::SubtractSkillByEvent(Skill skill, uint16_t subSkillValue) {
 }
 
 int cycleCharacter(bool backwards) {
-    int currentId = pParty->activeCharacterIndex() - 1;
+    int currentId = pParty->activeCharacterIndex();
 
     for (int i = 0; i < pParty->pCharacters.size(); i++) {
         currentId += (backwards ? -1 : 1);
@@ -5718,7 +5718,7 @@ int cycleCharacter(bool backwards) {
             currentId = 0;
         }
         if (!pParty->pCharacters[currentId].timeToRecovery) {
-            return currentId + 1;
+            return currentId;
         }
     }
 
@@ -6134,7 +6134,7 @@ void Character::OnInventoryLeftClick() {
                 CastSpellInfo* pSpellInfo;
                 pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
                 pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
-                pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
+                pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex();
                 pSpellInfo->targetInventoryIndex = enchantedItemPos.index();
                 ptr_50C9A4_ItemToEnchant = enchantedItemPos.get();
                 IsEnchantingInProgress = false;
@@ -6367,11 +6367,11 @@ void Character::_42ECB5_CharacterAttacksActor() {
          melee_attack = false;
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
-        pushSpellOrRangedAttack(SPELL_BLASTER_PROJECTILE, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), ON_CAST_AutoTarget);
+        pushSpellOrRangedAttack(SPELL_BLASTER_PROJECTILE, pParty->activeCharacterIndex(), CombinedSkillValue::none(), ON_CAST_AutoTarget);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
-        pushSpellOrRangedAttack(spellForWand(wand_item_id), pParty->activeCharacterIndex() - 1, WANDS_SKILL_VALUE, ON_CAST_AutoTarget);
+        pushSpellOrRangedAttack(spellForWand(wand_item_id), pParty->activeCharacterIndex(), WANDS_SKILL_VALUE, ON_CAST_AutoTarget);
 
         // reduce wand charges
         if (!--main_hand->numCharges && engine->config->gameplay.DestroyDischargedWands.value()) {
@@ -6383,7 +6383,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
         Vec3f a3 = actor->pos - pParty->pos;
         a3.normalize();
 
-        Actor::DamageMonsterFromParty(Pid(OBJECT_Character, pParty->activeCharacterIndex() - 1),
+        Actor::DamageMonsterFromParty(Pid(OBJECT_Character, pParty->activeCharacterIndex()),
                                       target_id, a3);
         if (character->wearsItem(ITEM_ARTIFACT_SPLITTER))
             _42FA66_do_explosive_impact(actor->pos + Vec3f(0, 0, actor->height / 2), 0, 512, pParty->activeCharacterIndex());
@@ -6391,7 +6391,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
         shooting_bow = true;
         // TODO(captainurist): target_pid is ignored here - the arrow re-resolves its target in castSpell() with a
         //                     different fallback, so it can fly at a different actor than the one checked above.
-        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex(), CombinedSkillValue::none(), 0);
     } else {
         melee_attack = true;
         // actor out of range or no actor; no ranged weapon so melee attacking air
@@ -6468,12 +6468,7 @@ void Character::_42FA66_do_explosive_impact(Vec3f pos, int a4, int16_t a5, int a
     a1a.spell_target_pid = Pid();
     a1a.field_60_distance_related_prolly_lod = 0;
     a1a.uFacing = 0;
-
-    if (actchar >= 1 || actchar <= 4) {
-        a1a.spell_caster_pid = Pid(OBJECT_Character, actchar - 1);
-    } else {
-        a1a.spell_caster_pid = Pid();
-    }
+    a1a.spell_caster_pid = Pid(OBJECT_Character, actchar);
 
     int id = a1a.Create(0, 0, 0, 0);
     if (id != -1) {

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6442,6 +6442,8 @@ void Character::_42ECB5_CharacterAttacksActor() {
 
 //----- (0042FA66) --------------------------------------------------------
 void Character::_42FA66_do_explosive_impact(Vec3f pos, int a4, int16_t a5, int actchar) {
+    assert(actchar >= 0 && actchar < std::ssize(pParty->pCharacters));
+
         // EXPLOSIVE IMPACT OF ARTIFACT SPLITTER
 
     // a5 is range?

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -132,7 +132,7 @@ bool Chest::open(int uChestID, Pid objectPid) {
             pSpellObject.explosionTraps();
             chest->flags &= ~CHEST_TRAPPED;
             if (pParty->hasActiveCharacter() && !OpenedTelekinesis) {
-                pParty->setDelayedReaction(SPEECH_TRAP_EXPLODED, pParty->activeCharacterIndex() - 1);
+                pParty->setDelayedReaction(SPEECH_TRAP_EXPLODED, pParty->activeCharacterIndex());
             }
             OpenedTelekinesis = false;
             return false;

--- a/src/Engine/Objects/NPC.cpp
+++ b/src/Engine/Objects/NPC.cpp
@@ -167,7 +167,7 @@ int UseNPCSkill(NpcProfession profession, int id) {
             } else {
                 // Spell power was changed to 0 because it does not have meaning for this buff
                 pParty->pPartyBuffs[PARTY_BUFF_FLY]
-                    .Apply(pParty->GetPlayingTime() + Duration::fromHours(2), MASTERY_MASTER, 0, 0, 0);
+                    .Apply(pParty->GetPlayingTime() + Duration::fromHours(2), MASTERY_MASTER, 0, 0, -1);
                 // Mark buff as GM because NPC buff does not drain mana
                 pParty->pPartyBuffs[PARTY_BUFF_FLY].isGM = true;
                 pAudioPlayer->playSpellSound(SPELL_AIR_FLY, false, SOUND_MODE_UI);
@@ -176,7 +176,7 @@ int UseNPCSkill(NpcProfession profession, int id) {
 
         case WaterMaster: {
             pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK]
-                .Apply(pParty->GetPlayingTime() + Duration::fromHours(3), MASTERY_MASTER, 0, 0, 0);
+                .Apply(pParty->GetPlayingTime() + Duration::fromHours(3), MASTERY_MASTER, 0, 0, -1);
             // Mark buff as GM because NPC buff does not drain mana
             pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGM = true;
             pAudioPlayer->playSpellSound(SPELL_WATER_WATER_WALK, false, SOUND_MODE_UI);

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -641,7 +641,7 @@ bool SpriteObject::applyShrinkRayAoe() {
 
             if (distanceSq <= checkDistanceSq) {
                 if (actor.DoesDmgTypeDoDamage(DAMAGE_DARK)) {
-                    actor.buffs[ACTOR_BUFF_SHRINK].Apply(pParty->GetPlayingTime() + duration, this->spell_skill, shrinkPower, 0, 0);
+                    actor.buffs[ACTOR_BUFF_SHRINK].Apply(pParty->GetPlayingTime() + duration, this->spell_skill, shrinkPower, 0, -1);
                     actor.attributes |= ACTOR_AGGRESSOR;
                     isApplied = true;
                 }
@@ -1128,7 +1128,7 @@ bool processSpellImpact(unsigned int uLayingItemID, Pid pid) {
                         pActors[actorId].aiState = Standing;
                         pActors[actorId].UpdateAnimation();
                     }
-                    pActors[actorId].buffs[buffIdx].Apply(pParty->GetPlayingTime() + duration, skillMastery, shrinkPower, 0, 0);
+                    pActors[actorId].buffs[buffIdx].Apply(pParty->GetPlayingTime() + duration, skillMastery, shrinkPower, 0, -1);
                 }
             } else {
                 isDamaged = object->applyShrinkRayAoe();

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -205,7 +205,7 @@ Item Party::takeHoldingItem() {
 void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems entering shops
     for (int i = 0; i < this->pCharacters.size(); ++i) {
         if (this->pCharacters[i].CanAct()) {
-            _activeCharacter = i + 1;
+            _activeCharacterIndex = i;
             return;
         }
     }
@@ -216,17 +216,17 @@ void Party::setActiveToFirstCanAct() {  // added to fix some nzi problems enteri
 //----- (0049370F) --------------------------------------------------------
 void Party::switchToNextActiveCharacter() {
     // avoid switching away from char that can act
-    if (hasActiveCharacter() && this->pCharacters[_activeCharacter - 1].CanAct() &&
-        this->pCharacters[_activeCharacter - 1].timeToRecovery <= 0_ticks)
+    if (hasActiveCharacter() && this->pCharacters[_activeCharacterIndex].CanAct() &&
+        this->pCharacters[_activeCharacterIndex].timeToRecovery <= 0_ticks)
         return;
 
     if (pParty->bTurnBasedModeOn) {
         // The queue is not re-sorted until the turn ticks, so its head can be a character that just went down.
         if (pTurnEngine->turn_stage != TE_ATTACK || pTurnEngine->pQueue[0].uPackedID.type() != OBJECT_Character ||
             !pCharacters[pTurnEngine->pQueue[0].uPackedID.id()].CanAct()) {
-            _activeCharacter = 0;
+            _activeCharacterIndex = -1;
         } else {
-            _activeCharacter = pTurnEngine->pQueue[0].uPackedID.id() + 1;
+            _activeCharacterIndex = pTurnEngine->pQueue[0].uPackedID.id();
         }
         return;
     }
@@ -243,24 +243,24 @@ void Party::switchToNextActiveCharacter() {
             playerAlreadyPicked[i] = true;
             if (i > 0) { // TODO(_) check if this condition really should be here. it is
                 // equal to the original source but still seems kind of weird
-                _activeCharacter = i + 1;
+                _activeCharacterIndex = i;
                 return;
             }
             break;
         }
     }
 
-    int selectedChar = 0; // zero for none
+    int selectedChar = -1;
     int highestSpeed = 0;
     for (int i = 0; i < this->pCharacters.size(); i++) {
         if (this->pCharacters[i].CanAct() && !this->pCharacters[i].timeToRecovery) {
-            if (selectedChar == 0 || this->pCharacters[i]._statBonuses[ATTRIBUTE_SPEED] > highestSpeed) {
+            if (selectedChar == -1 || this->pCharacters[i]._statBonuses[ATTRIBUTE_SPEED] > highestSpeed) {
                 highestSpeed = this->pCharacters[i]._statBonuses[ATTRIBUTE_SPEED];
-                selectedChar = i + 1;
+                selectedChar = i;
             }
         }
     }
-    _activeCharacter = selectedChar;
+    _activeCharacterIndex = selectedChar;
     return;
 }
 
@@ -488,7 +488,7 @@ void Party::Reset() {
 
     bTurnBasedModeOn = false;
 
-    _activeCharacter = 1;
+    _activeCharacterIndex = 0;
 
     pCharacters[0].ChangeClass(CLASS_KNIGHT);
     pCharacters[0].uCurrentFace = 17;
@@ -942,7 +942,7 @@ bool Party::addItemToParty(Item *pItem, bool isSilent) {
     }
 
     if (!pItemTable->items[pItem->itemId].iconName.empty()) {
-        int playerId = hasActiveCharacter() ? pParty->_activeCharacter - 1 : 0;
+        int playerId = hasActiveCharacter() ? pParty->_activeCharacterIndex : 0;
         for (int i = 0; i < pCharacters.size(); i++, playerId++) {
             if (playerId >= pCharacters.size()) {
                 playerId = 0;

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -91,12 +91,12 @@ struct Party {
     Item takeHoldingItem();
 
     /**
-    * Sets _activeCharacter to the first character that can act
+    * Sets _activeCharacterIndex to the first character that can act
     * Added to fix some nzi access problems
     */
     void setActiveToFirstCanAct();
     /**
-    * Sets _activeCharacter to the first active (recoverd) character
+    * Sets _activeCharacterIndex to the first active (recoverd) character
     */
     void switchToNextActiveCharacter();
 
@@ -360,32 +360,30 @@ struct Party {
     std::array<bool, 4> playerAlreadyPicked = {{}};  // Was at offset 0xAE3368 in vanilla, we moved it into Party in OE.
 
     /**
-     * @return                          1-based index of currently active character. Zero means that there is no
-     *                                  active character.
+     * @return                          0-based index of the currently active character.
      */
     int activeCharacterIndex() const {
         assert(hasActiveCharacter());
-        return _activeCharacter;
+        return _activeCharacterIndex;
     }
 
     /**
-     * @param id                        1-based index of currently active character. Pass zero to make no one active.
+     * @param index                     0-based index of the character to make active. Pass `-1` to make no one active.
      */
-    void setActiveCharacterIndex(int id) {
-        assert(id >= 0 && id <= pCharacters.size());
-        _activeCharacter = id;
+    void setActiveCharacterIndex(int index) {
+        assert(index >= -1 && index < std::ssize(pCharacters));
+        _activeCharacterIndex = index;
     }
     bool hasActiveCharacter() const {
-        return _activeCharacter > 0;
+        return _activeCharacterIndex >= 0;
     }
     Character &activeCharacter() {
         assert(hasActiveCharacter());
-        return pCharacters[_activeCharacter - 1];
+        return pCharacters[_activeCharacterIndex];
     }
 
  private:
-     // TODO(pskelton): make 0-based with -1 for none??
-     int _activeCharacter = 0;  // which character is active - 1 based; 0 for none
+     int _activeCharacterIndex = -1; // -1 for none.
 };
 
 extern Party *pParty;  // idb

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -361,7 +361,8 @@ struct Party {
     std::array<bool, 4> playerAlreadyPicked = {{}};  // Was at offset 0xAE3368 in vanilla, we moved it into Party in OE.
 
     /**
-     * @return                          0-based index of the currently active character.
+     * @return                          0-based index of the active character. Asserts that there is one, so check
+     *                                  `hasActiveCharacter()` first.
      */
     int activeCharacterIndex() const {
         assert(hasActiveCharacter());

--- a/src/Engine/Party.h
+++ b/src/Engine/Party.h
@@ -91,13 +91,14 @@ struct Party {
     Item takeHoldingItem();
 
     /**
-    * Sets _activeCharacterIndex to the first character that can act
-    * Added to fix some nzi access problems
-    */
+     * Makes the first character that can act the active one.
+     */
     void setActiveToFirstCanAct();
+
     /**
-    * Sets _activeCharacterIndex to the first active (recoverd) character
-    */
+     * Picks the active character for the next action. Keeps the current one if it can act and has recovered,
+     * otherwise picks the next character that has, or no one if none has.
+     */
     void switchToNextActiveCharacter();
 
     /**
@@ -383,7 +384,7 @@ struct Party {
     }
 
  private:
-     int _activeCharacterIndex = -1; // -1 for none.
+    int _activeCharacterIndex = -1;
 };
 
 extern Party *pParty;  // idb

--- a/src/Engine/SaveLoad.cpp
+++ b/src/Engine/SaveLoad.cpp
@@ -77,7 +77,7 @@ void loadGame(std::string_view fileName) {
     // We always start in realtime after loading a game.
     pParty->bTurnBasedModeOn = false;
 
-    pParty->setActiveCharacterIndex(0);
+    pParty->setActiveCharacterIndex(-1);
     pParty->setActiveToFirstCanAct();
 
 /*

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -433,7 +433,7 @@ void snapshot(const SpellBuff &src, SpellBuff_MM7 *dst) {
     dst->power = src.power;
     dst->skillMastery = std::to_underlying(src.skillMastery);
     dst->overlayId = src.overlayId;
-    dst->caster = src.caster;
+    dst->caster = src.caster + 1;
     dst->isGM = src.isGM;
 }
 
@@ -442,7 +442,7 @@ void reconstruct(const SpellBuff_MM7 &src, SpellBuff *dst) {
     dst->power = src.power;
     dst->skillMastery = static_cast<Mastery>(src.skillMastery);
     dst->overlayId = src.overlayId;
-    dst->caster = src.caster;
+    dst->caster = src.caster - 1;
     dst->isGM = src.isGM;
 }
 

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -102,7 +102,7 @@ static void setSpellRecovery(CastSpellInfo *pCastSpell,
 
         pPlayer->SetRecoveryTime(recoveryTime);
 
-        if (!enchantingActiveCharacter) {
+        if (enchantingActiveCharacter == -1) {
             pTurnEngine->ApplyPlayerAction();
         }
     } else {
@@ -3180,7 +3180,7 @@ void pushSpellOrRangedAttack(SpellId spell,
 void pushTempleSpell(SpellId spell) {
     CombinedSkillValue skill_value = CombinedSkillValue(pParty->uCurrentDayOfMonth % 7 + 1, MASTERY_MASTER);
 
-    pushSpellOrRangedAttack(spell, pParty->activeCharacterIndex() - 1, skill_value,
+    pushSpellOrRangedAttack(spell, pParty->activeCharacterIndex(), skill_value,
                             ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell);
 }
 

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -343,7 +343,7 @@ void CastSpellInfoHelpers::castSpell() {
                             break;
                     }
                     pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT]
-                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -560,7 +560,7 @@ void CastSpellInfoHelpers::castSpell() {
                     if (pActors[monster_id].DoesDmgTypeDoDamage(DAMAGE_LIGHT)) {
                         Actor::AI_Stand(monster_id, Pid::character(0), 128_ticks, 0);
                         pActors[monster_id].buffs[ACTOR_BUFF_PARALYZED]
-                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(3 * spell_level), spell_mastery, 0, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(3 * spell_level), spell_mastery, 0, 0, -1);
                         pActors[monster_id].attributes |= ACTOR_AGGRESSOR;
                         pActors[monster_id].velocity.x = 0;
                         pActors[monster_id].velocity.y = 0;
@@ -605,7 +605,7 @@ void CastSpellInfoHelpers::castSpell() {
                     // v721 = 836 * spell_targeted_at.id();
                     int monster_id = spell_targeted_at.id();
                     if (pActors[monster_id].DoesDmgTypeDoDamage(DAMAGE_EARTH)) {
-                        pActors[monster_id].buffs[ACTOR_BUFF_SLOWED].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                        pActors[monster_id].buffs[ACTOR_BUFF_SLOWED].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                         pActors[monster_id].attributes |= ACTOR_AGGRESSOR;
                         spell_fx_renderer->sparklesOnActorAfterItCastsBuff(&pActors[monster_id], Color()); // TODO(captainurist): why transparent black?
                     }
@@ -648,7 +648,7 @@ void CastSpellInfoHelpers::castSpell() {
 
                         pActors[monster_id].buffs[ACTOR_BUFF_BERSERK].Reset();
                         pActors[monster_id].buffs[ACTOR_BUFF_ENSLAVED].Reset();
-                        pActors[monster_id].buffs[ACTOR_BUFF_CHARM].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                        pActors[monster_id].buffs[ACTOR_BUFF_CHARM].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                         initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                         pSpellSprite.vPosition = pActors[monster_id].pos + Vec3f(0, 0, pActors[monster_id].height);
                         pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -762,7 +762,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                     pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_REGENERATION]
-                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -800,7 +800,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
 
-                    pParty->pPartyBuffs[resist].Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, 0);
+                    pParty->pPartyBuffs[resist].Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -837,7 +837,7 @@ void CastSpellInfoHelpers::castSpell() {
                         spellFailed(pCastSpell, LSTR_SPELL_FAILED);
                         continue;
                     }
-                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     break;
                 }
@@ -865,11 +865,11 @@ void CastSpellInfoHelpers::castSpell() {
                     if (spell_mastery == MASTERY_NOVICE) {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                         pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_BLESS]
-                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     } else {
                         for (size_t i = 0; i < pParty->pCharacters.size(); i++) {
                             pParty->pCharacters[i].pCharacterBuffs[CHARACTER_BUFF_BLESS]
-                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                         }
                         spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     }
@@ -943,7 +943,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[buff]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -966,7 +966,7 @@ void CastSpellInfoHelpers::castSpell() {
 
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_level, 0, pCastSpell->casterCharacterIndex + 1);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_level, 0, pCastSpell->casterCharacterIndex);
                     break;
                 }
 
@@ -1034,7 +1034,7 @@ void CastSpellInfoHelpers::castSpell() {
                 case SPELL_AIR_WIZARD_EYE:
                 {
                     pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE]
-                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, 0, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, 0, 0, -1);
                     break;
                 }
 
@@ -1059,7 +1059,7 @@ void CastSpellInfoHelpers::castSpell() {
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
 
                     pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     break;
                 }
 
@@ -1147,7 +1147,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -1166,7 +1166,7 @@ void CastSpellInfoHelpers::castSpell() {
                     pParty->pPartyBuffs[PARTY_BUFF_FLY].Apply(
                         pParty->GetPlayingTime() + Duration::fromHours(spell_level),
                             spell_mastery, 0, 0,
-                            pCastSpell->casterCharacterIndex + 1);
+                            pCastSpell->casterCharacterIndex);
                     pParty->pPartyBuffs[PARTY_BUFF_FLY].isGM = (spell_mastery == MASTERY_GRANDMASTER);
                     break;
                 }
@@ -1326,7 +1326,7 @@ void CastSpellInfoHelpers::castSpell() {
 
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, pCastSpell->casterCharacterIndex + 1);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, pCastSpell->casterCharacterIndex);
                     pParty->pPartyBuffs[PARTY_BUFF_WATER_WALK].isGM = (spell_mastery == MASTERY_GRANDMASTER);
                     break;
                 }
@@ -1627,7 +1627,7 @@ void CastSpellInfoHelpers::castSpell() {
 
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_DETECT_LIFE]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     break;
                 }
 
@@ -1654,11 +1654,11 @@ void CastSpellInfoHelpers::castSpell() {
                     if (!pCastSpell->targetPid) {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                         pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_FATE]
-                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), spell_mastery, spell_power, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), spell_mastery, spell_power, 0, -1);
                     } else if (pCastSpell->targetPid.type() == OBJECT_Actor) {
                         int monster_id = pCastSpell->targetPid.id();
                         pActors[monster_id].buffs[ACTOR_BUFF_FATE]
-                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), spell_mastery, spell_power, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + Duration::fromMinutes(5), spell_mastery, spell_power, 0, -1);
                         pActors[monster_id].attributes |= ACTOR_AGGRESSOR;
                         spell_fx_renderer->sparklesOnActorAfterItCastsBuff(&pActors[monster_id], Color()); // TODO(captainurist): why transparent black?
                     }
@@ -1720,11 +1720,11 @@ void CastSpellInfoHelpers::castSpell() {
                     if (spell_mastery == MASTERY_NOVICE || spell_mastery == MASTERY_EXPERT) {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                         pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_PRESERVATION]
-                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     } else {
                         for (Character &character : pParty->pCharacters) {
                             character.pCharacterBuffs[CHARACTER_BUFF_PRESERVATION]
-                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                         }
                         spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     }
@@ -1759,7 +1759,7 @@ void CastSpellInfoHelpers::castSpell() {
                             pSpellSprite.vPosition = actor->pos - Vec3f(0, 0, actor->height * -0.8);
                             pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
                             pSpellSprite.Create(0, 0, 0, 0);
-                            actor->buffs[ACTOR_BUFF_AFRAID].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                            actor->buffs[ACTOR_BUFF_AFRAID].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                         }
                     }
                     spell_fx_renderer->FadeScreen__like_Turn_Undead_and_mb_Armageddon(colorTable.White, 192_ticks);
@@ -2036,7 +2036,7 @@ void CastSpellInfoHelpers::castSpell() {
                         pActors[monster_id].buffs[ACTOR_BUFF_CHARM].Reset();
                         pActors[monster_id].buffs[ACTOR_BUFF_ENSLAVED].Reset();
                         pActors[monster_id].buffs[ACTOR_BUFF_BERSERK]
-                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                         pActors[monster_id].monsterInfo.hostilityType = HOSTILITY_LONG;
                     }
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
@@ -2073,7 +2073,7 @@ void CastSpellInfoHelpers::castSpell() {
                         pActors[monster_id].buffs[ACTOR_BUFF_BERSERK].Reset();
                         pActors[monster_id].buffs[ACTOR_BUFF_CHARM].Reset();
                         pActors[monster_id].buffs[ACTOR_BUFF_ENSLAVED]
-                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     }
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pActors[monster_id].pos + Vec3f(0, 0, pActors[monster_id].height);
@@ -2113,7 +2113,7 @@ void CastSpellInfoHelpers::castSpell() {
                             pSpellSprite.spell_target_pid = Pid(OBJECT_Actor, actor->id);
                             pSpellSprite.Create(0, 0, 0, 0);
                             if (actor->DoesDmgTypeDoDamage(DAMAGE_MIND)) {
-                                actor->buffs[ACTOR_BUFF_AFRAID].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                                actor->buffs[ACTOR_BUFF_AFRAID].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                             }
                         }
                     }
@@ -2359,7 +2359,7 @@ void CastSpellInfoHelpers::castSpell() {
                 {
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_PROTECTION_FROM_MAGIC]
-                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, 0, -1);
                     break;
                 }
 
@@ -2369,12 +2369,12 @@ void CastSpellInfoHelpers::castSpell() {
                         spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                         for (Character &character : pParty->pCharacters) {
                             character.pCharacterBuffs[CHARACTER_BUFF_HAMMERHANDS]
-                                .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, spell_level, 0);
+                                .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, spell_level, -1);
                         }
                     } else {
                     spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                     pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_HAMMERHANDS]
-                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, spell_level, 0);
+                        .Apply(pParty->GetPlayingTime() + Duration::fromHours(spell_level), spell_mastery, spell_level, spell_level, -1);
                     }
                     break;
                 }
@@ -2471,7 +2471,7 @@ void CastSpellInfoHelpers::castSpell() {
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     break;
                 }
 
@@ -2514,16 +2514,16 @@ void CastSpellInfoHelpers::castSpell() {
                             break;
                     }
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_BODY].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_MIND].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_FIRE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_WATER].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_AIR].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_RESIST_EARTH].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     // Spell power for Feather fall and Wizard eye was "spell_level + 5"
                     // Changed it to 0 because spell power isn't used for these spells.
-                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
-                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                    pParty->pPartyBuffs[PARTY_BUFF_FEATHER_FALL].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
+                    pParty->pPartyBuffs[PARTY_BUFF_WIZARD_EYE].Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     break;
                 }
 
@@ -2566,7 +2566,7 @@ void CastSpellInfoHelpers::castSpell() {
                     bool player_weak = false;
                     for (Character &character : pParty->pCharacters) {
                        character.pCharacterBuffs[CHARACTER_BUFF_BLESS]
-                            .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, -1);
                         if (character.conditions.has(CONDITION_WEAK)) {
                             player_weak = true;
                         }
@@ -2574,15 +2574,15 @@ void CastSpellInfoHelpers::castSpell() {
                     spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
 
                     pParty->pPartyBuffs[PARTY_BUFF_HEROISM]
-                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, -1);
                     pParty->pPartyBuffs[PARTY_BUFF_SHIELD]
-                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, 0, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, 0, 0, -1);
                     pParty->pPartyBuffs[PARTY_BUFF_STONE_SKIN]
-                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + other_duration, spell_mastery, target_skill_level, 0, -1);
                     if (!player_weak) {
                         // Spell power was changed to 0 because it is not used in Haste buff
                         pParty->pPartyBuffs[PARTY_BUFF_HASTE]
-                            .Apply(pParty->GetPlayingTime() + haste_duration, spell_mastery, 0, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + haste_duration, spell_mastery, 0, 0, -1);
                     }
                     break;
                 }
@@ -2759,7 +2759,7 @@ void CastSpellInfoHelpers::castSpell() {
                     pActors[monster_id].buffs[ACTOR_BUFF_BERSERK].Reset();
                     pActors[monster_id].buffs[ACTOR_BUFF_CHARM].Reset();
                     pActors[monster_id].buffs[ACTOR_BUFF_ENSLAVED]
-                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, 0);
+                        .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, 0, 0, -1);
                     initSpellSprite(&pSpellSprite, spell_level, spell_mastery, pCastSpell);
                     pSpellSprite.vPosition = pActors[monster_id].pos + Vec3f(0, 0, pActors[monster_id].height);
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
@@ -2829,11 +2829,11 @@ void CastSpellInfoHelpers::castSpell() {
                     if (spell_mastery != MASTERY_MASTER && spell_mastery != MASTERY_GRANDMASTER) {
                         spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->targetCharacterIndex);
                         pParty->pCharacters[pCastSpell->targetCharacterIndex].pCharacterBuffs[CHARACTER_BUFF_PAIN_REFLECTION]
-                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                            .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                     } else {
                         for (Character &character : pParty->pCharacters) {
                             character.pCharacterBuffs[CHARACTER_BUFF_PAIN_REFLECTION]
-                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, 0);
+                                .Apply(pParty->GetPlayingTime() + spell_duration, spell_mastery, spell_power, 0, -1);
                         }
                         spell_fx_renderer->SetPartyBuffAnim(pCastSpell->uSpellID);
                     }

--- a/src/Engine/Spells/SpellBuff.h
+++ b/src/Engine/Spells/SpellBuff.h
@@ -9,10 +9,10 @@ struct SpellBuff {
     /**
      * @offset 0x4584E0
      * TODO(pskelton): check for inconsistent use of caster
-     * caster = 0 for external source (potion / npc), 1 based for party character index
+     * caster is the 0-based party character index, or -1 for an external source like a potion or an npc
      */
     bool Apply(Time time, Mastery uSkillMastery,
-               int uPower, int uOverlayID, uint8_t caster);
+               int uPower, int uOverlayID, int caster);
 
     /**
      * @offset 0x458585
@@ -43,6 +43,6 @@ struct SpellBuff {
     uint16_t power = 0; // Spell power, semantics are spell-specific.
     Mastery skillMastery = MASTERY_NONE;
     uint16_t overlayId = 0;
-    uint8_t caster = 0; // 1-based character index.
+    int caster = -1; // -1 when the buff came from a potion or an npc.
     bool isGM = false; // Buff was casted at grandmaster mastery
 };

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -440,7 +440,7 @@ void SpellBuff::Reset() {
     skillMastery = MASTERY_NONE;
     power = 0;
     expireTime = Time();
-    caster = 0;
+    caster = -1;
     isGM = false;
     if (overlayId) {
         pActiveOverlayList->pOverlays[overlayId - 1].Reset();
@@ -461,7 +461,7 @@ bool SpellBuff::IsBuffExpiredToTime(Time time) {
 
 bool SpellBuff::Apply(Time expire_time, Mastery uSkillMastery,
                       int uPower, int uOverlayID,
-                      uint8_t caster) {
+                      int caster) {
     // For bug catching
     assert(uSkillMastery >= MASTERY_NOVICE && uSkillMastery <= MASTERY_GRANDMASTER);
 
@@ -688,7 +688,7 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
                     return;
                 }
             }
-            pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, 0, 0, 0);
+            pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, 0, 0, -1);
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],
             //    0, 0, fromx, fromy, 0, 0, 0);
@@ -725,7 +725,7 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
                 buff_id = PARTY_BUFF_HEROISM;
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
-            pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, 0);
+            pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, -1);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],
             //    0, 0, fromx, fromy, 0, 0, 0);
             //    Pid was 0
@@ -738,7 +738,7 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
                 spell_length = Duration::fromMinutes(skillLevel);
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
-            pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, skillLevel, 0, 0);
+            pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, skillLevel, 0, -1);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],
             //    0, 0, fromx, fromy, 0, 0, 0);
             //    Pid was 0
@@ -769,7 +769,7 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
             }
 
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
-            pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, 0);
+            pParty->pPartyBuffs[buff_id].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, -1);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],
             //    0, 0, fromx, fromy, 0, 0, 0);
             //    Pid was 0
@@ -795,7 +795,7 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
             }
             spell_fx_renderer->SetPartyBuffAnim(uSpellID);
 
-            pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, 0);
+            pParty->pPartyBuffs[PARTY_BUFF_DAY_OF_GODS].Apply(pParty->GetPlayingTime() + spell_length, skillMastery, spell_power, 0, -1);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],
             //    0, 0, fromx, fromy, 0, 0, 0);
             //    Pid was 0

--- a/src/Engine/TurnEngine/TurnEngine.cpp
+++ b/src/Engine/TurnEngine/TurnEngine.cpp
@@ -80,10 +80,10 @@ void stru262_TurnBased::SortTurnQueue() {
         return; // All characters are dead & no monsters around.
 
     if (pQueue[0].uPackedID.type() == OBJECT_Character) {  // we have player at queue top
-        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id() + 1);
+        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id());
         flags |= TE_PLAYER_TURN;
     } else {
-        pParty->setActiveCharacterIndex(0);
+        pParty->setActiveCharacterIndex(-1);
         flags &= ~TE_PLAYER_TURN;
     }
     for (i = 0; i < this->pQueue.size(); ++i) {
@@ -369,9 +369,9 @@ void stru262_TurnBased::NextTurn() {
 
     SortTurnQueue();
     if (pQueue[0].uPackedID.type() == OBJECT_Character)
-        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id() + 1);
+        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id());
     else
-        pParty->setActiveCharacterIndex(0);
+        pParty->setActiveCharacterIndex(-1);
 
     if (pending_actions) {
         pTurnEngine->flags |= TE_HAVE_PENDING_ACTIONS;
@@ -498,9 +498,9 @@ void stru262_TurnBased::_406457(int a2) {
     pQueue[a2].actor_initiative = v6.ticks();
     SortTurnQueue();
     if (pQueue[0].uPackedID.type() == OBJECT_Character)
-        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id() + 1);
+        pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id());
     else
-        pParty->setActiveCharacterIndex(0);
+        pParty->setActiveCharacterIndex(-1);
     while ((pQueue[0].actor_initiative > 0) && (turn_initiative > 0)) {
         for (i = 0; i < this->pQueue.size(); ++i) {
             --pQueue[i].actor_initiative;
@@ -551,9 +551,9 @@ void stru262_TurnBased::_4065B0() {
     } else {
         StepTurnQueue();
         if (pQueue[0].uPackedID.type() == OBJECT_Character)
-            pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id() + 1);
+            pParty->setActiveCharacterIndex(pQueue[0].uPackedID.id());
         else
-            pParty->setActiveCharacterIndex(0);
+            pParty->setActiveCharacterIndex(-1);
     }
     for (int i = 0; i < this->pQueue.size(); ++i)
         AIAttacks(i);
@@ -756,7 +756,7 @@ void stru262_TurnBased::ActorAISetMovementDecision() {
     int i;
 
     this->ai_turn_timer = 64_ticks;
-    pParty->setActiveCharacterIndex(0);
+    pParty->setActiveCharacterIndex(-1);
     for (i = 0; i < this->pQueue.size(); ++i) {
         if (pQueue[i].uPackedID.type() == OBJECT_Actor) {
             Pid target_pid =

--- a/src/Engine/mm7_data.cpp
+++ b/src/Engine/mm7_data.cpp
@@ -2254,9 +2254,9 @@ int KeyboardPageNum;
 Color uGameUIFontShadow;
 Color uGameUIFontMain;
 SpellId dword_507B00_spell_info_to_draw_in_popup;
-int dword_507CC0_activ_ch;
+int dword_507CC0_activ_ch = -1;
 bool OpenedTelekinesis;
-int enchantingActiveCharacter;
+int enchantingActiveCharacter = -1;
 int uSpriteID_Spell11;  // idb
 bool IsEnchantingInProgress;
 Duration ItemEnchantmentTimer;

--- a/src/GUI/GUIWindow.cpp
+++ b/src/GUI/GUIWindow.cpp
@@ -397,10 +397,10 @@ GUIButton *GUIWindow::CreateButton(std::string id, Pointi position, Sizei dimens
 }
 
 void GUIWindow::CreateCharacterButtons() {
-    CreateButton("Game_Character1", { 61, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 1, INPUT_ACTION_SELECT_CHAR_1);  // buttons for portraits
-    CreateButton("Game_Character2", { 177, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 2, INPUT_ACTION_SELECT_CHAR_2);
-    CreateButton("Game_Character3", { 292, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 3, INPUT_ACTION_SELECT_CHAR_3);
-    CreateButton("Game_Character4", { 407, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 4, INPUT_ACTION_SELECT_CHAR_4);
+    CreateButton("Game_Character1", { 61, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 0, INPUT_ACTION_SELECT_CHAR_1);  // buttons for portraits
+    CreateButton("Game_Character2", { 177, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 1, INPUT_ACTION_SELECT_CHAR_2);
+    CreateButton("Game_Character3", { 292, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 2, INPUT_ACTION_SELECT_CHAR_3);
+    CreateButton("Game_Character4", { 407, 424 }, { 31, 40 }, BUTTON_TYPE_CHARACTER, 94, UIMSG_SelectCharacter, 3, INPUT_ACTION_SELECT_CHAR_4);
 
     CreateButton({ pHealthBarPos[0], pHealthManaBarYPos }, { 5, 49 }, BUTTON_TYPE_NORMAL, UIMSG_ShowStatus_ManaHP, UIMSG_0, 1);  // buttons for HP
     CreateButton({ pHealthBarPos[1], pHealthManaBarYPos }, { 5, 49 }, BUTTON_TYPE_NORMAL, UIMSG_ShowStatus_ManaHP, UIMSG_0, 2);

--- a/src/GUI/UI/Houses/MagicGuild.cpp
+++ b/src/GUI/UI/Houses/MagicGuild.cpp
@@ -201,7 +201,7 @@ void GUIWindow_MagicGuild::buyBooksDialogue() {
                 if (pt.x >= testpos && pt.x <= testpos + (shop_ui_items_in_store[testx]->width())) {
                     if ((pt.y >= 90 && pt.y <= (90 + (shop_ui_items_in_store[testx]->height()))) || (pt.y >= 250 && pt.y <= (250 + (shop_ui_items_in_store[testx]->height())))) {
                         MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, HOUSE_TYPE_MAGIC_SHOP, houseId(), SHOP_SCREEN_BUY);
-                        std::string str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                        std::string str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                         int textHeight = assets->pFontArrus->CalcTextHeight(str, working_window.w, 0);
                         DrawTitleText(assets->pFontArrus.get(), 0, (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - textHeight) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET, colorTable.White, str, 3, working_window);
                         return;

--- a/src/GUI/UI/Houses/Shops.cpp
+++ b/src/GUI/UI/Houses/Shops.cpp
@@ -293,7 +293,7 @@ void GUIWindow_Shop::sellDialogue() {
 
         if (InventoryEntry entry = pParty->activeCharacter().inventory.entry(gridPos)) {
             MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(entry.get(), buildingType(), houseId(), SHOP_SCREEN_SELL);
-            std::string str = BuildDialogueString(pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, entry.get(), houseId(), SHOP_SCREEN_SELL);
+            std::string str = BuildDialogueString(pMerchantsSellPhrases[phrases_id], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, entry.get(), houseId(), SHOP_SCREEN_SELL);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3, dialogwin);
         }
@@ -323,9 +323,9 @@ void GUIWindow_Shop::identifyDialogue() {
             std::string str;
             if (!item->IsIdentified()) {
                 MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_IDENTIFY);
-                str = BuildDialogueString(pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
+                str = BuildDialogueString(pMerchantsIdentifyPhrases[phrases_id], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
             } else {
-                str = BuildDialogueString("%24", pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
+                str = BuildDialogueString("%24", pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_IDENTIFY);
             }
 
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
@@ -359,7 +359,7 @@ void GUIWindow_Shop::repairDialogue() {
         if (entry->flags & ITEM_BROKEN) {
             Item *item = entry.get();
             MerchantPhrase phrases_id = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_REPAIR);
-            std::string str = BuildDialogueString(pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_REPAIR);
+            std::string str = BuildDialogueString(pMerchantsRepairPhrases[phrases_id], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_REPAIR);
             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
             DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3, dialogwin);
         }
@@ -417,9 +417,9 @@ void GUIWindow_WeaponShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, HOUSE_TYPE_WEAPON_SHOP, houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3, dialogwin);
@@ -504,9 +504,9 @@ void GUIWindow_ArmorShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3, dialogwin);
@@ -607,9 +607,9 @@ void GUIWindow_MagicAlchemyShop::shopWaresDialogue(bool isSpecial) {
                             std::string str;
                             if (!isStealingModeActive()) {
                                 MerchantPhrase phrase = pParty->activeCharacter().SelectPhrasesTransaction(item, buildingType(), houseId(), SHOP_SCREEN_BUY);
-                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(pMerchantsBuyPhrases[phrase], pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             } else {
-                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex() - 1, houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
+                                str = BuildDialogueString(localization->str(LSTR_STEAL_24), pParty->activeCharacterIndex(), houseNpcs[currentHouseNpc].npc, item, houseId(), SHOP_SCREEN_BUY);
                             }
                             int vertMargin = (SIDE_TEXT_BOX_BODY_TEXT_HEIGHT - assets->pFontArrus->CalcTextHeight(str, dialogwin.w, 0)) / 2 + SIDE_TEXT_BOX_BODY_TEXT_OFFSET;
                             DrawTitleText(assets->pFontArrus.get(), 0, vertMargin, colorTable.White, str, 3, dialogwin);

--- a/src/GUI/UI/Houses/Temple.cpp
+++ b/src/GUI/UI/Houses/Temple.cpp
@@ -49,7 +49,7 @@ void GUIWindow_Temple::healDialogue() {
                 pParty->activeCharacter().uPrevVoiceID = pParty->activeCharacter().uVoiceID;
                 pParty->activeCharacter().uVoiceID = (pParty->activeCharacter().GetSexByVoice() != SEX_MALE) + 23;
                 pParty->activeCharacter().uCurrentFace = (pParty->activeCharacter().GetSexByVoice() != SEX_MALE) + 23;
-                GameUI_ReloadPlayerPortraits(pParty->activeCharacterIndex() - 1, (pParty->activeCharacter().GetSexByVoice() != SEX_MALE) + 23);
+                GameUI_ReloadPlayerPortraits(pParty->activeCharacterIndex(), (pParty->activeCharacter().GetSexByVoice() != SEX_MALE) + 23);
                 setZombie = true;
             }
         }
@@ -57,7 +57,7 @@ void GUIWindow_Temple::healDialogue() {
         if (pParty->activeCharacter().conditions.has(CONDITION_ZOMBIE)) {
             pParty->activeCharacter().uCurrentFace = pParty->activeCharacter().uPrevFace;
             pParty->activeCharacter().uVoiceID = pParty->activeCharacter().uPrevVoiceID;
-            GameUI_ReloadPlayerPortraits(pParty->activeCharacterIndex() - 1, pParty->activeCharacter().uPrevFace);
+            GameUI_ReloadPlayerPortraits(pParty->activeCharacterIndex(), pParty->activeCharacter().uPrevFace);
         }
     }
 
@@ -83,7 +83,7 @@ void GUIWindow_Temple::donateDialogue() {
             ddm->reputation -= 1;
         }
         int day = pParty->uCurrentDayOfMonth % 7;
-        int counter = _templeSpellCounter[pParty->activeCharacterIndex() - 1] % 7;
+        int counter = _templeSpellCounter[pParty->activeCharacterIndex()] % 7;
         if (counter == day) {
             if (ddm->reputation <= -5) {
                 pushTempleSpell(SPELL_AIR_WIZARD_EYE);
@@ -101,7 +101,7 @@ void GUIWindow_Temple::donateDialogue() {
                 pushTempleSpell(SPELL_LIGHT_DAY_OF_PROTECTION);
             }
         }
-        _templeSpellCounter[pParty->activeCharacterIndex() - 1]++;
+        _templeSpellCounter[pParty->activeCharacterIndex()]++;
         pParty->activeCharacter().playReaction(SPEECH_TEMPLE_DONATE);
         engine->_statusBar->setEvent(LSTR_THANK_YOU);
     } else {

--- a/src/GUI/UI/Houses/Training.cpp
+++ b/src/GUI/UI/Houses/Training.cpp
@@ -72,7 +72,7 @@ void GUIWindow_Training::trainDialogue() {
                 pParty->activeCharacter().health = pParty->activeCharacter().GetMaxHealth();
                 pParty->activeCharacter().mana = pParty->activeCharacter().GetMaxMana();
                 int maxLevelStepsBefore = *std::max_element(_charactersTrainedLevels.begin(), _charactersTrainedLevels.end());
-                _charactersTrainedLevels[pParty->activeCharacterIndex() - 1]++;
+                _charactersTrainedLevels[pParty->activeCharacterIndex()]++;
                 int maxLevelStepsAfter = *std::max_element(_charactersTrainedLevels.begin(), _charactersTrainedLevels.end());
                 if (maxLevelStepsAfter > maxLevelStepsBefore) {
                     Duration trainingTime = timeUntilDawn() + Duration::fromHours(4);

--- a/src/GUI/UI/Houses/Transport.cpp
+++ b/src/GUI/UI/Houses/Transport.cpp
@@ -102,7 +102,7 @@ void GUIWindow_Transport::mainDialogue() {
     travel_window.x = SIDE_TEXT_BOX_POS_X;
     travel_window.w = SIDE_TEXT_BOX_WIDTH;
 
-    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->activeCharacterIndex() = 0 and crash
+    assert(pParty->hasActiveCharacter());
 
     if (!checkIfPlayerCanInteract()) {
         return;
@@ -194,7 +194,7 @@ void GUIWindow_Transport::transportDialogue() {
 }
 
 void GUIWindow_Transport::houseSpecificDialogue() {
-    assert(pParty->hasActiveCharacter()); // code in this function couldn't handle pParty->activeCharacterIndex() = 0 and crash
+    assert(pParty->hasActiveCharacter());
 
     switch (_currentDialogue) {
       case DIALOGUE_MAIN:

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -45,18 +45,18 @@ static void CharacterUI_DrawItem(int x, int y, Item *item, int id, GraphicsImage
 /**
  * Prepare textures of character doll with wetsuit on.
  *
- * @param uPlayerID     ID of player, 1-based.
+ * @param characterIndex                0-based index of the character.
  * @offset 0x43EF2B
  */
-static void WetsuitOn(int uPlayerID);
+static void WetsuitOn(int characterIndex);
 
 /**
  * Prepare textures of character doll with wetsuit off.
  *
- * @param uPlayerID     ID of player, 1-based.
+ * @param characterIndex                0-based index of the character.
  * @offset 0x43F0BD
  */
-static void WetsuitOff(int uPlayerID);
+static void WetsuitOff(int characterIndex);
 
 HitMap<int> equipmentHitMap;
 
@@ -1358,9 +1358,9 @@ void CharacterUI_LoadPaperdollTextures() {
 
     for (int i = 0; i < pParty->pCharacters.size(); ++i) {
         if (pParty->pCharacters[i].hasUnderwaterSuitEquipped()) {
-            WetsuitOn(i + 1);
+            WetsuitOn(i);
         } else {
-            WetsuitOff(i + 1);
+            WetsuitOff(i);
         }
     }
 
@@ -1417,7 +1417,7 @@ void GUIWindow_CharacterRecord::CharacterUI_SkillsTab_CreateButtons() {
     Skill skill;
 
     int buttons_count = 0;
-    if (dword_507CC0_activ_ch) CharacterUI_ReleaseButtons();
+    if (dword_507CC0_activ_ch != -1) CharacterUI_ReleaseButtons();
     dword_507CC0_activ_ch = pParty->activeCharacterIndex();
     for (GUIButton *pButton : pGUIWindow_CurrentMenu->vButtons) {
         if (pButton->msg == UIMSG_InventoryLeftClick) {
@@ -1653,49 +1653,43 @@ void GUIWindow_CharacterRecord::fillAwardsData() {
     }
 }
 
-void WetsuitOn(int uPlayerID) {
-    if (uPlayerID > 0) {
-        int playerId0 = uPlayerID - 1;
-        Character *player = &pParty->pCharacters[playerId0];
-        int texture_num;
+void WetsuitOn(int characterIndex) {
+    Character *player = &pParty->pCharacters[characterIndex];
+    int texture_num;
 
-        if (player->GetRace() == RACE_DWARF) {
-            texture_num = (player->GetSexByVoice() != SEX_MALE) + 3;
-        } else {
-            texture_num = (player->GetSexByVoice() != SEX_MALE) + 1;
-        }
-        paperdoll_dbods[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}Bod", texture_num));  // Body texture
-        paperdoll_dlads[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}lad", texture_num));  // Left Hand
-        paperdoll_dlaus[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}lau", texture_num));  // Left Hand2
-        paperdoll_drhs[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}rh", texture_num));  // Right Hand
-        paperdoll_dlhs[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}lh", texture_num));  // Left Palm
-        paperdoll_dlhus[playerId0] = assets->getImage_Alpha(fmt::format("pc23v{}lhu", texture_num));  // Left Fist
-
-        if (player->uCurrentFace == 12 || player->uCurrentFace == 13) {
-            paperdoll_dbrds[player->uCurrentFace] = nullptr;
-        }
-        paperdoll_flying_feet[player->uCurrentFace] = nullptr;
+    if (player->GetRace() == RACE_DWARF) {
+        texture_num = (player->GetSexByVoice() != SEX_MALE) + 3;
+    } else {
+        texture_num = (player->GetSexByVoice() != SEX_MALE) + 1;
     }
+    paperdoll_dbods[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}Bod", texture_num));  // Body texture
+    paperdoll_dlads[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}lad", texture_num));  // Left Hand
+    paperdoll_dlaus[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}lau", texture_num));  // Left Hand2
+    paperdoll_drhs[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}rh", texture_num));  // Right Hand
+    paperdoll_dlhs[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}lh", texture_num));  // Left Palm
+    paperdoll_dlhus[characterIndex] = assets->getImage_Alpha(fmt::format("pc23v{}lhu", texture_num));  // Left Fist
+
+    if (player->uCurrentFace == 12 || player->uCurrentFace == 13) {
+        paperdoll_dbrds[player->uCurrentFace] = nullptr;
+    }
+    paperdoll_flying_feet[player->uCurrentFace] = nullptr;
 }
 
-void WetsuitOff(int uPlayerID) {
-    if (uPlayerID > 0) {
-        int playerId0 = uPlayerID - 1;
-        Character *player = &pParty->pCharacters[playerId0];
+void WetsuitOff(int characterIndex) {
+    Character *player = &pParty->pCharacters[characterIndex];
 
-        paperdoll_dbods[playerId0] = assets->getImage_Alpha(dbod_texnames_by_face[player->uCurrentFace]);
-        paperdoll_dlads[playerId0] = assets->getImage_Alpha(dlad_texnames_by_face[player->uCurrentFace]);
-        paperdoll_dlaus[playerId0] = assets->getImage_Alpha(dlau_texnames_by_face[player->uCurrentFace]);
-        paperdoll_drhs[playerId0] = assets->getImage_Alpha(drh_texnames_by_face[player->uCurrentFace]);
-        paperdoll_dlhs[playerId0] = assets->getImage_Alpha(dlh_texnames_by_face[player->uCurrentFace]);
-        paperdoll_dlhus[playerId0] = assets->getImage_Alpha(dlhu_texnames_by_face[player->uCurrentFace]);
+    paperdoll_dbods[characterIndex] = assets->getImage_Alpha(dbod_texnames_by_face[player->uCurrentFace]);
+    paperdoll_dlads[characterIndex] = assets->getImage_Alpha(dlad_texnames_by_face[player->uCurrentFace]);
+    paperdoll_dlaus[characterIndex] = assets->getImage_Alpha(dlau_texnames_by_face[player->uCurrentFace]);
+    paperdoll_drhs[characterIndex] = assets->getImage_Alpha(drh_texnames_by_face[player->uCurrentFace]);
+    paperdoll_dlhs[characterIndex] = assets->getImage_Alpha(dlh_texnames_by_face[player->uCurrentFace]);
+    paperdoll_dlhus[characterIndex] = assets->getImage_Alpha(dlhu_texnames_by_face[player->uCurrentFace]);
 
-        if (player->uCurrentFace == 12 || player->uCurrentFace == 13) {
-            paperdoll_dbrds[player->uCurrentFace] = assets->getImage_Alpha(fmt::format("pc{:02}brd", player->uCurrentFace + 1));
-        }
-
-        paperdoll_flying_feet[player->uCurrentFace] = assets->getImage_Alpha(fmt::format("item281pc{:02}", player->uCurrentFace + 1));
+    if (player->uCurrentFace == 12 || player->uCurrentFace == 13) {
+        paperdoll_dbrds[player->uCurrentFace] = assets->getImage_Alpha(fmt::format("pc{:02}brd", player->uCurrentFace + 1));
     }
+
+    paperdoll_flying_feet[player->uCurrentFace] = assets->getImage_Alpha(fmt::format("item281pc{:02}", player->uCurrentFace + 1));
 }
 
 //----- (00468F8A) --------------------------------------------------------
@@ -1983,7 +1977,7 @@ void OnPaperdollLeftClick() {
                 return;
                 //-------------------------------------------------------------------------------
             default:
-                pParty->activeCharacter().useItem(pParty->activeCharacterIndex() - 1, false);
+                pParty->activeCharacter().useItem(pParty->activeCharacterIndex(), false);
                 return;
         }
         return;
@@ -2039,7 +2033,7 @@ void OnPaperdollLeftClick() {
              *pEquipType;*/
             pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
             pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
-            pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
+            pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex();
             pSpellInfo->targetInventoryIndex = entry.index();
 
             ptr_50C9A4_ItemToEnchant = entry.get();
@@ -2108,7 +2102,7 @@ void OnPaperdollLeftClick() {
                  *pEquipType;*/
                 pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
                 pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
-                pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex() - 1;
+                pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex();
                 pSpellInfo->targetInventoryIndex = entry.index();
 
                 ptr_50C9A4_ItemToEnchant = entry.get();
@@ -2132,8 +2126,8 @@ void OnPaperdollLeftClick() {
 }
 
 void CharacterUI_ReleaseButtons() {
-    if (dword_507CC0_activ_ch) {
-        dword_507CC0_activ_ch = 0;
+    if (dword_507CC0_activ_ch != -1) {
+        dword_507CC0_activ_ch = -1;
         std::vector<GUIButton*> to_delete;
         for (GUIButton *pButton : pGUIWindow_CurrentMenu->vButtons) {
             if (pButton->uData & 0x8000) {

--- a/src/GUI/UI/UICharacter.cpp
+++ b/src/GUI/UI/UICharacter.cpp
@@ -2024,13 +2024,6 @@ void OnPaperdollLeftClick() {
 
         // enchant / recharge item
         if (IsEnchantingInProgress) {
-            /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
-             *0x7Fu;//CastSpellInfo
-             *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-             *pParty->activeCharacterIndex() - 1;
-             *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
-             *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-             *pEquipType;*/
             pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
             pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
             pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex();
@@ -2081,8 +2074,6 @@ void OnPaperdollLeftClick() {
         InventoryEntry entry = pParty->activeCharacter().inventory.entry(v34);
 
         if (entry) {
-            // v36 = v34 - 1;
-            // v38 = &pCharacters[pParty->_activeCharacter]->pInventoryItemList[v34 - 1];
             pEquipType = entry->type();
             if (entry->itemId == ITEM_QUEST_WETSUIT) {
                 if (engine->IsUnderwater()) {
@@ -2093,13 +2084,6 @@ void OnPaperdollLeftClick() {
             }
 
             if (IsEnchantingInProgress) {
-                /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
-                 *0x7Fu;//CastSpellInfo
-                 *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
-                 *pParty->activeCharacterIndex() - 1;
-                 *((int *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) = v36;
-                 *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 3) =
-                 *pEquipType;*/
                 pSpellInfo = pGUIWindow_CastTargetedSpell->spellInfo();
                 pSpellInfo->flags &= ~ON_CAST_TargetedEnchantment;
                 pSpellInfo->targetCharacterIndex = pParty->activeCharacterIndex();

--- a/src/GUI/UI/UIGame.cpp
+++ b/src/GUI/UI/UIGame.cpp
@@ -564,7 +564,7 @@ void GUIWindow_GameOptions::Update() {
 }
 
 void GameUI_OnPlayerPortraitLeftClick(int uPlayerID) {
-    Character *player = &pParty->pCharacters[uPlayerID - 1];
+    Character *player = &pParty->pCharacters[uPlayerID];
     if (pParty->pPickedItem.itemId != ITEM_NULL) {
         if (std::optional<Pointi> pos = player->inventory.findSpace(pParty->pPickedItem)) {
             player->inventory.add(*pos, pParty->takeHoldingItem());
@@ -1188,7 +1188,7 @@ void GameUI_WritePointedObjectStatusString() {
 void GameUI_DrawCharacterSelectionFrame() {
     if (pParty->hasActiveCharacter())
         render->DrawQuad2D(game_ui_player_selection_frame,
-            {pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing[pParty->activeCharacterIndex() - 1] - 9, 380});
+            {pPlayerPortraitsXCoords_For_PlayerBuffAnimsDrawing[pParty->activeCharacterIndex()] - 9, 380});
 }
 
 //----- (0044162D) --------------------------------------------------------
@@ -1731,7 +1731,7 @@ void GameUI_handleHintMessage(UIMessageType type, int param) {
         }
 
         case UIMSG_ShowStatus_Player: {
-            Character* character = &pParty->pCharacters[param - 1];
+            Character* character = &pParty->pCharacters[param];
             engine->_statusBar->setPermanent(fmt::format("{}: {}", NameAndTitle(character->name, character->classType),
                 localization->characterConditionName(character->GetMajorConditionIdx())));
             break;

--- a/src/GUI/UI/UIHouses.cpp
+++ b/src/GUI/UI/UIHouses.cpp
@@ -478,7 +478,7 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
 
     if (topic == DIALOGUE_13_hiring_related) {
         current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                               pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
+                                               pParty->activeCharacterIndex(), pCurrentNPCInfo);
         NPCHireableDialogPrepare();
         dialogue_show_profession_details = false;
         BackToHouseMenu();
@@ -491,10 +491,10 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
         if (topic == DIALOGUE_PROFESSION_DETAILS) {
             if (dialogue_show_profession_details) {
                 current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pBenefits,
-                                                       pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
+                                                       pParty->activeCharacterIndex(), pCurrentNPCInfo);
             } else {
                 current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                                       pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
+                                                       pParty->activeCharacterIndex(), pCurrentNPCInfo);
             }
         }
         BackToHouseMenu();
@@ -503,7 +503,7 @@ void selectHouseNPCDialogueOption(DialogueId topic) {
 
     if (!pCurrentNPCInfo->Hired()) {
         current_npc_text = BuildDialogueString(pNPCStats->pProfessions[pCurrentNPCInfo->profession].pJoinText,
-                                               pParty->activeCharacterIndex() - 1, pCurrentNPCInfo);
+                                               pParty->activeCharacterIndex(), pCurrentNPCInfo);
         BackToHouseMenu();
         return;
     }

--- a/src/GUI/UI/UIPopup.cpp
+++ b/src/GUI/UI/UIPopup.cpp
@@ -1083,7 +1083,7 @@ void CharacterUI_SkillsTab_ShowHint() {
         for (GUIButton *pButton : pGUIWindow_CurrentMenu->vButtons) {
             if (pButton->msg == UIMSG_SkillUp && pButton->Contains(pX, pY)) {
                 Skill skill = static_cast<Skill>(pButton->msg_param);
-                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex() - 1, skill);
+                std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex(), skill);
                 CharacterUI_DrawTooltip(localization->skillName(skill), pSkillDescText);
                 return;
             }
@@ -1452,7 +1452,7 @@ void ShowPopupShopSkills() {
                     if (skillMaxMasteryPerClass[pParty->activeCharacter().classType][skill_id] != MASTERY_NONE &&
                         !pParty->activeCharacter().pActiveSkills[skill_id]) {
                         // is this skill visible
-                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex() - 1, skill_id);
+                        std::string pSkillDescText = CharacterUI_GetSkillDescText(pParty->activeCharacterIndex(), skill_id);
                         CharacterUI_DrawTooltip(localization->skillName(skill_id), pSkillDescText);
                         return;
                     }

--- a/src/Scripting/GameBindings.cpp
+++ b/src/Scripting/GameBindings.cpp
@@ -100,9 +100,7 @@ void GameBindings::_registerPartyBindings(sol::state_view &solState, sol::table 
         }),
         "getActiveCharacter", sol::as_function([]() {
             if (pParty->hasActiveCharacter()) {
-                int index = pParty->activeCharacterIndex();
-                assert(index != 0); //keep an assert here in case we change the 1-based index to 0 in the future so we can adjust it accordingly
-                return index; //a 1-based index is totally fine for lua
+                return pParty->activeCharacterIndex() + 1; // Lua side counts characters from 1.
             } else {
                 return 0;
             }

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -489,7 +489,7 @@ GAME_TEST(Issues, Issue405) {
     auto runTrace = [&] {
         engine->config->debug.AllMagic.setValue(true);
         test.loadGameFromTestData("issue_405.mm7");
-        game.castSpell(1, SPELL_FIRE_IMMOLATION);
+        game.castSpell(0, SPELL_FIRE_IMMOLATION);
     };
 
     // 100ms/frame
@@ -648,7 +648,7 @@ GAME_TEST(Issues, Issue415a) {
     EXPECT_FALSE(stonedTitan->CanBeDamaged()); // ...and are invulnerable statues.
 
     // Armageddon deals damage when its 256-tick timer runs out, wait it out.
-    game.castSpell(1, SPELL_DARK_ARMAGEDDON);
+    game.castSpell(0, SPELL_DARK_ARMAGEDDON);
     game.tick(30);
     test.stopTaping();
 
@@ -682,7 +682,7 @@ GAME_TEST(Issues, Issue415b) {
     Actor *stoned = game.spawnMonster(pParty->pos + Vec3f(0, 900, 0), MONSTER_TITAN_A, SPAWN_DUMMY);
     stoned->buffs[ACTOR_BUFF_STONED].Apply(tomorrow, MASTERY_GRANDMASTER, 0, 0, 0);
 
-    game.castQuickSpell(1, SPELL_FIRE_FIREBALL);
+    game.castQuickSpell(0, SPELL_FIRE_FIREBALL);
     game.tick(30);
     test.stopTaping();
 
@@ -712,7 +712,7 @@ GAME_TEST(Issues, Issue415c) {
     Actor *stoned = game.spawnMonster(pParty->pos + Vec3f(0, 900, 0), MONSTER_TITAN_A, SPAWN_DUMMY);
     stoned->buffs[ACTOR_BUFF_STONED].Apply(tomorrow, MASTERY_GRANDMASTER, 0, 0, 0);
 
-    game.castQuickSpell(1, SPELL_DARK_SHRINKING_RAY);
+    game.castQuickSpell(0, SPELL_DARK_SHRINKING_RAY);
     game.tick(30);
     test.stopTaping();
 
@@ -781,7 +781,7 @@ GAME_TEST(Issues, Issue415e) {
         buffed->buffs[buff].Apply(pParty->GetPlayingTime() + Duration::fromDays(1), MASTERY_GRANDMASTER, 0, 0, 0);
         game.pointMouseAtActor(1);
 
-        game.castQuickSpell(1, SPELL_WATER_ICE_BOLT);
+        game.castQuickSpell(0, SPELL_WATER_ICE_BOLT);
         game.tick(30);
         test.stopTaping();
 

--- a/test/Bin/GameTest/GameTests_0500.cpp
+++ b/test/Bin/GameTest/GameTests_0500.cpp
@@ -56,7 +56,7 @@ GAME_TEST(Issues, Issue502) {
     auto expressionTape = charTapes.portrait(3);
     test.playTraceFromTestData("issue_502.mm7", "issue_502.json");
     EXPECT_CONTAINS(expressionTape, PORTRAIT_NO);
-    EXPECT_EQ(pParty->activeCharacterIndex(), 4);
+    EXPECT_EQ(pParty->activeCharacterIndex(), 3);
 }
 
 GAME_TEST(Issues, Issue503) {
@@ -118,7 +118,7 @@ GAME_TEST(Issues, Issue521) {
     test.playTraceFromTestData("issue_521.mm7", "issue_521.json");
     EXPECT_EQ(enduranceTape, tape(500)); // First char is beefy.
     EXPECT_LT(hpsTape.delta().max(), 0); // All chars took damage.
-    EXPECT_EQ(activeCharTape, tape(1)); // First char didn't flinch.
+    EXPECT_EQ(activeCharTape, tape(0)); // First char didn't flinch.
 }
 
 GAME_TEST(Issues, Issue527) {
@@ -219,7 +219,7 @@ GAME_TEST(Issues, Issue587) {
         drinker.SetCondition(CONDITION_ERADICATED, 0);
         drinker.health = 5;
         ASSERT_LT(drinker.health, drinker.GetMaxHealth());
-        pParty->setActiveCharacterIndex(2); // Active "giver" must be a non-eradicated char.
+        pParty->setActiveCharacterIndex(1); // Active "giver" must be a non-eradicated char.
 
         test.startTaping();
         game.tick(); // Baseline tick records health == 5.
@@ -296,14 +296,14 @@ GAME_TEST(Issues, Issue615a) {
     // Ensure that clicking between active portraits changes active character.
     auto activeCharTape = tapes.activeCharacterIndex();
     test.playTraceFromTestData("issue_615a.mm7", "issue_615a.json");
-    EXPECT_EQ(activeCharTape.frontBack(), tape(1, 3));
+    EXPECT_EQ(activeCharTape.frontBack(), tape(0, 2));
 }
 
 GAME_TEST(Issues, Issue615b) {
     // Assert when clicking on character portrait when no active character is present.
     auto activeCharTape = tapes.activeCharacterIndex();
     test.playTraceFromTestData("issue_615b.mm7", "issue_615b.json");
-    EXPECT_EQ(activeCharTape.frontBack(), tape(1, 4));
+    EXPECT_EQ(activeCharTape.frontBack(), tape(0, 3));
 }
 
 GAME_TEST(Issues, Issue625) {
@@ -442,7 +442,7 @@ GAME_TEST(Issues, Issue663) {
     test.playTraceFromTestData("issue_663.mm7", "issue_663.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_CHEST, SCREEN_CHEST_INVENTORY));
     // should switch to char 2 inv
-    EXPECT_EQ(pParty->activeCharacterIndex(), 2);
+    EXPECT_EQ(pParty->activeCharacterIndex(), 1);
     EXPECT_GT(pParty->activeCharacter().timeToRecovery, 0_ticks);
 }
 

--- a/test/Bin/GameTest/GameTests_1000.cpp
+++ b/test/Bin/GameTest/GameTests_1000.cpp
@@ -572,7 +572,7 @@ GAME_TEST(Issues, Issue1301a) {
         if (!skipIncapacitated)
             EXPECT_EQ(activeTape, tape(activeCharacterIndex));
         if (skipIncapacitated && turnBased)
-            EXPECT_EQ(activeTape, tape(activeCharacterIndex, 0)); // Outside the attack stage turn-based mode has no queue head to fall back on, so no one ends up selected.
+            EXPECT_EQ(activeTape, tape(activeCharacterIndex, -1)); // Outside the attack stage turn-based mode has no queue head to fall back on, so no one ends up selected.
         if (skipIncapacitated && !turnBased) {
             EXPECT_EQ(activeTape, tape(activeCharacterIndex, activeCharacterIndex + 1)); // Realtime mode stops on the first character that can act.
             EXPECT_TRUE(pParty->activeCharacter().CanAct());
@@ -612,7 +612,7 @@ GAME_TEST(Issues, Issue1301b) {
     EXPECT_EQ(deathsTape.delta(), +1);
     EXPECT_EQ(stateTape, tape(std::tuple(true, GAME_STATE_PLAYING), // The death path force-ends turn-based mode, and
                               std::tuple(false, GAME_STATE_PLAYING))); // the died state is gone before the next frame is drawn.
-    EXPECT_EQ(activeTape, tape(1)); // Every frame ends with the death path re-selecting the first character.
+    EXPECT_EQ(activeTape, tape(0)); // Every frame ends with the death path re-selecting the first character.
     EXPECT_EQ(pParty->canActCount(), 4);
 }
 

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -224,7 +224,7 @@ GAME_TEST(Issues, Issue1547) {
     test.stopTaping();
 
     EXPECT_EQ(actorsTape, tape(0));
-    EXPECT_EQ(activeCharTape, tape(1, 2, 3, 4, 0)); // All chars attacked.
+    EXPECT_EQ(activeCharTape, tape(0, 1, 2, 3, -1)); // All chars attacked.
 }
 
 GAME_TEST(Issues, Issue1569) {
@@ -573,13 +573,13 @@ GAME_TEST(Issues, Issue1786) {
     engine->config->debug.AllMagic.setValue(true);
     game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_4); // Select char 4.
     game.tick();
-    EXPECT_EQ(pParty->activeCharacterIndex(), 4);
+    EXPECT_EQ(pParty->activeCharacterIndex(), 3);
 
     game.pressAndReleaseKey(PlatformKey::KEY_S); // Quick cast fire bolt.
     game.tick(2);
     EXPECT_CONTAINS(sprites.back(), SPRITE_SPELL_FIRE_FIRE_BOLT);
 
-    while (pParty->activeCharacterIndex() != 4) {
+    while (pParty->activeCharacterIndex() != 3) {
         game.pressAndReleaseKey(PlatformKey::KEY_DIGIT_4);
         game.tick();
     }
@@ -612,7 +612,7 @@ GAME_TEST(Issues, Issue1808) {
     auto vasesTape = tapes.hasItem(ITEM_QUEST_VASE);
     auto goldTape = tapes.gold();
     test.playTraceFromTestData("issue_1808.mm7", "issue_1808.json");
-    EXPECT_EQ(activeCharTape, tape(1)); // First character was active.
+    EXPECT_EQ(activeCharTape, tape(0)); // First character was active.
     EXPECT_EQ(vaseTape, tape(true, false)); // Vase was taken from 3rd char.
     EXPECT_EQ(vasesTape, tape(true, false)); // And it was the only vase we had.
     EXPECT_EQ(classTape, tape(CLASS_THIEF, CLASS_ROGUE)); // 2nd char was promoted.
@@ -739,7 +739,7 @@ GAME_TEST(Issues, Issue1912) {
     auto hatTape = charTapes.haveItem(ITEM_QUEST_WEALTHY_HAT);
     auto activeCharTape = tapes.activeCharacterIndex();
     test.playTraceFromTestData("issue_1912.mm7", "issue_1912.json");
-    EXPECT_EQ(activeCharTape, tape(1)); // First char was talking.
+    EXPECT_EQ(activeCharTape, tape(0)); // First char was talking.
     EXPECT_EQ(potionTape, tape({false, true, false, false}, {false, false, false, false})); // But 2nd char had the potion.
     EXPECT_EQ(hatTape, tape({false, false, false, false}, {true, false, false, false})); // We passed the hat to the 1st char.
 }

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -188,7 +188,7 @@ GAME_TEST(Issues, Issue1535) {
     game.startNewGame();
     engine->config->debug.AllMagic.setValue(true);
 
-    game.castSpell(1, SPELL_FIRE_METEOR_SHOWER);
+    game.castSpell(0, SPELL_FIRE_METEOR_SHOWER);
 
     // Should have put the spell cast message to queue.
     UIMessageType message = UIMSG_Invalid;
@@ -519,7 +519,7 @@ GAME_TEST(Issues, Issue1717) {
     auto immoBuff = tapes.custom([]() { return pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].Active(); });
     test.playTraceFromTestData("issue_1717.mm7", "issue_1717.json");
     EXPECT_EQ(immoBuff, tape(false, true));
-    EXPECT_EQ(pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].caster, 4);
+    EXPECT_EQ(pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].caster, 3);
 
     std::regex regex("Immolation deals [0-9]+ damage to [0-9]+ target\\(s\\)");
     EXPECT_CONTAINS(statusBar, [&](const std::string &message) { return std::regex_match(message, regex); });
@@ -827,7 +827,7 @@ GAME_TEST(Issues, Issue1947) {
     engine->config->debug.TownPortal.setValue(true);
     engine->config->debug.AllMagic.setValue(true);
 
-    game.castSpell(1, SPELL_WATER_TOWN_PORTAL);
+    game.castSpell(0, SPELL_WATER_TOWN_PORTAL);
     game.tick(2);
     game.pressGuiButton("TownPortalBook_Marker10"); // Tatalia.
     game.tick();
@@ -848,7 +848,7 @@ GAME_TEST(Prs, Pr1953) {
     char0.inventory.add(Item(ITEM_LEATHER_ARMOR));
     char0.inventory.equip(ITEM_SLOT_ARMOUR, Item(ITEM_ROYAL_LEATHER));
 
-    game.goToInventory(1);
+    game.goToInventory(0);
     game.pressAndReleaseButton(BUTTON_LEFT, 20, 20); // Pick up leather armor.
     game.tick();
     EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_LEATHER_ARMOR);
@@ -895,7 +895,7 @@ GAME_TEST(Issues, Issue1959) {
     game.tick();
 
     for (int i = 0; i < 4; i++) {
-        game.castSpell(i + 1, SPELL_AIR_SPARKS);
+        game.castSpell(i, SPELL_AIR_SPARKS);
         game.tick(30); // Wait for the sparks to settle.
 
         std::vector<float> angles;
@@ -934,7 +934,7 @@ GAME_TEST(Issues, Issue1961) {
     pParty->pCharacters[3].pActiveSkills[SKILL_WATER] = CombinedSkillValue(10, MASTERY_GRANDMASTER);
     pParty->pCharacters[3].bHaveSpell[SPELL_WATER_ENCHANT_ITEM] = true;
 
-    game.castSpell(4, SPELL_WATER_ENCHANT_ITEM);
+    game.castSpell(3, SPELL_WATER_ENCHANT_ITEM);
     game.tick(1);
     game.pressAndReleaseButton(BUTTON_LEFT, 30, 30);
     game.tick(1); // Don't wait out the animation.
@@ -1094,7 +1094,7 @@ GAME_TEST(Issues, Issue1998) {
 
         // Right-click the item in the inventory grid, the popup does the identification and the repair.
         auto portraitTape = charTapes.portrait(0);
-        game.goToInventory(1);
+        game.goToInventory(0);
         test.startTaping();
         game.pressButton(BUTTON_RIGHT, 30, 30);
         game.tick();

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -135,7 +135,7 @@ GAME_TEST(Issues, Issue2021_2022) {
 GAME_TEST(Issues, Issue2061) {
     // Game Crashes if you click the border of the inventory screen.
     game.startNewGame();
-    game.goToInventory(1);
+    game.goToInventory(0);
     game.pressAndReleaseButton(BUTTON_LEFT, 3, 20); // This used to assert.
     game.tick();
     EXPECT_EQ(pParty->pPickedItem.itemId, ITEM_NULL); // Shouldn't pick anything.
@@ -150,7 +150,7 @@ GAME_TEST(Issues, Issue2066) {
     pParty->pCharacters[0].inventory.clear();
     pParty->pCharacters[0].inventory.add(Pointi(0, 0), Item(ITEM_LEATHER_ARMOR)); // Add leather armor at (0, 0).
 
-    game.goToInventory(1);
+    game.goToInventory(0);
     game.pressAndReleaseButton(BUTTON_LEFT, 30, 30); // Pick up leather armor.
     game.tick();
     game.pressAndReleaseButton(BUTTON_LEFT, 30, 0); // Try to place outside inventory boundaries.
@@ -265,7 +265,7 @@ GAME_TEST(Issues, Issue2108) {
     prepareForBattleTest();
 
     // Cast shield.
-    game.castSpell(1, SPELL_AIR_SHIELD);
+    game.castSpell(0, SPELL_AIR_SHIELD);
 
     // Spawn archers & wait.
     engine->config->debug.NoActors.setValue(false);
@@ -469,7 +469,7 @@ GAME_TEST(Prs, Pr2157a) {
     // Test that we can't equip items when inventory is full.
     auto soundsTape = tapes.sounds();
     game.startNewGame();
-    game.goToInventory(1);
+    game.goToInventory(0);
     test.startTaping();
 
     CharacterInventory &inventory = pParty->pCharacters[0].inventory;
@@ -518,7 +518,7 @@ GAME_TEST(Prs, Pr2157b) {
     // Test that we can't add items to grid when inventory is full.
     auto soundsTape = tapes.sounds();
     game.startNewGame();
-    game.goToInventory(1);
+    game.goToInventory(0);
     test.startTaping();
 
     CharacterInventory &inventory = pParty->pCharacters[0].inventory;
@@ -658,7 +658,7 @@ GAME_TEST(Issues, Issue2201) {
     pParty->pCharacters[3].bHaveSpell[SPELL_FIRE_HASTE] = true;
     pParty->pCharacters[0].SetCondition(CONDITION_WEAK, false);
 
-    game.castSpell(4, SPELL_FIRE_HASTE);
+    game.castSpell(3, SPELL_FIRE_HASTE);
     game.tick(10); // All mana from 4th character was drained in 10 ticks.
 
     EXPECT_CONTAINS(statusTape, "Spell failed");
@@ -1048,7 +1048,7 @@ GAME_TEST(Issues, Issue2451a) {
     EXPECT_EQ(swordEntry->specialEnchantment, ITEM_ENCHANTMENT_NULL);
 
     // Cast Fire Aura - this opens the enchantment targeting UI.
-    game.castSpell(1, SPELL_FIRE_FIRE_AURA);
+    game.castSpell(0, SPELL_FIRE_FIRE_AURA);
     game.tick();
     ASSERT_TRUE(IsEnchantingInProgress);
 
@@ -1076,7 +1076,7 @@ GAME_TEST(Issues, Issue2451b) {
     EXPECT_EQ(wandEntry->maxCharges, 10);
 
     // Cast Recharge Item - this opens the enchantment targeting UI.
-    game.castSpell(1, SPELL_WATER_RECHARGE_ITEM);
+    game.castSpell(0, SPELL_WATER_RECHARGE_ITEM);
     game.tick();
     ASSERT_TRUE(IsEnchantingInProgress);
 
@@ -1094,7 +1094,7 @@ GAME_TEST(Issues, Issue2452) {
     auto messageBoxesTape = tapes.messageBoxes();
     auto guiTextTape = tapes.allGUIWindowsText();
     game.startNewGame();
-    game.goToInventory(1);
+    game.goToInventory(0);
     game.pressAndReleaseKey(PlatformKey::KEY_S);
     game.tick(2);
     EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
@@ -1536,7 +1536,7 @@ GAME_TEST(Issues, Issue2636) {
     game.startNewGame();
     test.startTaping();
     game.tick(2);
-    game.goToInventory(1);
+    game.goToInventory(0);
     game.pressAndReleaseKey(PlatformKey::KEY_C); // Switch to the stats tab.
     game.tick(2);
     EXPECT_EQ(current_screen_type, SCREEN_CHARACTERS);
@@ -1715,7 +1715,7 @@ GAME_TEST(Prs, Pr2615c) {
     ASSERT_EQ(campfire.uEventID, 0); // The eventless interactive kind - Pr2615d covers the evented kind.
     game.teleportTo(MAP_EMERALD_ISLAND, campfire.vPosition - Vec3f(1000, 0, 0), 0); // Twice the click reach away.
     test.startTaping();
-    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
+    game.castSpell(0, SPELL_EARTH_TELEKINESIS);
     game.tick(2);
     game.pointMouseAtDecoration(7);
     game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());
@@ -1738,7 +1738,7 @@ GAME_TEST(Prs, Pr2615d) {
     pParty->GetPlayingTime() += Duration::fromDays(150);
     game.tick(2);
     ASSERT_EQ(pParty->pPickedItem.itemId, ITEM_NULL);
-    game.castSpell(1, SPELL_EARTH_TELEKINESIS);
+    game.castSpell(0, SPELL_EARTH_TELEKINESIS);
     game.tick(2);
     game.pointMouseAtDecoration(559);
     game.pressAndReleaseButton(BUTTON_LEFT, mouse->position());

--- a/test/Bin/GameTest/GameTests_2000.cpp
+++ b/test/Bin/GameTest/GameTests_2000.cpp
@@ -348,10 +348,10 @@ GAME_TEST(Issues, Issue2116) {
             game.tick();
         } while (!pParty->hasActiveCharacter());
     }
+    EXPECT_CONTAINS(activeCharacterTape, 0);
     EXPECT_CONTAINS(activeCharacterTape, 1);
     EXPECT_CONTAINS(activeCharacterTape, 2);
-    EXPECT_CONTAINS(activeCharacterTape, 3);
-    EXPECT_MISSES(activeCharacterTape, 4);
+    EXPECT_MISSES(activeCharacterTape, 3);
 
     pParty->pCharacters[3].conditions.reset(CONDITION_DEAD);
     pParty->pCharacters[3].conditions.reset(CONDITION_UNCONSCIOUS);
@@ -364,7 +364,7 @@ GAME_TEST(Issues, Issue2116) {
             game.tick();
         } while (!pParty->hasActiveCharacter());
     }
-    EXPECT_CONTAINS(activeCharacterTape, 4);
+    EXPECT_CONTAINS(activeCharacterTape, 3);
 }
 
 GAME_TEST(Issues, Issue2117) {
@@ -1261,8 +1261,8 @@ GAME_TEST(Issues, Issue2479) {
 
     test.playTraceFromTestData("issue_2479.mm7", "issue_2479.json");
     EXPECT_EQ(screenTape, tape(SCREEN_GAME, SCREEN_BRANCHLESS_NPC_DIALOG, SCREEN_GAME));
-    EXPECT_EQ(activeChar, tape(1, 4)); // We switched characters.
-    EXPECT_EQ(branchLessCharIndex, tape(-1, 1, -1)); // We didnt switch before the dialog closed.
+    EXPECT_EQ(activeChar, tape(0, 3)); // We switched characters.
+    EXPECT_EQ(branchLessCharIndex, tape(-1, 0, -1)); // We didnt switch before the dialog closed.
 }
 
 GAME_TEST(Issues, Issue2490) {

--- a/test/Testing/Game/CommonTapeRecorder.cpp
+++ b/test/Testing/Game/CommonTapeRecorder.cpp
@@ -161,7 +161,7 @@ TestMultiTape<SpriteId> CommonTapeRecorder::sprites() {
 }
 
 TestTape<int> CommonTapeRecorder::activeCharacterIndex() {
-    return custom([] { return pParty->hasActiveCharacter() ? pParty->activeCharacterIndex() : 0; });
+    return custom([] { return pParty->hasActiveCharacter() ? pParty->activeCharacterIndex() : -1; });
 }
 
 TestTape<bool> CommonTapeRecorder::questBit(QuestBit bit) {

--- a/test/Testing/Game/CommonTapeRecorder.h
+++ b/test/Testing/Game/CommonTapeRecorder.h
@@ -89,7 +89,7 @@ class CommonTapeRecorder {
 
     TestMultiTape<SpriteId> sprites();
 
-    TestTape<int> activeCharacterIndex(); // Remember that 0 means none!
+    TestTape<int> activeCharacterIndex(); // Remember that -1 means none!
 
     TestTape<bool> questBit(QuestBit bit);
 


### PR DESCRIPTION
`Party::activeCharacterIndex()` is 0-based now, with `-1` meaning no active character. Every reader dropped its `- 1`, the turn engine and the portrait buttons pass the index through unchanged, and the two globals that used zero as "none" (`enchantingActiveCharacter`, `dword_507CC0_activ_ch`) use `-1` too. The game test controller takes the same 0-based index, and `SpellBuff::caster` is 0-based with `-1` for a buff from a potion or an npc, converted at the snapshot boundary so the save format stays as it was. The Lua binding keeps returning a 1-based value.

No behaviour change is intended. The test tape expectations shifted down by one, and the dead decompiler comments next to the touched lines are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
