### PR TITLE
Turn LeakSanitizer on for the test steps

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -42,7 +42,7 @@ env:
   # This is required for ccache to work for android build, otherwise we get 100% cache misses.
   CCACHE_COMPILERCHECK: content
   # Luajit runs the minilua and buildvm tools that it builds, and both leak by design, so LeakSanitizer
-  # would fail the sanitizer build long before it reaches our code. Many of our own game tests leak too.
+  # would fail the sanitizer build long before it reaches our code. The test steps turn it back on.
   ASAN_OPTIONS: detect_leaks=0
 
 jobs:
@@ -252,6 +252,8 @@ jobs:
         working-directory: build
         run: |
           ninja Run_UnitTest
+        env:
+          ASAN_OPTIONS: detect_leaks=1
 
       - name: '[darwin/windows/linux] Run game tests'
         if: env.MATRIX_PLATFORM != 'android'
@@ -259,6 +261,7 @@ jobs:
         run: |
           ninja Run_GameTest_Headless_Parallel
         env:
+          ASAN_OPTIONS: detect_leaks=1
           OPENENROTH_MM7_PATH: ${{github.workspace}}/OpenEnroth_GameData/mm7
 
       - name: '[darwin/windows/linux] Run retrace tests'


### PR DESCRIPTION
The ASan job has run with `detect_leaks=0` since it was added. Now that #2745 and #2746 have taken the headless game suite from 142 leaking tests of 365 down to none of 366, the two test steps override that and run with leak detection on.

The workflow level value stays off rather than being flipped outright, because luajit runs the minilua and buildvm tools it builds during the build itself and both leak by design. They are instrumented along with everything else, so `buildvm` exits 1 under LeakSanitizer and would take the build step down before any test runs.

Worth watching on this PR, nobody has run LeakSanitizer on x86_64 before. All the measurements behind the two fixes were taken locally on aarch64, so if there are leaks specific to the CI architecture this is where they surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
