### PR TITLE
Replace overrideSoundId with ON_CAST_AutoTarget

### DIFF
--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -955,7 +955,7 @@ void Game::processQueuedMessages() {
                     continue;
                 }
                 pushSpellOrRangedAttack(pParty->activeCharacter().uQuickSpell, pParty->activeCharacterIndex() - 1,
-                                        CombinedSkillValue::none(), 0, pParty->activeCharacterIndex());
+                                        CombinedSkillValue::none(), ON_CAST_AutoTarget);
                 continue;
             }
 
@@ -1265,7 +1265,7 @@ void Game::processQueuedMessages() {
 
             case UIMSG_CastSpellFromBook:
                 if (pTurnEngine->turn_stage != TE_MOVEMENT) {
-                    pushSpellOrRangedAttack(static_cast<SpellId>(uMessageParam), uMessageParam2, CombinedSkillValue::none(), 0, 0);
+                    pushSpellOrRangedAttack(static_cast<SpellId>(uMessageParam), uMessageParam2, CombinedSkillValue::none(), 0);
                 }
                 continue;
 

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1305,7 +1305,6 @@ void RegeneratePartyHealthMana() {
         spellSprite.timeSinceCreated = 0_ticks;
         spellSprite.spell_caster_pid = Pid(OBJECT_Character, pParty->pPartyBuffs[PARTY_BUFF_IMMOLATION].caster - 1); // caster is 1 indexed so turn back to 0
         spellSprite.uFacing = 0;
-        spellSprite.uSoundID = 0;
 
         int actorsAffectedByImmolation[100];
         size_t numberOfActorsAffected = pParty->immolationAffectedActors(actorsAffectedByImmolation, 100, 307);

--- a/src/Engine/Graphics/Indoor.cpp
+++ b/src/Engine/Graphics/Indoor.cpp
@@ -1867,7 +1867,6 @@ void SpawnRandomTreasure(MapData *mapData, SpawnPoint *spawn) {
     }
 
     spawnedObject.uAttributes = 0;
-    spawnedObject.uSoundID = 0;
     spawnedObject.uFacing = 0;
     spawnedObject.vPosition = spawn->position;
     spawnedObject.spell_skill = MASTERY_NONE;

--- a/src/Engine/Objects/Actor.cpp
+++ b/src/Engine/Objects/Actor.cpp
@@ -257,7 +257,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.spell_skill = MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3f(0, 0, actorPtr->height / 2);
             sprite.uFacing = (short)pDir->uYawAngle;
-            sprite.uSoundID = 0;
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.timeSinceCreated = 0_ticks;
@@ -343,7 +342,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
                 sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
                 sprite.spell_target_pid = Pid();
                 sprite.uFacing = yaw;
-                sprite.uSoundID = 0;
                 sprite.field_60_distance_related_prolly_lod = distancemod;
                 sprite.spellCasterAbility = ABILITY_SPELL1;
 
@@ -386,7 +384,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.spell_skill = MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3f(0, 0, actorPtr->height / 2);
             sprite.uFacing = pDir->uYawAngle;
-            sprite.uSoundID = 0;
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
@@ -643,7 +640,6 @@ void Actor::AI_SpellAttack(unsigned int uActorID, AIDirection *pDir,
             sprite.spell_skill = MASTERY_NONE; // TODO(captainurist): why do we ignore passed skill mastery?
             sprite.vPosition = actorPtr->pos + Vec3f(0, 0, actorPtr->height / 2);
             sprite.uFacing = pDir->uYawAngle;
-            sprite.uSoundID = 0;
             sprite.uAttributes = 0;
             sprite.uSectorID = pIndoor->GetSector(sprite.vPosition);
             sprite.spell_caster_pid = Pid(OBJECT_Actor, uActorID);
@@ -753,7 +749,6 @@ void Actor::AI_RangedAttack(unsigned int uActorID, AIDirection *pDir,
     a1.spell_level = 0;
     a1.spell_skill = MASTERY_NONE;
     a1.uFacing = pDir->uYawAngle;
-    a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
     a1.timeSinceCreated = 0_ticks;
@@ -805,7 +800,6 @@ void Actor::Explode(unsigned int uActorID) {  // death explosion for some actors
     a1.vPosition.y = pActors[uActorID].pos.y;
     a1.vPosition.z = pActors[uActorID].pos.z + (pActors[uActorID].height * 0.75);
     a1.uFacing = 0;
-    a1.uSoundID = 0;
     a1.uAttributes = 0;
     a1.uSectorID = pIndoor->GetSector(a1.vPosition);
     a1.timeSinceCreated = 0_ticks;

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6367,13 +6367,11 @@ void Character::_42ECB5_CharacterAttacksActor() {
          melee_attack = false;
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
-        pushSpellOrRangedAttack(SPELL_BLASTER_PROJECTILE,
-                                pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), ON_CAST_AutoTarget);
+        pushSpellOrRangedAttack(SPELL_BLASTER_PROJECTILE, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), ON_CAST_AutoTarget);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
-        pushSpellOrRangedAttack(spellForWand(wand_item_id),
-                                pParty->activeCharacterIndex() - 1, WANDS_SKILL_VALUE, ON_CAST_AutoTarget);
+        pushSpellOrRangedAttack(spellForWand(wand_item_id), pParty->activeCharacterIndex() - 1, WANDS_SKILL_VALUE, ON_CAST_AutoTarget);
 
         // reduce wand charges
         if (!--main_hand->numCharges && engine->config->gameplay.DestroyDischargedWands.value()) {

--- a/src/Engine/Objects/Character.cpp
+++ b/src/Engine/Objects/Character.cpp
@@ -6368,13 +6368,12 @@ void Character::_42ECB5_CharacterAttacksActor() {
     if (laser_weapon_item_id != ITEM_NULL) {
         shotting_laser = true;
         pushSpellOrRangedAttack(SPELL_BLASTER_PROJECTILE,
-                                pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0,
-                                pParty->activeCharacterIndex() + 8); // TODO(captainurist): +8???
+                                pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), ON_CAST_AutoTarget);
     } else if (wand_item_id != ITEM_NULL) {
         shooting_wand = true;
 
         pushSpellOrRangedAttack(spellForWand(wand_item_id),
-                                pParty->activeCharacterIndex() - 1, WANDS_SKILL_VALUE, 0, pParty->activeCharacterIndex() + 8);
+                                pParty->activeCharacterIndex() - 1, WANDS_SKILL_VALUE, ON_CAST_AutoTarget);
 
         // reduce wand charges
         if (!--main_hand->numCharges && engine->config->gameplay.DestroyDischargedWands.value()) {
@@ -6394,7 +6393,7 @@ void Character::_42ECB5_CharacterAttacksActor() {
         shooting_bow = true;
         // TODO(captainurist): target_pid is ignored here - the arrow re-resolves its target in castSpell() with a
         //                     different fallback, so it can fly at a different actor than the one checked above.
-        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0, 0);
+        pushSpellOrRangedAttack(SPELL_BOW_ARROW, pParty->activeCharacterIndex() - 1, CombinedSkillValue::none(), 0);
     } else {
         melee_attack = true;
         // actor out of range or no actor; no ranged weapon so melee attacking air
@@ -6471,7 +6470,6 @@ void Character::_42FA66_do_explosive_impact(Vec3f pos, int a4, int16_t a5, int a
     a1a.spell_target_pid = Pid();
     a1a.field_60_distance_related_prolly_lod = 0;
     a1a.uFacing = 0;
-    a1a.uSoundID = 0;
 
     if (actchar >= 1 || actchar <= 4) {
         a1a.spell_caster_pid = Pid(OBJECT_Character, actchar - 1);

--- a/src/Engine/Objects/Chest.cpp
+++ b/src/Engine/Objects/Chest.cpp
@@ -120,7 +120,6 @@ bool Chest::open(int uChestID, Pid objectPid) {
             }
             pSpellObject.vPosition = pOut;
 
-            pSpellObject.uSoundID = 0;
             pSpellObject.uAttributes = SPRITE_IGNORE_RANGE | SPRITE_NO_Z_BUFFER;
             pSpellObject.uSectorID = pIndoor->GetSector(pSpellObject.vPosition);
             pSpellObject.timeSinceCreated = 0_ticks;

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -621,8 +621,7 @@ void CompactLayingItemsList() {
 void SpriteObject::InitializeSpriteObjects() {
     for (size_t i = 0; i < pSpriteObjects.size(); ++i) {
         SpriteObject *item = &pSpriteObjects[i];
-        // TODO(captainurist): item->uSoundID & 8 checks for laser projectiles, wtf...
-        if (item->uObjectDescID && (item->uSoundID & 8 || pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE)) {
+        if (item->uObjectDescID && pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
             SpriteObject::Remove(i);
         }
     }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -621,7 +621,8 @@ void CompactLayingItemsList() {
 void SpriteObject::InitializeSpriteObjects() {
     for (size_t i = 0; i < pSpriteObjects.size(); ++i) {
         SpriteObject *item = &pSpriteObjects[i];
-        if (item->uObjectDescID && pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
+        // Bit 3 of the sound slot is vanilla's mark for wand and blaster shots, and level files can carry it on anything.
+        if (item->uObjectDescID && (item->preloadedSoundSlot & 8 || pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE)) {
             SpriteObject::Remove(i);
         }
     }

--- a/src/Engine/Objects/SpriteObject.cpp
+++ b/src/Engine/Objects/SpriteObject.cpp
@@ -621,8 +621,7 @@ void CompactLayingItemsList() {
 void SpriteObject::InitializeSpriteObjects() {
     for (size_t i = 0; i < pSpriteObjects.size(); ++i) {
         SpriteObject *item = &pSpriteObjects[i];
-        // Bit 3 of the sound slot is vanilla's mark for wand and blaster shots, and level files can carry it on anything.
-        if (item->uObjectDescID && (item->preloadedSoundSlot & 8 || pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE)) {
+        if (item->uObjectDescID && pObjectList->pObjects[item->uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
             SpriteObject::Remove(i);
         }
     }

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -71,7 +71,6 @@ struct SpriteObject {
     Vec3f vPosition;
     Vec3f vVelocity;
     uint16_t uFacing = 0;
-    uint16_t preloadedSoundSlot = 0; // Vanilla's sound cache slot as loaded from the level file, never set by OE. Bit 3 purges the sprite on map entry.
     SpriteAttributes uAttributes = 0;
     int uSectorID = 0;
     Duration timeSinceCreated;

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -71,6 +71,7 @@ struct SpriteObject {
     Vec3f vPosition;
     Vec3f vVelocity;
     uint16_t uFacing = 0;
+    uint16_t preloadedSoundSlot = 0; // Vanilla's sound cache slot as loaded from the level file, never set by OE. Bit 3 purges the sprite on map entry.
     SpriteAttributes uAttributes = 0;
     int uSectorID = 0;
     Duration timeSinceCreated;

--- a/src/Engine/Objects/SpriteObject.h
+++ b/src/Engine/Objects/SpriteObject.h
@@ -71,7 +71,6 @@ struct SpriteObject {
     Vec3f vPosition;
     Vec3f vVelocity;
     uint16_t uFacing = 0;
-    uint16_t uSoundID = 0;
     SpriteAttributes uAttributes = 0;
     int uSectorID = 0;
     Duration timeSinceCreated;

--- a/src/Engine/Party.cpp
+++ b/src/Engine/Party.cpp
@@ -911,7 +911,6 @@ void Party::dropHeldItem() {
     sprite.uObjectDescID = pObjectList->ObjectIDByItemID(sprite.spriteId);
     sprite.spell_caster_pid = Pid(OBJECT_Character, 0);
     sprite.vPosition = pos + Vec3f(0, 0, eyeLevel);
-    sprite.uSoundID = 0;
     sprite.uFacing = 0;
     sprite.uAttributes = SPRITE_DROPPED_BY_PLAYER;
     sprite.uSectorID = pBLVRenderParams->uPartyEyeSectorID;

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1609,6 +1609,7 @@ void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->position = src.vPosition.toInt();
     snapshot(src.vVelocity, &dst->velocity);
     dst->yawAngle = src.uFacing;
+    dst->preloadedSoundSlot = src.preloadedSoundSlot;
     dst->uAttributes = std::to_underlying(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->uTimeSinceCreated = src.timeSinceCreated.ticks();
@@ -1632,6 +1633,7 @@ void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->vPosition = src.position.toFloat();
     reconstruct(src.velocity, &dst->vVelocity);
     dst->uFacing = src.yawAngle;
+    dst->preloadedSoundSlot = src.preloadedSoundSlot;
     dst->uAttributes = SpriteAttributes(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->timeSinceCreated = Duration::fromTicks(src.uTimeSinceCreated);

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1609,7 +1609,6 @@ void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->position = src.vPosition.toInt();
     snapshot(src.vVelocity, &dst->velocity);
     dst->yawAngle = src.uFacing;
-    dst->preloadedSoundSlot = src.preloadedSoundSlot;
     dst->uAttributes = std::to_underlying(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->uTimeSinceCreated = src.timeSinceCreated.ticks();
@@ -1633,7 +1632,6 @@ void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->vPosition = src.position.toFloat();
     reconstruct(src.velocity, &dst->vVelocity);
     dst->uFacing = src.yawAngle;
-    dst->preloadedSoundSlot = src.preloadedSoundSlot;
     dst->uAttributes = SpriteAttributes(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->timeSinceCreated = Duration::fromTicks(src.uTimeSinceCreated);

--- a/src/Engine/Snapshots/EntitySnapshots.cpp
+++ b/src/Engine/Snapshots/EntitySnapshots.cpp
@@ -1609,7 +1609,6 @@ void snapshot(const SpriteObject &src, SpriteObject_MM7 *dst) {
     dst->position = src.vPosition.toInt();
     snapshot(src.vVelocity, &dst->velocity);
     dst->yawAngle = src.uFacing;
-    dst->uSoundID = src.uSoundID;
     dst->uAttributes = std::to_underlying(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->uTimeSinceCreated = src.timeSinceCreated.ticks();
@@ -1633,7 +1632,6 @@ void reconstruct(const SpriteObject_MM7 &src, SpriteObject *dst) {
     dst->vPosition = src.position.toFloat();
     reconstruct(src.velocity, &dst->vVelocity);
     dst->uFacing = src.yawAngle;
-    dst->uSoundID = src.uSoundID;
     dst->uAttributes = SpriteAttributes(src.uAttributes);
     dst->uSectorID = src.uSectorID;
     dst->timeSinceCreated = Duration::fromTicks(src.uTimeSinceCreated);

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -962,7 +962,15 @@ struct SpriteObject_MM7 {
     Vec3i position;
     Vec3s velocity;
     uint16_t yawAngle;
-    uint16_t uSoundID;
+    uint16_t preloadedSoundSlot; // Vanilla keeps 17 sample pointers per sound, the sample itself and 16 cached copies.
+                                 // This is the cast sound's entry. The impact sound plays from entry + 4, 0 staying 0:
+                                 //   0      the sample itself, loaded on first use. Spellbook, scrolls, and always OE.
+                                 //   1-4    quick spell cast sound of party member 1-4.
+                                 //   5-8    quick spell impact sound of party member 1-4.
+                                 //   9-12   wand cast sound of party member 1-4. Blaster shots pass these numbers too.
+                                 //   13-16  wand impact sound of party member 1-4.
+                                 // Vanilla also treats bit 3, the wand rows, like the unpickable flag on level load.
+                                 // Every sprite that could carry it is unpickable anyway.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -962,16 +962,17 @@ struct SpriteObject_MM7 {
     Vec3i position;
     Vec3s velocity;
     uint16_t yawAngle;
-    uint16_t preloadedSoundSlotUnused; // Vanilla keeps 17 sample pointers per sound, the sample and 16 cached copies.
-                                       // This slot of the cast sound holds the cast sample, slot + 4 of the impact
-                                       // sound the impact sample, and each plays from its slot, 0 staying 0:
+    uint16_t preloadedSoundSlotUnused; // Index into SoundInfo_MM7::soundData of the cast sound, where vanilla cached
+                                       // the cast sample, and index + 4 of the impact sound the impact one, 0 stays 0:
                                        //   0      the sample itself, loaded at start or first use. Spellbook, scrolls.
                                        //   1-4    quick spell cast sound of party member 1-4.
                                        //   5-8    quick spell impact sound of party member 1-4.
                                        //   9-12   wand cast sound of party member 1-4. Blasters pass the same numbers.
                                        //   13-16  wand impact sound of party member 1-4.
-                                       // Vanilla purges bit 3 sprites, the 9-12 row, on map entry like unpickable ones.
-                                       // OE writes 0 and ignores it on load.
+                                       // The field holds only 0, 1-4 or 9-12, the impact rows live in the cache, so
+                                       // bit 3 is exactly the wand or blaster mark written as index | 8. Vanilla purges
+                                       // sprites carrying it on map entry like unpickable ones. OE writes 0 and never
+                                       // reads it back.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;
@@ -1268,7 +1269,9 @@ struct SoundInfo_MM6 {
     uint32_t soundId;
     uint32_t type;
     uint32_t flags;
-    std::array<uint32_t, 17> soundData; // Always 0 in MM7 data.
+    std::array<uint32_t, 17> soundData; // Vanilla's runtime pointers to a WAV from audio.snd, 0 a heap copy behind a
+                                        // 4-byte size, 1-16 raw copies in the per-character spell sound cache.
+                                        // Always 0 in MM7 data.
 };
 static_assert(sizeof(SoundInfo_MM6) == 112);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SoundInfo_MM6)

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -963,14 +963,15 @@ struct SpriteObject_MM7 {
     Vec3s velocity;
     uint16_t yawAngle;
     uint16_t preloadedSoundSlot; // Vanilla keeps 17 sample pointers per sound, the sample itself and 16 cached copies.
-                                 // This is the cast sound's entry. The impact sound plays from entry + 4, 0 staying 0:
-                                 //   0      the sample itself, loaded on first use. Spellbook, scrolls, and always OE.
+                                 // This slot of the cast sound holds the cast sample, slot + 4 of the impact sound the
+                                 // impact sample, and each plays from its slot, 0 staying 0:
+                                 //   0      the sample itself, loaded at startup or first use. Spellbook, scrolls, OE.
                                  //   1-4    quick spell cast sound of party member 1-4.
                                  //   5-8    quick spell impact sound of party member 1-4.
-                                 //   9-12   wand cast sound of party member 1-4. Blaster shots pass these numbers too.
+                                 //   9-12   wand cast sound of party member 1-4. Blasters pass the same numbers.
                                  //   13-16  wand impact sound of party member 1-4.
-                                 // Vanilla also treats bit 3, the wand rows, like the unpickable flag on level load.
-                                 // Every sprite that could carry it is unpickable anyway.
+                                 // Vanilla purges sprites with bit 3, the 9-12 row, on map entry like unpickable ones.
+                                 // OE keeps the value as loaded and writes it back, never setting it for its own casts.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -963,11 +963,9 @@ struct SpriteObject_MM7 {
     Vec3s velocity;
     uint16_t yawAngle;
     uint16_t preloadedSoundSlotUnused; // Index into SoundInfo_MM7::soundData of the cast sound, 1-4 for quick spells,
-                                       // 9-12 for wand and blaster shots, 0 for the spellbook and scrolls. The impact
-                                       // sound plays from index + 4 of the impact sound's entry, 0 staying 0. With only
-                                       // those values bit 3 is exactly the wand or blaster mark written as index | 8,
-                                       // and vanilla purges sprites carrying it on map entry like unpickable ones. OE
-                                       // writes 0 and never reads it back.
+                                       // 9-12 for wand and blaster shots, 0 for everything else. Bit 3 thus marks a
+                                       // wand or blaster shot, and vanilla purges sprites carrying it on map entry like
+                                       // unpickable ones. OE writes 0 and never reads it back.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;
@@ -1264,14 +1262,11 @@ struct SoundInfo_MM6 {
     uint32_t soundId;
     uint32_t type;
     uint32_t flags;
-    std::array<uint32_t, 17> soundData; // Vanilla's runtime pointers to a WAV from audio.snd, 0 a heap copy behind a
-                                        // 4-byte size, 1-16 raw copies in the per-character spell sound cache:
-                                        //   0      the sample itself, loaded at start or first use.
-                                        //   1-4    quick spell cast sound of party member 1-4.
-                                        //   5-8    quick spell impact sound of party member 1-4.
-                                        //   9-12   wand cast sound of party member 1-4.
-                                        //   13-16  wand impact sound of party member 1-4.
-                                        // Always 0 in MM7 data.
+    std::array<uint32_t, 17> soundData; // Vanilla's runtime sample pointers, serialized with the table, always 0 in MM7
+                                        // data. 0 is the WAV from audio.snd, the rest copies in the per-character spell
+                                        // sound cache:
+                                        //   1-4    quick spell cast sound of party member 1-4, 5-8 its impact sound.
+                                        //   9-12   wand cast sound of party member 1-4, 13-16 its impact sound.
 };
 static_assert(sizeof(SoundInfo_MM6) == 112);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SoundInfo_MM6)

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -962,16 +962,16 @@ struct SpriteObject_MM7 {
     Vec3i position;
     Vec3s velocity;
     uint16_t yawAngle;
-    uint16_t preloadedSoundSlot; // Vanilla keeps 17 sample pointers per sound, the sample itself and 16 cached copies.
-                                 // This slot of the cast sound holds the cast sample, slot + 4 of the impact sound the
-                                 // impact sample, and each plays from its slot, 0 staying 0:
-                                 //   0      the sample itself, loaded at startup or first use. Spellbook, scrolls, OE.
-                                 //   1-4    quick spell cast sound of party member 1-4.
-                                 //   5-8    quick spell impact sound of party member 1-4.
-                                 //   9-12   wand cast sound of party member 1-4. Blasters pass the same numbers.
-                                 //   13-16  wand impact sound of party member 1-4.
-                                 // Vanilla purges sprites with bit 3, the 9-12 row, on map entry like unpickable ones.
-                                 // OE keeps the value as loaded and writes it back, never setting it for its own casts.
+    uint16_t preloadedSoundSlotUnused; // Vanilla keeps 17 sample pointers per sound, the sample and 16 cached copies.
+                                       // This slot of the cast sound holds the cast sample, slot + 4 of the impact
+                                       // sound the impact sample, and each plays from its slot, 0 staying 0:
+                                       //   0      the sample itself, loaded at start or first use. Spellbook, scrolls.
+                                       //   1-4    quick spell cast sound of party member 1-4.
+                                       //   5-8    quick spell impact sound of party member 1-4.
+                                       //   9-12   wand cast sound of party member 1-4. Blasters pass the same numbers.
+                                       //   13-16  wand impact sound of party member 1-4.
+                                       // Vanilla purges bit 3 sprites, the 9-12 row, on map entry like unpickable ones.
+                                       // OE writes 0 and ignores it on load.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -1265,8 +1265,10 @@ struct SoundInfo_MM6 {
     std::array<uint32_t, 17> soundData; // Vanilla's runtime sample pointers, serialized with the table, always 0 in MM7
                                         // data. 0 is the WAV from audio.snd, the rest copies in the per-character spell
                                         // sound cache:
-                                        //   1-4    quick spell cast sound of party member 1-4, 5-8 its impact sound.
-                                        //   9-12   wand cast sound of party member 1-4, 13-16 its impact sound.
+                                        //   1-4    quick spell cast sound of party member 1-4.
+                                        //   5-8    quick spell impact sound of party member 1-4.
+                                        //   9-12   wand cast sound of party member 1-4.
+                                        //   13-16  wand impact sound of party member 1-4.
 };
 static_assert(sizeof(SoundInfo_MM6) == 112);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SoundInfo_MM6)

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -964,8 +964,10 @@ struct SpriteObject_MM7 {
     uint16_t yawAngle;
     uint16_t preloadedSoundSlotUnused; // Index into SoundInfo_MM7::soundData of the cast sound, 1-4 for quick spells,
                                        // 9-12 for wand and blaster shots, 0 for everything else. Bit 3 thus marks a
-                                       // wand or blaster shot, and vanilla purges sprites carrying it on map entry like
-                                       // unpickable ones. OE writes 0 and never reads it back.
+                                       // wand or blaster shot, and vanilla drops sprites carrying it on map entry (but
+                                       // not on save load). Vanilla also drops sprites based on OBJECT_DESC_UNPICKABLE
+                                       // flag, and all wand and blaster sprites carry it, so in OE this field is not
+                                       // used - we write 0 and never read it.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;
@@ -1262,13 +1264,23 @@ struct SoundInfo_MM6 {
     uint32_t soundId;
     uint32_t type;
     uint32_t flags;
-    std::array<uint32_t, 17> soundData; // Vanilla's runtime sample pointers, serialized with the table, always 0 in MM7
-                                        // data. 0 is the WAV from audio.snd, the rest copies in the per-character spell
-                                        // sound cache:
+    std::array<uint32_t, 17> soundData; // Vanilla's runtime sample pointers, always 0 in MM7 data. 0 is the WAV from
+                                        // audio.snd, the rest point into the static per-character spell sound buffers:
                                         //   1-4    quick spell cast sound of party member 1-4.
                                         //   5-8    quick spell impact sound of party member 1-4.
                                         //   9-12   wand cast sound of party member 1-4.
                                         //   13-16  wand impact sound of party member 1-4.
+                                        // Cast sounds use rows 1-4 and 9-12, impact sounds use rows 5-8 and 13-16, so
+                                        // no sound uses all rows.
+                                        //
+                                        // Why are cache pointers here? Vanilla frees slot 0 of a non-system sound as
+                                        // soon as it stops playing, so the party's own quick spell and wand sounds are
+                                        // kept resident in static per-member buffers and played from these slots. Every
+                                        // slot of a sound points at a copy of the same sample, slot N at the copy in
+                                        // the buffer of the member who owns row N. The owner matters because each
+                                        // buffer is overwritten when its member changes quick spell or wand, so a
+                                        // caster plays from its own member's slot, the one copy it knows is current,
+                                        // and stale slots left behind in other sounds are never read.
 };
 static_assert(sizeof(SoundInfo_MM6) == 112);
 MM_DECLARE_MEMCOPY_SERIALIZABLE(SoundInfo_MM6)

--- a/src/Engine/Snapshots/EntitySnapshots.h
+++ b/src/Engine/Snapshots/EntitySnapshots.h
@@ -962,17 +962,12 @@ struct SpriteObject_MM7 {
     Vec3i position;
     Vec3s velocity;
     uint16_t yawAngle;
-    uint16_t preloadedSoundSlotUnused; // Index into SoundInfo_MM7::soundData of the cast sound, where vanilla cached
-                                       // the cast sample, and index + 4 of the impact sound the impact one, 0 stays 0:
-                                       //   0      the sample itself, loaded at start or first use. Spellbook, scrolls.
-                                       //   1-4    quick spell cast sound of party member 1-4.
-                                       //   5-8    quick spell impact sound of party member 1-4.
-                                       //   9-12   wand cast sound of party member 1-4. Blasters pass the same numbers.
-                                       //   13-16  wand impact sound of party member 1-4.
-                                       // The field holds only 0, 1-4 or 9-12, the impact rows live in the cache, so
-                                       // bit 3 is exactly the wand or blaster mark written as index | 8. Vanilla purges
-                                       // sprites carrying it on map entry like unpickable ones. OE writes 0 and never
-                                       // reads it back.
+    uint16_t preloadedSoundSlotUnused; // Index into SoundInfo_MM7::soundData of the cast sound, 1-4 for quick spells,
+                                       // 9-12 for wand and blaster shots, 0 for the spellbook and scrolls. The impact
+                                       // sound plays from index + 4 of the impact sound's entry, 0 staying 0. With only
+                                       // those values bit 3 is exactly the wand or blaster mark written as index | 8,
+                                       // and vanilla purges sprites carrying it on map entry like unpickable ones. OE
+                                       // writes 0 and never reads it back.
     uint16_t uAttributes;
     int16_t uSectorID;
     uint16_t uTimeSinceCreated;
@@ -1270,7 +1265,12 @@ struct SoundInfo_MM6 {
     uint32_t type;
     uint32_t flags;
     std::array<uint32_t, 17> soundData; // Vanilla's runtime pointers to a WAV from audio.snd, 0 a heap copy behind a
-                                        // 4-byte size, 1-16 raw copies in the per-character spell sound cache.
+                                        // 4-byte size, 1-16 raw copies in the per-character spell sound cache:
+                                        //   0      the sample itself, loaded at start or first use.
+                                        //   1-4    quick spell cast sound of party member 1-4.
+                                        //   5-8    quick spell impact sound of party member 1-4.
+                                        //   9-12   wand cast sound of party member 1-4.
+                                        //   13-16  wand impact sound of party member 1-4.
                                         // Always 0 in MM7 data.
 };
 static_assert(sizeof(SoundInfo_MM6) == 112);

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -54,8 +54,8 @@ static constexpr Duration SPELL_FAILURE_RECOVERY_TIME_ON_CURSE = 100_ticks;
  * Fills in the spell fields of a freshly spawned projectile sprite.
  *
  * @param spritePtr                     Sprite to fill in, with its sprite id already set.
- * @param spellLevel                    Spell level to stamp on the sprite.
- * @param spellMastery                  Spell mastery to stamp on the sprite.
+ * @param spellLevel                    Spell level of the cast.
+ * @param spellMastery                  Spell mastery of the cast.
  * @param pCastSpell                    Queued cast that spawns the sprite.
  */
 static void initSpellSprite(SpriteObject *spritePtr,

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -51,10 +51,12 @@ static std::array<CastSpellInfo, CAST_SPELL_QUEUE_SIZE> pCastSpellInfo;
 static constexpr Duration SPELL_FAILURE_RECOVERY_TIME_ON_CURSE = 100_ticks;
 
 /**
- * Common initialization of SpriteObject for spell casting
+ * Fills in the spell fields of a freshly spawned projectile sprite.
  *
- * Correct field uType of spritePtr must be set before calling this function
- * because initialization depends on it.
+ * @param spritePtr                     Sprite to fill in, with its sprite id already set.
+ * @param spellLevel                    Spell level to stamp on the sprite.
+ * @param spellMastery                  Spell mastery to stamp on the sprite.
+ * @param pCastSpell                    Queued cast that spawns the sprite.
  */
 static void initSpellSprite(SpriteObject *spritePtr,
                             int spellLevel,
@@ -3042,8 +3044,9 @@ void pushSpellOrRangedAttack(SpellId spell,
             case SPELL_DARK_SHRINKING_RAY:
             case SPELL_DARK_SHARPMETAL:
             case SPELL_DARK_DRAGON_BREATH:
-                if (!(flags & ON_CAST_AutoTarget))
+                if (!(flags & ON_CAST_AutoTarget)) {
                     flags |= ON_CAST_TargetedActor;
+                }
                 break;
             case SPELL_MIND_TELEPATHY:
             case SPELL_MIND_BERSERK:

--- a/src/Engine/Spells/CastSpellInfo.cpp
+++ b/src/Engine/Spells/CastSpellInfo.cpp
@@ -69,7 +69,6 @@ static void initSpellSprite(SpriteObject *spritePtr,
     spritePtr->spell_skill = spellMastery;
     spritePtr->uObjectDescID = pObjectList->ObjectIDByItemID(spritePtr->spriteId);
     spritePtr->spell_caster_pid = Pid(OBJECT_Character, pCastSpell->casterCharacterIndex);
-    spritePtr->uSoundID = pCastSpell->overrideSoundId;
 }
 
 /**
@@ -2936,13 +2935,17 @@ void CastSpellInfoHelpers::castSpell() {
  * Add spell or skill into spell queue.
  * Spells from this queue will be cast in event queue processing.
  *
+ * @param uSpellID                      Spell id.
+ * @param casterIndex                   Zero-based index of the caster.
+ * @param skill_level                   Skill value to use for casting.
+ * @param uFlags                        Spell flags.
+ * @return                              Queue slot index, or size_t(-1) if the queue is full.
  * @offset 0x00427DA0
  */
 static size_t pushCastSpellInfo(SpellId uSpellID,
                                 int casterIndex,
                                 CombinedSkillValue skill_level,
-                                SpellCastFlags uFlags,
-                                int overrideSoundId) {
+                                SpellCastFlags uFlags) {
     for (size_t i = 0; i < pCastSpellInfo.size(); i++) {
         if (pCastSpellInfo[i].uSpellID == SPELL_NONE) {
             pCastSpellInfo[i].uSpellID = uSpellID;
@@ -2953,7 +2956,6 @@ static size_t pushCastSpellInfo(SpellId uSpellID,
             pCastSpellInfo[i].targetPid = Pid();
             pCastSpellInfo[i].flags = uFlags;
             pCastSpellInfo[i].overrideSkillValue = skill_level;
-            pCastSpellInfo[i].overrideSoundId = overrideSoundId;
             return i;
         }
     }
@@ -2987,8 +2989,7 @@ void CastSpellInfoHelpers::cancelSpellCastInProgress() {
 void pushSpellOrRangedAttack(SpellId spell,
                              int casterIndex,
                              CombinedSkillValue skill_value,
-                             SpellCastFlags flags,
-                             int overrideSoundId) {
+                             SpellCastFlags flags) {
     if (pParty->bTurnBasedModeOn) {
         if (pTurnEngine->turn_stage == TE_WAIT ||
             pTurnEngine->turn_stage == TE_MOVEMENT) {
@@ -3041,10 +3042,8 @@ void pushSpellOrRangedAttack(SpellId spell,
             case SPELL_DARK_SHRINKING_RAY:
             case SPELL_DARK_SHARPMETAL:
             case SPELL_DARK_DRAGON_BREATH:
-                if (!overrideSoundId) {
-                    // These spells are targeted unless used from quick spell button
+                if (!(flags & ON_CAST_AutoTarget))
                     flags |= ON_CAST_TargetedActor;
-                }
                 break;
             case SPELL_MIND_TELEPATHY:
             case SPELL_MIND_BERSERK:
@@ -3133,7 +3132,7 @@ void pushSpellOrRangedAttack(SpellId spell,
 
     CastSpellInfoHelpers::cancelSpellCastInProgress();
 
-    int result = pushCastSpellInfo(spell, casterIndex, skill_value, flags, overrideSoundId);
+    int result = pushCastSpellInfo(spell, casterIndex, skill_value, flags);
 
     // TODO: if no more place for spells in queue then spell is just ignored?
     //       Need assert?
@@ -3179,15 +3178,15 @@ void pushTempleSpell(SpellId spell) {
     CombinedSkillValue skill_value = CombinedSkillValue(pParty->uCurrentDayOfMonth % 7 + 1, MASTERY_MASTER);
 
     pushSpellOrRangedAttack(spell, pParty->activeCharacterIndex() - 1, skill_value,
-                            ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell, 0);
+                            ON_CAST_TargetIsParty | ON_CAST_NoRecoverySpell);
 }
 
 void pushNPCSpell(SpellId spell) {
-    pushSpellOrRangedAttack(spell, 0, SCROLL_OR_NPC_SPELL_SKILL_VALUE, 0, 0);
+    pushSpellOrRangedAttack(spell, 0, SCROLL_OR_NPC_SPELL_SKILL_VALUE, 0);
 }
 
 void pushScrollSpell(SpellId spell, int casterIndex) {
-    pushSpellOrRangedAttack(spell, casterIndex, SCROLL_OR_NPC_SPELL_SKILL_VALUE, ON_CAST_CastViaScroll, 0);
+    pushSpellOrRangedAttack(spell, casterIndex, SCROLL_OR_NPC_SPELL_SKILL_VALUE, ON_CAST_CastViaScroll);
 }
 
 void spellTargetPicked(Pid targetPid, int targetCharacterIndex) {

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -42,8 +42,7 @@ enum class SpellCastFlag : uint16_t {
     ON_CAST_TargetedEnchantment = 0x0080,      // Targeted spell, target is item in inventory
     ON_CAST_TargetedActorOrCharacter = 0x0100, // Targeted spell, target either actor or character
     ON_CAST_TargetedHireling = 0x0200,         // Targeted spell, target is hireling
-    ON_CAST_AutoTarget = 0x0400,               // Quick spell key or weapon shot, the target is taken from the cursor
-                                               // or the closest actor instead of a picker.
+    ON_CAST_AutoTarget = 0x0400,               // Quick spell key, wand or blaster shot, target from the cursor or the closest actor instead of a picker
 
     // Cumulative flags indicating that spell is targeted
     ON_CAST_CastingInProgress =

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -42,6 +42,8 @@ enum class SpellCastFlag : uint16_t {
     ON_CAST_TargetedEnchantment = 0x0080,      // Targeted spell, target is item in inventory
     ON_CAST_TargetedActorOrCharacter = 0x0100, // Targeted spell, target either actor or character
     ON_CAST_TargetedHireling = 0x0200,         // Targeted spell, target is hireling
+    ON_CAST_AutoTarget = 0x0400,               // Quick spell key or weapon shot, the target is taken from the cursor
+                                               // or the closest actor instead of a picker.
 
     // Cumulative flags indicating that spell is targeted
     ON_CAST_CastingInProgress =
@@ -70,9 +72,6 @@ struct CastSpellInfo {
     Pid targetPid; // Target pid, if any.
     int targetInventoryIndex = -1; // Target inventory item index (in Character::pInventoryItemList) in target
                                    // character's inventory, if any.
-
-    int overrideSoundId = 0; // TODO(captainurist): doesn't look like sound id. Maybe flags?
-                             //                     Bits 0-2 for caster (1-based), bit 3 for blaster.
 };
 
 /**
@@ -87,19 +86,16 @@ struct CastSpellInfo {
  * listed in ON_CAST_CastingInProgress and this flag will be removed
  * in event queue if correct target is picked.
  *
- * @offset 0x0042777D
- *
  * @param spell                         Spell id.
  * @param casterIndex                   Zero-based index of a character casting the spell.
  * @param skill_value                   Skill value that the spell is cast with.
  * @param flags                         Spell flags. Can be empty or have several flags.
- * @param overrideSoundId                            ???
+ * @offset 0x0042777D
  */
 void pushSpellOrRangedAttack(SpellId spell,
                              int casterIndex,
                              CombinedSkillValue skill_value,
-                             SpellCastFlags flags,
-                             int overrideSoundId);
+                             SpellCastFlags flags);
 
 /**
  * Register spell cast on party with temple donation.

--- a/src/Engine/Spells/CastSpellInfo.h
+++ b/src/Engine/Spells/CastSpellInfo.h
@@ -42,7 +42,7 @@ enum class SpellCastFlag : uint16_t {
     ON_CAST_TargetedEnchantment = 0x0080,      // Targeted spell, target is item in inventory
     ON_CAST_TargetedActorOrCharacter = 0x0100, // Targeted spell, target either actor or character
     ON_CAST_TargetedHireling = 0x0200,         // Targeted spell, target is hireling
-    ON_CAST_AutoTarget = 0x0400,               // Quick spell key, wand or blaster shot, target from the cursor or the closest actor instead of a picker
+    ON_CAST_AutoTarget = 0x0400,               // OE addition. Quick spell key, wand or blaster shot, target from the cursor or the closest actor instead of a picker
 
     // Cumulative flags indicating that spell is targeted
     ON_CAST_CastingInProgress =

--- a/src/Engine/Spells/Spells.cpp
+++ b/src/Engine/Spells/Spells.cpp
@@ -595,7 +595,6 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
             spell_sprites.field_60_distance_related_prolly_lod = distance_to_target;
             spell_sprites.timeSinceCreated = 0_ticks;
             spell_sprites.spell_caster_pid = Pid(OBJECT_Sprite, 1000); // 8000 | OBJECT_Sprite;
-            spell_sprites.uSoundID = 0;
             break;
         default:
             break;
@@ -623,7 +622,6 @@ void eventCastSpell(SpellId uSpellID, Mastery skillMastery, int skillLevel, Vec3
             // v20 = yaw;
             spell_sprites.spell_target_pid = Pid();
             spell_sprites.uFacing = yaw;
-            spell_sprites.uSoundID = 0;
             launch_speed = pObjectList->pObjects[(int16_t)spell_sprites.uObjectDescID].uSpeed;
             spriteid = spell_sprites.Create(yaw, pitch, launch_speed, 0);
             //    pAudioPlayer->PlaySound(word_4EE088_sound_ids[uSpellID],

--- a/test/Bin/GameTest/GameTests_0000.cpp
+++ b/test/Bin/GameTest/GameTests_0000.cpp
@@ -598,7 +598,7 @@ GAME_TEST(Issues, Issue414) {
     // Cast while cursed — sequential RNG returns 0 for grng->random(100), which is < 50,
     // so the spell always fails due to curse.
     character.conditions.set(CONDITION_CURSED, Time::fromTicks(1));
-    pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue::none(), 0, 0);
+    pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue::none(), 0);
     game.tick(1);
     int manaSpentOnFailure = 100 - character.mana;
     EXPECT_EQ(engine->_statusBar->get(), "Spell failed"); // Status bar shows failure message.
@@ -606,7 +606,7 @@ GAME_TEST(Issues, Issue414) {
     // Cast while not cursed — spell succeeds.
     character.conditions.reset(CONDITION_CURSED);
     character.mana = 100;
-    pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue::none(), 0, 0);
+    pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue::none(), 0);
     game.tick(1);
     int manaSpentOnSuccess = 100 - character.mana;
     int fireSpikeCount = std::ranges::count_if(pSpriteObjects, [](const SpriteObject &obj) {

--- a/test/Bin/GameTest/GameTests_1500.cpp
+++ b/test/Bin/GameTest/GameTests_1500.cpp
@@ -169,7 +169,7 @@ GAME_TEST(Issues, Issue1532) {
     // keep casting till the spell fails
     while (engine->_statusBar->get() != "Spell failed") {
         if (pParty->pCharacters[0].CanAct())
-            pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue(10, MASTERY_GRANDMASTER), 0, 0);
+            pushSpellOrRangedAttack(SPELL_FIRE_FIRE_SPIKE, 0, CombinedSkillValue(10, MASTERY_GRANDMASTER), 0);
         game.tick(1);
     }
 


### PR DESCRIPTION
`pushSpellOrRangedAttack` took an `overrideSoundId` integer that nobody could name. In the original engine it is the slot of the caster's preloaded spell sound, 1-4 for quick spells and 9-12 for wands and blasters, and vanilla plays the impact sound from slot + 4 out of a per-character cache. OpenEnroth never had that cache, so the value only ever meant "nonzero, skip the actor picker" and "bit 3, wand or blaster projectile". The first is now `ON_CAST_AutoTarget`, set by the quick spell key, wands and blasters.

The second was tested by the level-init purge off the sprite's misnamed `uSoundID` field. Every wand and blaster projectile description is unpickable in MM6, MM7 and MM8 data and no shipped MM7 level delta carries the bit, so the purge keeps only the description check and the field goes. The save layout keeps the slot as an unused member with the vanilla semantics spelled out next to it.

Splits the refactoring out of #2669, which now only moves five spells onto the flag and tests it.

Implemented with [Claude Code](https://claude.com/claude-code).
