### PR TITLE
Fix the renderer and movie player leaks that fail the game tests under LSan

### DIFF
--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -208,7 +208,7 @@ GameStarter::~GameStarter() {
     _engine.reset();
     _overlaySystem.reset();
     _scriptingSystem.reset();
-    _renderer.reset(); // Before the globals below, releasing a texture routes through ::render.
+    _renderer.reset();
 
     ::engine = nullptr;
     ::render = nullptr;

--- a/src/Application/Startup/GameStarter.cpp
+++ b/src/Application/Startup/GameStarter.cpp
@@ -206,6 +206,9 @@ GameStarter::~GameStarter() {
 
     _game.reset();
     _engine.reset();
+    _overlaySystem.reset();
+    _scriptingSystem.reset();
+    _renderer.reset(); // Before the globals below, releasing a texture routes through ::render.
 
     ::engine = nullptr;
     ::render = nullptr;

--- a/src/Engine/Graphics/Renderer/NullRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/NullRenderer.cpp
@@ -7,6 +7,10 @@
 
 #include "Library/Platform/Application/PlatformApplication.h"
 
+NullRenderer::~NullRenderer() {
+    releaseSolidFillTexture();
+}
+
 void NullRenderer::Initialize() {
     application->initializeOpenGLContext(PlatformOpenGLOptions());
     BaseRenderer::Initialize();

--- a/src/Engine/Graphics/Renderer/NullRenderer.h
+++ b/src/Engine/Graphics/Renderer/NullRenderer.h
@@ -7,6 +7,7 @@
 class NullRenderer : public BaseRenderer {
  public:
     using BaseRenderer::BaseRenderer;
+    virtual ~NullRenderer();
 
     virtual void Initialize() override;
     virtual bool Reinitialize(bool firstInit) override;

--- a/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
+++ b/src/Engine/Graphics/Renderer/OpenGLRenderer.cpp
@@ -203,6 +203,7 @@ OpenGLRenderer::OpenGLRenderer(
 
 OpenGLRenderer::~OpenGLRenderer() {
     MM_INFO("RenderGl - Destructor");
+    releaseSolidFillTexture();
     _shutdownImGui();
 }
 

--- a/src/Engine/Graphics/Renderer/Renderer.cpp
+++ b/src/Engine/Graphics/Renderer/Renderer.cpp
@@ -1,5 +1,6 @@
 #include "Renderer.h"
 
+#include <cassert>
 #include <memory>
 
 #include "Engine/Graphics/Image.h"
@@ -26,7 +27,9 @@ Renderer::Renderer(
     drawcalls = 0;
 }
 
-Renderer::~Renderer() = default;
+Renderer::~Renderer() {
+    assert(!_solidFillTexture);
+}
 
 void Renderer::DrawQuad2D(GraphicsImage *texture, const Recti &srcRect, Pointi dstPoint, Color color) {
     Recti dstRect(dstPoint.x, dstPoint.y, srcRect.w, srcRect.h);
@@ -45,6 +48,13 @@ GraphicsImage *Renderer::solidFillTexture() {
     if (!_solidFillTexture)
         _solidFillTexture = GraphicsImage::Create(RgbaImage::solid(colorTable.White, 1, 1));
     return _solidFillTexture;
+}
+
+void Renderer::releaseSolidFillTexture() {
+    if (_solidFillTexture) {
+        _solidFillTexture->release();
+        _solidFillTexture = nullptr;
+    }
 }
 
 void Renderer::FillRect(const Recti &rect, Color color) {

--- a/src/Engine/Graphics/Renderer/Renderer.h
+++ b/src/Engine/Graphics/Renderer/Renderer.h
@@ -181,6 +181,12 @@ class Renderer {
     GraphicsImage *solidFillTexture();
 
  protected:
+    /**
+     * Releases the lazily created solid fill texture. A concrete renderer must call this from its own
+     * destructor, because releasing a texture dispatches through the pure virtual `DeleteTexture`.
+     */
+    void releaseSolidFillTexture();
+
     DecalBuilder *decal_builder = nullptr;
     SpellFxRenderer *spell_fx_renderer = nullptr;
     std::shared_ptr<ParticleEngine> particle_engine = nullptr;

--- a/src/Engine/Graphics/Renderer/Renderer.h
+++ b/src/Engine/Graphics/Renderer/Renderer.h
@@ -181,10 +181,6 @@ class Renderer {
     GraphicsImage *solidFillTexture();
 
  protected:
-    /**
-     * Releases the lazily created solid fill texture. A concrete renderer must call this from its own
-     * destructor, because releasing a texture dispatches through the pure virtual `DeleteTexture`.
-     */
     void releaseSolidFillTexture();
 
     DecalBuilder *decal_builder = nullptr;

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -126,6 +126,17 @@ class AVStreamWrapper {
 
 class AVAudioStream : public AVStreamWrapper {
  public:
+    virtual ~AVAudioStream() {
+        // ~AVStreamWrapper also calls close(), but a virtual call from a base destructor lands on the base
+        // override, so the resampler has to be freed from here.
+        close();
+    }
+
+    virtual void close() override {
+        swr_free(&converter); // Null-safe, and nulls the pointer.
+        AVStreamWrapper::close();
+    }
+
     virtual bool open(AVFormatContext *format_ctx) override {
         if (!AVStreamWrapper::open(format_ctx, AVMEDIA_TYPE_AUDIO)) {
             return false;
@@ -203,6 +214,18 @@ class AVAudioStream : public AVStreamWrapper {
 
 class AVVideoStream : public AVStreamWrapper {
  public:
+    virtual ~AVVideoStream() {
+        // ~AVStreamWrapper also calls close(), but a virtual call from a base destructor lands on the base
+        // override, so the scaler has to be freed from here.
+        close();
+    }
+
+    virtual void close() override {
+        sws_freeContext(converter); // Null-safe.
+        converter = nullptr;
+        AVStreamWrapper::close();
+    }
+
     virtual bool open(AVFormatContext *format_ctx) override {
         if (!AVStreamWrapper::open(format_ctx, AVMEDIA_TYPE_VIDEO)) {
             return false;
@@ -480,6 +503,7 @@ class Movie : public IMovie {
                 Blob buffer = audio.decode_frame(&packet);
                 if (buffer) buffq.push(std::move(buffer));
             }
+            av_packet_unref(&packet); // Every read allocates a new reference, and the loop would drop the previous one.
         }
         MM_TRACE("Audio Packets Queued");
 
@@ -509,8 +533,10 @@ class Movie : public IMovie {
             } while (lastvideopts == desired_frame_number);
 
             // ignore audio packets
-            if (packet.stream_index == audio.stream_idx)
+            if (packet.stream_index == audio.stream_idx) {
+                av_packet_unref(&packet); // Skipping the unref at the end of the loop would leak this one.
                 continue;
+            }
 
             if (packet.stream_index == video.stream_idx) {
                 // check if anymore sound frames still in decoder

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -127,11 +127,11 @@ class AVStreamWrapper {
 class AVAudioStream : public AVStreamWrapper {
  public:
     virtual ~AVAudioStream() {
-        close(); // A virtual call from ~AVStreamWrapper lands on the base override, so the resampler needs this.
+        close();
     }
 
     virtual void close() override {
-        swr_free(&converter); // Null-safe, and nulls the pointer.
+        swr_free(&converter);
         AVStreamWrapper::close();
     }
 
@@ -213,11 +213,11 @@ class AVAudioStream : public AVStreamWrapper {
 class AVVideoStream : public AVStreamWrapper {
  public:
     virtual ~AVVideoStream() {
-        close(); // A virtual call from ~AVStreamWrapper lands on the base override, so the scaler needs this.
+        close();
     }
 
     virtual void close() override {
-        sws_freeContext(converter); // Null-safe.
+        sws_freeContext(converter);
         converter = nullptr;
         AVStreamWrapper::close();
     }
@@ -499,7 +499,7 @@ class Movie : public IMovie {
                 Blob buffer = audio.decode_frame(&packet);
                 if (buffer) buffq.push(std::move(buffer));
             }
-            av_packet_unref(&packet); // Every read allocates a new reference, and the loop would drop the previous one.
+            av_packet_unref(&packet);
         }
         MM_TRACE("Audio Packets Queued");
 

--- a/src/Media/MediaPlayer.cpp
+++ b/src/Media/MediaPlayer.cpp
@@ -127,9 +127,7 @@ class AVStreamWrapper {
 class AVAudioStream : public AVStreamWrapper {
  public:
     virtual ~AVAudioStream() {
-        // ~AVStreamWrapper also calls close(), but a virtual call from a base destructor lands on the base
-        // override, so the resampler has to be freed from here.
-        close();
+        close(); // A virtual call from ~AVStreamWrapper lands on the base override, so the resampler needs this.
     }
 
     virtual void close() override {
@@ -215,9 +213,7 @@ class AVAudioStream : public AVStreamWrapper {
 class AVVideoStream : public AVStreamWrapper {
  public:
     virtual ~AVVideoStream() {
-        // ~AVStreamWrapper also calls close(), but a virtual call from a base destructor lands on the base
-        // override, so the scaler has to be freed from here.
-        close();
+        close(); // A virtual call from ~AVStreamWrapper lands on the base override, so the scaler needs this.
     }
 
     virtual void close() override {
@@ -534,7 +530,7 @@ class Movie : public IMovie {
 
             // ignore audio packets
             if (packet.stream_index == audio.stream_idx) {
-                av_packet_unref(&packet); // Skipping the unref at the end of the loop would leak this one.
+                av_packet_unref(&packet); // The continue below skips the unref at the end of the loop.
                 continue;
             }
 


### PR DESCRIPTION
142 of the 365 headless game tests leak under LeakSanitizer, and two root causes account for almost all of them. `Renderer::solidFillTexture` caches a 1x1 white `GraphicsImage` in a raw pointer that nothing deletes, and `AVAudioStream` and `AVVideoStream` allocate a `SwrContext` and a `SwsContext` in `open()` that are only freed on the failure paths. `PlayBink` also drops a packet reference per iteration of its audio pre-queue pass, and one for every audio packet its video pass skips.

Releasing the texture has to happen in the concrete renderer, because `GraphicsImage::release` dispatches through the pure virtual `DeleteTexture` and routes through the global `render` pointer, so neither is usable from `~Renderer`. Both renderers now do it and `~Renderer` asserts they did. The ffmpeg converters need a destructor on each derived class for a similar reason, a virtual `close()` called from `~AVStreamWrapper` lands on the base override.

This takes the suite from 142 leaking tests to 1. The last one is Lloyd's Beacon images created in `reconstruct(SaveGame_MM7, SaveGame *)` and left for a follow up, since `~LloydBeacon` has its release commented out on purpose and untangling that ownership belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
