### PR TITLE
Promote the test-local TemporaryDir into a shared ScopedTestFolder

### DIFF
--- a/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Directory/Tests/DirectoryFileSystem_ut.cpp
@@ -10,25 +10,6 @@
 
 #include "Utility/Streams/FileOutputStream.h"
 
-class TemporaryDir {
- public:
-    explicit TemporaryDir(std::string_view name): _name(name) {
-        if (std::filesystem::exists(_name))
-            std::filesystem::remove_all(_name);
-
-        std::filesystem::create_directory(name);
-        EXPECT_TRUE(std::filesystem::exists(name));
-    }
-
-    ~TemporaryDir() {
-        std::filesystem::remove_all(_name);
-        EXPECT_FALSE(std::filesystem::exists(_name));
-    }
-
- private:
-    std::string _name;
-};
-
 UNIT_TEST(DirectoryFileSystem, LsRoot) {
     // Make sure passing empty paths works as intended.
     ScopedTestFile tmp("1.txt", "");
@@ -112,7 +93,7 @@ UNIT_TEST(DirectoryFileSystem, DisplayPathSymmetry) {
 }
 
 UNIT_TEST(DirectoryFileSystem, EscapingPaths) {
-    TemporaryDir tmp("a");
+    ScopedTestFolder tmp("a");
     ScopedTestFile tmp2("1.txt", "");
     ScopedTestFile tmp3("a/1.txt", "");
 

--- a/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
+++ b/src/Library/FileSystem/Lowercase/Tests/LowercaseFileSystem_ut.cpp
@@ -7,8 +7,6 @@
 #include "Library/FileSystem/Memory/MemoryFileSystem.h"
 #include "Library/FileSystem/Directory/DirectoryFileSystem.h"
 
-#include "Utility/ScopeGuard.h"
-
 UNIT_TEST(LowercaseFileSystem, Empty) {
     MemoryFileSystem fs0("");
     LowercaseFileSystem fs(&fs0);
@@ -28,7 +26,7 @@ UNIT_TEST(LowercaseFileSystem, ExistsStatUppercase) {
 }
 
 UNIT_TEST(LowercaseFileSystem, KeepEmptyFolders) {
-    MM_AT_SCOPE_EXIT(std::filesystem::remove_all("tmp_dir"));
+    ScopedTestFolder tmp("tmp_dir");
 
     DirectoryFileSystem fs0(NativePath("tmp_dir"));
     fs0.write("a/b/c.bin", Blob());

--- a/test/Testing/Extensions/CMakeLists.txt
+++ b/test/Testing/Extensions/CMakeLists.txt
@@ -4,13 +4,15 @@ if(OE_BUILD_TESTS)
     set(TESTING_EXTENSIONS_SOURCES
             ThrowingAssertions.cpp
             ScopedTestFile.cpp
-            ScopedTestFileSlot.cpp)
+            ScopedTestFileSlot.cpp
+            ScopedTestFolder.cpp)
 
     set(TESTING_EXTENSIONS_HEADERS
             ThrowingAssertions.h
             ExpectExtensions.h
             ScopedTestFile.h
-            ScopedTestFileSlot.h)
+            ScopedTestFileSlot.h
+            ScopedTestFolder.h)
 
     add_library(testing_extensions ${TESTING_EXTENSIONS_SOURCES} ${TESTING_EXTENSIONS_HEADERS})
     target_link_libraries(testing_extensions PUBLIC GTest::gtest utility)

--- a/test/Testing/Extensions/ScopedTestFolder.cpp
+++ b/test/Testing/Extensions/ScopedTestFolder.cpp
@@ -1,0 +1,20 @@
+#include "ScopedTestFolder.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+ScopedTestFolder::ScopedTestFolder(const NativePath &path) : _path(path) {
+    std::error_code ec;
+    std::filesystem::remove_all(_path.toStdPath(), ec); // An earlier run could have left the folder behind.
+    std::filesystem::create_directories(_path.toStdPath());
+
+    EXPECT_TRUE(std::filesystem::exists(_path.toStdPath()));
+}
+
+ScopedTestFolder::~ScopedTestFolder() {
+    std::error_code ec;
+    std::filesystem::remove_all(_path.toStdPath(), ec);
+
+    EXPECT_FALSE(std::filesystem::exists(_path.toStdPath())); // A folder left behind poisons the next run.
+}

--- a/test/Testing/Extensions/ScopedTestFolder.h
+++ b/test/Testing/Extensions/ScopedTestFolder.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Utility/System/NativePath.h"
+
+/**
+ * Helper class to create a temporary folder at the given path & remove it, with everything that's in it, when
+ * leaving the current scope.
+ */
+class ScopedTestFolder {
+ public:
+    explicit ScopedTestFolder(const NativePath &path);
+    ~ScopedTestFolder();
+
+ private:
+    NativePath _path;
+};

--- a/test/Testing/Unit/UnitTest.h
+++ b/test/Testing/Unit/UnitTest.h
@@ -5,6 +5,7 @@
 #include "Testing/Extensions/ExpectExtensions.h"
 #include "Testing/Extensions/ScopedTestFile.h"
 #include "Testing/Extensions/ScopedTestFileSlot.h"
+#include "Testing/Extensions/ScopedTestFolder.h"
 
 #define UNIT_TEST(SuiteName, TestName) \
     TEST(SuiteName, TestName)


### PR DESCRIPTION
The same scoped temporary folder logic existed twice and neither copy was reusable. `DirectoryFileSystem_ut` carried an 18 line `TemporaryDir` class for a single call site, and `LowercaseFileSystem_ut` spelled it as a scope guard around `remove_all`, which removed the folder but never created it and never checked that the cleanup worked.

`test/Testing/Extensions` already holds `ScopedTestFile` and `ScopedTestFileSlot` as the sanctioned shape for this, so the folder case goes there as their sibling. Both call sites now use it, and both pick up the create step and the post-condition checks that only the `TemporaryDir` copy had.

This is a slice split out of #2557, where the same helper appears written against `Path` and `fs::`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)