### PR TITLE
Build luajit's host tools without sanitizers

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -41,9 +41,6 @@ env:
   NDK_VERSION: 28.1.13356709
   # This is required for ccache to work for android build, otherwise we get 100% cache misses.
   CCACHE_COMPILERCHECK: content
-  # Luajit runs the minilua and buildvm tools that it builds, and both leak by design, so LeakSanitizer
-  # would fail the sanitizer build long before it reaches our code. The test steps turn it back on.
-  ASAN_OPTIONS: detect_leaks=0
 
 jobs:
   build_all:
@@ -252,8 +249,6 @@ jobs:
         working-directory: build
         run: |
           ninja Run_UnitTest
-        env:
-          ASAN_OPTIONS: detect_leaks=1
 
       - name: '[darwin/windows/linux] Run game tests'
         if: env.MATRIX_PLATFORM != 'android'
@@ -261,7 +256,6 @@ jobs:
         run: |
           ninja Run_GameTest_Headless_Parallel
         env:
-          ASAN_OPTIONS: detect_leaks=1
           OPENENROTH_MM7_PATH: ${{github.workspace}}/OpenEnroth_GameData/mm7
 
       - name: '[darwin/windows/linux] Run retrace tests'

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -33,6 +33,12 @@ set(LUAJIT_DIR ${CMAKE_CURRENT_LIST_DIR}/luajit)
 include(${CMAKE_CURRENT_LIST_DIR}/luajit-cmake/LuaJIT.cmake)
 target_include_directories(libluajit INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(libluajit PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS}" LINK_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}") # Make it compile under x86.
+if(OE_USE_SANITIZERS AND NOT CMAKE_CROSSCOMPILING) # A cross build makes the host tools in a separate project that never sees these flags.
+    foreach(TOOL minilua buildvm) # Luajit runs these during the build, and they leak by design.
+        target_compile_options(${TOOL} PRIVATE -fno-sanitize=all)
+        target_link_options(${TOOL} PRIVATE -fno-sanitize=all)
+    endforeach()
+endif()
 if(TARGET check_tidy)
     add_dependencies(check_tidy libluajit) # Scripting sources include the luajit.h that's generated here.
 endif()


### PR DESCRIPTION
`OE_USE_SANITIZERS` adds `-fsanitize` to every target, so luajit's `minilua` and `buildvm` were instrumented too. Luajit runs both during the build and both leak by design, so under LeakSanitizer `buildvm` exits 1 and takes the build down. CI worked around it with `detect_leaks=0` at the workflow level and per-step overrides to turn it back on, and a local sanitizer build failed unless you knew to set `ASAN_OPTIONS` yourself.

The two host tools now build with `-fno-sanitize=all`, which lets the workflow drop `ASAN_OPTIONS` entirely. Cross builds are untouched, since luajit-cmake builds its host tools there as a separate project that never sees our flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
