### PR TITLE
Guard InvalidUtf8FileNames with an ifdef instead of skipping it

### DIFF
--- a/src/Utility/System/Tests/NativePath_ut.cpp
+++ b/src/Utility/System/Tests/NativePath_ut.cpp
@@ -51,17 +51,25 @@ UNIT_TEST(NativePath, Absolute) {
 }
 
 #ifndef _WINDOWS
-UNIT_TEST(NativePath, InvalidUtf8FileNames) {
-    // File names on Linux are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is
+UNIT_TEST(NativePath, InvalidUtf8RoundTrip) {
+    // File names on POSIX are byte strings, so fromWtf8 / toWtf8 have to pass invalid UTF-8 through as-is. "\xD0" is
     // an incomplete UTF-8 sequence, "\xFF" can't appear in UTF-8 at all.
-    for (std::string_view name : {"tmp_lol\xD0kek.txt", "tmp_lol\xFFkek.txt", "tmp_trailing\xD0"}) {
-        NativePath path = NativePath::fromWtf8(name);
-        EXPECT_EQ(path.toWtf8(), name);
+    for (std::string_view name : {"lol\xD0kek.txt", "lol\xFFkek.txt", "trailing\xD0"})
+        EXPECT_EQ(NativePath::fromWtf8(name).toWtf8(), name);
+}
+#endif
 
-        // APFS rejects such names, and so do APFS-backed mounts in a dev container, so we skip instead of asserting.
+#if !defined(_WINDOWS) && !defined(__APPLE__)
+UNIT_TEST(NativePath, InvalidUtf8FileNames) {
+    // A name with invalid UTF-8 in it is not just convertible, it's also usable to actually open a file. APFS is the
+    // exception, it only takes file names that are valid UTF-8, so this test doesn't run on MacOS.
+    NativePath tmpDir = NativePath::fromStdPath(std::filesystem::temp_directory_path()); // A build dir can sit on an APFS-backed mount in a dev container.
+
+    for (std::string_view name : {"tmp_lol\xD0kek.txt", "tmp_lol\xFFkek.txt", "tmp_trailing\xD0"}) {
+        NativePath path = tmpDir / NativePath::fromWtf8(name);
+
         std::ofstream stream(path.toStdPath());
-        if (!stream.is_open())
-            GTEST_SKIP() << "File system rejected an invalid UTF-8 name.";
+        ASSERT_TRUE(stream.is_open()) << name;
         stream << "lol";
         stream.close();
 


### PR DESCRIPTION
`NativePath.InvalidUtf8FileNames` gave up at runtime whenever the file system refused an invalid UTF-8 name, and the `GTEST_SKIP` sat inside the loop after the first assertion, so only one of the three names was ever checked. It was the only skip in the unit test run.

The conversion checks work on any POSIX system, so they move into their own test that always runs. The half that creates files is now excluded at compile time on MacOS, because APFS only takes names that are valid UTF-8, and it writes into the temp dir since a build dir can sit on an APFS-backed mount in a dev container. The runtime skip becomes an assert.

Locally this takes the unit run from 411 tests with one skip to 412 tests with none. This is a slice split out of #2557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)