### PR TITLE
Enable bugprone-suspicious-stringview-data-usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,10 +15,11 @@ Checks: >
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
   -bugprone-std-namespace-modification,
-  -bugprone-suspicious-stringview-data-usage,
   -bugprone-switch-missing-default-case,
   -bugprone-throwing-static-initialization,
   -bugprone-unchecked-optional-access
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(src|test)/'
 ExcludeHeaderFilterRegex: '/thirdparty/' # Submodules have src and test dirs of their own.
+CheckOptions:
+  bugprone-suspicious-stringview-data-usage.AllowedCallees: 'std::from_chars;fast_float::from_chars;noCaseCompare' # These take an explicit end or size.

--- a/src/Scripting/LuaItemQueryTable.h
+++ b/src/Scripting/LuaItemQueryTable.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <sol/sol.hpp>
 
+#include "Utility/String/TransparentFunctors.h"
+
 typedef std::vector<std::string_view> QueryTable;
 
 // A helper class used to fill a lua table with all the requested information
@@ -33,7 +35,7 @@ class LuaItemQueryTable {
             }
         } else {
             for (auto &&key : queryTable) {
-                if (auto itr = _mapping.find(key.data()); itr != _mapping.end()) {
+                if (auto itr = _mapping.find(key); itr != _mapping.end()) {
                     table[key] = itr->second(item);
                 }
             }
@@ -42,7 +44,7 @@ class LuaItemQueryTable {
     }
 
  private:
-    typedef std::unordered_map<std::string, std::function<sol::object(const ItemType &)>> MapFunctions;
+    using MapFunctions = std::unordered_map<std::string, std::function<sol::object(const ItemType &)>, TransparentStringHash, TransparentStringEquals>;
 
     MapFunctions _mapping;
     sol::state_view _luaState;


### PR DESCRIPTION
Takes another check off the exclusion list in `.clang-tidy`.

Eight of the nine findings pass `string_view::data()` to callees that already take an explicit end or size, `std::from_chars` and `fast_float::from_chars` in `CommonSerialization` and the sized `noCaseCompare` helper in `Ascii`. They go into the check's `AllowedCallees` option rather than collecting NOLINTs.

The ninth is a latent bug in `LuaItemQueryTable`. The map is keyed by `std::string`, so `find(key.data())` built its lookup key by reading up to the first NUL instead of the length of the view, which goes wrong for a Lua key with an embedded NUL. The map now uses `TransparentStringHash` and `TransparentStringEquals`, so `find(key)` looks the view up directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
